### PR TITLE
webapp: let copy operation write to clipboard (if allowed)

### DIFF
--- a/src/smc-webapp/copy-paste-buffer.coffee
+++ b/src/smc-webapp/copy-paste-buffer.coffee
@@ -15,4 +15,7 @@ exports.get_buffer = ->
 
 exports.set_buffer = (s) ->
     buffer = s ? ''
+    try
+        # https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+        document.execCommand('copy')
     return


### PR DESCRIPTION
adding this line here, because it's quite odd to me to not write to the clipboard