### PR TITLE
webapp: ignore query strings like "?session=local" in internal links

### DIFF
--- a/src/smc-webapp/process-links.coffee
+++ b/src/smc-webapp/process-links.coffee
@@ -5,7 +5,15 @@ when we fully switch to react.
 
 misc = require('smc-util/misc')
 
-load_target = require('./smc-react').redux.getActions('projects').load_target
+projects_load_target = require('./smc-react').redux.getActions('projects').load_target
+
+load_target = (target, switch_to) ->
+    # get rid of "?something" in "path/file.ext?something"
+    i = target.lastIndexOf('/')
+    if i > 0 and '?' in target[i..]
+        j = target[i..].indexOf('?')
+        target = target[...(i + j)]
+    projects_load_target(target, switch_to)
 
 # make all links open internally or in a new tab; etc.
 # opts={project_id:?, file_path:path that contains file}

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -206,6 +206,7 @@ class ProjectsActions extends Actions
 
     # should not be in projects...?
     load_target: (target, switch_to) =>
+        #if DEBUG then console.log("projects actions/load_target: #{target}")
         if not target or target.length == 0
             redux.getActions('page').set_active_tab('projects')
             return


### PR DESCRIPTION
This is a small detail for queries like session=local in the URL. When someone copies that link into a file for internal linking, the `?session=local` part should be ignored. 

Test: external links should still work as they are. Example, create a test.md file:

```
open [new.ipynb](new.ipynb?session=local)

open [external](https://www.google.at/search?q=cocalc)
```

There is still a design question open, namely if this logic should be in the `ProjectsActions::load_target` function instead.