### PR TITLE
webapp/latex: exclusive lock to avoid concurrent latex operations

### DIFF
--- a/src/smc-webapp/latex/document.coffee
+++ b/src/smc-webapp/latex/document.coffee
@@ -270,16 +270,28 @@ class exports.PDFLatexDocument
         sha_marker = misc.uuid()
         @_need_to_run ?= {}
         @_need_to_run.latex = false
+        # exclusive lock, wait 5 secs to run or fail, exit code on timeout acquiring lock is 99,
+        # release read lock to avoid stuck subprocesses to interfere, file descriptor 9 points to lockfile (derived from tex file)
+        flock = "flock -x -o -w 5 9 || exit 99;"
         # yes x business recommended by http://tex.stackexchange.com/questions/114805/pdflatex-nonstopmode-with-tikz-stops-compiling
-        latex_cmd = "yes x 2> /dev/null | #{command}; echo '#{sha_marker}'; test -r '#{sagetex_file}' && sha1sum '#{sagetex_file}'"
+        latex_cmd = "( #{flock} yes x 2> /dev/null | #{command}; echo '#{sha_marker}'; test -r '#{sagetex_file}' && sha1sum '#{sagetex_file}' ) 9> '.#{@filename_tex}.lock'"
+        #if DEBUG then console.log("_run_latex cmd:", latex_cmd)
         @_exec
             command     : latex_cmd
             bash        : true
-            timeout     : 30
+            timeout     : 45
             err_on_exit : false
             cb          : (err, output) =>
+                #if DEBUG then console.log("_run_latex done: output=", output, ", err=", err)
                 if err
                     cb?(err)
+                else if output.exit_code == 99
+                    #if DEBUG then console.log("_run_latex: most likely there was a lock-acquiring timeout.")
+                    # TODO schedule a retry?
+                    log = 'Timeout: ongoing concurrent LaTeX operation.'
+                    log += '\n\n' + output.stdout + '\n\n' + output.stderr
+                    @last_latex_log = log
+                    cb?(false, log)
                 else
                     i = output.stdout.lastIndexOf(sha_marker)
                     if i != -1


### PR DESCRIPTION
this is the idea for #2379 I had some time ago to avoid this.

test: open same tex file in two tabs, next to each other, and you'll should able to trigger timeout errors. edit the latex compile command by adding `sleep 5; <latex command>; sleep 5` to slow it down!

process: to understand what's going on, run this line in two terminals at the same time: `(flock -E 99 -x -o -w 5 9 || exit 1; echo "a"; sleep 10; echo "c") 9> l1` and check the exit code via `echo $?`.