### PR TITLE
webapp: introduce ?fullscreen=kiosk mode, as a no-way-back to normal fullscreen state

### DIFF
--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -301,13 +301,13 @@ exports.FullscreenButton = rclass
 
     reduxProps :
         page :
-            fullscreen : rtypes.bool
+            fullscreen : rtypes.oneOf(['default', 'kiosk'])
 
     on_fullscreen: (ev) ->
         if ev.shiftKey
-            @actions('page').set_kiosk(true)
+            @actions('page').set_fullscreen('kiosk')
         else
-            @actions('page').set_fullscreen(not @props.fullscreen)
+            @actions('page').toggle_fullscreen()
 
     render: ->
         icon = if @props.fullscreen then 'expand' else 'compress'

--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -303,28 +303,40 @@ exports.FullscreenButton = rclass
         page :
             fullscreen : rtypes.bool
 
-    on_fullscreen: ->
-        @actions('page').set_fullscreen(not @props.fullscreen)
+    on_fullscreen: (ev) ->
+        if ev.shiftKey
+            @actions('page').set_kiosk(true)
+        else
+            @actions('page').set_fullscreen(not @props.fullscreen)
 
     render: ->
         icon = if @props.fullscreen then 'expand' else 'compress'
-        styles =
+
+        outer_style =
             position   : 'fixed'
             zIndex     : 10000
             right      : 0
             top        : '1px'
+            borderRadius: '3px'
+
+        icon_style =
             fontSize   : '13pt'
             padding    : 4
             color      : COLORS.GRAY
             cursor     : 'pointer'
-            borderRadius: '3px'
 
         if @props.fullscreen
-            styles.background = '#fff'
-            styles.opacity    = .7
-            styles.border     = '1px solid grey'
+            outer_style.background = '#fff'
+            outer_style.opacity    = .7
+            outer_style.border     = '1px solid grey'
 
-        <Icon style={styles} name={icon} onClick={@on_fullscreen} />
+        <Tip
+            style     = {outer_style}
+            title     = {'Removes navigational chrome from the UI. Shift-click to enter "kiosk-mode".'}
+            placement = {'left'}
+        >
+            <Icon style={icon_style} name={icon} onClick = {(e) => @on_fullscreen(e)} />
+        </Tip>
 
 exports.AppLogo = rclass
     displayName : 'AppLogo'

--- a/src/smc-webapp/chat-indicator.cjsx
+++ b/src/smc-webapp/chat-indicator.cjsx
@@ -50,7 +50,7 @@ exports.ChatIndicator = rclass
         file_use :
             file_use : rtypes.immutable
         page :
-            fullscreen : rtypes.bool
+            fullscreen : rtypes.oneOf(['default', 'kiosk'])
 
     propTypes :
         project_id   : rtypes.string.isRequired

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -79,6 +79,7 @@ Page = rclass
             connection_status : rtypes.string
             new_version       : rtypes.object
             fullscreen        : rtypes.bool
+            kiosk             : rtypes.bool
             cookie_warning    : rtypes.bool
             local_storage_warning : rtypes.bool
             show_file_use     : rtypes.bool
@@ -226,7 +227,7 @@ Page = rclass
                 {@render_right_nav()}
             </Navbar> if not @props.fullscreen}
             {<div className="smc-sticky-position-hack" style={minHeight:positionHackHeight}> </div>if not @props.fullscreen}
