### PR TITLE
Persist Markdown Inputs

### DIFF
--- a/src/smc-webapp/course/assignments_panel.cjsx
+++ b/src/smc-webapp/course/assignments_panel.cjsx
@@ -233,6 +233,7 @@ Assignment = rclass
             <Col xs=10>
                 <MarkdownInput
                     persist_id    = {@props.assignment.get('path') + @props.assignment.get('assignment_id')}
+                    attach_to     = {@props.name}
                     rows          = 6
                     placeholder   = 'Private notes about this assignment (not visible to students)'
                     default_value = {@props.assignment.get('note')}

--- a/src/smc-webapp/course/assignments_panel.cjsx
+++ b/src/smc-webapp/course/assignments_panel.cjsx
@@ -232,6 +232,7 @@ Assignment = rclass
             </Col>
             <Col xs=10>
                 <MarkdownInput
+                    persist_id    = {@props.assignment.get('path') + @props.assignment.get('assignment_id')}
                     rows          = 6
                     placeholder   = 'Private notes about this assignment (not visible to students)'
                     default_value = {@props.assignment.get('note')}

--- a/src/smc-webapp/entry-point.coffee
+++ b/src/smc-webapp/entry-point.coffee
@@ -24,8 +24,9 @@ require('./system_notifications')
 # Makes some things work. Like the save button
 require('./jquery_plugins')
 
-# Initializes app stores, actions, etc.
+# Initialize app stores, actions, etc.
 require('./init_app')
+require('./widget-markdown-input/main').init(redux)
 
 mobile = require('./mobile_app')
 desktop = require('./desktop_app')

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -656,12 +656,17 @@ exports.SearchInput = rclass
                 </InputGroup.Button>
             </InputGroup>
         </FormGroup>
+# Important:
+# Can be controlled or uncontrolled -- use default_value for an *uncontrolled* widget
+# with callbacks, and value for a controlled one!
+#    See http://facebook.github.io/react/docs/forms.html#controlled-components
 
 exports.MarkdownInput = rclass
     displayName : 'Misc-MarkdownInput'
 
     propTypes :
         default_value : rtypes.string
+        value         : rtypes.string
         on_change     : rtypes.func
         on_save       : rtypes.func   # called when saving from editing and switching back
         on_edit       : rtypes.func   # called when editing starts
@@ -699,19 +704,10 @@ exports.MarkdownInput = rclass
 
     render: ->
         if @state.editing
-
             tip = <span>
                 You may enter (Github flavored) markdown here.  In particular, use # for headings, > for block quotes, *'s for italic text, **'s for bold text, - at the beginning of a line for lists, back ticks ` for code, and URL's will automatically become links.
             </span>
-
             <div>
-                <ButtonToolbar style={paddingBottom:'5px'}>
-                    <Button key='save' bsStyle='success' onClick={@save}
-                            disabled={@state.value == @props.default_value}>
-                        <Icon name='edit' /> Save
-                    </Button>
-                    <Button key='cancel' onClick={@cancel}>Cancel</Button>
-                </ButtonToolbar>
                 <form onSubmit={@save} style={marginBottom: '-20px'}>
                     <FormGroup>
                         <FormControl autoFocus
@@ -730,11 +726,18 @@ exports.MarkdownInput = rclass
                         Format using <a href='https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/' target='_blank'>Markdown</a>
                     </Tip>
                 </div>
+                <ButtonToolbar style={paddingBottom:'5px'}>
+                    <Button key='save' bsStyle='success' onClick={@save}
+                            disabled={@state.value == @props.default_value}>
+                        <Icon name='edit' /> Save
+                    </Button>
+                    <Button key='cancel' onClick={@cancel}>Cancel</Button>
+                </ButtonToolbar>
             </div>
         else
             <div>
-                {<Button onClick={@edit}>Edit</Button>}
                 <div onClick={@edit} dangerouslySetInnerHTML={@to_html()}></div>
+                <Button onClick={@edit}>Edit</Button>
             </div>
 
 exports.HTML = rclass

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -40,6 +40,8 @@ markdown    = require('./markdown')
 
 {defaults, required} = misc
 
+exports.MarkdownInput = require('./widget-markdown-input/main').MarkdownInput
+
 # base unit in pixel for margin/size/padding
 exports.UNIT = UNIT = 15
 
@@ -656,144 +658,6 @@ exports.SearchInput = rclass
                 </InputGroup.Button>
             </InputGroup>
         </FormGroup>
