### PR TITLE
project: optional deadman switch if internal GCE network is accessible

### DIFF
--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -20,6 +20,7 @@
     "node-cleanup": "^2.1.2",
     "posix": "^4.0.0",
     "pty.js": "^0.3.0",
+    "request": "^2",
     "serve-index": "^1.7.2",
     "start-stop-daemon": "^0.1.1",
     "temp": "^0.8.3",


### PR DESCRIPTION
This is part of the Kucalc efforts. The project's local hub kills itself if it can access information that's supposed to be firewalled (server is the same as DNS, etc.)