### PR TITLE
longer sage_server startup timeout for kucalc & sage-8.0

### DIFF
--- a/src/smc-project/sage_session.coffee
+++ b/src/smc-project/sage_session.coffee
@@ -25,7 +25,7 @@ blobs  = require('./blobs')
 # connection requests, after we restart it.  It can
 # take a while, since it pre-imports the sage library
 # at startup, before forking.
-SAGE_SERVER_MAX_STARTUP_TIME_S = 30
+SAGE_SERVER_MAX_STARTUP_TIME_S = 60
 
 _restarting_sage_server = false
 _restarted_sage_server  = 0   # time when we last restarted it


### PR DESCRIPTION
SAGE_SERVER_MAX_STARTUP_TIME_S from 30 → 60

Tested by adding 35 sec delay to `src/smc_sagews/smc_sagews/sage_server.py:run_server()` and verifying that worksheet startup timed out before the change and did not timeout after the change.