### PR TITLE
mocha tests for API get_usernames and create_account

### DIFF
--- a/src/smc-hub/test/api/account.coffee
+++ b/src/smc-hub/test/api/account.coffee
@@ -1,0 +1,65 @@
+###
+Using API to interact with a project
+###
+
+api   = require('./apitest')
+{setup, teardown} = api
+
+expect = require('expect')
+
+
+describe 'testing api calls relating to user accounts -- ', ->
+    before(setup)
+    after(teardown)
+
+    project_id = undefined
+
+    it "gets names for empty list of users", (done) ->
+        api.call
+            event : 'get_usernames'
+            body  :
+                account_ids    : []
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('usernames')
+                expect(resp?.usernames).toEqual({})
+                done(err)
+
+    it "gets names for api test account", (done) ->
+        api.call
+            event : 'get_usernames'
+            body  :
+                account_ids    : [api.account_id]
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('usernames')
+                expect(resp?.usernames).toEqual
+                    "#{api.account_id}":
+                        first_name: 'Sage'
+                        last_name: 'CoCalc'
+                done(err)
+
+    it "uses api call to create a second account", (done) ->
+        api.call
+            event : 'create_account'
+            body  :
+                first_name      : "Sage2"
+                last_name       : "CoCalc2"
+                email_address   : "cocalc+2@sagemath.com"
+                password        : "1234qwerty"
+                agreed_to_terms : true
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('account_created')
+                expect(resp?.account_id.match(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i))
+                done(err)
+
+    it "tries to create the same account again", (done) ->
+        api.call
+            event : 'create_account'
+            body  :
+                first_name      : "Sage2"
+                last_name       : "CoCalc2"
+                email_address   : "cocalc+2@sagemath.com"
+                password        : "1234qwerty"
+                agreed_to_terms : true
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('account_creation_failed')
+                done(err)


### PR DESCRIPTION
Adds 1 API test file only for get_usernames and create_account.