### PR TITLE
Coupons

### DIFF
--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -2026,6 +2026,7 @@ class exports.Client extends EventEmitter
                         @validate_coupon options.coupon, (err, coupon, coupon_history) =>
                             if err
                                 cb(err)
+                                return
                             coupon_history[coupon.id] += 1
                             @database.update_coupon_history
                                 account_id     : @account_id
@@ -2099,6 +2100,7 @@ class exports.Client extends EventEmitter
                         @validate_coupon mesg.coupon_id, (err, coupon, coupon_history) =>
                             if err
                                 cb(err)
+                                return
                             coupon_history[coupon.id] += 1
                             @database.update_coupon_history
                                 account_id     : @account_id
@@ -2168,11 +2170,14 @@ class exports.Client extends EventEmitter
         ], (err, [coupon, coupon_history]) =>
             if err
                 cb(err)
+                return
             if not coupon.valid
                 cb("Sorry! This coupon has expired.")
+                return
             times_used = coupon_history[coupon.id] ? 0
             if times_used >= (coupon.metadata.max_per_account ? 1)
                 cb("You've already used this coupon.")
+                return
 
             coupon_history[coupon.id] = times_used
             cb(err, coupon, coupon_history)

--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -2002,7 +2002,7 @@ class exports.Client extends EventEmitter
             options =
                 plan     : mesg.plan
                 quantity : mesg.quantity
-                coupon   : mesg.coupon
+                coupon   : mesg.coupon_id
 
             subscription = undefined
             tax_rate = undefined
@@ -2113,7 +2113,7 @@ class exports.Client extends EventEmitter
                     changes =
                         quantity : mesg.quantity
                         plan     : mesg.plan
-                        coupon   : mesg.coupon
+                        coupon   : mesg.coupon_id
                     @_stripe.customers.updateSubscription(customer_id, subscription_id, changes, cb)
                 (cb) =>
                     @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id, cb: cb)

--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -2095,6 +2095,16 @@ class exports.Client extends EventEmitter
             subscription = undefined
             async.series([
                 (cb) =>
+                    if mesg.coupon_id
+                        @validate_coupon mesg.coupon_id, (err, coupon, coupon_history) =>
+                            if err
+                                cb(err)
+                            coupon_history[coupon.id] += 1
+                            @database.update_coupon_history
+                                account_id     : @account_id
+                                coupon_history : coupon_history
+                                cb             : cb
+                (cb) =>
                     dbg("Update the subscription.")
                     changes =
                         quantity : mesg.quantity

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -666,6 +666,34 @@ class exports.PostgreSQL extends PostgreSQL
         ], opts.cb)
 
     ###
+    Auxillary billing related queries
+    ###
+    get_coupon_history: (opts) =>
+        opts = defaults opts,
+            account_id : required
+            cb         : undefined
+        @_dbg("Getting coupon history")
+        @_query
+            query : "SELECT coupon_history FROM accounts"
+            where : 'account_id = $::UUID' : opts.account_id
+            cb    : one_result("coupon_history", opts.cb)
+
+    update_coupon_history: (opts) =>
+        opts = defaults opts,
+            account_id     : required
+            coupon_history : required
+            cb             : undefined
+        @_dbg("Setting to #{opts.coupon_history}")
+        async.series([
+            (cb) =>
+                @_query
+                    query : 'UPDATE accounts'
+                    set   : 'coupon_history::JSONB' : opts.coupon_history
+                    where : 'account_id = $::UUID'  : opts.account_id
+                    cb    : opts.cb
+            ])
+
+    ###
     Querying for searchable information about accounts.
     ###
     account_ids_to_usernames: (opts) =>

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -684,14 +684,11 @@ class exports.PostgreSQL extends PostgreSQL
             coupon_history : required
             cb             : undefined
         @_dbg("Setting to #{opts.coupon_history}")
