### PR TITLE
Update client stripe version

### DIFF
--- a/src/smc-hub/stripe/connect.coffee
+++ b/src/smc-hub/stripe/connect.coffee
@@ -10,8 +10,10 @@ misc                 = require('smc-util/misc')
 {defaults, required} = misc
 
 stripe  = undefined
+DEFAULT_VERSION = '2017-08-15'
 
-exports.get_stripe = ->
+exports.get_stripe = (version) ->
+    stripe.setApiVersion(version ? DEFAULT_VERSION)
     return stripe
 
 # TODO: this could listen to a changefeed on the database


### PR DESCRIPTION
Based on my testing of our Stripe calls, this [changelog](https://stripe.com/docs/upgrades?since=2015-07-07#api-changelog), and their api [docs](https://stripe.com/docs/api).

How to tell the new version is running? The way I did it was using `subscriptions.list`
>You can now view canceled subscriptions by specifying status=canceled or status=all when listing subscriptions. In addition, you can now retrieve a canceled subscription by its ID