### PR TITLE
add API message docs

### DIFF
--- a/src/smc-hub/test/api/account.coffee
+++ b/src/smc-hub/test/api/account.coffee
@@ -119,3 +119,44 @@ describe 'testing invalid input to creating user accounts -- ', ->
                 delete resp?.id
                 expect(resp).toEqual(event:'account_creation_failed', reason: { last_name: 'Enter your last name.' })
                 done(err)
+
+describe 'testing user_search -- ', ->
+    before(setup)
+    after(teardown)
+
+    it "searches by email", (done) ->
+        api.call
+            event : 'user_search'
+            body  :
+                query : 'cocalc@sagemath.com'
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('user_search_results')
+                expect(resp?.results?.length).toBe(1)
+                expect(resp?.results?[0].first_name).toBe('Sage')
+                expect(resp?.results?[0].last_name).toBe('CoCalc')
+                expect(resp?.results?[0].email_address).toBe('cocalc@sagemath.com')
+                done(err)
+
+
+    it "searches by first and last name prefixes", (done) ->
+        api.call
+            event : 'user_search'
+            body  :
+                query : 'coc sag'
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('user_search_results')
+                expect(resp?.results?.length).toBe(1)
+                expect(resp?.results?[0].first_name).toBe('Sage')
+                expect(resp?.results?[0].last_name).toBe('CoCalc')
+                expect(resp?.results?[0]).toExcludeKey('email_address')
+                done(err)
+
+    it "searches by email and first and last name prefixes", (done) ->
+        api.call
+            event : 'user_search'
+            body  :
+                query : 'coc sag,cocalc@sagemath.com'
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('user_search_results')
+                expect(resp?.results?.length).toBe(2)
+                done(err)

--- a/src/smc-hub/test/api/messages.coffee
+++ b/src/smc-hub/test/api/messages.coffee
@@ -1,0 +1,37 @@
+###
+Test message and message2 definitions
+###
+
+messages = require('../../../smc-util/message.coffee')
+
+expect = require('expect')
+
+
+describe 'checking message definition for ping', ->
+    it "checks existence of ping api message", ->
+        expect(messages.api_messages.ping).toBe(true)
+
+    it "checks nonexistence of xxping api message", ->
+        expect(messages.api_messages.xxping?).toBe(false)
+
+    it "gets definition for ping message", -> 
+        expect(messages.ping({})).toEqual({'event':'ping'})
+
+describe 'checking message2 features', ->
+    it "checks ping documentation", ->
+        expect(messages.documentation.ping.description).toInclude("curl -X POST")
+    it "checks get_usernames documentation", ->
+        expect(messages.documentation.get_usernames.description).toInclude("/api/v1/get_usernames")
+    it "checks create_account documentation", ->
+        expect(messages.documentation.create_account.description).toInclude("/api/v1/create_account")
+    it "checks delete_account documentation", ->
+        expect(messages.documentation.delete_account.description).toInclude("/api/v1/delete_account")
+    it "checks create_project documentation", ->
+        expect(messages.documentation.create_project.description).toInclude("/api/v1/create_project")
+    it "checks query documentation", ->
+        expect(messages.documentation.query.description).toInclude("/api/v1/query")
+    it "checks change_email_address documentation", ->
+        expect(messages.documentation.change_email_address.description).toInclude("set a new email address")
+        expect(messages.documentation.change_email_address.fields.account_id).toMatch('required')
+        expect(messages.documentation.change_email_address.fields.new_email_address).toMatch('required')
+        

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -825,11 +825,68 @@ message
 ## search ---------------------------
 
 # client --> hub
-API message
+API message2
     event : 'user_search'
-    id    : undefined
-    query : required    # searches for match in first_name or last_name.
-    limit : 20          # maximum number of results requested
+    fields:
+        id:
+            init  : undefined
+            desc  : 'A unique UUID for the query'
+        query:
+            init  : required
+            desc  : "comma separated list of email addresses or strings such as 'foo bar'"
+        limit:
+            init  : 20
+            desc  : 'maximum number of results returned'
+    desc: """
+There are two possible item types in the query list: email addresses
+and strings that are not email addresses. An email query item will return
+account id, first name, last name, and email address for the unique
+account with that email address, if there is one. A string query item
+will return account id, first name, and last name for all matching
+accounts. We do not reveal email addresses of users queried by name.
+String query matches first and last names that start with the given string.
+If a string query item consists of two strings separated by space,
+the search will return accounts in which the first name begins with one
+of the two strings and the last name begins with the other.
+String and email queries may be mixed in the list for a single
+user_search call. Searches are case-insensitive.
+
+Note: there is a hard limit of 50 returned items in the results.
+
+Examples:
+
+Search for account by email.
+  curl -u sk_abcdefQWERTY090900000000: -d query=jd@m.local https://cocalc.com/api/v1/user_search
+  ==> {"event":"user_search_results",
+       "id":"3818fa50-b892-4167-b9d9-d22d521b36af",
+       "results":[{"account_id":"96c523b8-321e-41a3-9523-39fde95dc71d",
+                   "first_name":"John",
+                   "last_name":"Doe",
+                   "email_address":"jd@m.local"}
+
+Search for at most 3 accounts where first and last name begin with 'foo' or 'bar'.
+  curl -u sk_abcdefQWERTY090900000000: -d 'query=foo bar' -d limit=3 https://cocalc.com/api/v1/user_search
+  ==> {"event":"user_search_results",
+       "id":"fd9b025b-25d0-4e27-97f4-2c080bb07155",
+       "results":[{"account_id":"1a842a67-eed3-405d-a222-2f23a33f675e",
+                   "first_name":"foo",
+                   "last_name":"bar"},
+                  {"account_id":"0e9418a7-af6a-4004-970a-32fafe733f29",
+                   "first_name":"bar123",
+                   "last_name":"fooxyz"},
+                  {"account_id":"93f8131c-6c21-401a-897d-d4abd9c6c225",
+                   "first_name":"Foo",
+                   "last_name":"Bar"}]}
+  The same result would be returned with a search string of 'bar foo'.
+  A name of "Xfoo YBar" would not match.
+  Note that email addresses are not returned for string search items.
+
+Email and string search types may be mixed in a single query:
+  curl -u sk_abcdefQWERTY090900000000: \
+    -d 'query=foo bar,jd@m.local' \
+    -d limit=4 \
+    https://cocalc.com/api/v1/user_search
+"""
 
 # hub --> client
 message


### PR DESCRIPTION
Ref: #1987 

This PR includes src/smc-hub/test/api/messsages.coffee, a file which has been useful when defining message docs. I'm not sure the team will want it in the src tree, though.

Mainly, this PR adds 'API message2' docs for more events.