### PR TITLE
eliminate deprecation for mocha test on compiler option

### DIFF
--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "test": "(npm run testpg && npm run testapi && npm run testmisc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres",
-    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/api",
+    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/api/*.coffee",
     "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",
     "lint": "node_modules/.bin/coffeelint -f ../smc-util/coffeelint.json -c *.coffee"

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -68,9 +68,9 @@
   },
   "scripts": {
     "test": "(npm run testpg && npm run testapi && npm run testmisc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
-    "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres",
+    "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres/*.coffee",
     "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/api/*.coffee",
-    "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc",
+    "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",
     "lint": "node_modules/.bin/coffeelint -f ../smc-util/coffeelint.json -c *.coffee"
   },

--- a/src/smc-hub/test/mocha.opts
+++ b/src/smc-hub/test/mocha.opts
@@ -1,4 +1,4 @@
---compilers coffee:coffee-script/register
+--require coffee-script/register
 --reporter spec
 --recursive
 


### PR DESCRIPTION
Ref #2415.

Note: most tests in src/smc-hub/test/api hang after the tests pass. That is a separate issue independent of #2415 