### PR TITLE
Issue/1835b updates to sagews pytest

### DIFF
--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -14,11 +14,17 @@ class TestLex:
     def test_lex_1(self, execdoc):
         execdoc("x = random? # bar")
     def test_lex_2(self, execdoc):
-        execdoc("x = random? # plot?")
+        execdoc("x = random? # plot?",pattern='random')
     def test_lex_3(self, exec2):
         exec2("x = 1 # plot?\nx","1\n")
     def test_lex_4(self, exec2):
         exec2('x="random?" # plot?\nx',"'random?'\n")
+    def test_lex_5(self, exec2):
+        code = dedent(r'''
+        x = """
+        salvus?
+        """;pi''')
+        exec2(code, "pi\n")
 
 class TestDecorators:
     def test_simple_dec(self, exec2):

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -240,6 +240,7 @@ class TestAnaconda3Mode:
     def test_a3_error(self, exec2):
         exec2('%a3\nxyz*', html_pattern = 'span style.*color')
 
+@pytest.mark.skip(reason="drop support for sagemath kernel in jupyter bridge")
 class TestSageMode:
     def test_sagemath(self, exec2):
         exec2('sm = jupyter(\'sagemath\')\nsm(\'e^(i*pi)\')', output='-1')


### PR DESCRIPTION
Ref: #1835 

There are no changes to production code in this PR, only changes to sagews pytest.

- This does not fix #1835 but updates pytest to get ready for that fix.
- Also skips test for sagemath kernel in jupyter bridge, which we no longer support.

```
cd ~/cocalc/src/smc_sagews/smc_sagews/tests
python -m pytest
...
137 passed, 6 skipped in 206.32 seconds
```