### PR TITLE
webapp/project: calculate a "slowdown" estimate depending on quotas.core and normalized load 5

### DIFF
--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -246,7 +246,7 @@ FreeProjectWarning = rclass ({name}) ->
 
         if @props.free_compute_slowdown? and @props.free_compute_slowdown > 0.0
             pct = Math.round(@props.free_compute_slowdown)
-            slowdown = <span>and due to heavy load, computations in this project are running <b>{pct}% slower than they would on a members server</b>.</span>
+            slowdown = <span>and computations in this project could run up to <b>{pct}% faster after upgrading</b> to member server hosting.</span>
         else
             slowdown = ''
 

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -246,12 +246,12 @@ FreeProjectWarning = rclass ({name}) ->
 
         if @props.free_compute_slowdown? and @props.free_compute_slowdown > 0.0
             pct = Math.round(@props.free_compute_slowdown)
-            slowdown = <span>and due to heavy load, computations on this project are currently <b>{pct}% slower than they would be on a members server</b>.</span>
+            slowdown = <span>Due to heavy load, computations in this project are running <b>{pct}% slower than they would on a members server</b>.</span>
         else
             slowdown = ''
 
         <Alert bsStyle='warning' style={styles}>
-            <Icon name='exclamation-triangle' /> WARNING: This project runs {<span>on a <b>free server</b> (which may become unavailable) {slowdown}</span> if host} {<span>without <b>internet access</b></span> if internet} &mdash;
+            <Icon name='exclamation-triangle' /> WARNING: This project runs {<span>on a <b>free server</b></span> if host} {<span>without <b>internet access</b></span> if internet} {slowdown if host} &mdash;
             <a onClick={=>@actions(project_id: @props.project_id).show_extra_free_warning()} style={cursor:'pointer'}> learn more...</a>
             <a style={dismiss_styles} onClick={@actions(project_id: @props.project_id).close_free_warning}>×</a>
             {@extra(host, internet)}

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -246,7 +246,7 @@ FreeProjectWarning = rclass ({name}) ->
 
         if @props.free_compute_slowdown? and @props.free_compute_slowdown > 0.0
             pct = Math.round(@props.free_compute_slowdown)
-            slowdown = <span>and due to heavy load your computations are currently <b>slowed down by at least {pct}%</b>.</span>
+            slowdown = <span>and due to heavy load, computations on this project are currently <b>{pct}% slower than they would be on a members server</b>.</span>
         else
             slowdown = ''
 

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -246,7 +246,7 @@ FreeProjectWarning = rclass ({name}) ->
 
         if @props.free_compute_slowdown? and @props.free_compute_slowdown > 0.0
             pct = Math.round(@props.free_compute_slowdown)
-            slowdown = <span>Due to heavy load, computations in this project are running <b>{pct}% slower than they would on a members server</b>.</span>
+            slowdown = <span>and due to heavy load, computations in this project are running <b>{pct}% slower than they would on a members server</b>.</span>
         else
             slowdown = ''
 

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -185,6 +185,7 @@ FreeProjectWarning = rclass ({name}) ->
         "#{name}" :
             free_warning_extra_shown : rtypes.bool
             free_warning_closed      : rtypes.bool
+            free_compute_slowdown    : rtypes.number
 
     propTypes:
         project_id : rtypes.string
@@ -192,6 +193,7 @@ FreeProjectWarning = rclass ({name}) ->
     shouldComponentUpdate: (nextProps) ->
         return @props.free_warning_extra_shown != nextProps.free_warning_extra_shown or
             @props.free_warning_closed != nextProps.free_warning_closed or
+            @props.free_compute_slowdown != nextProps.free_compute_slowdown or
             @props.project_map?.get(@props.project_id)?.get('users') != nextProps.project_map?.get(@props.project_id)?.get('users')
 
     extra: (host, internet) ->