-        async.series([
-            (cb) =>
-                @_query
-                    query : 'UPDATE accounts'
-                    set   : 'coupon_history::JSONB' : opts.coupon_history
-                    where : 'account_id = $::UUID'  : opts.account_id
-                    cb    : opts.cb
-            ])
+        @_query
+            query : 'UPDATE accounts'
+            set   : 'coupon_history::JSONB' : opts.coupon_history
+            where : 'account_id = $::UUID'  : opts.account_id
+            cb    : opts.cb
 
     ###
     Querying for searchable information about accounts.

--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -1605,29 +1605,20 @@ class exports.Connection extends EventEmitter
 
     # Gets the coupon for this account. Returns an error if invalid
     # https://stripe.com/docs/api#retrieve_coupon
-    stripe_fetch_coupon: (opts) =>
-        # TODO: Types
+    stripe_get_coupon: (opts) =>
         opts = defaults opts,
-            id : undefined
-            cb : required
+            coupon_id : undefined
+            cb        : required
 
-        # TODO: Call stripe.coupons.retrieve(opts.id, opts.cb)
-        opts.cb undefined,
-            id                 : opts.id
-            object             : "coupon"
-            amount_off         : 5
-            created            : 1441750359
-            currency           : "usd"
-            duration           : "once"
-            duration_in_months : null
-            livemode           : false
-            max_redemptions    : null
-            percent_off        : null
-            redeem_by          : null
-            times_redeemed     : 2
-            valid              : false
-            metadata           :
-                description : "$5 off your first subscription!"
+        @call
+            message     :
+                message.stripe_get_coupon(coupon_id : opts.coupon_id)
+            error_event : true
+            cb          : (err, mesg) =>
+                if err
+                    opts.cb(err)
+                else
+                    opts.cb(undefined, mesg.coupon)
 
     # gets list of invoices for this account.
     stripe_get_invoices: (opts) =>

--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -1625,7 +1625,7 @@ class exports.Connection extends EventEmitter
             percent_off        : null
             redeem_by          : null
             times_redeemed     : 2
-            valid              : true
+            valid              : false
             metadata           :
                 description : "$5 off your first subscription!"
 

--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -1603,6 +1603,32 @@ class exports.Connection extends EventEmitter
                 else
                     opts.cb(undefined, mesg.subscriptions)
 
+    # Gets the coupon for this account. Returns an error if invalid
+    # https://stripe.com/docs/api#retrieve_coupon
+    stripe_fetch_coupon: (opts) =>
+        # TODO: Types
+        opts = defaults opts,
+            id : undefined
+            cb : required
+
+        # TODO: Call stripe.coupons.retrieve(opts.id, opts.cb)
+        return
+            id                 : opts.id
+            object             : "coupon"
+            amount_off         : 5
+            created            : 1441750359
+            currency           : "usd"
+            duration           : "once"
+            duration_in_months : null
+            livemode           : false
+            max_redemptions    : null
+            percent_off        : null
+            redeem_by          : null
+            times_redeemed     : 2
+            valid              : true
+            metadata           :
+                description : "$5 off your first subscription!"
+
     # gets list of invoices for this account.
     stripe_get_invoices: (opts) =>
         opts = defaults opts,

--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -1541,15 +1541,15 @@ class exports.Connection extends EventEmitter
 
     stripe_create_subscription: (opts) =>
         opts = defaults opts,
-            plan     : required
-            quantity : 1
-            coupon   : undefined
-            cb       : required
+            plan      : required
+            quantity  : 1
+            coupon_id : undefined
+            cb        : required
         @call
             message : message.stripe_create_subscription
-                plan     : opts.plan
-                quantity : opts.quantity
-                coupon   : opts.coupon
+                plan      : opts.plan
+                quantity  : opts.quantity
+                coupon_id : opts.coupon_id
             error_event : true
             cb          : opts.cb
 
@@ -1568,18 +1568,18 @@ class exports.Connection extends EventEmitter
     stripe_update_subscription: (opts) =>
         opts = defaults opts,
             subscription_id : required
