### PR TITLE
process frame and other extra kwds in threed()

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2590,6 +2590,14 @@ def show(*objs, **kwds):
         elif isinstance(obj, Animation):
             show_animation(obj, **kwds)
         elif isinstance(obj, Graphics3d):
+
+            # _extra_kwds processing follows the example of
+            # src/smc_sagews/smc_sagews/graphics.py:show_3d_plot_using_threejs()
+            extra_kwds = {} if obj._extra_kwds is None else obj._extra_kwds
+            for k in ['spin', 'renderer', 'viewer', 'frame', 'height', 'width', 'background', 'foreground', 'aspect_ratio']:
+                if k in extra_kwds and k not in kwds:
+                    kwds[k] = obj._extra_kwds[k]
+
             if kwds.get('viewer') == 'tachyon':
                 show_3d_plot_using_tachyon(obj, **kwds)
             else:


### PR DESCRIPTION
Ref: #2240.

To test:
1. Install the patch (1 file changed, sage_salvus.py).
1. Try any 3d plot with `frame=False` and notice that a frame is not drawn, for example:
    ```
    sphere(frame=False)
    line3d([(0,0,0),(1,1,1)],frame=False)
    ```
1. Try other options that were ignored before this fix:
    ```
    icosahedron(frame={'color':'darkgreen','fontsize':20,'thickness':5})
    cube(viewer='tachyon')
    ```

