### PR TITLE
add left and right margins for public view of .md files

### DIFF
--- a/src/smc-webapp/public/editor_md.cjsx
+++ b/src/smc-webapp/public/editor_md.cjsx
@@ -45,8 +45,12 @@ PublicMarkdown = rclass ({name}) ->
         else if not @props.content?
             <Loading />
         else
-            <div className="webapp-editor-static-html-content" style="margin-left:2em;margin-right:2em">
-                <Markdown project_id={@props.project_id} file_path={@props.file_path} value={@props.content} />
+            <div className="webapp-editor-static-html-content">
+                <Markdown
+                    project_id  = {@props.project_id}
+                    file_path   = {@props.file_path}
+                    style       = {marginLeft: "2em", marginRight: "2em"}
+                    value       = {@props.content} />
             </div>
 
 class MDActions extends Actions

--- a/src/smc-webapp/public/editor_md.cjsx
+++ b/src/smc-webapp/public/editor_md.cjsx
@@ -45,11 +45,19 @@ PublicMarkdown = rclass ({name}) ->
         else if not @props.content?
             <Loading />
         else
-            <div className="webapp-editor-static-html-content">
+            md_style =
+                margin          : '20px'
+                padding         : '15px'
+                boxShadow       : 'rgba(87, 87, 87, 0.2) 0px 0px 12px 1px'
+                backgroundColor : 'white'
+                display         : 'block'   # because wrapped HTML in Markdown is a span by default
+            <div
+                className = "webapp-editor-static-html-content"
+                style     = {backgroundColor: 'rgb(238, 238, 238)'}>
                 <Markdown
                     project_id  = {@props.project_id}
                     file_path   = {@props.file_path}
-                    style       = {marginLeft: "2em", marginRight: "2em"}
+                    style       = {md_style}
                     value       = {@props.content} />
             </div>
 

--- a/src/smc-webapp/public/editor_md.cjsx
+++ b/src/smc-webapp/public/editor_md.cjsx
@@ -45,7 +45,7 @@ PublicMarkdown = rclass ({name}) ->
         else if not @props.content?
             <Loading />
         else
-            <div className="webapp-editor-static-html-content">
+            <div className="webapp-editor-static-html-content" style="margin-left:2em;margin-right:2em">
                 <Markdown project_id={@props.project_id} file_path={@props.file_path} value={@props.content} />
             </div>
 


### PR DESCRIPTION
See #2077 

Hard to test public view of a project from cc-in-cc due to cookies (needed to access the project, but don't want for public view). I tested the change using live update of html using browser tools page editor (Inspect with Chrome and Firefox).

Before the change:
<img width="675" alt="no-margins" src="https://user-images.githubusercontent.com/528072/27001275-a93cdbfe-4d8b-11e7-92fa-3e1b559b28d6.png">

After:
<img width="672" alt="margins" src="https://user-images.githubusercontent.com/528072/27001277-ac3f7366-4d8b-11e7-993e-6a05fefc80ff.png">