-            quantity : undefined  # if given, must be >= number of projects
-            coupon   : undefined
-            projects : undefined  # ids of projects that subscription applies to
-            plan     : undefined
-            cb       : required
+            quantity  : undefined  # if given, must be >= number of projects
+            coupon_id : undefined
+            projects  : undefined  # ids of projects that subscription applies to
+            plan      : undefined
+            cb        : required
         @call
             message : message.stripe_update_subscription
                 subscription_id : opts.subscription_id
-                quantity : opts.quantity
-                coupon   : opts.coupon
-                projects : opts.projects
-                plan     : opts.plan
+                quantity  : opts.quantity
+                coupon_id : opts.coupon_id
+                projects  : opts.projects
+                plan      : opts.plan
             error_event : true
             cb          : opts.cb
 

--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -1612,7 +1612,7 @@ class exports.Connection extends EventEmitter
             cb : required
 
         # TODO: Call stripe.coupons.retrieve(opts.id, opts.cb)
-        return
+        opts.cb undefined,
             id                 : opts.id
             object             : "coupon"
             amount_off         : 5

--- a/src/smc-util/db-schema.coffee
+++ b/src/smc-util/db-schema.coffee
@@ -189,6 +189,9 @@ schema.accounts =
         stripe_customer :
             type : 'map'
             desc : 'Information about customer from the point of view of stripe (exactly what is returned by stripe.customers.retrieve).'
+        coupon_history :
+            type : 'map'
+            desc : 'Information about which coupons the customer has used and the number of times'
         profile :
             type : 'map'
             desc : 'Information related to displaying this users location and presence in a document or chatroom.'
@@ -259,6 +262,7 @@ schema.accounts =
                 groups          : []
                 last_active     : null
                 stripe_customer : null
+                coupon_history  : null
                 profile :
                     image       : undefined
                     color       : undefined

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -1815,11 +1815,11 @@ API message
 
 # Create a subscription to a plan
 API message
-    event    : 'stripe_create_subscription'
-    id       : undefined
-    plan     : required   # name of plan
-    quantity : 1
-    coupon   : undefined
+    event     : 'stripe_create_subscription'
+    id        : undefined
+    plan      : required   # name of plan
+    quantity  : 1
+    coupon_id : undefined
 
 # Delete a subscription to a plan
 API message
@@ -1836,7 +1836,7 @@ API message
     quantity        : undefined   # only give if changing
     projects        : undefined   # change associated projects from what they were to new list
     plan            : undefined   # change plan to this
-    coupon          : undefined   # apply a coupon to this subscription
+    coupon_id       : undefined   # apply a coupon to this subscription
 
 API message
     event          : 'stripe_get_subscriptions'

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -1850,6 +1850,17 @@ message
     id            : undefined
     subscriptions : undefined
 
+API message
+    event     : 'stripe_get_coupon'
+    id        : undefined
+    coupon_id : required
+
+message
+    event  : 'stripe_coupon'
+    id     : undefined
+    coupon : undefined
+
+
 # charges
 API message
     event          : 'stripe_get_charges'

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -145,7 +145,13 @@ class BillingActions extends Actions
             @setState(action:'', error: 'Too many subscription attempts in the last minute.  Please **REFRESH YOUR BROWSER** THEN  DOUBLE CHECK YOUR SUBSCRIPTION LIST!')
         else
             @setState(error: '')
-            @_action('create_subscription', 'Create a subscription', plan : plan)
+            # TODO: Support multiple coupons.
+            if store.get('applied_coupons').size > 0
+                coupon = store.get('applied_coupons').first()
+            opts =
+                plan   : plan
+                coupon : coupon.id
+            @_action('create_subscription', 'Create a subscription', opts)
             last_subscription_attempt = misc.server_time()
             @track_subscription(plan)
 
@@ -154,7 +160,7 @@ class BillingActions extends Actions
             if err
                 @setState(coupon_error: "An error has occurred: err")
             else if not coupon.valid
