### PR TITLE
Issue/756

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -1677,19 +1677,17 @@ def asy(code=None, **kwds):
     # asy command can also be used to make .eps file
     import tempfile
     import subprocess
-    # FIXME delete tempfiles after viewing
+    import os
     fname1 = tempfile.mkstemp(suffix=".asy")[1]
-    fname2 = tempfile.mkstemp(suffix=".pdf")[1]
+    fname2 = tempfile.mkstemp(suffix=".png")[1]
     with open(fname1,"w") as outf1:
-        outf1.write(code)
-    cmd = "/usr/bin/asy -offscreen -f pdf -o {} {}".format(fname2, fname1)
-    p = subprocess.Popen(cmd, shell=True)
-    ldoc = r"""
-\begin{{center}}
-\includegraphics[width=.8\textwidth]{{{}}}
-\end{{center}}
-""".format(fname2)
-    latex0(ldoc)
+        outf1.write(code + '\n')
+    cmd = "/usr/bin/asy -offscreen -f png -o {} {}".format(fname2, fname1)
+    p = subprocess.call(cmd.split())
+    salvus.file(fname2)
+    os.unlink(fname1)
+    os.unlink(fname2)
+    print('')
 
 def cython(code=None, **kwds):
     """

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -1672,6 +1672,25 @@ capture = Capture(stdout=None, stderr=None, append=False, echo=False)
 
 import sage.misc.cython
 
+def asy(code=None, **kwds):
+    # make a .pdf from .asy code and display it
+    # asy command can also be used to make .eps file
+    import tempfile
+    import subprocess
+    # FIXME delete tempfiles after viewing
+    fname1 = tempfile.mkstemp(suffix=".asy")[1]
+    fname2 = tempfile.mkstemp(suffix=".pdf")[1]
+    with open(fname1,"w") as outf1:
+        outf1.write(code)
+    cmd = "/usr/bin/asy -offscreen -f pdf -o {} {}".format(fname2, fname1)
+    p = subprocess.Popen(cmd, shell=True)
+    ldoc = r"""
+\begin{{center}}
+\includegraphics[width=.8\textwidth]{{{}}}
+\end{{center}}
+""".format(fname2)
+    latex0(ldoc)
+
 def cython(code=None, **kwds):
     """
     Block decorator to easily include Cython code in CoCalc worksheets.

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1819,7 +1819,7 @@ def serve(port, host, extra_imports=False):
 
         namespace['_salvus_parsing'] = sage_parsing
 
-        for name in ['attach', 'auto', 'capture', 'cell', 'clear', 'coffeescript', 'cython',
+        for name in ['asy', 'attach', 'auto', 'capture', 'cell', 'clear', 'coffeescript', 'cython',
                      'default_mode', 'delete_last_output', 'dynamic', 'exercise', 'fork',
                      'fortran', 'go', 'help', 'hide', 'hideall', 'input', 'java', 'javascript', 'julia',
                      'jupyter', 'license', 'load', 'md', 'mediawiki', 'modes', 'octave', 'pandoc',


### PR DESCRIPTION
Ref: #756.

I think I solved the display problem with today's commit. Should still be reviewed, but I think I'm unstuck. Ignore bug reports in remainder of this comment.

 ~~@haraldschilly Please review. I wonder if I'm invoking the latex viewer incorrectly. Main sticking point seems to be how to display a .pdf (or .eps) inside a sagews with code called inside sage_salvus.py.~~

```
%asy
// 1.  sine curve
unitsize(2.5cm);
draw((0,0){(1,1)} .. {right}(pi/2,1)
.. {(1,-1)}(pi,0) ..
{right}(3*pi/2,-1)
.. {(1,1)}(2*pi, 0));
----
%asy
// 2. two circles and an ellipse
size(3cm);
draw(circle((0,1), 0.5), red);
draw(circle((1,0), 1.5), blue);
draw(ellipse((1,0), 1.5, 0.5));
---
%asy
// 3. pentagon in a circle
unitsize(1.5cm);
draw(unitcircle);
draw(polygon(5), blue);
```

**[no longer] Issues:**
- you have to restart the worksheet before running each %asy cell to avoid latex error.
- some files error out even after restarting the sagews, for example:
```
// 4. say hello
label("HELLO");
```
and this large file when pasted into an %asy cell:
5. https://cocalc.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/ISSUES/calc.asy

All 5 of the above examples successfully create expected output when put in a .asy file and run with the following steps in a sagews:
```
%sh
asy -offscreen -f pdf -o myfile.pdf myfile.asy
---
%latex
\begin{center}
\includegraphics[width=.8\textwidth]{/absolute/path/to/myfile.pdf}
\end{center}
```
