### PR TITLE
fix for empty files list

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -1560,8 +1560,8 @@ class exports.PostgreSQL extends PostgreSQL
                     # some files in the listing might not be public, since the containing path isn't public, so we filter
                     # WARNING: this is kind of stupid since misc.path_is_in_public_paths is badly implemented, especially
                     # for this sort of iteration.  TODO: make this faster.  This could matter since is done on server.
-                    if not misc.is_array(listing?.files?)  # There is no telling what listing actually is, so be careful.
-                        listing.files = {files:[]}
+                    if not listing?.files?[0]?  # There is no telling what listing actually is, so be careful.
+                        listing.files = []
                     else
                         listing.files = (x for x in listing.files when \
                             misc.path_is_in_public_paths(misc.path_to_file(opts.path, x.name), public_paths))


### PR DESCRIPTION
Ref: #2370.
All api mocha tests pass with this change. There is something odd, though. Please see second item.

1. The change at line 1564, `listing.files = []`, looks ok to me, but...

1. After adding the above change, but without the change at line 1563, another test fails that should pass. If the public path requested exists and contains a file, the value of listing just before line 1563 is (correctly) displayed by console.log as

    ```
    {"files":[{"size":11,"name":"doc1.txt","mtime":1505195811}]}
    ```
but the test for `if not misc.is_array(listing?.files?)` succeeds, causing the API call to return an empty files list. This problem is eliminated by the change to line 1563, `if not listing?.files?[0]?`.