@@ -241,8 +243,15 @@ FreeProjectWarning = rclass ({name}) ->
             color      : 'grey'
             position   : 'relative'
             height     : 0
+
+        if @props.free_compute_slowdown? and @props.free_compute_slowdown > 0.0
+            pct = Math.round(@props.free_compute_slowdown)
+            slowdown = <span>and due to heavy load your computations are currently <b>slowed down by at least {pct}%</b>.</span>
+        else
+            slowdown = ''
+
         <Alert bsStyle='warning' style={styles}>
-            <Icon name='exclamation-triangle' /> WARNING: This project runs {<span>on a <b>free server (which may be unavailable during peak hours)</b></span> if host} {<span>without <b>internet access</b></span> if internet} &mdash;
+            <Icon name='exclamation-triangle' /> WARNING: This project runs {<span>on a <b>free server</b> (which may become unavailable) {slowdown}</span> if host} {<span>without <b>internet access</b></span> if internet} &mdash;
             <a onClick={=>@actions(project_id: @props.project_id).show_extra_free_warning()} style={cursor:'pointer'}> learn more...</a>
             <a style={dismiss_styles} onClick={@actions(project_id: @props.project_id).close_free_warning}>×</a>
             {@extra(host, internet)}
@@ -434,11 +443,11 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
         page :
             fullscreen : rtypes.oneOf(['default', 'kiosk'])
         "#{name}" :
-            active_project_tab  : rtypes.string
-            open_files          : rtypes.immutable
-            open_files_order    : rtypes.immutable
-            free_warning_closed : rtypes.bool     # Makes bottom height update
-            num_ghost_file_tabs : rtypes.number
+            active_project_tab    : rtypes.string
+            open_files            : rtypes.immutable
+            open_files_order      : rtypes.immutable
+            free_warning_closed   : rtypes.bool     # Makes bottom height update
+            num_ghost_file_tabs   : rtypes.number
 
     propTypes :
         project_id : rtypes.string

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -947,6 +947,8 @@ ProjectSettingsBody = rclass ({name}) ->
             get_upgrades_you_applied_to_project : rtypes.func
             get_total_project_quotas : rtypes.func
             get_upgrades_to_project : rtypes.func
+        "#{name}" :
+            free_compute_slowdown    : rtypes.number
 
     shouldComponentUpdate: (nextProps) ->
         return @props.project != nextProps.project or @props.user_map != nextProps.user_map or \
@@ -968,7 +970,7 @@ ProjectSettingsBody = rclass ({name}) ->
         {commercial} = require('./customize')
 
         <div>
-            {if commercial and total_project_quotas? and not total_project_quotas.member_host then <NonMemberProjectWarning upgrade_type='member_host' upgrades_you_can_use={upgrades_you_can_use} upgrades_you_applied_to_all_projects={upgrades_you_applied_to_all_projects} course_info={course_info} account_id={webapp_client.account_id} email_address={@props.email_address}/>}
+            {if commercial and total_project_quotas? and not total_project_quotas.member_host then <NonMemberProjectWarning upgrade_type='member_host' upgrades_you_can_use={upgrades_you_can_use} upgrades_you_applied_to_all_projects={upgrades_you_applied_to_all_projects} course_info={course_info} account_id={webapp_client.account_id} email_address={@props.email_address} free_compute_slowdown={@props.free_compute_slowdown}/>}
             {if commercial and total_project_quotas? and not total_project_quotas.network then <NoNetworkProjectWarning upgrade_type='network' upgrades_you_can_use={upgrades_you_can_use} upgrades_you_applied_to_all_projects={upgrades_you_applied_to_all_projects} /> }
             {if @props.project.get('deleted') then <DeletedProjectWarning />}
             <h1 style={marginTop:"0px"}><Icon name='wrench' /> Settings and configuration</h1>

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1226,7 +1226,23 @@ class ProjectActions extends Actions
         {webapp_client} = require('./webapp_client')
         ncpu = undefined
 
