### PR TITLE
project/local_hub: idea for a simple health check

### DIFF
--- a/src/smc-project/kucalc.coffee
+++ b/src/smc-project/kucalc.coffee
@@ -114,4 +114,19 @@ exports.init_gce_firewall_test = (logger, interval_ms=60*1000) ->
     setInterval(test_firewall, interval_ms)
     return
 
+# called inside raw_server
+exports.init_health_metrics = (raw_server) ->
+    return if not exports.IN_KUCALC
 
+    # Setup health and metrics (no url base prefix needed)
+    raw_server.use '/health', (req, res) ->
+        res.setHeader("Content-Type", "text/plain")
+        res.setHeader('Cache-Control', 'private, no-cache, must-revalidate')
+        res.send('OK')
+
+    # prometheus text format -- https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details
+    raw_server.use '/metrics', (req, res) ->
+        res.setHeader("Content-Type", "text/plain; version=0.0.4")
+        res.setHeader('Cache-Control', 'private, no-cache, must-revalidate')
+        {get_bugs_total} = require('./local_hub')
+        res.send("kucalc_project_bugs_total #{get_bugs_total()}\n")

--- a/src/smc-project/local_hub.coffee
+++ b/src/smc-project/local_hub.coffee
@@ -16,6 +16,9 @@ doing a lot of IO-based things is what Node.JS is good at.
 
 require('coffee-cache').setCacheDir("#{process.env.HOME}/.coffee")
 
+
+BUG_COUNTER = 0
+
 process.addListener "uncaughtException", (err) ->
     winston.debug("BUG ****************************************************************************")
     winston.debug("Uncaught exception: " + err)
@@ -23,6 +26,10 @@ process.addListener "uncaughtException", (err) ->
     winston.debug("BUG ****************************************************************************")
     if console? and console.trace?
         console.trace()
+    BUG_COUNTER += 1
+
+exports.get_bugs_total = ->
+    return BUG_COUNTER
 
 path    = require('path')
 async   = require('async')

--- a/src/smc-project/raw_server.coffee
+++ b/src/smc-project/raw_server.coffee
@@ -63,6 +63,9 @@ exports.start_raw_server = (opts) ->
             base = "#{base_url}/#{project_id}/raw/"
             opts.logger?.info("raw server: port=#{port}, host='#{host}', base='#{base}'")
 
+            {init_health_metrics} = require('./kucalc')
+            init_health_metrics(raw_server)
+
             # Setup the /.smc/jupyter/... server, which is used by our jupyter server for blobs, etc.
             raw_server.use(base, jupyter_router(express))
 


### PR DESCRIPTION
This adds two endpoints to the local hub raw server in a project.

* only if `IN_KUCALC` is true (so, when testing, I did comment out the check in the init function)
* health: returns 200 and OK, should be useful for k8s
* metrics: returns the prometheus stats, for now not much there, but that's for later.

How I tested it in cocalc is to query the endpoint from within a terminal, i.e.:

```
$ curl http://localhost:`cat ~/.smc/local_hub/raw.port`/metrics
kucalc_project_bugs_total 0

$ curl http://localhost:`cat ~/.smc/local_hub/raw.port`/health
OK
```