### PR TITLE
Rename/move Side Chat files with the source files.

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -499,14 +499,17 @@ exports.path_split = (path) ->
     v = path.split('/')
     return {head:v.slice(0,-1).join('/'), tail:v[v.length-1]}
 
-# See http://stackoverflow.com/questions/29855098/is-there-a-built-in-javascript-function-similar-to-os-path-join
-exports.path_join = (parts...) ->
+# Takes parts to a path and intelligently merges them on '/'.
+# Continuous non-'/' portions of each part will have at most
+# one '/' on either side.
+# Each part will have exactly one '/' between it and adjacent parts
+# Does NOT resolve up-level references
+# See misc-tests for examples.
+exports.normalized_path_join = (parts...) ->
     sep = '/'
     replace = new RegExp(sep+'{1,}', 'g')
-    s = ("#{x}" for x in parts).join(sep).replace(replace, sep)
-    #console.log parts, s
+    s = ("#{x}" for x in parts when x? and "#{x}".length > 0).join(sep).replace(replace, sep)
     return s
-
 
 # Takes a path string and file name and gives the full path to the file
 exports.path_to_file = (path, file) ->

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -524,6 +524,35 @@ describe "copy flavours:", =>
             co[2].ref[0].should.be.eql d
             co[2].ref[1].should.be.eql r
 
+describe "normalized_path_join", ->
+    pj = misc.normalized_path_join
+    it "Leaves single argument joins untouched", ->
+        pj("lonely").should.be.eql "lonely"
+
+    it "Does nothing with empty strings", ->
+        pj("", "thing").should.be.eql "thing"
+
+    it "Ignores undefined parts", ->
+        pj(undefined, undefined, "thing").should.be.eql "thing"
+
+    it "Does not skip previous upon an absolute path", ->
+        pj("not-skipped!", "/", "thing").should.be.eql "not-skipped!/thing"
+
+    it "Shrinks multiple /'s into one / if found anywhere", ->
+        pj("//", "thing").should.be.eql "/thing"
+        pj("a//", "//", "//thing").should.be.eql "a/thing"
+        pj("slashes////inside").should.be.eql "slashes/inside"
+
+    it "Ignores empty strings in the middle", ->
+        pj("a", "", "thing").should.be.eql "a/thing"
+
+    it "Allows generating absolute paths using a leading /", ->
+        pj("/", "etc", "stuff", "file.name").should.be.eql "/etc/stuff/file.name"
+
+    it "Allows generating a folder path using a trailing /", ->
+        pj("/", "etc", "stuff", "folder/").should.be.eql "/etc/stuff/folder/"
+        pj("/", "etc", "stuff", "folder", "/").should.be.eql "/etc/stuff/folder/"
+
 
 describe "path_split", ->
     ps = misc.path_split

--- a/src/smc-webapp/process-links.coffee
+++ b/src/smc-webapp/process-links.coffee
@@ -62,7 +62,7 @@ $.fn.process_smc_links = (opts={}) ->
                             target = opts.project_id + '/files/' + decodeURI(target)
                         else if opts.project_id and opts.file_path?
                             # realtive to current path
-                            target = misc.path_join(opts.project_id, 'files', opts.file_path ? '', decodeURI(target) ? '')
+                            target = misc.normalized_path_join(opts.project_id, 'files', opts.file_path ? '', decodeURI(target) ? '')
                         load_target(target, not(e.which==2 or (e.ctrlKey or e.metaKey)))
                         return false
                 else
@@ -91,14 +91,14 @@ $.fn.process_smc_links = (opts={}) ->
                             # j-i should be 36, unless we ever start to have different (vanity) project_ids
                             path = src.slice(j + '/files/'.length)
                             project_id = src.slice(i + '/projects/'.length, j) ? ''
-                            new_src = misc.path_join('/', window.app_base_url, project_id, 'raw', path)
+                            new_src = misc.normalized_path_join('/', window.app_base_url, project_id, 'raw', path)
                             y.attr(attr, new_src)
                             continue
                         if src.indexOf('://') != -1
                             # link points somewhere else
                             continue
                         # we do not have an absolute url, hence we assume it is a relative URL to a file in a project