-
-redux.createStore
-    name: "markdown_inputs"
-
-    stateTypes:
-        open_inputs : rtypes.immutable.Map
-
-    getInitialState: =>
-        open_inputs : immutable.Map({}) # {id : String}
-
-class MarkdownInputActions extends Actions
-    get_store: ->
-        redux.getStore("markdown_inputs")
-
-    clear: (id) =>
-        return unless id?
-        open_inputs = @get_store().get('open_inputs').delete(id)
-        @setState({open_inputs})
-
-    set_value: (id, value) =>
-        return unless id?
-        open_inputs = @get_store().get('open_inputs').set(id, value)
-        @setState({open_inputs})
-
-redux.createActions("markdown_inputs", MarkdownInputActions)
-
-exports.MarkdownInput = rclass
-    displayName : 'Misc-MarkdownInput'
-
-    propTypes :
-        persist_id    : rtypes.string # A unique id to identify the input. Required if you want automatic persistence
-        attach_to     : rtypes.string # Removes record when given store name is destroyed
-        default_value : rtypes.string
-        on_change     : rtypes.func
-        on_save       : rtypes.func   # called when saving from editing and switching back
-        on_edit       : rtypes.func   # called when editing starts
-        on_cancel     : rtypes.func   # called when cancel button clicked
-        rows          : rtypes.number
-        placeholder   : rtypes.string
-
-    reduxProps:
-        markdown_inputs :
-            open_inputs : rtypes.immutable.Map.isRequired
-
-    getInitialState: ->
-        value = @props.default_value ? ''
-        editing = false
-        if @props.persist_id and @props.open_inputs.has(@props.persist_id)
-            value = @props.open_inputs.get(@props.persist_id)
-            editing = true
-
-        editing : editing
-        value   : value
-
-    componentDidMount: ->
-        if @props.attach_to
-            redux.getStore(@props.attach_to).on('destroy', @clear_persist)
-
-    componentWillUnmount: ->
-        if @props.persist_id? and not @state.editing
-                @clear_persist()
-
-    persist_value: (value) ->
-        @actions("markdown_inputs").set_value(@props.persist_id, value ? @state.value)
-
-    clear_persist: ->
-        @actions('markdown_inputs').clear(@props.persist_id)
-
-    set_value: (value) ->
-        @props.on_change?(value)
-        @persist_value(value)
-        @setState(value : value)
-
-    edit: ->
-        @props.on_edit?()
-        @persist_value()
-        @setState(editing:true)
-
-    cancel: ->
-        @props.on_cancel?()
-        @clear_persist()
-        @setState(editing:false)
-
-    save: ->
-        @props.on_save?(@state.value)
-        @clear_persist()
-        @setState(editing:false)
-
-    keydown: (e) ->
-        if e.keyCode==27
-            @setState(editing:false)
-        else if e.keyCode==13 and e.shiftKey
-            @save()
-
-    to_html: ->
-        if @props.default_value
-            {__html: markdown.markdown_to_html(@props.default_value).s}
-        else
-            {__html: ''}
-
-    render: ->
-        if @state.editing
-            tip = <span>
-                You may enter (Github flavored) markdown here.  In particular, use # for headings, > for block quotes, *'s for italic text, **'s for bold text, - at the beginning of a line for lists, back ticks ` for code, and URL's will automatically become links.
-            </span>
-            <div>
-                <form onSubmit={@save} style={marginBottom: '-20px'}>
-                    <FormGroup>
-                        <FormControl
-                            autoFocus      = {@props.autoFocus ? true}
-                            ref            = 'input'
-                            componentClass = 'textarea'
-                            rows           = {@props.rows ? 4}
-                            placeholder    = {@props.placeholder}
-                            value          = {@state.value}
-                            onChange       = {(e)=>@set_value(ReactDOM.findDOMNode(@refs.input).value)}
-                            onKeyDown      = {@keydown}
-                        />
-                    </FormGroup>
-                </form>
-                <div style={paddingTop:'8px', color:'#666'}>
-                    <Tip title='Use Markdown' tip={tip}>
-                        Format using <a href='https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/' target='_blank'>Markdown</a>
-                    </Tip>
-                </div>
-                <ButtonToolbar style={paddingBottom:'5px'}>
-                    <Button key='save' bsStyle='success' onClick={@save}
-                            disabled={@state.value == @props.default_value}>
-                        <Icon name='edit' /> Save
-                    </Button>
-                    <Button key='cancel' onClick={@cancel}>Cancel</Button>
-                </ButtonToolbar>
-            </div>
-        else
-            <div>
-                <div onClick={@edit} dangerouslySetInnerHTML={@to_html()}></div>
-                <Button onClick={@edit}>Edit</Button>
-            </div>
 
 exports.HTML = rclass
     displayName : 'Misc-HTML'

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -138,7 +138,6 @@ class Store extends EventEmitter
             @emit('change', state)
 
     destroy: =>
