### PR TITLE
Don't show extension warning for urls in new file

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -1776,10 +1776,13 @@ exports.peer_grading_demo = (S = 10, N = 2) ->
 exports.ticket_id_to_ticket_url = (tid) ->
     return "https://sagemathcloud.zendesk.com/requests/#{tid}"
 
+# Checks if the string only makes sense (heuristically) as downloadable url
+is_only_downloadable = (string) ->
+    string.indexOf('://') != -1 or exports.startswith(string, 'git@github.com')
+
 # Apply various transformations to url's before downloading a file using the "+ New" from web thing:
 # This is useful, since people often post a link to a page that *hosts* raw content, but isn't raw
 # content, e.g., ipython nbviewer, trac patches, github source files (or repos?), etc.
-
 exports.transform_get_url = (url) ->  # returns something like {command:'wget', args:['http://...']}
     URL_TRANSFORMS =
         'http://trac.sagemath.org/attachment/ticket/'  :'http://trac.sagemath.org/raw-attachment/ticket/'

--- a/src/smc-webapp/project_new.cjsx
+++ b/src/smc-webapp/project_new.cjsx
@@ -250,7 +250,7 @@ ProjectNewForm = rclass ({name}) ->
             @create_file(ext)
         else if @state.filename[@state.filename.length - 1] == '/'
             @create_folder()
-        else if misc.filename_extension(@state.filename) or @state.filename.indexOf("http") == 0
+        else if misc.filename_extension(@state.filename) or misc.is_only_downloadable(@state.filename)
             @create_file()
         else
             @setState(extension_warning : true)

--- a/src/smc-webapp/project_new.cjsx
+++ b/src/smc-webapp/project_new.cjsx
@@ -250,7 +250,7 @@ ProjectNewForm = rclass ({name}) ->
             @create_file(ext)
         else if @state.filename[@state.filename.length - 1] == '/'
             @create_folder()
-        else if misc.filename_extension(@state.filename)
+        else if misc.filename_extension(@state.filename) or @state.filename.indexOf("http") == 0
             @create_file()
         else
             @setState(extension_warning : true)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1123,7 +1123,7 @@ class ProjectActions extends Actions
         if (name == ".." or name == ".") and not opts.ext?
             @setState(file_creation_error: "Cannot create a file named . or ..")
             return
-        if name.indexOf('://') != -1 or misc.startswith(name, 'git@github.com')
+        if misc.is_only_downloadable(name)
             @new_file_from_web(name, opts.current_path)
             return
         if name[name.length - 1] == '/'


### PR DESCRIPTION
Fixes #2322. 

Shows no warning since the text already offers URLs as a valid option to enter. You hit enter or create and you'll be redirected to the project files page and a `downloading [url]...` notification in the upper right.