-        # TODO figure out how to start and stop load estimation based on project state and member quota
+        ###
+        # Comment out f() at the bottom of init_free_compute_slowdown to use f_test
+        # Expect load to increase by 1% every second while load should be displayed
+        test_load = 0
+        f_test = =>
+            proj_store = @redux.getStore('projects')
+            quotas = proj_store.get_total_project_quotas(@project_id)
+            state  = proj_store.getIn(['project_map', @project_id, 'state', 'state'])
+            if state == 'running' and (quotas?) and (not quotas.member_host)
+                test_load = test_load + 1
+                @setState(free_compute_slowdown : test_load)
+            else
+                @setState(free_compute_slowdown : 0.0)
+            setTimeout(f_test, 1000)
+        f_test()
+        ###
+
         f = =>
             proj_store = @redux.getStore('projects')
             quotas = proj_store.get_total_project_quotas(@project_id)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1231,11 +1231,8 @@ class ProjectActions extends Actions
             proj_store = @redux.getStore('projects')
             quotas = proj_store.get_total_project_quotas(@project_id)
             state  = proj_store.getIn(['project_map', @project_id, 'state', 'state'])
-            if state != 'running'
-                @setState(free_compute_slowdown : undefined)
-                return # end tail recursion
             # project running and not on a members host
-            if (quotas?) and (not quotas.member_host)
+            if state == 'running' and (quotas?) and (not quotas.member_host)
                 webapp_client.exec
                     project_id   : @project_id
                     command      : '/bin/cat'

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1218,10 +1218,10 @@ class ProjectActions extends Actions
                 cb?(err)
 
     # slowdown is an estimate how much longer computations take -- unit is percent
+    # After initialization, updated every 30 seconds if the store exists
+    # Requires the store to be initialized
     init_free_compute_slowdown: =>
-        if not @get_store()?
-            setTimeout(@init_free_compute_slowdown, 5000)
-        return if @get_store().free_compute_slowdown?
+        return if not @get_store()? or @get_store().free_compute_slowdown?
         @setState(free_compute_slowdown : 0.0)
         {webapp_client} = require('./webapp_client')
         ncpu = undefined
@@ -1257,11 +1257,11 @@ class ProjectActions extends Actions
                                 @setState(free_compute_slowdown : Math.max(0.0, slowdown))
                             else
                                 @setState(free_compute_slowdown : 0.0)
-                        setTimeout(f, 30 * 1000)
+                        setTimeout(f, 30 * 1000) if @get_store()?
             else
                 # otherwise, check again later ...
                 @setState(free_compute_slowdown : 0.0)
-                setTimeout(f, 120 * 1000)
+                setTimeout(f, 120 * 1000) if @get_store()?
 
         # get the number of cpus, which is constant
         webapp_client.exec

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1226,22 +1226,23 @@ class ProjectActions extends Actions
         {webapp_client} = require('./webapp_client')
         ncpu = undefined
 
-        ###
         # Comment out f() at the bottom of init_free_compute_slowdown to use f_test
         # Expect load to increase by 1% every second while load should be displayed