-                @setState(coupon_error: "Sorry! That coupon has expired."
+                @setState(coupon_error: "Sorry! That coupon has expired.")
             else if coupon
                 @setState(applied_coupons : store.get('applied_coupons').set(coupon.id, coupon))
 
@@ -1035,7 +1041,7 @@ CouponAdder = rclass
         <Well>
             <h4><Icon name='plus' /> Add a coupon?</h4>
             {<CouponList applied_coupons={@props.applied_coupons} /> if @props.applied_coupons?.size > 0}
-            <FormGroup style={marginTop:'5px'}>
+            {<FormGroup style={marginTop:'5px'}>
                 <InputGroup>
                     <FormControl
                         value       = {@state.coupon_id}
@@ -1052,7 +1058,7 @@ CouponAdder = rclass
                         </Button>
                     </InputGroup.Button>
                 </InputGroup>
-            </FormGroup>
+            </FormGroup> if @props.applied_coupons?.size == 0}{# TODO: Support multiple coupons}
             {<SkinnyError error_text={@props.coupon_error} on_close={@actions('billing').clear_coupon_error} /> if @props.coupon_error}
         </Well>
 
@@ -1078,6 +1084,7 @@ CouponInfo = rclass
             </Col>
             <Col md=8>
                 {@props.coupon.metadata.description}
+                <CloseX on_close={=>@actions('billing').remove_coupon(@props.coupon.id)} />
             </Col>
         </Row>
 

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -152,9 +152,12 @@ class BillingActions extends Actions
     fetch_coupon: (id) =>
         cb = (err, coupon) =>
             if err
-                @setState(coupon_error: err)
+                @setState(coupon_error: "An error has occurred: err")
+            else if not coupon.valid
+                @setState(coupon_error: "Sorry! That coupon has expired."
             else if coupon
                 @setState(applied_coupons : store.get('applied_coupons').set(coupon.id, coupon))
+
         opts =
             id     : id
             cb     : cb

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -159,10 +159,9 @@ class BillingActions extends Actions
         cb = (err, coupon) =>
             if err
                 @setState(coupon_error: JSON.stringify(err))
-            else if not coupon.valid
-                @setState(coupon_error: "Sorry! That coupon has expired.")
-            else if coupon
-                @setState(applied_coupons : store.get('applied_coupons').set(coupon.id, coupon))
+            else
+                applied_coupons = store.get('applied_coupons').set(coupon.id, coupon)
+                @setState(applied_coupons : applied_coupons, coupon_error:'')
 
         opts =
             coupon_id : id

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -141,7 +141,7 @@ class BillingActions extends Actions
     create_subscription: (plan='standard') =>
         {webapp_client} = require('./webapp_client')   # do not put at top level, since some code runs on server
         lsa = last_subscription_attempt
-        if lsa? and lsa > misc.server_minutes_ago(2)
+        if lsa? and lsa.plan == plan and lsa.timestamp > misc.server_minutes_ago(2)
             @setState(action:'', error: 'Too many subscription attempts in the last minute.  Please **REFRESH YOUR BROWSER** THEN  DOUBLE CHECK YOUR SUBSCRIPTION LIST!')
         else
             @setState(error: '')
@@ -152,7 +152,7 @@ class BillingActions extends Actions
                 plan      : plan
                 coupon_id : coupon?.id
             @_action('create_subscription', 'Create a subscription', opts)
-            last_subscription_attempt = misc.server_time()
+            last_subscription_attempt = {timestamp:misc.server_time(), plan:plan}
             @track_subscription(plan)
 
     get_coupon: (id) =>

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -926,6 +926,7 @@ AddSubscription = rclass
                     {<ConfirmPaymentMethod
                         is_recurring = {@is_recurring()}
                     /> if @props.selected_plan isnt ''}
+                    {<CouponAdder />}
                     {@render_create_subscription_buttons()}
                 </Well>
                 <ExplainResources type='shared'/>
@@ -971,6 +972,65 @@ ConfirmPaymentMethod = rclass
                 />
             </Well>
         </Alert>
+
+CouponAdder = rclass
+    displayName : 'CouponAdder'
+
+    propTypes:
+        applied_coupons : rtypes.immutable.List
+
+    render: ->
+        # TODO: Error when a coupon duplicate is added
+        # TODO: (Here or elsewhere) Your final cost is:
+        #       $2 for the first month
+        #       $7/mo after the first
+        <Well>
+            <h4><Icon name='plus' /> Add a coupon?</h4>
+            {<CouponList applied_coupons={@props.appied_coupons} /> if @props.applied_coupons?.size > 0}
+            <FormGroup>
+                <InputGroup>
+                    <FormControl
+                        ref         = 'coupon_adder'
+                        type        = 'text'
+                        size        = '7'
+                        placeholder = ''
+                        onChange    = {=>console.log "TODO: Update coupon"}
+
+                    />
+                    <InputGroup.Button>
+                        <Button onClick={=>console.log "TODO: Submit coupon:"} >
+                            <Icon name='check' />
+                        </Button>
+                    </InputGroup.Button>
+                </InputGroup>
+            </FormGroup>
+        </Well>
+
+CouponList = rclass
+    displayName : 'CouponList'
+
+    propTypes:
+        applied_coupons : rtypes.immutable.List
+
+    render: ->
+        for coupon in @props.applied_coupons
+            <CouponInfo coupon={coupon} id={coupon.get('id')} />
+
+CouponInfo = rclass
+    displayName : 'CouponInfo'
+
+    propTypes:
+        coupon : rtypes.immutable.Map
+
+    render: ->
+        <Row>
+            <Col md=4>
+                Name
+            </Col>
+            <Col md=8>
+                Description. ie. 30% off all payments or $10 of credit or $2 off all payments
+            </Col>
+        </Row>
 
 
 exports.SubscriptionGrid = SubscriptionGrid = rclass

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -149,8 +149,8 @@ class BillingActions extends Actions
             if store.get('applied_coupons').size > 0
                 coupon = store.get('applied_coupons').first()
             opts =
-                plan   : plan
-                coupon : coupon?.id
+                plan      : plan
+                coupon_id : coupon?.id
             @_action('create_subscription', 'Create a subscription', opts)
             last_subscription_attempt = misc.server_time()
             @track_subscription(plan)

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1021,7 +1021,7 @@ CouponAdder = rclass
         <Well>
             <h4><Icon name='plus' /> Add a coupon?</h4>
             {<CouponList applied_coupons={@props.applied_coupons} /> if @props.applied_coupons?.size > 0}
-            <FormGroup>
+            <FormGroup style={marginTop:'5px'}>
                 <InputGroup>
                     <FormControl
                         value       = {@state.coupon_id}

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1059,6 +1059,7 @@ CouponAdder = rclass
                 </InputGroup>
             </FormGroup> if @props.applied_coupons?.size == 0}{# TODO: Support multiple coupons}
             {<SkinnyError error_text={@props.coupon_error} on_close={@actions('billing').clear_coupon_error} /> if @props.coupon_error}
+            {<div style={color:'rgb(153, 153, 153)', fontWeight:'200'}>No coupons applied</div> if @props.applied_coupons?.size == 0}
         </Well>
 
 CouponList = rclass

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -90,7 +90,7 @@ class BillingActions extends Actions
         cb = opts.cb
         opts.cb = (err, value) =>
             @setState(action:'')
-            if action == 'fetch_coupon'
+            if action == 'get_coupon'
                 cb(err, value)
             else if err
                 @setState(error:JSON.stringify(err))
@@ -155,19 +155,19 @@ class BillingActions extends Actions
             last_subscription_attempt = misc.server_time()
             @track_subscription(plan)
 
-    fetch_coupon: (id) =>
+    get_coupon: (id) =>
         cb = (err, coupon) =>
             if err
-                @setState(coupon_error: "An error has occurred: err")
+                @setState(coupon_error: JSON.stringify(err))
             else if not coupon.valid
                 @setState(coupon_error: "Sorry! That coupon has expired.")
             else if coupon
                 @setState(applied_coupons : store.get('applied_coupons').set(coupon.id, coupon))
 
         opts =
-            id     : id
-            cb     : cb
-        @_action('fetch_coupon', "Getting coupon: #{id}", opts)
+            coupon_id : id
+            cb        : cb
+        @_action('get_coupon', "Getting coupon: #{id}", opts)
 
     clear_coupon_error: =>
         @setState(coupon_error : '')
@@ -1027,7 +1027,7 @@ CouponAdder = rclass
 
     submit: (e) ->
         e?.preventDefault()
-        @actions('billing').fetch_coupon(@state.coupon_id) if @state.coupon_id
+        @actions('billing').get_coupon(@state.coupon_id) if @state.coupon_id
 
     render: ->
         # TODO: (Here or elsewhere) Your final cost is:

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -147,6 +147,15 @@ class BillingActions extends Actions
             last_subscription_attempt = misc.server_time()
             @track_subscription(plan)
 
+    fetch_coupon: (id) =>
+        cb = (err, coupon) =>
+            if err
+                @setState(action:'', error: err)
+            else if coupon
+                @setState(applied_coupons : store.get('applied_coupons').push(coupon))
+
+        @_action('fetch_coupon', 'Get a coupon', {coupon_id : id})
+
     # conversion tracking (commercial only)
     track_subscription: (plan) =>
         usd = 7.00 # TODO derive this from the plan

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1048,10 +1048,7 @@ CouponList = rclass
         applied_coupons : rtypes.immutable.Map
 
     render: ->
-        v = []
-        @props.applied_coupons.forEach (coupon, id) =>
-            v.push(<CouponInfo key={id} coupon={coupon}/>)
-        return v
+        [<CouponInfo key={coupon.id} coupon={coupon}/> for coupon from @props.applied_coupons.values()]
 
 CouponInfo = rclass
     displayName : 'CouponInfo'

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -150,7 +150,7 @@ class BillingActions extends Actions
                 coupon = store.get('applied_coupons').first()
             opts =
                 plan   : plan
-                coupon : coupon.id
+                coupon : coupon?.id
             @_action('create_subscription', 'Create a subscription', opts)
             last_subscription_attempt = misc.server_time()
             @track_subscription(plan)

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1001,6 +1001,10 @@ CouponAdder = rclass
     getInitialState: ->
         coupon_id : ''
 
+    componentWillReceiveProps: (next_props) ->
+        if next_props.applied_coupons.has(@state.coupon_id)
+            @setState(coupon_id : '')
+
     key_down: (e) ->
         if e.keyCode == 13
             @submit()
@@ -1020,6 +1024,7 @@ CouponAdder = rclass
             <FormGroup>
                 <InputGroup>
                     <FormControl
+                        value       = {@state.coupon_id}
                         ref         = 'coupon_adder'
                         type        = 'text'
                         size        = '7'

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1869,9 +1869,7 @@ BillingPage = rclass
 
     render_action: ->
         if @props.action
-            <div style={position:'relative', top:'-70px'}>   {# probably ActivityDisplay should manage its own position better. }
-                <ActivityDisplay activity ={[@props.action]} on_clear={=>@props.redux.getActions('billing').clear_action()} />
-            </div>
+            <ActivityDisplay style={position:'fixed', right:'45px', top:'85px'} activity ={[@props.action]} on_clear={=>@props.redux.getActions('billing').clear_action()} />
 
     render_error: ->
         if @props.error

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -213,7 +213,7 @@ exports.CloseX = CloseX = rclass
             <Icon style={@props.style} name='times' />
         </a>
 
-SimpleX = ({onClick}) ->
+exports.SimpleX = SimpleX = ({onClick}) ->
     <a href='' onClick={(e)=>e.preventDefault(); onClick()}>
         <Icon name='times' />
     </a>

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -213,6 +213,15 @@ exports.CloseX = CloseX = rclass
             <Icon style={@props.style} name='times' />
         </a>
 
+SimpleX = ({onClick}) ->
+    <a href='' onClick={(e)=>e.preventDefault(); onClick()}>
+        <Icon name='times' />
+    </a>
+
+exports.SkinnyError = ({error_text, on_close}) ->
+    <div style={color:'red'}>
+         <SimpleX onClick={on_close} /> {error_text}
+    </div>
 
 error_text_style =
     marginRight : '1ex'

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -826,6 +826,7 @@ exports.ActivityDisplay = rclass
         activity : rtypes.array.isRequired   # array of strings
         trunc    : rtypes.number             # truncate activity messages at this many characters (default: 80)
         on_clear : rtypes.func               # if given, called when a clear button is clicked
+        style    : rtypes.object             # additional styles to be merged onto activity_style
 
     render_items: ->
         n = @props.trunc ? 80
@@ -837,7 +838,10 @@ exports.ActivityDisplay = rclass
 
     render: ->
         if misc.len(@props.activity) > 0
-            <div key='activity' style={activity_style}>
+            if @props.style
+                adjusted_style = Object.assign({}, activity_style, @props.style)
+
+            <div key='activity' style={adjusted_style ? activity_style}>
                 {<CloseX on_close={@props.on_clear} /> if @props.on_clear?}
                 {@render_items() if @props.activity.length > 0}
             </div>


### PR DESCRIPTION
# Description
Screenshots are at the bottom.

Non-coupon Billing UI changes
- Multiple subscription warning only fires if you try to add multiple of the **same kind**.
- Activity spinner on billing page floats in the top right so you see it even if you're scrolled down

Coupons
- Coupons are validated when you add them *and* when you create the subscription.
  - The latter won't be relevant when done via the UI
- Coupons default to single use per account
  - Can set `max_per_account` in metadata if we want a multi-use coupon for some reason...
- Coupon descriptions are set on their metadata via Stripe
- Subscriptions only take one coupon
- No implementation for adding a coupon to the account

# Test
Use Stripe test data.

1. Make some coupons
2. Add any metadata eg. `description : "Takes $30 your first 3 billing cycles"`
3. Try to use the coupons
4. Get errors or successes as appropriate

**Empty**
<img width="917" alt="screen shot 2017-11-06 at 6 51 58 pm" src="https://user-images.githubusercontent.com/618575/32474965-468872fc-c324-11e7-83a9-37e30d301b65.png">

**Typed In** 
Notice the `No coupons applied` becomes relevant incase they think typing it in is sufficient
<img width="934" alt="screen shot 2017-11-06 at 6 55 34 pm" src="https://user-images.githubusercontent.com/618575/32474967-47b15784-c324-11e7-8ab2-ba393f01254d.png">

**Successfully Added**
<img width="933" alt="screen shot 2017-11-06 at 6 55 41 pm" src="https://user-images.githubusercontent.com/618575/32474970-48f1a702-c324-11e7-8c46-c5753d5ce5fd.png">

**Non-existant Coupon**
<img width="932" alt="screen shot 2017-11-06 at 6 52 19 pm" src="https://user-images.githubusercontent.com/618575/32474974-4afd4d26-c324-11e7-91fe-e6d7a885781a.png">

**Already Used**
<img width="929" alt="screen shot 2017-11-06 at 6 52 29 pm" src="https://user-images.githubusercontent.com/618575/32474975-4c09a4b2-c324-11e7-88d6-3a70daf9e78e.png">

**Expired Coupon**
This happens any time Stripe says the coupon is invalid.
<img width="931" alt="screen shot 2017-11-06 at 6 53 07 pm" src="https://user-images.githubusercontent.com/618575/32474976-4cd96242-c324-11e7-82ef-29ec590889e4.png">
