### PR TITLE
webapp/latex: restore png pdf preview scroll location when switching tabs

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -2630,6 +2630,7 @@ class PDF_Preview extends FileEditor
         @message   = @element.find(".webapp-editor-pdf-preview-message")
         @highlight = @element.find(".webapp-editor-pdf-preview-highlight").hide()
         @page.text('Loading preview...')
+        @_output_scroll_top = 0 # used in conjunction with @output.scrollTop()
         @_first_output = true
         @_needs_update = true
         @_dragpos = null
@@ -2731,7 +2732,9 @@ class PDF_Preview extends FileEditor
         @output.on 'scroll', () =>
             @_needs_update = true
         f = () =>
-            if @_needs_update and @element.is(':visible')
+            return if not @element.is(':visible')
+            @_output_scroll_top = @output.scrollTop()
+            if @_needs_update
                 @_needs_update = false
                 @update cb:(err) =>
                     if err
@@ -2958,6 +2961,7 @@ class PDF_Preview extends FileEditor
         cb()
 
     show: =>
+        @output.scrollTop(@_output_scroll_top)
 
     hide: =>
 

--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -346,7 +346,6 @@ class exports.LatexEditor extends editor.FileEditor
         @_split_pos = Math.max(editor.MIN_SPLIT, Math.min(editor.MAX_SPLIT, @_split_pos))
         @element.find(".webapp-editor-latex-latex_editor").css('flex-basis',"#{@_split_pos*100}%")
 
-
     set_conf: (obj) =>
         conf = @load_conf()
         for k, v of obj
@@ -424,7 +423,6 @@ class exports.LatexEditor extends editor.FileEditor
             @_passive_forward_search_disabled = false
 
         setTimeout(f, 3000)
-
 
     _passive_inverse_search: (cb) =>
         if @_passive_inverse_search_disabled


### PR DESCRIPTION
issue #1621

test: latex editor with many png preview pages and switching tabs works as advertised

process: I was on the wrong track for quite some time, because I thought some reactification-related resets happen, then I tried to figure out how sagews files keep their position, etc. in the end, it turns out the dom elements are there, but only invisible and all I had to figure out is when exactly to record and when to restore the position. The whole reason why it scrolls up seems to be related to making elements invisible. Then, they have a scroll height (or overall height) of zero and that's why showing them again restores them at the top position.

time: 1 hour