### PR TITLE
Drag n drop chat images

### DIFF
--- a/src/smc-webapp/smc-dropzone.cjsx
+++ b/src/smc-webapp/smc-dropzone.cjsx
@@ -92,14 +92,14 @@ exports.SMC_Dropwrapper = rclass
         config           : rtypes.object               # All supported dropzone.js config options
         event_handlers   : rtypes.object
         preview_template : rtypes.func                 # See http://www.dropzonejs.com/#layout
-        show_upload      : rtypes.bool
+        show_upload      : rtypes.bool                 # Whether or not to show upload area
         on_close         : rtypes.func
         disabled         : rtypes.bool
 
     getDefaultProps: ->
         config         : {}
-        hide_previewer : false
         disabled       : false
+        show_upload    : true
 
     getInitialState: ->
         files : []
@@ -182,7 +182,7 @@ exports.SMC_Dropwrapper = rclass
         @setState(files : [])
 
     render_preview: ->
-        if not @props.show_upload and @state.files.length == 0
+        if not @props.show_upload or @state.files.length == 0
             style = display : 'none'
         box_style =
             border       : '2px solid #ccc'

--- a/src/smc-webapp/smc-dropzone.cjsx
+++ b/src/smc-webapp/smc-dropzone.cjsx
@@ -87,13 +87,14 @@ exports.SMC_Dropwrapper = rclass
     displayName: 'dropzone-wrapper'
 
     propTypes:
-        project_id     : rtypes.string.isRequired    # The project to upload files to
-        dest_path      : rtypes.string.isRequired    # The path for files to be sent
-        config         : rtypes.object               # All supported dropzone.js config options
-        event_handlers : rtypes.object
-        show_upload    : rtypes.bool
-        on_close       : rtypes.func
-        disabled       : rtypes.bool
+        project_id       : rtypes.string.isRequired    # The project to upload files to
+        dest_path        : rtypes.string.isRequired    # The path for files to be sent
+        config           : rtypes.object               # All supported dropzone.js config options
+        event_handlers   : rtypes.object
+        preview_template : rtypes.func                 # See http://www.dropzonejs.com/#layout
+        show_upload      : rtypes.bool
+        on_close         : rtypes.func
+        disabled         : rtypes.bool
 
     getDefaultProps: ->
         config         : {}
@@ -161,6 +162,9 @@ exports.SMC_Dropwrapper = rclass
                 @dropzone.options = $.extend(true, {}, @dropzone.options, @get_djs_config())
 
     preview_template: ->
+        if @props.preview_template?
+            return @props.preview_template()
+
         <div className='dz-preview dz-file-preview'>
             <div className='dz-details'>
                 <div className='dz-filename'><span data-dz-name></span></div>
@@ -193,7 +197,7 @@ exports.SMC_Dropwrapper = rclass
                 <span
                     onClick   = {@close_preview}
                     className = 'close-button-x'
-                    style     = {cursor: 'pointer', fontSize: '18px', color:'gray'}
+                    style     = {cursor: 'pointer', fontSize: '18px', color:'gray', marginRight: '20px'}
                 >
                     <i className="fa fa-times"></i>
                 </span>

--- a/src/smc-webapp/smc_chat.cjsx
+++ b/src/smc-webapp/smc_chat.cjsx
@@ -634,7 +634,7 @@ exports.ChatRoom = rclass ({name}) ->
 
     append_file: (file) ->
         if file.type.indexOf("image") isnt -1
-            final_insertion_text = "<img src=\"#{file.name}\" width='60%'>"
+            final_insertion_text = "<img src=\".chat-images/#{file.name}\" width='60%'>"
         else
             final_insertion_text = "[#{file.name}](#{file.name})"
 
@@ -687,7 +687,7 @@ exports.ChatRoom = rclass ({name}) ->
                 <Col xs={10} md={11} style={padding:'0px 2px 0px 2px'}>
                     <SMC_Dropwrapper
                         project_id     = {@props.project_id}
-                        dest_path      = {@props.redux.getProjectStore(@props.project_id).get('current_path')}
+                        dest_path      = {misc.normalized_path_join(@props.redux.getProjectStore(@props.project_id).get('current_path'), "/.chat-images")}
                         event_handlers = {complete : @append_file, sending : @start_upload}
                     >
                         <FormGroup>


### PR DESCRIPTION
First version of dragging items onto the chat text area.

Images will embed as `<img ...>` tags with width='60%'. This can be made smarter later.
Files will embed as `[file_name.ext](file_name.ext)`, making a link which opens as a new file tab.

Text is inserted where the cursor is at the time of dropping. 
If you have highlighted text, it will replace that text.

Items get uploaded to the current directory of the `project_store`. Right now this is always the directory of the open file (in this case, chat).

**Not** implemented for side chats yet.

# Testing
Needs testing on more platforms
- [ ] Firefox
  - [x] OSX
  - [x] Linux
  - [ ] Windows
- [ ] Safari
- [ ] Chrome
  - [x] OSX
  - [x] Linux
  - [ ] Windows