-            <FullscreenButton />
+            {<FullscreenButton /> if not @props.kiosk}
             {# Children must define their own padding from navbar and screen borders}
             {# Note that the parent is a flex container}
             <ActiveAppContent active_top_tab={@props.active_top_tab}/>

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -78,8 +78,7 @@ Page = rclass
             avgping           : rtypes.number
             connection_status : rtypes.string
             new_version       : rtypes.object
-            fullscreen        : rtypes.bool
-            kiosk             : rtypes.bool
+            fullscreen        : rtypes.oneOf(['default', 'kiosk'])
             cookie_warning    : rtypes.bool
             local_storage_warning : rtypes.bool
             show_file_use     : rtypes.bool
@@ -227,7 +226,7 @@ Page = rclass
                 {@render_right_nav()}
             </Navbar> if not @props.fullscreen}
             {<div className="smc-sticky-position-hack" style={minHeight:positionHackHeight}> </div>if not @props.fullscreen}
-            {<FullscreenButton /> if not @props.kiosk}
+            {<FullscreenButton /> if (@props.fullscreen != 'kiosk')}
             {# Children must define their own padding from navbar and screen borders}
             {# Note that the parent is a flex container}
             <ActiveAppContent active_top_tab={@props.active_top_tab}/>

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -177,21 +177,13 @@ class PageActions extends Actions
         @setState(new_version : version)
 
     set_fullscreen: (val) =>
+        # if kiosk is ever set, disable toggling back
+        if redux.getStore('page').get('fullscreen') == 'kiosk'
+            return
         @setState(fullscreen : val)
 
-    set_kiosk: (val) =>
-        # if kiosk is ever set, disable toggling back
-        if redux.getStore('page').get('kiosk') and not val
-            return
-        @setState(kiosk : val)
-        if val
-            @set_fullscreen(val)
-
     toggle_fullscreen: =>
-        # if kiosk is ever set, disable toggling back
-        if redux.getStore('page').get('kiosk')
-            return
-        @setState(fullscreen : not redux.getStore('page').get('fullscreen'))
+        @set_fullscreen(if redux.getStore('page').get('fullscreen')? then undefined else 'default')
 
     show_cookie_warning: =>
         @setState(cookie_warning : true)
@@ -235,8 +227,7 @@ redux.createStore
         avgping               : rtypes.number
         connection_status     : rtypes.string
         new_version           : rtypes.object
-        fullscreen            : rtypes.bool
-        kiosk                 : rtypes.bool
+        fullscreen            : rtypes.oneOf(['default', 'kiosk'])
         cookie_warning        : rtypes.bool
         local_storage_warning : rtypes.bool
         show_file_use         : rtypes.bool
@@ -342,5 +333,9 @@ webapp_client.on 'new_version', (ver) ->
 # enable fullscreen mode upon a URL like /app?fullscreen and additionally kiosk-mode upon /app?fullscreen=kiosk
 misc_page = require('./misc_page')
 fullscreen_query_value = misc_page.get_query_param('fullscreen')
-redux.getActions('page').set_fullscreen(!!fullscreen_query_value)
-redux.getActions('page').set_kiosk(fullscreen_query_value == 'kiosk')
+if fullscreen_query_value
+    if fullscreen_query_value == 'kiosk'
+        redux.getActions('page').set_fullscreen('kiosk')
+    else
+        redux.getActions('page').set_fullscreen('default')
+

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -179,7 +179,18 @@ class PageActions extends Actions
     set_fullscreen: (val) =>
         @setState(fullscreen : val)
 
+    set_kiosk: (val) =>
+        # if kiosk is ever set, disable toggling back
+        if redux.getStore('page').get('kiosk') and not val
+            return
+        @setState(kiosk : val)
+        if val
+            @set_fullscreen(val)
+
     toggle_fullscreen: =>
+        # if kiosk is ever set, disable toggling back
+        if redux.getStore('page').get('kiosk')
+            return
         @setState(fullscreen : not redux.getStore('page').get('fullscreen'))
 
     show_cookie_warning: =>
@@ -225,6 +236,7 @@ redux.createStore
         connection_status     : rtypes.string
         new_version           : rtypes.object
         fullscreen            : rtypes.bool
+        kiosk                 : rtypes.bool
         cookie_warning        : rtypes.bool
         local_storage_warning : rtypes.bool
         show_file_use         : rtypes.bool
@@ -327,8 +339,8 @@ webapp_client.on "connecting", () ->
 webapp_client.on 'new_version', (ver) ->
     redux.getActions('page').set_new_version(ver)
 
-# enable fullscreen mode upon a URL like /app?fullscreen
+# enable fullscreen mode upon a URL like /app?fullscreen and additionally kiosk-mode upon /app?fullscreen=kiosk
 misc_page = require('./misc_page')
-if misc_page.get_query_param('fullscreen')
-    redux.getActions('page').set_fullscreen(true)
-
+fullscreen_query_value = misc_page.get_query_param('fullscreen')
+redux.getActions('page').set_fullscreen(!!fullscreen_query_value)
+redux.getActions('page').set_kiosk(fullscreen_query_value == 'kiosk')

--- a/src/smc-webapp/mobile_app.cjsx
+++ b/src/smc-webapp/mobile_app.cjsx
@@ -20,7 +20,7 @@ React Component for displaying the entire page on a mobile device.
 misc = require('smc-util/misc')
 
 {ProjectsNav} = require('./projects_nav')
-{ActiveAppContent, CookieWarning, LocalStorageWarning, ConnectionIndicator, ConnectionInfo, FullscreenButton, NavTab, NotificationBell, AppLogo, VersionWarning} = require('./app_shared')
+{ActiveAppContent, CookieWarning, LocalStorageWarning, ConnectionIndicator, ConnectionInfo, NavTab, NotificationBell, AppLogo, VersionWarning} = require('./app_shared')
 
 # Project tabs's names are their project id
 Page = rclass
@@ -35,6 +35,7 @@ Page = rclass
             connection_status : rtypes.string
             new_version       : rtypes.object
             fullscreen        : rtypes.bool
+            kiosk             : rtypes.bool
             cookie_warning    : rtypes.bool
             local_storage_warning : rtypes.bool
             show_file_use     : rtypes.bool
@@ -169,7 +170,7 @@ Page = rclass
                 <ProjectsNav dropdown={true} />
                 {@render_menu_button()}
             </Navbar> if not @props.fullscreen}
-            {@render_menu() if @state.show_menu}
+            {@render_menu() if (@state.show_menu and not @props.kiosk)}
             {# Children must define their own padding from navbar and screen borders}
             <ActiveAppContent active_top_tab={@props.active_top_tab} render_small={true}/>
         </div>

--- a/src/smc-webapp/mobile_app.cjsx
+++ b/src/smc-webapp/mobile_app.cjsx
@@ -34,8 +34,7 @@ Page = rclass
             avgping           : rtypes.number
             connection_status : rtypes.string
             new_version       : rtypes.object
-            fullscreen        : rtypes.bool
-            kiosk             : rtypes.bool
+            fullscreen        : rtypes.oneOf(['default', 'kiosk'])
             cookie_warning    : rtypes.bool
             local_storage_warning : rtypes.bool
             show_file_use     : rtypes.bool
@@ -170,7 +169,7 @@ Page = rclass
                 <ProjectsNav dropdown={true} />
                 {@render_menu_button()}
             </Navbar> if not @props.fullscreen}
-            {@render_menu() if (@state.show_menu and not @props.kiosk)}
+            {@render_menu() if (@state.show_menu and (@props.fullscreen != 'kiosk'))}
             {# Children must define their own padding from navbar and screen borders}
             <ActiveAppContent active_top_tab={@props.active_top_tab} render_small={true}/>
         </div>

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -431,8 +431,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
             project_map  : rtypes.immutable
             get_my_group : rtypes.func
         page :
-            fullscreen : rtypes.bool
-            kiosk      : rtypes.bool
+            fullscreen : rtypes.oneOf(['default', 'kiosk'])
         "#{name}" :
             active_project_tab  : rtypes.string
             open_files          : rtypes.immutable
@@ -513,7 +512,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
                         is_active  = {@props.active_project_tab == k}
                         shrink     = {shrink_fixed_tabs}
                     /> for k, v of fixed_project_pages when ((is_public and v.is_public) or (not is_public))]}
-                </Nav> if not @props.kiosk}
+                </Nav> if (@props.fullscreen != 'kiosk')}
                 <div
                     style = {display:'flex', overflow:'hidden', flex: 1}
                 >
