### PR TITLE
webapp/files: no newline wrap for create-dropdown button when narrow

### DIFF
--- a/src/smc-webapp/_projects.sass
+++ b/src/smc-webapp/_projects.sass
@@ -58,3 +58,7 @@
 
 .highlight
   background-color : yellow
+
+.cc-project-files-create-dropdown
+  > .dropdown.btn-group
+    display: flex

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -101,7 +101,7 @@ PathSegmentLink = rclass
             return @props.display
 
     render: ->
-        <Breadcrumb.Item bsSize='small' onClick={@handle_click} active={@props.active}>
+        <Breadcrumb.Item onClick={@handle_click} active={@props.active}>
             {@render_content()}
         </Breadcrumb.Item>
 
@@ -1798,7 +1798,9 @@ ProjectFilesNew = rclass
     new_file_button_types : ['sagews', 'term', 'ipynb', 'tex', 'rnw', 'md', 'tasks', 'course', 'sage', 'py', 'sage-chat']
 
     file_dropdown_icon: ->
-        <span><Icon name='plus-circle' /> Create</span>
+        <span style={whiteSpace: 'nowrap'}>
+            <Icon name='plus-circle' /> Create
+        </span>
 
     file_dropdown_item: (i, ext) ->
         {file_options} = require('./editor')
@@ -1824,19 +1826,15 @@ ProjectFilesNew = rclass
             @props.create_file()
 
     render: ->
-        # This div prevents the split button from line-breaking when the page is small
-        <div style={whiteSpace: 'nowrap', display: 'inline-block'}>
-            <SplitButton id='new_file_dropdown'
-                title={@file_dropdown_icon()}
-                style={whiteSpace: 'nowrap'}
-                onClick={@on_create_button_clicked} >
+        <SplitButton id='new_file_dropdown'
+            title={@file_dropdown_icon()}
+            onClick={@on_create_button_clicked} >
                 {(@file_dropdown_item(i, ext) for i, ext of @new_file_button_types)}
                 <MenuItem divider />
                 <MenuItem eventKey='folder' key='folder' onSelect={@props.create_folder}>
                     <Icon name='folder' /> Folder
                 </MenuItem>
-            </SplitButton>
-        </div>
+        </SplitButton>
 
 error_style =
     marginRight : '1ex'
@@ -2188,8 +2186,10 @@ exports.ProjectFiles = rclass ({name}) ->
                         create_folder       = {@create_folder}
                         public_view         = {public_view} />
                 </div>
-                {<div style={flex: '0 1 auto', marginLeft: '10px'}>
-                    {@render_new_file()}
+                {<div
+                    style={flex: '0 1 auto', marginLeft: '10px'}
+                    className='cc-project-files-create-dropdown' >
+                        {@render_new_file()}
                 </div> if not public_view}
                 <div style={flex: '5 1 auto', marginLeft: '10px'}>
                     <ProjectFilesPath current_path={@props.current_path} actions={@props.actions} />

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -2170,8 +2170,8 @@ exports.ProjectFiles = rclass ({name}) ->
             {@render_deleted()}
             {@render_error()}
             {@render_activity()}
-            <div style={display: 'flex', flexDirection: 'row', flexWrap: 'nowrap', justifyContent: 'space-between', alignItems: 'stretch'}>
-                <div style={flex: '0 1 25%'}>
+            <div style={display: 'flex', flexFlow: 'row wrap', justifyContent: 'space-between', alignItems: 'stretch'}>
+                <div style={flex: '1 0 25%', marginRight: '10px', minWidth: '20em'}>
                     <ProjectFilesSearch
                         project_id          = {@props.project_id}
                         key                 = {@props.current_path}
@@ -2187,17 +2187,17 @@ exports.ProjectFiles = rclass ({name}) ->
                         public_view         = {public_view} />
                 </div>
                 {<div
-                    style={flex: '0 1 auto', marginLeft: '10px'}
+                    style={flex: '0 1 auto', marginRight: '10px', marginBottom:'15px'}
                     className='cc-project-files-create-dropdown' >
                         {@render_new_file()}
                 </div> if not public_view}
-                <div style={flex: '5 1 auto', marginLeft: '10px'}>
+                <div style={flex: '5 1 auto', marginRight: '10px', marginBottom:'15px'}>
                     <ProjectFilesPath current_path={@props.current_path} actions={@props.actions} />
                 </div>
-                {<div style={flex: '0 1 auto', marginLeft: '10px'}>
+                {<div style={flex: '0 1 auto', marginRight: '10px', marginBottom:'15px'}>
                     <UsersViewing project_id={@props.project_id} />
                 </div> if not public_view}
-                {<div style={flex: '1 0 auto'}>
+                {<div style={flex: '1 0 auto', marginBottom:'15px'}>
                     <ProjectFilesButtons
                         show_hidden  = {@props.show_hidden ? false}
                         current_path = {@props.current_path}


### PR DESCRIPTION
I got angry with that stupid line break.

process: less is more (getting rid of a div) for more control and the wrapping itself can only be dealt with dynamically reassigning flex layout to the element. I think under the hood some element-juggling-magic happens ... 

also, removing an erroneously set bsSize argument.

tested in Chrome and FF, no impact on the other parts of this horizontal row.

![ugly-but-ok](https://user-images.githubusercontent.com/207405/29182274-8e9e20fc-7dfe-11e7-8e78-32ef1cdfec87.png)
