### PR TITLE
Docker image: some improvements and cleanup

### DIFF
--- a/src/dev/docker/Dockerfile
+++ b/src/dev/docker/Dockerfile
@@ -130,13 +130,6 @@ RUN \
   && cp -rv /usr/local/sage/local/share/texmf/tex/latex/sagetex/ /usr/share/texmf/tex/latex/ \
   && texhash
 
-COPY login.defs /etc/login.defs
-COPY login /etc/defaults/login
-COPY nginx.conf /etc/nginx/sites-available/default
-COPY haproxy.conf /etc/haproxy/haproxy.cfg
-COPY run.py /root/run.py
-COPY bashrc /root/.bashrc
-
 RUN echo "umask 077" >> /etc/bash.bashrc
 
 # Install R Jupyter Kernel package into R itself (so R kernel works)
@@ -150,6 +143,16 @@ COPY kernels/ir/Rprofile.site /usr/local/sage/local/lib/R/etc/Rprofile.site
 
 # Build a UTF-8 locale, so that tmux works -- see https://unix.stackexchange.com/questions/277909/updated-my-arch-linux-server-and-now-i-get-tmux-need-utf-8-locale-lc-ctype-bu
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+
+
+### Configuration
+
+COPY login.defs /etc/login.defs
+COPY login /etc/defaults/login
+COPY nginx.conf /etc/nginx/sites-available/default
+COPY haproxy.conf /etc/haproxy/haproxy.cfg
+COPY run.py /root/run.py
+COPY bashrc /root/.bashrc
 
 CMD /root/run.py
 

--- a/src/dev/docker/Dockerfile
+++ b/src/dev/docker/Dockerfile
@@ -149,7 +149,7 @@ COPY kernels /usr/local/share/jupyter/kernels
 COPY kernels/ir/Rprofile.site /usr/local/sage/local/lib/R/etc/Rprofile.site
 
 # Build a UTF-8 locale, so that tmux works -- see https://unix.stackexchange.com/questions/277909/updated-my-arch-linux-server-and-now-i-get-tmux-need-utf-8-locale-lc-ctype-bu
-RUN apt -y install locales && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
 
 CMD /root/run.py
 

--- a/src/dev/docker/haproxy.conf
+++ b/src/dev/docker/haproxy.conf
@@ -39,9 +39,13 @@ backend proxy
     timeout server 20s
     server proxy localhost:5001 cookie server:localhost:5000 check inter 4000 maxconn 10000
 
+frontend http
+    bind *:80
+    # permanent redirect to https
+    redirect scheme https code 301
+
 frontend https
     bind *:443 ssl crt /nopassphrase.pem no-sslv3
-    bind *:80
     timeout client 120s
 
     # we don't want to show known users the landing page -- hence redirect based on a cookie

--- a/src/dev/docker/haproxy.conf
+++ b/src/dev/docker/haproxy.conf
@@ -41,8 +41,15 @@ backend proxy
 
 frontend http
     bind *:80
+
+    # acme request path (for ssl certificates)
+    acl is_acme path_beg /.well-known/acme-challenge
+
     # permanent redirect to https
-    redirect scheme https code 301
+    redirect scheme https code 301 if !is_acme
+
+    # static serve acme request
+    use_backend static if is_acme
 
 frontend https
     bind *:443 ssl crt /nopassphrase.pem no-sslv3

--- a/src/dev/docker/haproxy.conf
+++ b/src/dev/docker/haproxy.conf
@@ -52,7 +52,7 @@ frontend http
     use_backend static if is_acme
 
 frontend https
-    bind *:443 ssl crt /nopassphrase.pem no-sslv3
+    bind *:443 ssl crt /run/haproxy.pem no-sslv3
     timeout client 120s
 
     # we don't want to show known users the landing page -- hence redirect based on a cookie

--- a/src/dev/docker/haproxy.conf
+++ b/src/dev/docker/haproxy.conf
@@ -1,5 +1,8 @@
 global
     tune.ssl.default-dh-param 2048
