### PR TITLE
Issue/1987f API collaborator message doc

### DIFF
--- a/src/smc-hub/test/api/account.coffee
+++ b/src/smc-hub/test/api/account.coffee
@@ -1,12 +1,16 @@
 ###
 Testing API functions relating to users and user accounts
+
+COPYRIGHT : (c) 2017 SageMath, Inc.
+LICENSE   : AGPLv3
 ###
 
 api   = require('./apitest')
 {setup, teardown} = api
-misc = require('smc-util/misc')
-expect = require('expect')
 
+misc = require('smc-util/misc')
+
+expect = require('expect')
 
 describe 'testing calls relating to creating user accounts -- ', ->
     before(setup)
@@ -64,6 +68,67 @@ describe 'testing calls relating to creating user accounts -- ', ->
             cb    : (err, resp) ->
                 expect(resp?.event).toBe('account_creation_failed')
                 expect(resp?.reason).toEqual({"email_address":"This e-mail address is already taken."})
+                done(err)
+
+    project_id = undefined
+    it "creates test project", (done) ->
+        api.call
+            event : 'create_project'
+            body  :
+                title       : 'COLLABTEST'
+                description : 'Testing collaboration ops'
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('project_created')
+                project_id = resp.project_id
+                done(err)
+
+    it "invites collaborator to project", (done) ->
+        api.call
+            event : 'invite_collaborator'
+            body  :
+                account_id : account_id2
+                project_id : project_id
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('success')
+                done(err)
+
+    it "lists project collaborators", (done) ->
+        api.call
+            event : 'query'
+            body  :
+                query : {projects:{project_id:project_id, users:null}}
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('query')
+                expect(resp?.query?.projects?.users[account_id2]).toEqual( group: 'collaborator' )
+                done(err)
+
+    base_url = 'https://cocalc.com'
+    it.skip "invites non-cloud collaborators", (done) ->
+    # TODO: fails because api.last_email isn't set until after this test runs
+    # see smc-hub/client.coffee around L1220 where cb() is called before
+    # email is sent
+        api.call
+            event : 'invite_noncloud_collaborators'
+            body  :
+                project_id : project_id
+                to         :  'someone@m.local'
+                email      :  'Plese sign up and join this project.'
+                title      :  'Team Project'
+                link2proj  :  "#{base_url}/projects/#{project_id}"
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('invite_noncloud_collaborators_resp')
+                expect(api.last_email?.subject).toBe('CoCalc Invitation')
+                done(err)
+
+
+    it "removes collaborator", (done) ->
+        api.call
+            event : 'remove_collaborator'
+            body  :
+                account_id : account_id2
+                project_id : project_id
+            cb    : (err, resp) ->
+                expect(resp?.event).toBe('success')
                 done(err)
 
     it "deletes the second account", (done) ->

--- a/src/smc-hub/test/api/account.coffee
+++ b/src/smc-hub/test/api/account.coffee
@@ -104,9 +104,10 @@ describe 'testing calls relating to creating user accounts -- ', ->
 
     base_url = 'https://cocalc.com'
     it.skip "invites non-cloud collaborators", (done) ->
-    # TODO: fails because api.last_email isn't set until after this test runs
-    # see smc-hub/client.coffee around L1220 where cb() is called before
-    # email is sent
+        # TODO: this test is skipped for now.
+        # The test fails because api.last_email isn't set until after this test runs.
+        # See smc-hub/client.coffee around L1220 where cb() is called before
+        # email is sent.
         api.call
             event : 'invite_noncloud_collaborators'
             body  :

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -1194,17 +1194,61 @@ API message
     id    : undefined
     users : required   # list of {account_id:?, first_name:?, last_name:?, mode:?, state:?}
 
-API message
+API message2
     event      : 'invite_collaborator'
-    id         : undefined
-    project_id : required
-    account_id : required
+    fields:
+        id:
+            init  : undefined
+            desc  : 'A unique UUID for the query'
+        project_id:
+            init  : required
+            desc  : 'project_id of project into which user is invited'
+        account_id:
+            init  : required
+            desc  : 'account_id of invited user'
+    desc       : """
+Invite a user who already has a CoCalc account to
+become a collaborator on a project. You must be owner
+or collaborator on the target project.
 
-API message
+Example:
+```
+  curl -u sk_abcdefQWERTY090900000000: \\
+    -d account_id=99ebde5c-58f8-4e29-b6e4-b55b8fd71a1b \\
+    -d project_id=18955da4-4bfa-4afa-910c-7f2358c05eb8 \\
+    https://cocalc.com/api/v1/invite_collaborator
+  ==> {"event":"success",
+       "id":"e80fd64d-fd7e-4cbc-981c-c0e8c843deec"}
+```
+"""
+
+API message2
     event      : 'remove_collaborator'
