### PR TITLE
webapp: kucalc infrastructure change warning banner, and changing entry in account.other_settings to be a (string) timestamp instead of a boolean (one step towards #1982)

### DIFF
--- a/src/smc-util/db-schema.coffee
+++ b/src/smc-util/db-schema.coffee
@@ -244,7 +244,7 @@ schema.accounts =
                     page_size         : 50
                     standby_timeout_m : 10
                     default_file_sort : 'time'
-                    show_global_info  : true
+                    show_global_info2 : null
                 first_name      : ''
                 last_name       : ''
                 terminal        :

--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -444,10 +444,10 @@ exports.GlobalInformationMessage = rclass
     displayName: 'GlobalInformationMessage'
 
     dismiss: ->
-        redux.getTable('account').set(other_settings:{show_global_info:false})
+        redux.getTable('account').set(other_settings:{show_global_info2:webapp_client.server_time()})
 
     render: ->
-        more_url = 'https://github.com/sagemathinc/cocalc/wiki/CoCalc'
+        more_url = 'https://github.com/sagemathinc/cocalc/wiki/KubernetesMigration'
         bgcol = COLORS.YELL_L
         style =
             padding         : '5px 0 5px 5px'
@@ -461,7 +461,8 @@ exports.GlobalInformationMessage = rclass
 
         <Row style={style}>
             <Col sm={9} style={paddingTop: 3}>
-                <p>Welcome to <strong>CoCalc</strong>! SageMathCloud outgrew itself and changed its name.
+                <p>Upcoming <strong><a target='_blank' href={more_url}>Kubernetes Migration</a></strong>!
+                {' '}The entire CoCalc infrastructure will be upgraded soon.
                 {' '}<a target='_blank' href={more_url}>Read more...</a></p>
             </Col>
             <Col sm={3}>

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -92,6 +92,7 @@ Page = rclass
             user_type    : rtypes.string # Necessary for is_logged_in
             is_logged_in : rtypes.func
             other_settings : rtypes.object
+            is_global_info_visible : rtypes.func
         support :
             show : rtypes.bool
 
@@ -197,7 +198,7 @@ Page = rclass
             width         : '100vw'
             overflow      : 'hidden'
 
-        show_global_info = (@props.other_settings.show_global_info ? false) and (not @props.fullscreen) and @props.is_logged_in()
+        show_global_info = @props.is_global_info_visible() and (not @props.fullscreen) and @props.is_logged_in()
 
         style_top_bar =
             display       : 'flex'

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -974,6 +974,10 @@ OtherSettings = rclass
         other_settings : rtypes.object
         redux          : rtypes.object
 
+    reduxProps :
+        account :
+            is_global_info_visible : rtypes.func
+
     on_change: (name, value) ->
         @props.redux.getTable('account').set(other_settings:{"#{name}":value})
 
@@ -1006,9 +1010,9 @@ OtherSettings = rclass
                 Mask files: grey-out files in the files viewer that you probably do not want to open
             </Checkbox>
             <Checkbox
-                checked  = {@props.other_settings.show_global_info}
-                ref      = 'show_global_info'
-                onChange = {(e)=>@on_change('show_global_info', e.target.checked)}
+                checked  = {@props.is_global_info_visible()}
+                ref      = 'show_global_info2'
+                onChange = {(e)=>@on_change('show_global_info2', if e.target.checked then null else webapp_client.server_time())}
             >
                 Show global information: if enabled, a dismissible banner is visible on top
             </Checkbox>

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -257,11 +257,19 @@ class AccountStore extends Store
     get_page_size: =>
         return @getIn(['other_settings', 'page_size']) ? 50  # at least have a valid value if loading...
 
+    is_global_info_visible: =>
+        # TODO when there is more time, rewrite this to be tied to announcements of a specific type (and use their timestamps)
+        # for now, we use the existence of a timestamp value to indicate that the banner is not shown
+        sgi2 = @getIn(['other_settings', 'show_global_info2'])
+        if sgi2 == 'loading'   # unknown state, right after opening the application
+            return false
+        return not sgi2?   # undefined means to show the banner, for now
+
 # Register account store
 # Use the database defaults for all account info until this gets set after they login
 init = misc.deep_copy(require('smc-util/schema').SCHEMA.accounts.user_query.get.fields)
-# ... except for show_global_info
-init.other_settings.show_global_info = false
+# ... except for show_global_info2 (null or a timestamp)
+init.other_settings.show_global_info2 = 'loading' # indicates it is starting up
 init.user_type = if misc.get_local_storage(remember_me) then 'signing_in' else 'public'  # default
 redux.createStore('account', AccountStore, init)
 


### PR DESCRIPTION
all this is still confusing, but apart from further cleanup and enhancing this in a way that #1982 is solved, I hope this does its job.

test:
* nothing set, don't show banner it initially and then it comes up when it is certain that there is no timestamp in the DB
* timestamp set in DB: initially no banner, and still none once data is loaded.
* toggling in the account settings works as expected

includes a slight db-schema change!