### PR TITLE
Issue/1982 part 1

### DIFF
--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -197,7 +197,7 @@ Page = rclass
             width         : '100vw'
             overflow      : 'hidden'
 
-        show_global_info = (@props.other_settings.show_global_info ? false) and (not @props.fullscreen)
+        show_global_info = (@props.other_settings.show_global_info ? false) and (not @props.fullscreen) and @props.is_logged_in()
 
         style_top_bar =
             display       : 'flex'

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -1010,7 +1010,7 @@ OtherSettings = rclass
                 ref      = 'show_global_info'
                 onChange = {(e)=>@on_change('show_global_info', e.target.checked)}
             >
-                Show global information: if enabled, a dismissable banner is visible on top
+                Show global information: if enabled, a dismissible banner is visible on top
             </Checkbox>
             <LabeledRow label='Default file sort'>
                 <SelectorInput

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -246,6 +246,8 @@ class AccountStore extends Store
 # Register account store
 # Use the database defaults for all account info until this gets set after they login
 init = misc.deep_copy(require('smc-util/schema').SCHEMA.accounts.user_query.get.fields)
+# ... except for show_global_info
+init.other_settings.show_global_info = false
 init.user_type = if misc.get_local_storage(remember_me) then 'signing_in' else 'public'  # default
 redux.createStore('account', AccountStore, init)
 


### PR DESCRIPTION
ticket #1982

This took me a while to figure out. I thought those redux values are set when loaded from the database, but they are apparently also in a intermediate default state. Is there a better way to do this? I would have thought the UI only renders once the values are set and not earlier...

test:
* no banner on refresh if you've disabled it
* sign out and create a new user. info banner only shows up after signed in