### PR TITLE
jupyter2: special case regarding processing ?/?? help for the language "prolog"

### DIFF
--- a/src/smc-webapp/jupyter/actions.coffee
+++ b/src/smc-webapp/jupyter/actions.coffee
@@ -703,7 +703,9 @@ class exports.JupyterActions extends Actions
         switch cell_type
             when 'code'
                 code = @_get_cell_input(id).trim()
-                switch parsing.run_mode(code, @store.getIn(['cm_options', 'mode', 'name']))
+                cm_mode = @store.getIn(['cm_options', 'mode', 'name'])
+                language = @store.getIn(['kernel_info', 'language'])
+                switch parsing.run_mode(code, cm_mode, language)
                     when 'show_source'
                         @introspect(code.slice(0,code.length-2), 1)
                     when 'show_doc'

--- a/src/smc-webapp/jupyter/parsing.coffee
+++ b/src/smc-webapp/jupyter/parsing.coffee
@@ -10,18 +10,14 @@ last_style = (code, mode='python') ->
         style = s
     return style
 
-exports.run_mode = (code, mode) ->
+exports.run_mode = (code, mode, language) ->
     if not code  # code assumed trimmed
         return 'empty'
-    else if misc.endswith(code, '??')
+    else if language != 'prolog'
         if last_style(code, mode) in ['comment', 'string']
             return 'execute'
-        else
+        else if misc.endswith(code, '??')
             return 'show_source'
-    else if misc.endswith(code, '?')
-        if last_style(code, mode) in ['comment', 'string']
-            return 'execute'
-        else
+        else if misc.endswith(code, '?')
             return 'show_doc'
-    else
-        return 'execute'
+    return 'execute'


### PR DESCRIPTION
se issue #2233

process: the main feature of prolog is to answer questions about some believes. in calisto, these questions end with a questionmark. this jupyter implementation triggers introspection when the code line ends with a questionmark regardless of which programming language we deal with ... that's not going to work. (https://github.com/Calysto/calysto_prolog)

test:
* `has(a, b).`
* `has(a, b)?` → true

