### PR TITLE
webapp/course: a rename of status_map to status seems to be the culprit for 1547

### DIFF
--- a/src/smc-webapp/course/actions.coffee
+++ b/src/smc-webapp/course/actions.coffee
@@ -1498,16 +1498,16 @@ exports.CourseActions = class CourseActions extends Actions
             student = store.get_student(student)
             handout = store.get_handout(handout)
             obj = {table:'handouts', handout_id:handout.get('handout_id')}
-            status_map = @_get_one(obj)?.status_map
-            if not status_map?
+            status = @_get_one(obj)?.status
+            if not status?
                 return
-            student_status = (status_map[student.get('student_id')])
+            student_status = (status[student.get('student_id')])
             if not student_status?
                 return
             if student_status.start?
                 delete student_status.start
-                status_map[student.get('student_id')] = student_status
-                obj.status_map = status_map
+                status[student.get('student_id')] = student_status
+                obj.status = status
                 @_set(obj)
 
     # Copy the files for the given handout to the given student. If


### PR DESCRIPTION
see #1547

test: assign handouts and immediately refresh the site. that causes you to show these stale distribute buttons. with that patch, clicking on cancel at least let's you to get out of this stuck state. (in the future we can figure out how to properly sync this, but that's out of the scope here)

process: at some point, `status_map` must have been renamed to `status`. that causes the code to exit the function because the status is always undefined.

time: 30 min