### PR TITLE
change nargs for `public_get_text_file` mocha test

### DIFF
--- a/src/smc_pyutil/smc_pyutil/smc_compute.py
+++ b/src/smc_pyutil/smc_pyutil/smc_compute.py
@@ -940,7 +940,7 @@ def main():
                 print json.dumps(out)
             if errors:
                 sys.exit(1)
-        subparser.add_argument("project_id", help="UUID of project", type=str, nargs="*")
+        subparser.add_argument("project_id", help="UUID of project", type=str, nargs="+")
         subparser.set_defaults(func=g)
 
     # optional arguments to all subcommands


### PR DESCRIPTION
Please review. I am have confirmed that this 1-character change fixes the problem in #2348, e.g.
```
# start test postgresql in background...
~/cocalc/src/smc-hub$ mocha --opts test/mocha.opts test/api/text_files.coffee
 ==>
12 passing (6s)
```

If I understand the change to `nargs` correctly, it _should_ be benign for other cases, e.g. kucalc testing, but it should be reviewed.