### PR TITLE
Issue/1880

### DIFF
--- a/src/smc-webapp/_projects_nav.sass
+++ b/src/smc-webapp/_projects_nav.sass
@@ -3,6 +3,13 @@
   border-color:     $COL_TOP_BAR_BG
   border-width:     0 0 0 0
 
+=nav-tab-button-styles
+  padding : 0px
+  +disable-user-select
+  color: $COL_TOP_BAR_TEXT
+  &:hover
+    color: $COL_TOP_BAR_TEXT
+
 .smc-top-bar > .container
   position        : absolute
   display         : flex
@@ -10,11 +17,10 @@
   width           : 100%
   background-color: $COL_GRAY_L0
   > ul > li > a
-    padding : 0px
-    +disable-user-select
-    color: $COL_TOP_BAR_TEXT
-    &:hover
-      color: $COL_TOP_BAR_TEXT
+    +nav-tab-button-styles
+
+.smc-project-tab-sorter > li > a
+    +nav-tab-button-styles
 
 .smc-top-bar.navbar-default .navbar-nav>.active>a,
 .smc-top-bar.navbar-default .navbar-nav>.active>a:focus,

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -518,20 +518,23 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
                         shrink     = {shrink_fixed_tabs}
                     /> for k, v of fixed_project_pages when ((is_public and v.is_public) or (not is_public))]}
                 </Nav>
-                <SortableNav
-                    className            = "smc-file-tabs-files-desktop"
-                    helperClass          = {'smc-file-tab-floating'}
-                    onSortEnd            = {@on_sort_end}
-                    axis                 = {'x'}
-                    lockAxis             = {'x'}
-                    lockToContainerEdges = {true}
-                    distance             = {3 if not IS_MOBILE}
-                    bsStyle              = "pills"
-                    style                = {display:'flex', overflow:'hidden', flex: 1}
-                    shouldCancelStart    = {(e)=>e.target.getAttribute('class')?.includes('smc-file-tabs')}
+                <div
+                    style = {display:'flex', overflow:'hidden', flex: 1}
                 >
-                    {@file_tabs()}
-                </SortableNav>
+                    <SortableNav
+                        className            = "smc-file-tabs-files-desktop"
+                        helperClass          = {'smc-file-tab-floating'}
+                        onSortEnd            = {@on_sort_end}
+                        axis                 = {'x'}
+                        lockAxis             = {'x'}
+                        lockToContainerEdges = {true}
+                        distance             = {3 if not IS_MOBILE}
+                        bsStyle              = "pills"
+                        style                = {display:'flex', overflow:'hidden'}
+                    >
+                        {@file_tabs()}
+                    </SortableNav>
+                </div>
                 {@render_chat_indicator() if not is_public}
             </div>
         </div>

--- a/src/smc-webapp/projects_nav.cjsx
+++ b/src/smc-webapp/projects_nav.cjsx
@@ -183,7 +183,7 @@ FullProjectsNav = rclass
         >
             <SortableNav
                 className            = "smc-project-tab-sorter"
-                style                = {display:'flex', overflow: 'hidden', height:'40px', margin:'0'}
+                style                = {display:'flex', overflow: 'hidden'}
                 helperClass          = {'smc-project-tab-floating'}
                 onSortEnd            = {@on_sort_end}
                 axis                 = {'x'}

--- a/src/smc-webapp/projects_nav.cjsx
+++ b/src/smc-webapp/projects_nav.cjsx
@@ -178,20 +178,22 @@ FullProjectsNav = rclass
             paddingLeft : '0px'
             width       : '100%'
             display     : 'flex'
-
-        <SortableNav
-            className            = "smc-project-tab-sorter"
-            style                = {display:'flex', flex:'1', overflow: 'hidden', height:'40px', margin:'0'}
-            helperClass          = {'smc-project-tab-floating'}
-            onSortEnd            = {@on_sort_end}
-            axis                 = {'x'}
-            lockAxis             = {'x'}
-            lockToContainerEdges = {true}
-            distance             = {3 if not isMobile.tablet()}
-            shouldCancelStart    = {(e)=>e.target.getAttribute('class')?.includes('smc-project-tab-sorter')}
+        <div
+            style = {display:'flex', flex:'1', overflow:'hidden', height:'40px', margin:'0'}
         >
-            {@project_tabs()}
-        </SortableNav>
+            <SortableNav
+                className            = "smc-project-tab-sorter"
+                style                = {display:'flex', overflow: 'hidden', height:'40px', margin:'0'}
+                helperClass          = {'smc-project-tab-floating'}
+                onSortEnd            = {@on_sort_end}
+                axis                 = {'x'}
+                lockAxis             = {'x'}
+                lockToContainerEdges = {true}
+                distance             = {3 if not isMobile.tablet()}
+            >
+                {@project_tabs()}
+            </SortableNav>
+        </div>
 
 OpenProjectMenuItem = rclass
     propTypes:


### PR DESCRIPTION
Fixes #1880 by changing the structure of navs to no longer need `shouldCancelStart`. I have a hunch that the bug is caused by some odd behavior of `e.target.getAttribute`.

# Test
- Projects and files tabs can be dragged around
- Opening files and projects works
- Opening *many* files and projects works as expected