### PR TITLE
support: replace or add ?session=support to the support requests or included URLs in the body

### DIFF
--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -67,9 +67,10 @@
     "sinon": "^1.15.3"
   },
   "scripts": {
-    "test": "(npm run testpg && npm run testapi); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
+    "test": "(npm run testpg && npm run testapi && npm run testmisc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres",
     "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/api",
+    "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",
     "lint": "node_modules/.bin/coffeelint -f ../smc-util/coffeelint.json -c *.coffee"
   },

--- a/src/smc-hub/support.coffee
+++ b/src/smc-hub/support.coffee
@@ -32,6 +32,38 @@ if not SMC_TEST
 zendesk_password_filename = ->
     return (process.env.SMC_ROOT ? '.') + '/data/secrets/zendesk'
 
+fixSessions = (body) ->
+    # takes the body of the ticket, searches for http[s]://<theme.DNS>/ URLs and either replaces ?session=* by ?session=support or adds it
+    body = body.replace(/\?session=([^\s]*)/g, '?session=support')
+
+    urlPattern = new RegExp("(http[s]?://[^\\s]*#{theme.DNS}[^\\s]+)", "g")
+    reSession = /session=([^\s]*)/g
+
+    ret = ''
+    offset = 0
+
+    while m = urlPattern.exec(body)
+        url = m[0]
+        i = m.index
+        j = i + url.length
+        #console.log(i, j)
+        #console.log(x[i..j])
+
+        ret += body[offset...i]
+
+        q = url.indexOf('?session')
+        if q >= 0
+            url = url[0...q]
+        q = url.indexOf('?')
+        if q >= 0
+            url += '&session=support'
+        else
+            url += '?session=support'
+        ret += url
+        offset = j
+    ret += body[offset...body.length]
+    return ret
+
 support = undefined
 exports.init_support = (cb) ->
     support = new Support cb: (err, s) =>
@@ -213,16 +245,19 @@ class Support
         remaining_info = _.omit(opts.info, _.keys(cus_fld_id))
         custom_fields.push(id: cus_fld_id.info, value: JSON.stringify(remaining_info))
 
+        # fix any copy/pasted links from inside the body of the message to replace an optional session
+        body = fixSessions(opts.body)
+
         # below the body message, add a link to the location
         # TODO fix hardcoded URL
         if opts.location?
             url  = "https://" + path.join(theme.DNS, opts.location)
-            body = opts.body + "\n\n#{url}"
+            body = body + "\n\n#{url}?session=support"
         else
-            body = opts.body + "\n\nNo location provided."
+            body = body + "\n\nNo location provided."
 
         if misc.is_valid_uuid_string(opts.info.course)
-            body += "\n\nCourse: #{theme.DOMAIN_NAME}/projects/#{opts.info.course}"
+            body += "\n\nCourse: #{theme.DOMAIN_NAME}/projects/#{opts.info.course}?session=support"
 
         # https://developer.zendesk.com/rest_api/docs/core/tickets#request-parameters
         ticket =
@@ -283,3 +318,5 @@ class Support
         )
 
 
+if SMC_TEST
+    exports.fixSessions = fixSessions

--- a/src/smc-hub/test/misc/support.coffee
+++ b/src/smc-hub/test/misc/support.coffee
@@ -1,0 +1,40 @@
+expect  = require('expect')
+
+support = require('../../support')
+
+{DNS} = require('smc-util/theme')
+
+body1 = """
+foo foo foo
+aasdf  ölkj ölkj ölkj
+bar https://cocalc.com/projects/14eed217-2d3c-4975-a381-b69edcb40e0e/files/scratch/coffee.sagews?session=default  baz
+https://this.not.com/asdf not
+or http://www.cocalc.com/asdf?something=123
+and this: https://cocalc.com/asdfasdfsafd/asdf.xx
+baz
+"""
+
+body1_exp = """
+foo foo foo
+aasdf  ölkj ölkj ölkj
+bar https://cocalc.com/projects/14eed217-2d3c-4975-a381-b69edcb40e0e/files/scratch/coffee.sagews?session=support  baz
+https://this.not.com/asdf not
+or http://www.cocalc.com/asdf?something=123&session=support
+and this: https://cocalc.com/asdfasdfsafd/asdf.xx?session=support
+baz
+"""
+
+describe 'support fixSessions -- ', ->
+    fs = support.fixSessions
+
+    it "detects http #{DNS}", ->
+        expect(fs("foo http://#{DNS}/foo bar")).toBe("foo http://#{DNS}/foo?session=support bar")
+    it "detects https #{DNS}", ->
+        expect(fs("foo https://#{DNS}/foo bar")).toBe("foo https://#{DNS}/foo?session=support bar")
+
+    it "ignores other domains", ->
+        x = "test https://bazbar.info/ next"
+        expect(fs(x)).toBe(x)
+
+    it 'body1', ->
+        expect(fs(body1)).toBe(body1_exp)


### PR DESCRIPTION
(this ticket also enabled hub/misc tests!)

This is mainly to help us with support, and I gave it a brief dry run and added some tests (4 postgres tests fail for me, though, so that's why `npm run testmisc` is all there is for this)