-        @emit('destroy')
         @redux.removeStore(@name)
 
     getState: =>
@@ -371,6 +370,7 @@ class AppRedux
             throw Error("name must be a string")
         if @_stores[name]?
             S = @_stores[name]
+            S.emit('destroy')
             delete @_stores[name]
             S.removeAllListeners()
             @_redux_store.dispatch(action_remove_store(name))

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -138,6 +138,7 @@ class Store extends EventEmitter
             @emit('change', state)
 
     destroy: =>
+        @emit('destroy')
         @redux.removeStore(@name)
 
     getState: =>

--- a/src/smc-webapp/widget-markdown-input/actions.coffee
+++ b/src/smc-webapp/widget-markdown-input/actions.coffee
@@ -1,0 +1,25 @@
+# 3rd Party Libraries
+
+# Internal Libraries
+misc = require('smc-util/misc')
+{Actions} = require('../smc-react')
+
+# Sibling Libraries
+info = require('./info')
+
+exports.create = (redux) =>
+    class MarkdownInputActions extends Actions
+        get_store: ->
+            redux.getStore(info.name)
+
+        clear: (id) =>
+            return unless id?
+            open_inputs = @get_store().get('open_inputs').delete(id)
+            @setState({open_inputs})
+
+        set_value: (id, value) =>
+            return unless id?
+            open_inputs = @get_store().get('open_inputs').set(id, value)
+            @setState({open_inputs})
+
+    return MarkdownInputActions

--- a/src/smc-webapp/widget-markdown-input/info.coffee
+++ b/src/smc-webapp/widget-markdown-input/info.coffee
@@ -1,0 +1,8 @@
+###
+# Information for MarkdownInput Widgets
+###
+
+# Unique name for our store namespace
+exports.name = "markdown_inputs"
+
+exports.guide_link = "https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/"

--- a/src/smc-webapp/widget-markdown-input/main.cjsx
+++ b/src/smc-webapp/widget-markdown-input/main.cjsx
@@ -49,7 +49,7 @@ exports.MarkdownInput = rclass
         value   : value
 
     componentDidMount: ->
-        if @props.attach_to
+        if @props.attach_to and not @props.open_inputs.has(@props.persist_id)
             state_app.getStore(@props.attach_to).on('destroy', @clear_persist)
 
     componentWillUnmount: ->

--- a/src/smc-webapp/widget-markdown-input/main.cjsx
+++ b/src/smc-webapp/widget-markdown-input/main.cjsx
@@ -69,8 +69,7 @@ exports.MarkdownInput = rclass
 
     edit: ->
         @props.on_edit?()
-        @persist_value()
-        @setState(editing : true)
+        @setState(editing : true, value : @props.default_value)
 
     cancel: ->
         @props.on_cancel?()