-        test_load = 0
-        f_test = =>
-            proj_store = @redux.getStore('projects')
-            quotas = proj_store.get_total_project_quotas(@project_id)
-            state  = proj_store.getIn(['project_map', @project_id, 'state', 'state'])
-            if state == 'running' and (quotas?) and (not quotas.member_host)
-                test_load = test_load + 1
-                @setState(free_compute_slowdown : test_load)
-            else
-                @setState(free_compute_slowdown : 0.0)
-            setTimeout(f_test, 1000)
-        f_test()
-        ###
+        # Console logs should stop when project is closed
+        # Projects should have independent load values
+        # test_load = 0
+        # f_test = =>
+        #     proj_store = @redux.getStore('projects')
+        #     quotas = proj_store.get_total_project_quotas(@project_id)
+        #     state  = proj_store.getIn(['project_map', @project_id, 'state', 'state'])
+        #     if state == 'running' and (quotas?) and (not quotas.member_host)
+        #         test_load = test_load + 1
+        #         @setState(free_compute_slowdown : test_load)
+        #     else
+        #         @setState(free_compute_slowdown : 0.0)
+        #     console.log "test load for", @project_id, "is", test_load
+        #     setTimeout(f_test, 1000) if @get_store()?
+        # f_test()
 
         f = =>
             proj_store = @redux.getStore('projects')

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1752,6 +1752,7 @@ exports.getStore = getStore = (project_id, redux) ->
     actions = redux.createActions(name, ProjectActions)
     actions.project_id = project_id  # so actions can assume this is available on the object
     store = redux.createStore(create_project_store_def(name, project_id))
+    actions.init_free_compute_slowdown()
 
     queries = misc.deep_copy(QUERIES)
     create_table = (table_name, q) ->

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -225,7 +225,7 @@ class ProjectsActions extends Actions
         relation = redux.getStore('projects').get_my_group(opts.project_id)
         if not relation? or relation in ['public', 'admin']
             @fetch_public_project_title(opts.project_id)
-        project_actions.fetch_directory_listing(finish_cb:project_actions.init_free_compute_slowdown)
+        project_actions.fetch_directory_listing()
         redux.getActions('page').set_active_tab(opts.project_id) if opts.switch_to
         @set_project_open(opts.project_id)
         if opts.target?

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -225,7 +225,7 @@ class ProjectsActions extends Actions
         relation = redux.getStore('projects').get_my_group(opts.project_id)
         if not relation? or relation in ['public', 'admin']
             @fetch_public_project_title(opts.project_id)
-        project_actions.fetch_directory_listing()
+        project_actions.fetch_directory_listing(finish_cb:project_actions.init_free_compute_slowdown)
         redux.getActions('page').set_active_tab(opts.project_id) if opts.switch_to
         @set_project_open(opts.project_id)
         if opts.target?

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1169,7 +1169,7 @@ exports.NonMemberProjectWarning = (opts) ->
 
     if free_compute_slowdown? and free_compute_slowdown > 0
         pct = Math.round(free_compute_slowdown)
-        slowdown = <span><Space />Due to heavy load your computations are currently slowed down by at least {pct}%.</span>
+        slowdown = <span><Space />Due to heavy load computations on this project are currently {pct}% slower than they would be on a member's server.</span>
     else
         slowdown = ''
 

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1169,7 +1169,7 @@ exports.NonMemberProjectWarning = (opts) ->
 
     if free_compute_slowdown? and free_compute_slowdown > 0
         pct = Math.round(free_compute_slowdown)
-        slowdown = <span><Space />Due to heavy load computations on this project are running {pct}% slower than they would on a member's server.</span>
+        slowdown = <span>Computations in this project could run up to {pct}% faster after upgrading to member server hosting.</span>
     else
         slowdown = ''
 
@@ -1177,6 +1177,7 @@ exports.NonMemberProjectWarning = (opts) ->
         <h4><Icon name='exclamation-triangle'/>  Warning: this project is <strong>running on a free server</strong></h4>
         <p>
             {slowdown}
+            <Space />
             Projects running on free servers compete for resources with a large number of other free projects.
             The free servers are <b><i>randomly rebooted frequently</i></b>,
             and are often <b><i>much more heavily loaded</i></b> than members-only servers.

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1169,17 +1169,17 @@ exports.NonMemberProjectWarning = (opts) ->
 
     if free_compute_slowdown? and free_compute_slowdown > 0
         pct = Math.round(free_compute_slowdown)
