### PR TITLE
Space warning

### DIFF
--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -271,10 +271,10 @@ DiskSpaceWarning = rclass ({name}) ->
         if not quotas?.disk_quota? or not project_status?
             return null
         else
-            disk = project_status.get('disk_MB')
+            disk = project_status.get('disk_MB') ? 0
             if disk?
                 disk = Math.ceil(disk)
-        if not disk or quotas.disk_quota - 5 > disk
+        if quotas.disk_quota - 5 > disk
             return null
 
         styles =

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -259,8 +259,7 @@ DiskSpaceWarning = rclass ({name}) ->
         project_id : rtypes.string
 
     shouldComponentUpdate: (nextProps) ->
-        return true
-        #@props.project_map?.get(@props.project_id) != nextProps.project_map?.get(nextProps.project_id)
+        return @props.project_map?.get(@props.project_id) != nextProps.project_map?.get(nextProps.project_id)
 
     render: ->
         if not require('./customize').commercial
@@ -275,8 +274,8 @@ DiskSpaceWarning = rclass ({name}) ->
             disk = project_status.get('disk_MB')
             if disk?
                 disk = Math.ceil(disk)
-        #if not disk or quotas.disk_quota - 5 > disk
-        #    return null
+        if not disk or quotas.disk_quota - 5 > disk
+            return null
 
         styles =
             marginBottom : 0

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -269,23 +269,16 @@ DiskSpaceWarning = rclass ({name}) ->
             return null
         quotas = @props.get_total_project_quotas(@props.project_id)
         project_status = @props.project_map?.get(@props.project_id)?.get('status')
-        console.log "Quotas?", quotas, "status?", project_status?.toJS()
         if not quotas?.disk_quota? or not project_status?
             return null
         else
-            rss = project_status.get('memory')?.get('rss')
-            if rss?
-                memory = Math.round(rss/1000)
             disk = project_status.get('disk_MB')
             if disk?
                 disk = Math.ceil(disk)
-        if disk
-            console.log "Disk is:", disk
+        #if not disk or quotas.disk_quota - 5 > disk
+        #    return null
 
         styles =
-            padding      : 3
-            paddingLeft  : 7
-            paddingRight : 7
             marginBottom : 0
             fontSize     : '13pt'
         dismiss_styles =
@@ -299,7 +292,7 @@ DiskSpaceWarning = rclass ({name}) ->
             position   : 'relative'
             height     : 0
         <Alert bsStyle='danger' style={styles}>
-            <Icon name='exclamation-triangle' /> WARNING: This project is running out of disk space. Please increase the quota or delete some files.
+            <Icon name='exclamation-triangle' /> WARNING: This project is running out of disk space. Please increase the quota in <a onClick={=>@actions(project_id: @props.project_id).set_active_tab('settings')} style={cursor:'pointer'}>settings</a> or delete some files.
         </Alert>
 # is_public below -- only show this tab if this is true
 

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -174,7 +174,7 @@ SortableNav = SortableContainer(NavWrapper)
 FreeProjectWarning = rclass ({name}) ->
     displayName : 'FreeProjectWarning'
 
-    reduxProps :
+    reduxProps:
         projects :
             # get_total_project_quotas relys on this data
             # Will be removed by #1084
@@ -185,15 +185,15 @@ FreeProjectWarning = rclass ({name}) ->
             free_warning_extra_shown : rtypes.bool
             free_warning_closed      : rtypes.bool
 
-    propTypes :
+    propTypes:
         project_id : rtypes.string
 
-    shouldComponentUpdate : (nextProps) ->
+    shouldComponentUpdate: (nextProps) ->
         return @props.free_warning_extra_shown != nextProps.free_warning_extra_shown or
             @props.free_warning_closed != nextProps.free_warning_closed or
             @props.project_map?.get(@props.project_id)?.get('users') != nextProps.project_map?.get(@props.project_id)?.get('users')
 
-    extra : (host, internet) ->
+    extra: (host, internet) ->
         {PolicyPricingPageUrl} = require('./customize')
         if not @props.free_warning_extra_shown
             return null
@@ -209,7 +209,7 @@ FreeProjectWarning = rclass ({name}) ->
             </ul>
         </div>
 
-    render : ->
+    render: ->
         if not require('./customize').commercial
             return null
         if @props.free_warning_closed
@@ -258,17 +258,19 @@ DiskSpaceWarning = rclass ({name}) ->
     propTypes :
         project_id : rtypes.string
 
-    shouldComponentUpdate : (nextProps) ->
-        return @props.project_map?.get(@props.project_id) != nextProps.project_map?.get(nextProps.project_id)
+    shouldComponentUpdate: (nextProps) ->
+        return true
+        #@props.project_map?.get(@props.project_id) != nextProps.project_map?.get(nextProps.project_id)
 
-    render : ->
+    render: ->
         if not require('./customize').commercial
             return null
         if @props.free_warning_closed
             return null
         quotas = @props.get_total_project_quotas(@props.project_id)
-        project_status = @props.project_map.get(@prop.project_id)?.get('status')
-        if not quotas?.disk_quota? or project_status?
+        project_status = @props.project_map?.get(@props.project_id)?.get('status')
+        console.log "Quotas?", quotas, "status?", project_status?.toJS()
+        if not quotas?.disk_quota? or not project_status?
             return null
         else
             rss = project_status.get('memory')?.get('rss')
@@ -297,8 +299,7 @@ DiskSpaceWarning = rclass ({name}) ->
             position   : 'relative'
             height     : 0
         <Alert bsStyle='danger' style={styles}>
-            <Icon name='exclamation-triangle' /> WARNING: This project is running out of space. &mdash;
-            <a style={dismiss_styles} onClick={@actions(project_id: @props.project_id).close_free_warning}>×</a>
+            <Icon name='exclamation-triangle' /> WARNING: This project is running out of disk space. Please increase the quota or delete some files.
         </Alert>
 # is_public below -- only show this tab if this is true
 

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -268,7 +268,7 @@ QuotaConsole = rclass
         settings     = @props.project_settings
         if not settings?
             return <Loading/>
-        status       = @props.project_status
+        status       = @props.project_status   # <------ Current status of disk
         total_quotas = @props.total_project_quotas
         if not total_quotas?
             # this happens for the admin -- just ignore any upgrades from the users

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -268,7 +268,7 @@ QuotaConsole = rclass
         settings     = @props.project_settings
         if not settings?
             return <Loading/>
-        status       = @props.project_status   # <------ Current status of disk
+        status       = @props.project_status
         total_quotas = @props.total_project_quotas
         if not total_quotas?
             # this happens for the admin -- just ignore any upgrades from the users


### PR DESCRIPTION
Shows up when disk space used is within 5mb of the quota limit.
- No `x` to remove the warning. Delete files, increase quota, or suffer the warning.
- Disappears automatically when quota is adjusted
![annoying](https://user-images.githubusercontent.com/618575/29175821-ea4899f6-7d9e-11e7-8533-34e151499001.png)

# Testing
I tested on smc-in-smc by using admin edit to reduce a project quota to under 5mb since "usage" is always undefined/zero.