+    # NOTE: haproxy can only log to syslog or a unix socket
+    # needs a syslog daemon !
+    log localhost local0
 
 defaults
     log global
@@ -39,7 +42,6 @@ backend proxy
 frontend https
     bind *:443 ssl crt /nopassphrase.pem no-sslv3
     bind *:80
-    reqadd X-Forwarded-Proto:\ https
     timeout client 120s
 
     # we don't want to show known users the landing page -- hence redirect based on a cookie
@@ -58,11 +60,17 @@ frontend https
 
     # replace "/policies/" with "/static/policies/" at the beginning of any request path.
     reqrep ^([^\ :]*)\ /policies/(.*)     \1\ /static/policies/\2
+
+    reqadd X-Forwarded-Proto:\ https
+
     acl is_static path_beg /static
     use_backend static if is_static
+
     acl is_hub path_beg /customize /hub /cookies /blobs /api /invoice /upload /alive /auth /stats /registration /projects /help /settings
     use_backend hub if is_hub
+
     acl is_proxy path_reg ^/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/port
     acl is_proxy path_reg ^/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/raw
     use_backend proxy if is_proxy
+
     default_backend static

--- a/src/dev/docker/makefile
+++ b/src/dev/docker/makefile
@@ -1,9 +1,9 @@
 build:
-	docker build -t smc .
+	docker build -t cocalc .
 
 build-full:
-	docker build --no-cache -t smc .
+	docker build --no-cache -t cocalc .
 
 run:
-	mkdir -p ../../data/projects && docker run -v `pwd`/../../data/projects:/projects -P smc
+	mkdir -p ../../data/projects && docker run -v `pwd`/../../data/projects:/projects -P cocalc
 

--- a/src/dev/docker/nginx.conf
+++ b/src/dev/docker/nginx.conf
@@ -7,5 +7,11 @@ server {
                 rewrite ^/static/(.*) /$1;
                 try_files $uri $uri/ =404;
         }
+
         location / {}  # Needed for access to the index.htm
+
+        # acme request path (for ssl certificates)
+        location /.well-known/acme-challenge {
+                alias /run/acme-challenge;
+        }
 }

--- a/src/dev/docker/run.py
+++ b/src/dev/docker/run.py
@@ -89,7 +89,15 @@ def root_ssh_keys():
     run("cp -v /root/.ssh/id_ecdsa.pub /root/.ssh/authorized_keys")
 
 def start_hub():
-    run(". smc-env && hub start --host=localhost --port 5000 --proxy_port 5001 --update --single --logfile /var/log/hub.log --pidfile /root/hub.pid &", path='/cocalc/src')
+    run(". smc-env && hub start \
+            --host=localhost \
+            --port 5000 \
+            --proxy_port 5001 \
+            --update \
+            --single \
+            --logfile /var/log/hub.log \
+            --pidfile /run/hub.pid &", \
+        path='/cocalc/src')
 
 def postgres_perms():
     run("mkdir -p /projects/postgres && chown -R sage. /projects/postgres && chmod og-rwx -R /projects/postgres")
@@ -122,7 +130,7 @@ def tail_logs():
     run("tail -f /var/log/compute.log /var/log/compute.err /cocalc/logs/*")
 
 def main():
-    self_signed_cert('/nopassphrase.pem')
+    self_signed_cert('/run/haproxy.pem')
     init_projects_path()
     start_services()
     root_ssh_keys()


### PR DESCRIPTION
Several improvements and cleanup for the docker image:
 * avoid warnings in haproxy
 * use haproxy for the http->https redirect
 * set up acme-challenge to allow using an acme client to obtain certificates from letsencrypt
 * move some runtime files into /run, for consistency (intent is to put /run in a tmpfs)
 * in the Dockerfile, have the configuration files be last so changes don't spoil the docker cache
 * use "cocalc" for the image name in makefile, instead of "smc"