### PR TITLE
Fix vertical spacing when chat is open

### DIFF
--- a/src/smc-webapp/video-chat.cjsx
+++ b/src/smc-webapp/video-chat.cjsx
@@ -178,10 +178,10 @@ exports.VideoChatButton = rclass
 
     render: ->
         num_users_chatting = @video_chat.num_users_chatting()
+        style = {height : '31.4px'}
         if num_users_chatting > 0
-            style = {color: '#c9302c'}
-        else
-            style = {}
+            style.color = '#c9302c'
+
         <Button onClick={@click_video_button} style={style}>
             <Tip
                 title     = {<span>Toggle Video Chat</span>}


### PR DESCRIPTION
Notice how the file tab floats above the editor.
![offset](https://cloud.githubusercontent.com/assets/618575/26370521/ede98b22-3fac-11e7-8694-627343919fc0.png)

Shrinking the video button a little bit fixes this.
![fixed](https://cloud.githubusercontent.com/assets/618575/26370514/e792d38c-3fac-11e7-801f-449efd72e4b7.png)