### PR TITLE
webpack: allowing for more chunks, and two points where it is introduced in the webapp code

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -3322,11 +3322,13 @@ jupyter = require('./editor_jupyter')
 
 class JupyterNotebook extends FileEditorWrapper
     init_wrapped: () =>
-        @init_font_size() # get the @default_font_size
-        # console.log("JupyterNotebook@default_font_size: #{@default_font_size}")
-        @opts.default_font_size = @default_font_size
-        @element = jupyter.jupyter_notebook(@, @filename, @opts)
-        @wrapped = @element.data('jupyter_notebook')
+        @element = $("<div><span>&nbsp;&nbsp;Loading...</span></div>")
+        require.ensure [], =>
+            @init_font_size() # get the @default_font_size
+            # console.log("JupyterNotebook@default_font_size: #{@default_font_size}")
+            @opts.default_font_size = @default_font_size
+            @element = jupyter.jupyter_notebook(@, @filename, @opts)
+            @wrapped = @element.data('jupyter_notebook')
 
     mount: () =>
         if not @mounted
@@ -3399,16 +3401,17 @@ exports.register_nonreact_editors = () ->
 
     # wrapper for registering private and public editors
     register = (is_public, cls, extensions) ->
-        icon = file_icon_class(extensions[0])
-        reg
-            ext       : extensions
-            is_public : is_public
-            icon      : icon
-            f         : (project_id, path, opts) ->
-                e = new cls(project_id, path, undefined, opts)
-                if not e.ext?
-                    console.error('You have to call super(@project_id, @filename) in the constructor to properly initialize this FileEditor instance.')
-                return e
+        require.ensure [], ->
+            icon = file_icon_class(extensions[0])
+            reg
+                ext       : extensions
+                is_public : is_public
+                icon      : icon
+                f         : (project_id, path, opts) ->
+                    e = new cls(project_id, path, undefined, opts)
+                    if not e.ext?
+                        console.error('You have to call super(@project_id, @filename) in the constructor to properly initialize this FileEditor instance.')
+                    return e
 
     # Editors for private normal editable files.
     register(false, HTML_MD_Editor,   html_md_exts)

--- a/src/webpack.config.coffee
+++ b/src/webpack.config.coffee
@@ -457,9 +457,9 @@ if PRODMODE
     # plugins.push new webpack.optimize.CommonsChunkPlugin(name: "lib")
     plugins.push new webpack.optimize.DedupePlugin()
     plugins.push new webpack.optimize.OccurenceOrderPlugin()
-    # TODO change this back to a number at about 10, once we know how to keep old chunks around
-    plugins.push new webpack.optimize.LimitChunkCountPlugin(maxChunks: 1)
-    plugins.push new webpack.optimize.MinChunkSizePlugin(minChunkSize: 32768)
+    # configuration for the number of chunks and their minimum size
+    plugins.push new webpack.optimize.LimitChunkCountPlugin(maxChunks: 5)
+    plugins.push new webpack.optimize.MinChunkSizePlugin(minChunkSize: 30000)
 
 if PRODMODE or MINIFY
     # to get source maps working in production mode, one has to figure out how


### PR DESCRIPTION
I tested this with webpack-production and I don't see any issues. Still, there are two additional points in the code where require.ensure is added. So, this warrants for some caution.

With that configuration, I see two chunks now:

```
1.1M Jun 15 13:16 static/0-172927f1c2224e5fb061.cacheme.js
  49K Jun 15 13:16 static/1-172927f1c2224e5fb061.cacheme.js
```

That's not much, but once we have a better refactored code base, this could pay off much more. E.g. right now when reloading, chunk "1" is loaded initially anyways, and I think "0" when I opened a sagews.