### PR TITLE
hub/tests: being explicit about not using cached results in testing stats changefeeds

### DIFF
--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -69,7 +69,7 @@
     "sinon": "^1.15.3"
   },
   "scripts": {
-    "test": "npm run testpg && npm run testapi",
+    "test": "(npm run testpg && npm run testapi); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres",
     "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/api",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -2121,6 +2121,7 @@ class exports.PostgreSQL extends PostgreSQL
                             cb     : cb
                 )
         ], (err) =>
+            dbg("get_stats final CB: (#{misc.to_json(err)}, #{misc.to_json(stats)})")
             opts.cb?(err, stats)
         )
 

--- a/src/smc-hub/test/postgres/postgres-user-queries-changefeeds-2.coffee
+++ b/src/smc-hub/test/postgres/postgres-user-queries-changefeeds-2.coffee
@@ -797,7 +797,7 @@ describe 'test stats changefeed: ', ->
                         (cb) ->
                             create_projects(10, account_id, cb)
                         (cb) ->
-                            db.get_stats(ttl:0, cb:cb)
+                            db.get_stats(ttl:0, ttl_db:0, ttl_dt:0, cb:cb)
                     ], cb)
                 (x, cb) ->
                     expect(x).toEqual({ action: 'insert', new_val: { accounts: 101, accounts_created: { '1d': 101, '1h': 101, '30d': 101, '7d': 101 }, hub_servers: [], id:x.new_val.id, projects: 110, projects_created: { '1d': 110, '1h': 110, '30d': 110, '7d': 110 }, projects_edited: { '1d': 110, '1h': 110, '30d': 110, '5min': 110, '7d': 110 }, time: x.new_val.time } })


### PR DESCRIPTION
 also: calling mocha_clean.sh after each test invocation.

issue #2173 