### PR TITLE
webapp/top bar: show avatar and account instead of name

### DIFF
--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -36,6 +36,7 @@
 {AccountPage}  = require('./account_page') # SMELL: Not used but gets around a webpack error..
 {FileUsePage}  = require('./file_use')
 {Support}      = require('./support')
+{Avatar}       = require('./other-users')
 
 # CoCalc Libraries
 misc = require('smc-util/misc')
@@ -86,6 +87,7 @@ Page = rclass
             file_use         : rtypes.immutable.Map
             get_notify_count : rtypes.func
         account :
+            account_id   : rtypes.string
             first_name   : rtypes.string # Necessary for get_fullname
             last_name    : rtypes.string # Necessary for get_fullname
             get_fullname : rtypes.func
@@ -108,14 +110,19 @@ Page = rclass
             name = misc.trunc_middle(@props.get_fullname(), 32)
         if not name.trim()
             name = "Account"
-
         return name
 
     render_account_tab: ->
+        if @props.account_id
+            a = <Avatar
+                    size        = {20}
+                    account_id  = {@props.account_id}  />
+        else
+            a = 'cog'
         <NavTab
             name           = 'account'
-            label          = {@account_name()}
-            icon           = 'cog'
+            label          = {'Account'}           # @account_name()
+            icon           = {a}
             actions        = {@actions('page')}
             active_top_tab = {@props.active_top_tab}
         />


### PR DESCRIPTION
this is quick idea how to make it clear that this is for the account settings, while keeping the ui personalized.

![screenshot from 2017-11-01 22-10-15](https://user-images.githubusercontent.com/207405/32298070-7b17eaf6-bf51-11e7-9727-e0c640a10cf9.png)