-                        new_src = misc.path_join('/', window.app_base_url, opts.project_id, 'raw', opts.file_path, src)
+                        new_src = misc.normalized_path_join('/', window.app_base_url, opts.project_id, 'raw', opts.file_path, src)
                     y.attr(attr, new_src)
 
         return e

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1172,8 +1172,8 @@ ProjectFilesActionBox = rclass
 
     move_click: ->
         @props.actions.move_files
-            src  : @props.checked_files.toArray()
-            dest : @state.move_destination
+            src           : @props.checked_files.toArray()
+            dest          : @state.move_destination
         @props.actions.set_file_action()
         @props.actions.set_all_files_unchecked()
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1174,6 +1174,7 @@ ProjectFilesActionBox = rclass
         @props.actions.move_files
             src           : @props.checked_files.toArray()
             dest          : @state.move_destination
+            include_chats : true
         @props.actions.set_file_action()
         @props.actions.set_all_files_unchecked()
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -730,7 +730,6 @@ ProjectFilesButtons = rclass
     handle_hidden_toggle: (e) ->
         e.preventDefault()
         @props.actions.setState(show_hidden : not @props.show_hidden)
-        @props.actions.fetch_directory_listing(show_hidden : not @props.show_hidden)
 
     render_refresh: ->
         <a href='' onClick={@handle_refresh}><Icon name='refresh' /> </a>

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1072,14 +1072,15 @@ ProjectFilesActionBox = rclass
             </Row>
         </div>
 
-    rename_or_duplicate_click: () ->
+    rename_or_duplicate_click: ->
         rename_dir = misc.path_split(@props.checked_files?.first()).head
         destination = ReactDOM.findDOMNode(@refs.new_name).value
         switch @props.file_action
             when 'rename'
                 @props.actions.move_files
-                    src  : @props.checked_files.toArray()
-                    dest : misc.path_to_file(rename_dir, destination)
+                    src           : @props.checked_files.toArray()
+                    dest          : misc.path_to_file(rename_dir, destination)
+                    include_chats : true
             when 'duplicate'
                 @props.actions.copy_paths
                     src           : @props.checked_files.toArray()

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1077,9 +1077,10 @@ ProjectFilesActionBox = rclass
         switch @props.file_action
             when 'rename'
                 @props.actions.move_files
-                    src           : @props.checked_files.toArray()
-                    dest          : misc.path_to_file(rename_dir, destination)
-                    include_chats : true
+                    src            : @props.checked_files.toArray()
+                    dest           : misc.path_to_file(rename_dir, destination)
+                    dest_is_folder : false
+                    include_chats  : true
             when 'duplicate'
                 @props.actions.copy_paths
                     src           : @props.checked_files.toArray()
@@ -1172,9 +1173,10 @@ ProjectFilesActionBox = rclass
 
     move_click: ->
         @props.actions.move_files
-            src           : @props.checked_files.toArray()
-            dest          : @state.move_destination
-            include_chats : true
+            src            : @props.checked_files.toArray()
+            dest           : @state.move_destination
+            dest_is_folder : true
+            include_chats  : true
         @props.actions.set_file_action()
         @props.actions.set_all_files_unchecked()
 

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -942,20 +942,14 @@ class ProjectActions extends Actions
             #misc.normalized_path_join(head ? '', ".#{tail ? ''}.sage-chat")
 
         if opts.include_chats
-            if opts.src.length > 1
+            if opts.dest_is_folder
                 for path in opts.src
                     chat_path = get_chat_path(path)
                     opts.src.push(chat_path) unless opts.src.includes(chat_path)
 
-            else if opts.src.length == 1
-                # Cannot just append because of renames
+            else
                 old_chat_path = get_chat_path(opts.src[0])
