### PR TITLE
webapp: attempted fix for target paths not opening files properly

### DIFF
--- a/src/smc-webapp/account.coffee
+++ b/src/smc-webapp/account.coffee
@@ -70,8 +70,8 @@ signed_in = (mesg) ->
         # The underscore below should make it clear that this is hackish.
         redux.getTable('account')._table.once 'connected', ->
             load_app ->
-                    require('./history').load_target(window.smc_target)
-                    window.smc_target = ''
+                require('./history').load_target(window.smc_target)
+                window.smc_target = ''
 
 
 # Listen for pushed sign_in events from the server.  This is one way that

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -37,7 +37,7 @@ class AccountActions extends Actions
                     when 'sign_in_failed'
                         @setState(sign_in_error : mesg.reason)
                     when 'signed_in'
-                        redux.getActions('page').set_active_tab('projects')
+                        #redux.getActions('page').set_active_tab('projects')
                         break
                     when 'error'
                         @setState(sign_in_error : mesg.reason)


### PR DESCRIPTION
see issue #2150

This still contains debug lines, so please someone has to clean this up a bit afterwards. I've also no idea if my contraption is any good, or if there is a much better fix. I also didn't catch how and where the problem was actually introduced.

Open question: why is `redux_account.coffee`  opening up the projects list? this could interfere with other callbacks reacting to "sigend_in". I've commented the line, maybe erroneously ...