-        slowdown = <span><Space />Due to heavy load computations on this project are currently {pct}% slower than they would be on a member's server.</span>
+        slowdown = <span><Space />Due to heavy load computations on this project are running {pct}% slower than they would on a member's server.</span>
     else
         slowdown = ''
 
     <Alert bsStyle='warning' style={marginTop:'10px'}>
         <h4><Icon name='exclamation-triangle'/>  Warning: this project is <strong>running on a free server</strong></h4>
         <p>
+            {slowdown}
             Projects running on free servers compete for resources with a large number of other free projects.
             The free servers are <b><i>randomly rebooted frequently</i></b>,
             and are often <b><i>much more heavily loaded</i></b> than members-only servers.
-            {slowdown}
             {suggestion}
         </p>
     </Alert>

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1098,17 +1098,18 @@ exports.course_warning = (pay) ->
     return webapp_client.server_time() <= misc.months_before(-3, pay)  # require subscription until 3 months after start (an estimate for when class ended, and less than when what student did pay for will have expired).
 
 project_warning_opts = (opts) ->
-    {upgrades_you_can_use, upgrades_you_applied_to_all_projects, course_info, account_id, email_address, upgrade_type} = opts
+    {upgrades_you_can_use, upgrades_you_applied_to_all_projects, course_info, account_id, email_address, upgrade_type, free_compute_slowdown} = opts
     total = upgrades_you_can_use?[upgrade_type] ? 0
     used  = upgrades_you_applied_to_all_projects?[upgrade_type] ? 0
     x =
-        total          : total
-        used           : used
-        avail          : total - used
-        course_warning : exports.course_warning(course_info?.get?('pay'))  # no *guarantee* that course_info is immutable.js since just comes from database
-        course_info    : opts.course_info
-        account_id     : account_id
-        email_address  : email_address
+        total                 : total
+        used                  : used
+        avail                 : total - used
+        course_warning        : exports.course_warning(course_info?.get?('pay'))  # no *guarantee* that course_info is immutable.js since just comes from database
+        course_info           : opts.course_info
+        account_id            : account_id
+        email_address         : email_address
+        free_compute_slowdown : free_compute_slowdown
     return x
 
 exports.CourseProjectExtraHelp = CourseProjectExtraHelp = ->
@@ -1150,7 +1151,7 @@ exports.CourseProjectWarning = (opts) ->
     </Alert>
 
 exports.NonMemberProjectWarning = (opts) ->
-    {total, used, avail, course_warning} = project_warning_opts(opts)
+    {total, used, avail, course_warning, free_compute_slowdown} = project_warning_opts(opts)
 
     ## Disabled until a pay-in-place version gets implemented
     #if course_warning
@@ -1166,12 +1167,19 @@ exports.NonMemberProjectWarning = (opts) ->
         else
             suggestion = <span><Space /><a href={url} target='_blank' style={cursor:'pointer'}>Subscriptions start at only $7/month.</a></span>
 
+    if free_compute_slowdown? and free_compute_slowdown > 0
+        pct = Math.round(free_compute_slowdown)
+        slowdown = <span><Space />Due to heavy load your computations are currently slowed down by at least {pct}%.</span>
+    else
+        slowdown = ''
+
     <Alert bsStyle='warning' style={marginTop:'10px'}>
         <h4><Icon name='exclamation-triangle'/>  Warning: this project is <strong>running on a free server</strong></h4>
         <p>
             Projects running on free servers compete for resources with a large number of other free projects.
             The free servers are <b><i>randomly rebooted frequently</i></b>,
             and are often <b><i>much more heavily loaded</i></b> than members-only servers.
+            {slowdown}
             {suggestion}
         </p>
     </Alert>


### PR DESCRIPTION
The purpose of this is to make "free users" aware of the current load and the impact on running any calculations. It shows an estimate about how much longer a computation takes compared to having no elevated load or cpu core limits.

The problem is, I'm sure what I coded is at the wrong spot and can be done much better. I think what I wrote is at least safe to do.

I've assigned j3 because I think he knows exactly how to properly trigger this upon project startup.