### PR TITLE
db query fix

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -1672,7 +1672,7 @@ class exports.PostgreSQL extends PostgreSQL
             cb         : required
         if not @_validate_opts(opts) then return
         @_query
-            query : "SELECT invite#>'{#{opts.to}}' AS to FROM projects"
+            query : "SELECT invite#>'{\"#{opts.to}\"}' AS to FROM projects"
             where : 'project_id :: UUID = $' : opts.project_id
             cb    : one_result 'to', (err, y) =>
                 opts.cb(err, if not y? or y.error or not y.time then 0 else new Date(y.time))


### PR DESCRIPTION
fix  string-interpolation that should result in a string for postgres containing a "-string for the key in a json object.

This is how I tested it:

```
coffee> opts = {}
{}
coffee> opts.to = 'test@email'
'test@email'
coffee> "SELECT invite#>'{\"#{opts.to}\"}' AS to FROM projects"
'SELECT invite#>\'{"test@email"}\' AS to FROM projects'
coffee> console.log("SELECT invite#>'{\"#{opts.to}\"}' AS to FROM projects")
SELECT invite#>'{"test@email"}' AS to FROM projects
```