--- a/src/smc-webapp/widget-markdown-input/main.cjsx
+++ b/src/smc-webapp/widget-markdown-input/main.cjsx
@@ -1,0 +1,135 @@
+# 3rd Party Libraries
+markdown = require('../markdown')
+{Button, ButtonToolbar, FormControl, FormGroup} = require('react-bootstrap')
+
+# Internal Libraries
+misc = require('smc-util/misc')
+{React, ReactDOM, rclass, rtypes} = require('../smc-react')
+
+# Sibling Libraries
+info = require('./info')
+actions = require('./actions')
+store = require('./store')
+
+state_app = undefined # Expects a state application with stores and actions
+exports.init = (redux) =>
+    return if redux.getActions(info.name)
+
+    redux.createStore(store.definition)
+    redux.createActions(info.name, actions.create(redux))
+    state_app = redux
+    return exports.MarkdownInput
+
+exports.MarkdownInput = rclass
+    displayName : 'WidgetMarkdownInput'
+
+    propTypes :
+        persist_id    : rtypes.string # A unique id to identify the input. Required if you want automatic persistence
+        attach_to     : rtypes.string # Removes record when given store name is destroyed
+        default_value : rtypes.string
+        on_change     : rtypes.func
+        on_save       : rtypes.func   # called when saving from editing and switching back
+        on_edit       : rtypes.func   # called when editing starts
+        on_cancel     : rtypes.func   # called when cancel button clicked
+        rows          : rtypes.number
+        placeholder   : rtypes.string
+
+    reduxProps:
+        markdown_inputs :
+            open_inputs : rtypes.immutable.Map.isRequired
+
+    getInitialState: ->
+        value = @props.default_value ? ''
+        editing = false
+        if @props.persist_id and @props.open_inputs.has(@props.persist_id)
+            value = @props.open_inputs.get(@props.persist_id)
+            editing = true
+
+        editing : editing
+        value   : value
+
+    componentDidMount: ->
+        if @props.attach_to
+            state_app.getStore(@props.attach_to).on('destroy', @clear_persist)
+
+    componentWillUnmount: ->
+        if @props.persist_id? and not @state.editing
+            @clear_persist()
+
+    persist_value: (value) ->
+        @actions(info.name).set_value(@props.persist_id, value ? @state.value)
+
+    clear_persist: ->
+        @actions(info.name).clear(@props.persist_id)
+
+    set_value: (value) ->
+        @props.on_change?(value)
+        @persist_value(value)
+        @setState(value : value)
+
+    edit: ->
+        @props.on_edit?()
+        @persist_value()
+        @setState(editing : true)
+
+    cancel: ->
+        @props.on_cancel?()
+        @clear_persist()
+        @setState(editing : false)
+
+    save: ->
+        @props.on_save?(@state.value)
+        @clear_persist()
+        @setState(editing : false)
+
+    keydown: (e) ->
+        if e.keyCode==27
+            @setState(editing:false)
+        else if e.keyCode==13 and e.shiftKey
+            @save()
+
+    to_html: ->
+        if @props.default_value
+            {__html: markdown.markdown_to_html(@props.default_value).s}
+        else
+            {__html: ''}
+
+    render: ->
+        {Tip, Icon} = require('../r_misc')
+        if @state.editing
+            tip = <span>
+                You may enter (Github flavored) markdown here.  In particular, use # for headings, > for block quotes, *'s for italic text, **'s for bold text, - at the beginning of a line for lists, back ticks ` for code, and URL's will automatically become links.
+            </span>
+            <div>
+                <form onSubmit={@save} style={marginBottom: '-20px'}>
+                    <FormGroup>
+                        <FormControl
+                            autoFocus      = {@props.autoFocus ? true}
+                            ref            = 'input'
+                            componentClass = 'textarea'
+                            rows           = {@props.rows ? 4}
+                            placeholder    = {@props.placeholder}
+                            value          = {@state.value}
+                            onChange       = {(e)=>@set_value(ReactDOM.findDOMNode(@refs.input).value)}
+                            onKeyDown      = {@keydown}
+                        />
+                    </FormGroup>
+                </form>
+                <div style={paddingTop:'8px', color:'#666'}>
+                    <Tip title='Use Markdown' tip={tip}>
+                        Format using <a href={info.guide_link} target='_blank'>Markdown</a>
+                    </Tip>
+                </div>
+                <ButtonToolbar style={paddingBottom:'5px'}>
+                    <Button key='save' bsStyle='success' onClick={@save}
+                            disabled={@state.value == @props.default_value}>
+                        <Icon name='edit' /> Save
+                    </Button>
+                    <Button key='cancel' onClick={@cancel}>Cancel</Button>
+                </ButtonToolbar>
+            </div>
+        else
+            <div>
+                <div onClick={@edit} dangerouslySetInnerHTML={@to_html()}></div>
+                <Button onClick={@edit}>Edit</Button>
+            </div>

--- a/src/smc-webapp/widget-markdown-input/main.cjsx
+++ b/src/smc-webapp/widget-markdown-input/main.cjsx
@@ -94,6 +94,8 @@ exports.MarkdownInput = rclass
             {__html: ''}
 
     render: ->
+        # Maybe there's a better way to fix this.
+        # Required here because of circular requiring otherwise.
         {Tip, Icon} = require('../r_misc')
         if @state.editing
             tip = <span>

--- a/src/smc-webapp/widget-markdown-input/store.coffee
+++ b/src/smc-webapp/widget-markdown-input/store.coffee
@@ -1,0 +1,18 @@
+# 3rd Party Libraries
+immutable = require('immutable')
+
+# Internal Libraries
+misc = require('smc-util/misc')
+{types} = misc
+
+# Sibling Libraries
+info = require('./info')
+
+exports.definition =
+    name: info.name
+
+    stateTypes:
+        open_inputs : types.immutable.Map
+
+    getInitialState: =>
+        open_inputs : immutable.Map({}) # {id : String}


### PR DESCRIPTION
- Fixes #1546.
- Moves save/cancel buttons to the bottom of the markdown input
- Allows MarkdownInputs to be "attached" to stores instead of having to write the saving code in stores/actions for every possible location. 

TODO:
- [x] More Comprehensive Testing
- [x] Refactor MarkdownInput into its own file (especially actions/store).

## Test
- Toggle edit mode, change the value, hit cancel, then hit edit. The edit value should be what the display value was.
- Toggle edit mode, navigate away, come back, editing should remain.
- Toggle edit mode, change the value, close the file, reopen the file, edit state should be lost
- Open multiple MarkdownInputs, each one should maintain their state independently of each other.