### PR TITLE
zoom width for preview was uninitialized in latex editor #2001

### DIFF
--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -93,10 +93,7 @@ class exports.LatexEditor extends editor.FileEditor
             @spell_check()
 
         @latex_editor.syncdoc.on 'connect', () =>
-            if @load_conf().zoom_width?
-                @preview.zoom_width = @load_conf().zoom_width
-            else
-                @preview.zoom_width = 100
+            @preview.zoom_width = @load_conf().zoom_width ? 100
             @update_preview()
             @spell_check()
 

--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -93,7 +93,10 @@ class exports.LatexEditor extends editor.FileEditor
             @spell_check()
 
         @latex_editor.syncdoc.on 'connect', () =>
-            @preview.zoom_width = @load_conf().zoom_width
+            if @load_conf().zoom_width?
+                @preview.zoom_width = @load_conf().zoom_width
+            else
+                @preview.zoom_width = 100
             @update_preview()
             @spell_check()
 


### PR DESCRIPTION
Ref: #2001 

To test
1. install the PR
1. create a new .tex file and wait for preview to appear in right pane.
1. before doing any edits, click "zoom out a little". Preview should shrink to show black margins at sides
1. save and reload the .tex file and confirm preview size is remembered
1. create another new .tex file and confirm that "zoom in a little" works as expected before any edits are done