### PR TITLE
project ssh key note about account key

### DIFF
--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -1038,6 +1038,9 @@ SSHPanel = rclass
                 ssh_keys   = {@props.project.getIn(['users', webapp_client.account_id, 'ssh_keys'])}
                 delete_key = {@delete_ssh_key}
             >
+            <div>
+            <span>NOTE: If you want to use the same ssh key for all your projects, add a key using the "SSH Keys" tab under Account Settings. If you have done that, there is no need to configure an ssh key here.</span>
+            </div>
                 <SSHKeyAdder
                     add_ssh_key  = {@add_ssh_key}
                     toggleable   = {true}


### PR DESCRIPTION
Tell user who is about to add an ssh key for a project that it's possible to add key for all projects using account settings.

<img width="614" alt="add-account-key" src="https://user-images.githubusercontent.com/528072/29798295-e122dbac-8c21-11e7-954e-d407f632d4ab.png">