-    id         : undefined
-    project_id : required
-    account_id : required
+    fields:
+        id:
+            init  : undefined
+            desc  : 'A unique UUID for the query'
+        project_id:
+            init  : required
+            desc  : 'project_id of project from which user is removed'
+        account_id:
+            init  : required
+            desc  : 'account_id of removed user'
+    desc       : """
+Remove a user from a CoCalc project.
+You must be owner or collaborator on the target project.
+You cannot remove the project owner.
+
+Example:
+```
+  curl -u sk_abcdefQWERTY090900000000: \\
+    -d account_id=99ebde5c-58f8-4e29-b6e4-b55b8fd71a1b \\
+    -d project_id=18955da4-4bfa-4afa-910c-7f2358c05eb8 \\
+    https://cocalc.com/api/v1/remove_collaborator
+  ==> {"event":"success",
+       "id":"e80fd64d-fd7e-4cbc-981c-c0e8c843deec"}
+```
+"""
 
 # DANGER -- can be used to spam people.
 API message

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -623,7 +623,7 @@ Given the `account_id` for an account, set a new email address.
 Examples:
 
 Successful change of email address.
-
+```
   curl -u sk_abcdefQWERTY090900000000: \\
     -d account_id=99ebde5c-58f8-4e29-b6e4-b55b8fd71a1b \\
     -d password=secret_password \\
@@ -632,9 +632,11 @@ Successful change of email address.
   ==> {"event":"changed_email_address",
        "id":"8f68f6c4-9851-4b88-bd65-37cb983298e3",
        "error":false}
+```
 
 Fails if new email address is already in use.
 
+```
   curl -u sk_abcdefQWERTY090900000000: \\
     -d account_id=99ebde5c-58f8-4e29-b6e4-b55b8fd71a1b \\
     -d password=secret_password \\
@@ -643,6 +645,7 @@ Fails if new email address is already in use.
   ==> {"event":"changed_email_address",
        "id":"4501f022-a57c-4aaf-9cd8-af0eb05ebfce",
        "error":"email_already_taken"}
+```
 
 **Note:** `account_id` and `password` must match the `id` of the current login.
 """

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -1251,17 +1251,80 @@ Example:
 """
 
 # DANGER -- can be used to spam people.
-API message
+API message2
     event         : 'invite_noncloud_collaborators'
-    id            : undefined
-    project_id    : required
-    replyto       : undefined
-    replyto_name  : undefined
-    to            : required
-    subject       : undefined
-    email         : required    # spam vector
-    title         : required
-    link2proj     : required
+    fields        :
+        id:
+            init  : undefined
+            desc  : 'A unique UUID for the query'
+        project_id:
+            init  : required
+            desc  : 'project_id of project into which users are invited'
+        to:
+            init  : required
+            desc  : 'comma- or semicolon-delimited string of email addresses'
+        email:
+            init  : required
+            desc  : 'body of the email to be sent, may include HTML markup'
+        title:
+            init  : required
+            desc  : 'string that will be used for project title in the email'
+        link2proj:
+            init  : required
+            desc  : 'URL for the target project'
+        replyto:
+            init  : undefined
+            desc  : 'Reply-To email address'
+        replyto_name:
+            init  : undefined
+            desc  : 'Reply-To name'
+        subject:
+            init  : undefined
+            desc  : 'email Subject'
+    desc          : """
+Invite users who do not already have a CoCalc account
+to join a project.
+An invitation email is sent to each user in the `to`
+option.
+Invitation is not sent if there is already a CoCalc
+account with the given email address.
+You must be owner or collaborator on the target project.
+
+Limitations:
+- Total length of the request message must be less than or equal to 1024 characters.
+- Length of each email address must be less than 128 characters.
+
+
+Example:
+```
+  curl -u sk_abcdefQWERTY090900000000: \\
+    -d project_id=18955da4-4bfa-4afa-910c-7f2358c05eb8 \\
+    -d to=someone@m.local \\
+    -d 'email=Please sign up and join this project.' \\
+    -d 'title=Class Project' \\
+    -d link2proj=https://cocalc.com/projects/18955da4-4bfa-4afa-910c-7f2358c05eb8 \\
+    https://cocalc.com/api/v1/invite_noncloud_collaborators
+  ==>  {"event":"invite_noncloud_collaborators_resp",
+        "id":"39d7203d-89b1-4145-8a7a-59e41d5682a3",
+        "mesg":"Invited someone@m.local to collaborate on a project."}
+```
+
+Email sent by the previous example:
+
+```
+To: someone@m.local
+From: CoCalc <invites@sagemath.com
+Reply-To: help@sagemath.com
+Subject: CoCalc Invitation
+
+Please sign up and join this project.<br/><br/>\\n<b>
+To accept the invitation, please sign up at\\n
+<a href='https://cocalc.com'>https://cocalc.com</a>\\n
+using exactly the email address 'someone@m.local'.\\n
+Then go to <a href='https://cocalc.com/projects/18955da4-4bfa-4afa-910c-7f2358c05eb8'>
+the project 'Team Project'</a>.</b><br/>
+```
+"""
 
 message
     event      : 'invite_noncloud_collaborators_resp'


### PR DESCRIPTION
Ref: #1987 #1988 

Doc & mocha test for
- invite_collaborator
- invite_noncloud_collaborators
- remove_collaborator

Test for `invite_noncloud_collaborators` is skipped in `account.coffee` for now due to callback issue. To be fixed in a later PR.

Result of test run on api:
```
~/smc/src/smc-hub$ mocha test/api
...
  76 passing (16s)
  1 pending
```