### PR TITLE
font files and webpack

### DIFF
--- a/src/webapp-lib/cocalc-icons-font/style.css
+++ b/src/webapp-lib/cocalc-icons-font/style.css
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'cocalc-icons';
-  src:  url('./cocalc-icons.eot');
-  src:  url('./cocalc-icons.eot') format('embedded-opentype'),
-    url('./cocalc-icons.ttf') format('truetype'),
-    url('./cocalc-icons.woff') format('woff'),
-    url('./cocalc-icons.svg') format('svg');
+  src:  url('./cocalc-icons.eot?v=1.0.0');
+  src:  url('./cocalc-icons.eot?v=1.0.0#iefix') format('embedded-opentype'),
+    url('./cocalc-icons.ttf?v=1.0.0') format('truetype'),
+    url('./cocalc-icons.woff?v=1.0.0') format('woff'),
+    url('./cocalc-icons.svg?v=1.0.0#cocalc-icons') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/webpack.config.coffee
+++ b/src/webpack.config.coffee
@@ -523,14 +523,14 @@ module.exports =
             { test: /\.json$/,   loaders: ['json-loader'] },
             { test: /\.png$/,    loader: "file-loader?#{pngconfig}" },
             { test: /\.ico$/,    loader: "file-loader?#{icoconfig}" },
-            { test: /\.svg(\?v=[0-9].[0-9].[0-9])?$/,    loader: "url-loader?#{svgconfig}" },
+            { test: /\.svg(\?[a-z0-9]+)?$/,    loader: "url-loader?#{svgconfig}" },
             { test: /\.(jpg|jpeg|gif)$/,    loader: "file-loader?name=#{hashname}"},
             # .html only for files in smc-webapp!
             { test: /\.html$/, include: [path.resolve(__dirname, 'smc-webapp')], loader: "raw!html-minify?conservativeCollapse"},
             # { test: /\.html$/, include: [path.resolve(__dirname, 'webapp-lib')], loader: "html-loader"},
             { test: /\.hbs$/,    loader: "handlebars-loader" },
-            { test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/, loader: "url-loader?#{woffconfig}" },
-            { test: /\.(ttf|eot)(\?v=[0-9].[0-9].[0-9])?$/, loader: "file-loader?name=#{hashname}" },
+            { test: /\.woff(2)?(\?[a-z0-9]+)?$/, loader: "url-loader?#{woffconfig}" },
+            { test: /\.(ttf|eot)(\?[a-z0-9]+)?$/, loader: "file-loader?name=#{hashname}" },
             { test: /\.(ttf|eot)$/, loader: "file-loader?name=#{hashname}" },
             # { test: /\.css$/,    loader: 'style!css' },
             { test: /\.css$/, loaders: ["style-loader", "css-loader?#{cssConfig}"]}, # loader: extractTextCss }, #

--- a/src/webpack.config.coffee
+++ b/src/webpack.config.coffee
@@ -523,16 +523,19 @@ module.exports =
             { test: /\.json$/,   loaders: ['json-loader'] },
             { test: /\.png$/,    loader: "file-loader?#{pngconfig}" },
             { test: /\.ico$/,    loader: "file-loader?#{icoconfig}" },
-            { test: /\.svg(\?[a-z0-9]+)?$/,    loader: "url-loader?#{svgconfig}" },
+            { test: /\.svg(\?[a-z0-9\.-=]+)?$/,    loader: "url-loader?#{svgconfig}" },
             { test: /\.(jpg|jpeg|gif)$/,    loader: "file-loader?name=#{hashname}"},
             # .html only for files in smc-webapp!
             { test: /\.html$/, include: [path.resolve(__dirname, 'smc-webapp')], loader: "raw!html-minify?conservativeCollapse"},
             # { test: /\.html$/, include: [path.resolve(__dirname, 'webapp-lib')], loader: "html-loader"},
             { test: /\.hbs$/,    loader: "handlebars-loader" },
-            { test: /\.woff(2)?(\?[a-z0-9]+)?$/, loader: "url-loader?#{woffconfig}" },
-            { test: /\.(ttf|eot)(\?[a-z0-9]+)?$/, loader: "file-loader?name=#{hashname}" },
-            { test: /\.(ttf|eot)$/, loader: "file-loader?name=#{hashname}" },
-            # { test: /\.css$/,    loader: 'style!css' },
+            { test: /\.woff(2)?(\?[a-z0-9\.-=]+)?$/, loader: "url-loader?#{woffconfig}" },
+            # this is the previous file-loader config for ttf and eot fonts -- but see #1974 which for me looks like a webpack sillyness
+            #{ test: /\.(ttf|eot)(\?[a-z0-9\.-=]+)?$/, loader: "file-loader?name=#{hashname}" },
+            #{ test: /\.(ttf|eot)$/, loader: "file-loader?name=#{hashname}" },
+            { test: /\.ttf(\?[a-z0-9\.-=]+)?$/, loader: "url-loader?limit=10000&mimetype=application/octet-stream" },
+            { test: /\.eot(\?[a-z0-9\.-=]+)?$/, loader: "file-loader?name=#{hashname}" },
+            # ---
             { test: /\.css$/, loaders: ["style-loader", "css-loader?#{cssConfig}"]}, # loader: extractTextCss }, #
             { test: /\.pug$/, loader: 'pug-loader' },
         ]


### PR DESCRIPTION
For some reasons, webpack did create small one-line wrapper scripts disguised as font files. Of course, that's not going to work out well, if the content type of e.g. a *.ttf file is binary but contains a small js script. 

This here changes the configuration and well, the most important aspect is to test it. I.e. when webpack-production compiles, that there are no errors about unknown file types (that happens, when e.g. the regex `\.ttf(\?[a-z0-9\.-=]+)?$` doesn't match and it falls back to a default). The second aspect to test is that when the page loads the newer font-icons for the symbols show up. (right at the moment when I wrote this, https://test.cocalc.com/ works with that newer config)