@@ -570,7 +569,7 @@ exports.MobileProjectPage = rclass ({name}) ->
             project_map  : rtypes.immutable
             get_my_group : rtypes.func
         page :
-            fullscreen : rtypes.bool
+            fullscreen : rtypes.oneOf(['default', 'kiosk'])
         "#{name}" :
             active_project_tab  : rtypes.string
             open_files          : rtypes.immutable

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -432,6 +432,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
             get_my_group : rtypes.func
         page :
             fullscreen : rtypes.bool
+            kiosk      : rtypes.bool
         "#{name}" :
             active_project_tab  : rtypes.string
             open_files          : rtypes.immutable
@@ -499,7 +500,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
 
         <div className="smc-file-tabs" ref="projectNav" style={width:'100%', height:'32px'}>
             <div style={display:'flex'}>
-                <Nav
+                {<Nav
                     bsStyle   = "pills"
                     className = "smc-file-tabs-fixed-desktop"
                     style     = {overflow:'hidden', float:'left'} >
@@ -512,7 +513,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
                         is_active  = {@props.active_project_tab == k}
                         shrink     = {shrink_fixed_tabs}
                     /> for k, v of fixed_project_pages when ((is_public and v.is_public) or (not is_public))]}
-                </Nav>
+                </Nav> if not @props.kiosk}
                 <div
                     style = {display:'flex', overflow:'hidden', flex: 1}
                 >


### PR DESCRIPTION
see issue #2234

Test: kiosk-mode is triggered in two ways
* append `?fullscreen=kiosk` to the URL
* shift-click on fullscreen
* no regressions: i.e. appending `?fullscreen` still shows the toggle button