### PR TITLE
fullscreen query parameter

### DIFF
--- a/src/smc-hub/hub_http_server.coffee
+++ b/src/smc-hub/hub_http_server.coffee
@@ -259,7 +259,9 @@ exports.init_express_http_server = (opts) ->
 
     # Save other paths in # part of URL then redirect to the single page app.
     router.get ['/projects*', '/help*', '/settings*'], (req, res) ->
-        res.redirect(opts.base_url + "/app#" + req.path.slice(1))
+        url = require('url')
+        q = url.parse(req.url, true).search # gives exactly "?key=value,key=..."
+        res.redirect(opts.base_url + "/app#" + req.path.slice(1) + q)
 
     # Return global status information about smc
     router.get '/stats', (req, res) ->

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -292,3 +292,8 @@ webapp_client.on "connecting", () ->
 
 webapp_client.on 'new_version', (ver) ->
     redux.getActions('page').set_new_version(ver)
+
+# enable fullscreen mode upon a URL like /app?fullscreen
+misc_page = require('./misc_page')
+if misc_page.get_query_param('fullscreen')
+    redux.getActions('page').set_fullscreen(true)

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1799,3 +1799,23 @@ exports.clear_selection = ->
         window.getSelection().removeAllRanges() # firefox
     else
         document.selection?.empty?()
+
+# read the query string of the URL and transform it to a key/value map
+# based on: https://stackoverflow.com/a/4656873/54236
+# the main difference is that multiple identical keys are collected in an array
+# test: check that /app?fullscreen&a=1&a=4 gives {fullscreen : true, a : [1, 4]}
+exports.get_query_params = ->
+    vars = {}
+    href = window.location.href
+    for part in href.slice(href.indexOf('?') + 1).split('&')
+        [k, v] = part.split('=')
+        if vars[k]?
+            if not Array.isArray(vars[k])
+                vars[k] = [vars[k]]
+            vars[k] = vars[k].concat(v)
+        else
+            vars[k] = v ? true
+    return vars
+
+exports.get_query_param = (p) ->
+    return exports.get_query_params()[p]

--- a/src/smc-webapp/webapp_client.coffee
+++ b/src/smc-webapp/webapp_client.coffee
@@ -30,7 +30,12 @@ if window?
         window.app_base_url = ""
 
     if window.location.hash.length > 1
-        window.smc_target = decodeURIComponent(window.location.hash.slice(1))
+        q = decodeURIComponent(window.location.hash.slice(1))
+        # the location hash could again contain a query param, hence this
+        i = q.indexOf('?')
+        if i >= 0
+            q = q.slice(0, i)
+        window.smc_target = q
 
     client_browser = require('client_browser')
     exports.webapp_client = client_browser.connect()


### PR DESCRIPTION
Ref #2028 -- this introduces a query parameter `?fullscreen` to toggle it on.

process: mainly finding my way around how various redirects work and how `smc_target` is used, etc.

test and edge cases:
* `/app?fullscreen`
* `/projects/ ... /files/dir/name.ipynb?fullscreen` → opens up that ipynb file in fullscreen (and does not stupidly add the `?...` part to the filename)
* all normal paths still work, i.e. `/projects`, `/`, `/projects/.../files/...`, etc. (e.g. that when opening a file, `*.ipynb` isn't mangled into `*.ipyn` or so)

deployment: don't miss that it also touches the hub

time: 1 hour 10 min