### PR TITLE
hub: fixing problems with updating stats based on ttl and also being explicit about disabling calculating them

### DIFF
--- a/src/smc-hub/hub.coffee
+++ b/src/smc-hub/hub.coffee
@@ -674,7 +674,6 @@ command_line = () ->
         .option('--host [string]', 'host of interface to bind to (default: "127.0.0.1")', String, "127.0.0.1")
         .option('--pidfile [string]', 'store pid in this file (default: "data/pids/hub.pid")', String, "data/pids/hub.pid")
         .option('--logfile [string]', 'write log to this file (default: "data/logs/hub.log")', String, "data/logs/hub.log")
-        .option('--statsfile [string]', 'if set, this file contains periodically updated metrics (default: null, suggest value: "data/logs/stats.json")', String, null)
         .option('--database_nodes <string,string,...>', "database address (default: '#{default_db}')", String, default_db)
         .option('--keyspace [string]', 'Database name to use (default: "smc")', String, 'smc')
         .option('--passwd [email_address]', 'Reset password of given user', String, '')

--- a/src/smc-hub/hub_http_server.coffee
+++ b/src/smc-hub/hub_http_server.coffee
@@ -295,8 +295,8 @@ exports.init_express_http_server = (opts) ->
             res.json({error:"not connected to database"})
             return
         opts.database.get_stats
-            ttl: 3600*24*180   # basically never update in hub -- too slow
-            cb : (err, stats) ->
+            update : false   # never update in hub b/c too slow. instead, run $ hub --update_stats via a cronjob every minute
+            cb     : (err, stats) ->
                 res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate')
                 if err
                     res.status(500).send("internal error: #{err}")


### PR DESCRIPTION
Since our hubs started to run longer and are more stable, we have this problem of outdated stats (or, when dispatched randomly across hubs, significant jitter). Root cause is the very long ttl time, which causes a hub to think its local data is still valid although it's not. 

The changes I made address a couple of things:

1. what if there is no data? don't do anything, but give a warning
2. when  a hub is explicitly being told to not update, always live with the best known information
3. related to that, even when that information is outdated, do not query the DB each time a hub is being asked (e.g. consider the case where the cronjob task is no longer updating). that's the reason for a 30 secs db query ttl.
4. The TTL time is now set to 5 minutes (it was 2 minutes). I think that's good enough ... if not, that's easy to tune.
5. Previously, the cronjob calls the update task every 2 minutes, and the calculation of the stats takes 5 to 8 seconds. So, every now and then, checking for a valid result 2 minutes ago yields one and hence stats aren't updated regularly. My solution here is to introduce an offset of 15 seconds, which is only taken into account when allowed to update. I've also changed the cronjob on admin0 to update every minute. This should give us evenly spaced 5 minute stats.
6. there was a statsfile parameter, must be a leftover...