### PR TITLE
webapp/jupyter2: cell is clearly not defined, this should fix it

### DIFF
--- a/src/smc-webapp/jupyter/actions.coffee
+++ b/src/smc-webapp/jupyter/actions.coffee
@@ -265,7 +265,8 @@ class exports.JupyterActions extends Actions
     clear_selected_outputs: =>
         cells = @store.get('cells')
         for id in @store.get_selected_cell_ids_list()
-            if cells.get(id).get('output')? or cell.get('exec_count')
+            cell = cells.get(id)
+            if cell.get('output')? or cell.get('exec_count')
                 @_set({type:'cell', id:id, output:null, exec_count:null}, false)
         @_sync()
 


### PR DESCRIPTION
issue #2495

* I haven't tested this at all
* I'm not sure what the general meaning is, i.e. it tests if there is output and if not that `exec_count` of the cell is defined? or > 0 ?