### PR TITLE
documentation and examples for message protocol as data

### DIFF
--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -31,6 +31,7 @@
 misc     = require('./misc')
 defaults = misc.defaults
 required = defaults.required
+_        = require('underscore')
 
 
 message = (obj) ->
@@ -40,8 +41,36 @@ message = (obj) ->
         defaults(opts, obj)
     return obj
 
+# message2 for "version 2" of the message definitions
+# TODO document it, for now just search for "message2" to see examples
+message2 = (obj) ->
+
+    mk_descr = (val) ->
+        descr = val.descr 
+        descr += ' (required)' if val.init == required
+        return descr
+
+    init   = _.mapObject(obj.fields, ((val) -> val.init))
+    fdescr = _.mapObject(obj.fields, mk_descr)
+    exports.documentation[obj.event] =
+                                descr : obj.descr ? ''
+                                fields: fdescr
+    exports.tests[obj.event] = obj.tests
+
+    exports[obj.event] = (opts={}) ->
+        if opts.event?
+            throw Error("ValueError: must not define 'event' when calling message creation function (opts=#{JSON.stringify(opts)}, obj=#{JSON.stringify(obj)})")
+        defaults(opts, init)
+    return obj
+
 # messages that can be used by the HTTP api.   {'event':true, ...}
 exports.api_messages = {}
+
+# this holds the documentation for the message protocol
+exports.documentation = {}
+
+# holds all the tests
+exports.tests = {}
 
 API = (obj) ->
     exports.api_messages[obj.event] = true
@@ -1034,13 +1063,29 @@ message # client ← hub
 Queries directly to the database (sort of like Facebook's GraphQL)
 ###
 
-API message
+API message2
     event          : 'query'
-    id             : undefined
-    query          : required
-    changes        : undefined
-    multi_response : false
-    options        : undefined
+    descr          : "This queries directly the database (sort of Facebook's GraphQL)"
+    fields:
+        id:
+             init  : undefined
+             descr : 'A unique UUID for the query'
+        query:
+             init  : required
+             descr : 'The actual query'
+        changes:
+             init  : undefined
+             descr : ''
+        multi_response:
+             init  : false
+             descr : ''
+        options:
+             init  : undefined
+             descr : ''
+    tests: [
+        [{query: 'test-query'}, "expected response"],
+        [{query: '2nd-query'}, "expected 2nd response"]
+    ]
 
 message
     event : 'query_cancel'


### PR DESCRIPTION
This introduces a version 2 as `message2`.

The way I tested this is minimal, in `coffee`:

```
coffee> m = require('./message')

coffee> m.query(query: "test")
{ query: 'test', multi_response: false, event: 'query' }

coffee> m.documentation
{ query:
   { description: 'This queries directly the database (sort of Facebook\'s GraphQL)',
     fields:
      { id: 'A unique UUID for the query',
        query: 'The actual query (required)',
        changes: '',
        multi_response: ' (default: false)',
        options: '' } } }

coffee> m.examples
{ query: [ [ [Object], [Object] ], [ [Object], [Object] ] ] }
```