-
-                if opts.dest_is_folder
-                    name = misc.path_split(old_chat_path).tail
-                    new_chat_path = misc.normalized_path_join(opts.dest, name)
-                else
-                    new_chat_path = get_chat_path(opts.dest)
+                new_chat_path = get_chat_path(opts.dest)
 
                 @move_files
                     src            : [old_chat_path]

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -925,14 +925,37 @@ class ProjectActions extends Actions
 
     move_files: (opts) =>
         opts = defaults opts,
-            src     : required    # Array of src paths to mv
-            dest    : required    # Single dest string
-            path    : undefined   # default to root of project
-            mv_args : undefined
-            id      : undefined
+            src           : required    # Array of src paths to mv
+            dest          : required    # Single dest string
+            path          : undefined   # default to root of project
+            mv_args       : undefined
+            id            : undefined
+            include_chats : false       # If we want to copy .filename.sage-chat
+
         id = opts.id ? misc.uuid()
         @set_activity(id:id, status: "Moving #{opts.src.length} #{misc.plural(opts.src.length, 'file')} to #{opts.dest}")
         delete opts.id
+
+        if opts.include_chats
+            if opts.src.length > 1
+                for path in opts.src
+                    {head, tail} = misc.path_split(path)
+                    opts.src.push(misc.path_join(head ? '', ".#{tail ? ''}.sage-chat"))
+                    # TODO: Read chat file naming from settings somewhere
+
+            else if opts.src.length == 1
+                {head, tail} = misc.path_split(opts.src[0])
+                old_chat_path = misc.path_join(head ? '', ".#{tail ? ''}.sage-chat")
+
+                {head, tail} = misc.path_split(opts.dest)
+                new_chat_path = misc.path_join(head ? '', ".#{tail ? ''}.sage-chat")
+
+                @move_files
+                    src  : old_chat_path
+                    dest : new_chat_path
+
+        delete opts.include_chats
+
         opts.cb = (err) =>
             if err
                 @set_activity(id:id, error:err)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -927,12 +927,13 @@ class ProjectActions extends Actions
 
     move_files: (opts) =>
         opts = defaults opts,
-            src           : required    # Array of src paths to mv
-            dest          : required    # Single dest string
-            path          : undefined   # default to root of project
-            mv_args       : undefined
-            id            : undefined
-            include_chats : false       # If we want to copy .filename.sage-chat
+            src            : required    # Array of src paths to mv
+            dest           : required    # Single dest string
+            dest_is_folder : required
+            path           : undefined   # default to root of project
+            mv_args        : undefined
+            id             : undefined
+            include_chats  : false       # If we want to copy .filename.sage-chat
 
         # TODO: Put this somewhere else!
         get_chat_path = (path) ->
@@ -950,18 +951,19 @@ class ProjectActions extends Actions
                 # Cannot just append because of renames
                 old_chat_path = get_chat_path(opts.src[0])
 
-                if opts.dest.endsWith('/')
+                if opts.dest_is_folder
                     name = misc.path_split(old_chat_path).tail
-                    console.log "Sending to ", opts.dest, name
                     new_chat_path = misc.normalized_path_join(opts.dest, name)
                 else
                     new_chat_path = get_chat_path(opts.dest)
 
                 @move_files
-                    src  : [old_chat_path]
-                    dest : new_chat_path
+                    src            : [old_chat_path]
+                    dest           : new_chat_path
+                    dest_is_folder : opts.dest_is_folder
 
         delete opts.include_chats
+        delete opts.dest_is_folder
 
         check_existence_of = (path) =>
             path = misc.path_split(path)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -940,15 +940,15 @@ class ProjectActions extends Actions
             if opts.src.length > 1
                 for path in opts.src
                     {head, tail} = misc.path_split(path)
-                    opts.src.push(misc.path_join(head ? '', ".#{tail ? ''}.sage-chat"))
+                    opts.src.push(misc.normalized_path_join(head ? '', ".#{tail ? ''}.sage-chat"))
                     # TODO: Read chat file naming from settings somewhere
 
             else if opts.src.length == 1
                 {head, tail} = misc.path_split(opts.src[0])
