### PR TITLE
Issue/2236 sage_server with sage-8.0

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1770,7 +1770,17 @@ def serve(port, host, extra_imports=False):
         log("imported sage.")
 
         # Monkey patch the html command.
+        try:
+            # need the following for sage_server to start with sage-8.0
+            # or `import sage.interacts.library` will fail
+            import sage.repl.user_globals
+            sage.repl.user_globals.set_globals(globals())
+            log("initialized user_globals")
+        except RuntimeError:
+            # may happen with sage version < 8.0
+            log("user_globals.set_globals failed, continuing",sys.exc_info())
         import sage.interacts.library
+
         sage.all.html = sage.misc.html.html = sage.interacts.library.html = sage_salvus.html
 
         # Set a useful figsize default; the matplotlib one is not notebook friendly.

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -462,7 +462,7 @@ def exec2(request, sagews, test_id):
             assert 'stdout' in mesg
             mout = mesg['stdout']
             if output is not None:
-                assert output in mout
+                assert output.strip() in mout
             elif pattern is not None:
                 assert re.search(pattern, mout) is not None
         elif html_pattern:

--- a/src/smc_sagews/smc_sagews/tests/test_00_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_00_timing.py
@@ -44,7 +44,7 @@ class TestSageTiming:
         tick = time.time()
         elapsed = tick - start
         print("elapsed %s"%elapsed)
-        assert elapsed < 10.0
+        assert elapsed < 20.0
 
 class TestStartSageServer:
     def test_2plus2_timing(self, test_id):

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 
 class TestSingularMode:
     def test_singular_version(self, exec2):
-        exec2('%singular_kernel\nsystem("version");','4100\n')
+        exec2('%singular_kernel\nsystem("version");',pattern='(4100|4103)\n')
     def test_singular_factor_polynomial(self, exec2):
         code = dedent('''
         %singular_kernel
@@ -239,11 +239,6 @@ class TestAnaconda3Mode:
 
     def test_a3_error(self, exec2):
         exec2('%a3\nxyz*', html_pattern = 'span style.*color')
-
-@pytest.mark.skip(reason="drop support for sagemath kernel in jupyter bridge")
-class TestSageMode:
-    def test_sagemath(self, exec2):
-        exec2('sm = jupyter(\'sagemath\')\nsm(\'e^(i*pi)\')', output='-1')
 
 class TestJuliaMode:
     def test_julia1(self, exec2):


### PR DESCRIPTION
Ref: #2236.

These changes, plus @hsy fix hiding sage binary for python3 so that sage_server uses /usr/bin/python3, allow sage worksheets to run with sage-8.0.

```
# testing with sage-8.0:
~/cocalc/src/smc_sagews/smc_sagews/tests
python -m pytest
...
== 137 passed, 5 skipped in 195.90 seconds ==

# testing with sage-7.6:
...
== 137 passed, 5 skipped in 207.19 seconds ==

# testing with sage-7.5:
== 137 passed, 5 skipped in 210.55 seconds ==
```
