### PR TITLE
add mocha tests for gap and pari kernels

### DIFF
--- a/src/smc-project/jupyter/test/supported-kernels.coffee
+++ b/src/smc-project/jupyter/test/supported-kernels.coffee
@@ -213,6 +213,43 @@ describe 'test the scala kernel --', ->
     it 'closes the kernel', ->
         kernel.close()
 
+describe 'test the gap kernel --', ->
+    @timeout(10000)
+    kernel = undefined
+    it 'evaluates 3^74', (done) ->
+        kernel = common.kernel('gap')
+        kernel.execute_code
+            code : '3^74'
+            all  : true
+            cb   : (err, v) ->
+                if err
+                    done(err)
+                else
+                    expect(output(v)).toEqual("202755595904452569706561330872953769")
+                    done()
+
+    it 'closes the kernel', ->
+        kernel.close()
+
+describe 'test the pari kernel --', ->
+    # if test succeeds, it usually does so in under 3 seconds
+    # otherwise, kernel has stalled during startup
+    @timeout(5000)
+    kernel = undefined
+    it 'evaluates nextprime(33)', (done) ->
+        kernel = common.kernel('pari_jupyter')
+        kernel.execute_code
+            code : 'nextprime(33)'
+            all  : true
+            cb   : (err, v) ->
+                if err
+                    done(err)
+                else
+                    expect(output(v)).toEqual({ 'text/plain': '37' })
+                    done()
+
+    it 'closes the kernel', ->
+        kernel.close()
 
 
 


### PR DESCRIPTION
See #2243.

Needs work, but opening PR in case others have ideas. The test for `pari_jupyter` follows the pattern for other kernel mocha tests, but fails about 60% of the time. DEBUG output for failure cases shows kernel output ending when jupyter message channels are created.

I left the timeout for the pari test at 5 seconds because there is nothing to gain by increasing it. Either the test succeeds, usually in under 3 seconds, or it times out indefinitely. Here's sample failure output:

```
~/cocalc/src/smc-project/jupyter$ DEBUG=1 mocha --opts test/mocha.opts --grep "pari kernel" test/supported-kernels.coffee
DEBUG = true
 
 
  test the pari kernel --
Client.jupyter.Kernel('pari_jupyter',path='').constructor:
Client.jupyter.Kernel('pari_jupyter',path='')._process_execute_code_queue:  state='off'
Client.jupyter.Kernel('pari_jupyter',path='')._process_execute_code_queue:  queue has 1 items; ensure kernel running
Client.jupyter.Kernel('pari_jupyter',path='').spawn:  spawning kernel...
Client.jupyter.Kernel('pari_jupyter',path='').spawn:  spawned kernel; now creating comm channels...
[kernel_info_request message on iopub channel should happen next but does not appear]
```
