### PR TITLE
Clean up smc-react Stores/Actions abstraction a little

### DIFF
--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1619,12 +1619,11 @@ exports.getTable = (project_id, name, redux) ->
 exports.deleteStoreActionsTable = (project_id, redux) ->
     must_define(redux)
     name = key(project_id)
-    redux.getStore(name)?.destroy?()
+    redux.removeStore(name)
     redux.getActions(name).close_all_files()
     redux.removeActions(name)
     for table,_ of QUERIES
         redux.removeTable(key(project_id, table))
-    redux.removeStore(name)
 
 get_directory_listing = (opts) ->
     opts = defaults opts,

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -78,8 +78,6 @@ class Actions
         @redux._set_state({"#{@name}": obj})
         return
 
-    destroy: =>
-        @redux.removeActions(@name)
 ###
 store_def =
     reduxState:
@@ -138,7 +136,8 @@ class Store extends EventEmitter
             @emit('change', state)
 
     destroy: =>
-        @redux.removeStore(@name)
+        @emit('destroy')
+        @removeAllListeners()
 
     getState: =>
         return @redux._redux_store.getState().get(@name)
@@ -365,14 +364,14 @@ class AppRedux
             @_tables[name]._table?.close()
             delete @_tables[name]
 
+    # Removing a Store also destroys it
     removeStore: (name) =>
         if not name?
             throw Error("name must be a string")
         if @_stores[name]?
             S = @_stores[name]
-            S.emit('destroy')
             delete @_stores[name]
-            S.removeAllListeners()
+            S.destroy()
             @_redux_store.dispatch(action_remove_store(name))
 
     removeActions: (name) =>
@@ -381,7 +380,6 @@ class AppRedux
         if @_actions[name]?
             A = @_actions[name]
             delete @_actions[name]
-            A.destroy()
 
     getTable: (name) =>
         if not name?


### PR DESCRIPTION
Stores should clean up after themselves
Neither needs to know they are within a `ReduxApp`
Actions should not have any state or listeners to destroy

# Test
- Search codebase for any relevant uses of `destroy` that I may have missed
- Confirm that MarkdownInputs still work.