### PR TITLE
Hub stats opened files

### DIFF
--- a/src/smc-hub/hub_http_server.coffee
+++ b/src/smc-hub/hub_http_server.coffee
@@ -268,10 +268,12 @@ exports.init_express_http_server = (opts) ->
             return
         opts.database.get_stats
             cb : (err, stats) ->
+                res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate')
                 if err
                     res.status(500).send("internal error: #{err}")
                 else
-                    res.json(stats)
+                    res.header("Content-Type", "application/json")
+                    res.send(JSON.stringify(stats, null, 1))
 
     ###
     # Stripe webhooks -- not done

--- a/src/smc-hub/postgres-base.coffee
+++ b/src/smc-hub/postgres-base.coffee
@@ -247,7 +247,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                                      # case that key is deleted from the JSONB object fieldi.  Simple as that!  This is much, much
                                      # cleaner to use than SQL.   Also, if the value in fieldi itself is NULL, it gets
                                      # created automatically.
-            jsonb_merge : undefined  # Exactly lke jsonb_set, but when val1 (say) is an object, it merges that object in,
+            jsonb_merge : undefined  # Exactly like jsonb_set, but when val1 (say) is an object, it merges that object in,
                                      # *instead of* setting field1[key1]=val1.  So after this field1[key1] has what was in it
                                      # and also what is in val1.  Obviously field1[key1] had better have been an array or NULL.
             order_by    : undefined

--- a/src/smc-hub/test/get_stats.coffee
+++ b/src/smc-hub/test/get_stats.coffee
@@ -1,0 +1,12 @@
+# little helper for developing get_stats against the current dev database
+
+postgres = require('../postgres')
+misc = require('../../smc-util/misc')
+
+db = postgres.db(database:'smc', debug:true, connect:false)
+
+db.connect cb: ->
+    db.get_stats
+        cb: (err, x) ->
+            console.log JSON.stringify(x, null, 2)
+            process.exit 0

--- a/src/smc-util/db-schema.coffee
+++ b/src/smc-util/db-schema.coffee
@@ -1001,6 +1001,8 @@ schema.stats =
             pg_check : 'NOT NULL CHECK (accounts >= 0)'
         accounts_created    :
             type : 'map'
+        files_opened :
+            type : 'map'
         projects            :
             type : 'integer'
             pg_check : 'NOT NULL CHECK (projects >= 0)'

--- a/src/webapp-lib/index.coffee
+++ b/src/webapp-lib/index.coffee
@@ -12,6 +12,11 @@ stat_rows = [
     ['Created projects', 'projects_created'],
     ['Created accounts', 'accounts_created'],
 ]
+opened_files = [
+    ['Sage Worksheets',     'sagews'],
+    ['Jupyter Notebooks',   'ipynb'],
+    ['LaTeX Documents',     'tex']
+]
 
 sum_clients = (stats) ->
     hubs = stats?['hub_servers'] ? []
@@ -26,16 +31,38 @@ update_stats = (stats) ->
     if table.rows.length >= 2
         for i in [table.rows.length...1]
             table.deleteRow(i-1)
+
     for [name, key] in stat_rows
         row    = table.insertRow()
         cell   = row.insertCell()
         cell.className = 'left'
-        rowname = document.createElement("strong")
-        rowname.appendChild(document.createTextNode(name))
-        cell.appendChild(rowname)
+        cell.innerHTML = "<strong>#{name}</strong>"
         for j in window.stat_times
             cell = row.insertCell()
             cell.appendChild(document.createTextNode("#{stats[key][j]}"))
+
+    row   = table.insertRow()
+    delim = row.insertCell()
+    delim.innerHTML = '&nbsp;'
+    delim.setAttribute("colspan", 5)
+    row   = table.insertRow()
+    cell  = row.insertCell()
+    cell.className = 'left'
+    cell.innerHTML = '<strong>Number of files</strong>'
+    cell  = row.insertCell()
+    cell.setAttribute("colspan", 4)
+    cell.innerHTML = 'opened or edited, counting total and unique file paths'
+
+    for [name, ext] in opened_files
+        row     = table.insertRow()
+        cell    = row.insertCell()
+        cell.className = 'left'
+        cell.innerHTML = "<strong>#{name}</strong>"
+        for j in window.stat_times
+            cell       = row.insertCell()
+            total      = stats.files_opened?.total[j]?[ext] ? 0
+            distinct   = stats.files_opened?.distinct[j]?[ext] ? 0
+            cell.innerHTML = "<span title='total files opened'>#{total}</span>  (<span title='distinct files opened'>#{distinct})</span>"
 
     document.getElementById("sum_clients").innerHTML = sum_clients(stats)
 


### PR DESCRIPTION
This adds some stats about files on the landing page. Most importantly, it requires a schema update!

There is also some compactification of the code for those stats tasks in the hub; and in case the query looks scary, it isn't so bad as it looks.

Test:
* calling `/stats` should still contain the old entries and of course, doesn't cause exceptions in the hub.
* The landing page should shows more data in the stats table.