### PR TITLE
landing page: embed mark quinn video with dynamic sizing

### DIFF
--- a/src/webapp-lib/_base.pug
+++ b/src/webapp-lib/_base.pug
@@ -137,7 +137,16 @@ html.no-js(lang="en")
             visibility     : visible
             &:hover
               color        : $COL_GRAY
+        .youtube-video-container
+          width            : 100%
+          height           : 0
+          padding-bottom   : 56.25%
+          overflow         : hidden
 
+          iframe, object, embed
+            position   : absolute
+            width      : 95%
+            height     : 95%
 
     script
       :coffee-script

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -48,7 +48,11 @@ block content
       div.col-md-12.center
         h1 Online computing environment
       div.col-sm-6
-        img(src=require('!file-loader!sagepreview/01-worksheet.png'))
+        //- img(src=require('!file-loader!sagepreview/01-worksheet.png'))
+        div.
+          Intro to CoCalc (credits: Mark Quinn, University of Sheffield)
+        div.youtube-video-container
+          iframe(src="https://www.youtube.com/embed/fHr0LFjE8Uk?rel=0" frameborder="0" allowfullscreen)
       div.col-sm-6
         p #{NAME} is a #[strong sophisticated web service] for online computation:
         ul


### PR DESCRIPTION
this replaces the static image with the mark quinn intro video. Adds credits and dynamically scales. This scaling should be tested in browsers. (I'll do it later, still setting it to review ... we should only merge if we're sure the landing page isn't too distorted by that in a common browser)