### PR TITLE
consolidating links to the "croucher smc tutorial"

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1149,7 +1149,7 @@ exports.ExplainPlan = ExplainPlan = rclass
                 <p>
                 We offer course packages to support teaching using <SiteName/>.
                 They start right after purchase and last for the indicated period and do <b>not auto-renew</b>.
-                Following <a href="https://github.com/mikecroucher/SMC_tutorial/blob/master/README.md" target="_blank">this
+                Following <a href="https://tutorial.cocalc.com/" target="_blank">this
                 guide</a>, create a course file.
                 Each time you add a student to your course, a project will be automatically created for that student.
                 You can create and distribute assignments,

--- a/src/smc-webapp/course/help_box.cjsx
+++ b/src/smc-webapp/course/help_box.cjsx
@@ -8,7 +8,7 @@ exports.HelpBox = rclass
             <span style={color:"#666"}>
                 <ul>
                     <li>
-                        <a href="https://github.com/mikecroucher/SMC_tutorial#sagemathcloud" target="_blank">
+                        <a href="https://tutorial.cocalc.com/" target="_blank">
                             A tutorial for anyone wanting to use CoCalc for teaching
                         </a> (by Mike Croucher)
                     </li>

--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -494,7 +494,7 @@ SMC_Quote = ->
         <p className='lighten'>"CoCalc provides a user-friendly interface. Students don’t need to install any software at all.
         They just open up a web browser and go to {DOMAIN_NAME} and that’s it. They just type code directly
         in, hit shift+enter and it runs, and they can see if it works. It provides immediate feedback.
-        The <a href='https://mikecroucher.github.io/SMC_tutorial/' target='_blank'>course
+        The <a href='https://tutorial.cocalc.com/' target='_blank'>course
         management features</a> work really well." - Will Conley, Math professor, University of California at Los Angeles
         </p>
         <p style={marginBottom:0} >
@@ -564,7 +564,7 @@ SagePreview = rclass
                             <SiteName /> helps to you to <strong>conveniently organize a course</strong>: add students, create their projects, see their progress,
                             understand their problems by dropping right into their files from wherever you are.
                             Conveniently handout assignments, collect them, grade them, and finally return them.
-                            (<a href="https://github.com/sagemathinc/cocalc/wiki/Teaching" target="_blank"><SiteName /> used for Teaching</a> and <a href="https://mikecroucher.github.io/SMC_tutorial/" target="_blank">learn more about courses</a>).
+                            (<a href="https://tutorial.cocalc.com/" target="_blank"><SiteName /> used for Teaching</a>).
                         </ExampleBox>
                     </Col>
                 </Row>

--- a/src/smc-webapp/r_help.cjsx
+++ b/src/smc-webapp/r_help.cjsx
@@ -164,7 +164,7 @@ SUPPORT_LINKS =
         text : 'Please include the URL link to the relevant project or file!'
     teaching :
         icon : 'graduation-cap'
-        href : 'https://mikecroucher.github.io/SMC_tutorial/'
+        href : 'https://tutorial.cocalc.com/'
         link : <span>How to teach a course with <SiteName/></span>
     pricing :
         icon : 'money'

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -167,7 +167,7 @@ block content
               They just open up a web browser and go to #[a(href=URL) #{URL}] and that's it.
               They just type code directly in, hit shift+enter and it runs, and they can see if it works.
               It provides immediate feedback.
-              The #[a(href="https://mikecroucher.github.io/SMC_tutorial/") course management features] work really well.
+              The #[a(href="https://tutorial.cocalc.com/") course management features] work really well.
             footer.
               #[strong Will Conley] &mdash; Math professor, University of California at Los Angeles, Fall 2016
 


### PR DESCRIPTION
pointing to https://tutorial.cocalc.com/ now

this is some bulk editing to get to the correct landing page. we should fine adjust where to point once the fate of the tutorial is clear and we know the names of relevant individual pages.