-                old_chat_path = misc.path_join(head ? '', ".#{tail ? ''}.sage-chat")
+                old_chat_path = misc.normalized_path_join(head ? '', ".#{tail ? ''}.sage-chat")
 
                 {head, tail} = misc.path_split(opts.dest)
-                new_chat_path = misc.path_join(head ? '', ".#{tail ? ''}.sage-chat")
+                new_chat_path = misc.normalized_path_join(head ? '', ".#{tail ? ''}.sage-chat")
 
                 @move_files
                     src  : old_chat_path

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -930,6 +930,7 @@ class ProjectActions extends Actions
             id            : undefined
             include_chats : false       # If we want to copy .filename.sage-chat
 
+        # TODO: Put this somewhere else!
         get_chat_path = (path) ->
             {head, tail} = misc.path_split(path)
             misc.normalized_path_join(head ? '', ".#{tail ? ''}.sage-chat")
@@ -937,10 +938,10 @@ class ProjectActions extends Actions
         if opts.include_chats
             if opts.src.length > 1
                 for path in opts.src
-                    opts.src.push(get_chat_path(path))
-                    # TODO: Read chat file naming from settings somewhere
+                    chat_path = get_chat_path(path)
+                    opts.src.push(get_chat_path(path)) unless opts.src.includes(chat_path)
 
-            else if opts.src.length == 1 and not opts.src[0].startsWith('.')
+            else if opts.src.length == 1
                 old_chat_path = get_chat_path(opts.src[0])
                 new_chat_path = get_chat_path(opts.dest)
 

--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -491,9 +491,6 @@ render = (redux, project_id, path) ->
     name = redux_name(project_id, path)
     file_use_id = require('smc-util/schema').client_db.sha1(project_id, path)
     actions = redux.getActions(name)
-    if not actions?
-        init_redux(@props.path, @props.redux, @props.project_id)
-        actions = redux.getActions(name)
     <ChatRoom redux={redux} actions={actions} name={name} project_id={project_id} path={path} file_use_id={file_use_id} />
 
 # Render the given chatroom, and return the name of the redux actions/store

--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -473,9 +473,6 @@ exports.SideChat = ({path, redux, project_id}) ->
     name        = redux_name(project_id, path)
     file_use_id = require('smc-util/schema').client_db.sha1(project_id, path)
     actions     = redux.getActions(name)
-    if not actions?
-        init_redux(path, redux, project_id)
-        actions = redux.getActions(name)
     <ChatRoom
         redux       = {redux}
         actions     = {redux.getActions(name)}

--- a/src/smc-webapp/test-client/project.coffee
+++ b/src/smc-webapp/test-client/project.coffee
@@ -123,7 +123,7 @@ describe 'starting and stopping a project and getting directory listing', ->
 
     it 'gets directory listing including hidden (and confirm some dirs)', (done) ->
         @timeout(5000)
-        smc.redux.getProjectActions(project_id).fetch_directory_listing({path:'', sort_by_time:true, show_hidden:true})
+        smc.redux.getProjectActions(project_id).fetch_directory_listing({path:'', sort_by_time:true})
         s = smc.redux.getProjectStore(project_id)
         s.wait
             until : => s.getIn(['directory_listings', ""])?.toJS()?.length > 0


### PR DESCRIPTION
Fixes a portion of #2103 
Also fixes `setState(...)` warnings of Side chat

# Testing
Things with chats should have their chats be moved/renamed with them

Be aware of #2119.
Do each of the following with with hidden files and visible files
Do each of the following with files in the home directory and a subdirectory
Do the same from a subfolder to the home folder
1. Test moving 1 file without a chat into subfolder
2. Test moving 2 files without chats into a subfolder
3. Test moving 1 file with a chat into a subfolder
4. Test moving 2 files with chats in to a subfolder
5. Test moving 2 files into a subfolder where one has a chat and the other does not.
6. Test renaming a file without a chat
7. Test renaming a file that has a chat

Additionally, trying to copy associated chat files with their files manually should not throw an error
