### PR TITLE
webapp: fix newline wrapping of upload button in files listing

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1974,7 +1974,8 @@ exports.ProjectFiles = rclass ({name}) ->
             actions      = {@props.actions} />
 
     render_new_file : ->
-        <Col sm=3 md=2>
+        # hsy: for me, without the "nowrap", the upload button usually shows up on the next line
+        <Col sm=3 md=2 style={whiteSpace: 'nowrap'}>
             <ProjectFilesNew
                 file_search   = {@props.file_search}
                 current_path  = {@props.current_path}


### PR DESCRIPTION
Hi @johnjeng ... thank you for reviewing the last one, but your little change reverted a problem I'm usually seeing in my files listing. The upload button wraps into the next line, hence the nowrap style.

This fix reverts it, and to show you what I mean, here are before/after screenshots:

![files-whitespace-button-wrapping](https://user-images.githubusercontent.com/207405/29075101-bbe7641e-7c51-11e7-920a-ee873d67817f.png)

vs.

![fix-button-wrapping-afterwards](https://user-images.githubusercontent.com/207405/29075110-c14a3332-7c51-11e7-88f9-a778c50406af.png)


