### PR TITLE
webapp: prefix local session with app base url

### DIFF
--- a/src/smc-webapp/session.coffee
+++ b/src/smc-webapp/session.coffee
@@ -12,8 +12,11 @@ exports.session_manager = (name, redux) ->
 
 class SessionManager
     constructor: (@name, @redux) ->
-        console.log 'session manager', @name
-        @_local_storage_name = "session.#{@name}"
+        #if DEBUG then console.log 'session manager', @name
+        {APP_BASE_URL} = require('misc_page')
+        prefix = if APP_BASE_URL then ".#{APP_BASE_URL}" else ''
+        @_local_storage_name = "session#{prefix}.#{@name}"
+        #if DEBUG then console.log '_local_storage_name: ', @_local_storage_name
         @save = throttle(@save, 1000)
 
     save: =>


### PR DESCRIPTION
there is another detail I just saw while testing: the local session info is shared with the main site and hence there are interferences when doing cc-in-cc dev. this patch prefixes they key with the app base url. it doesn't change the already existing key.