### PR TITLE
Sagews warn quotes

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1022,9 +1022,9 @@ class Salvus(object):
                             break
                     sys.stderr.write('\n\n')
 
-                from exceptions import SyntaxError
+                from exceptions import SyntaxError,TypeError
                 exc_type, _, _ = sys.exc_info()
-                if exc_type is SyntaxError:
+                if exc_type in [SyntaxError,TypeError]:
                     implicit_mul = RE_POSSIBLE_IMPLICIT_MUL.findall(code)
                     if len(implicit_mul) > 0:
                         # we know there is a SyntaxError and there could be an implicit multiplication

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -583,8 +583,8 @@ def sagews(request):
     print("host %s  port %s"%(host, port))
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect((host, port))
-    # jupyter kernels can take over 10 seconds to start
-    sock.settimeout(45)
+    # scala jupyter kernel can take over 45 seconds to start
+    sock.settimeout(50)
     print("connected to socket")
 
     # unlock

--- a/src/smc_sagews/smc_sagews/tests/test_unicode.py
+++ b/src/smc_sagews/smc_sagews/tests/test_unicode.py
@@ -76,7 +76,7 @@ class TestErr:
         code = ("x = " + unichr(295) + "\nx").encode('utf-8')
         m = conftest.message.execute_code(code = code, id = test_id)
         sagews.send_json(m)
-        # expect 2 messages from worksheet client, including final done:true
+        # expect 2 messages from worksheet client
         # 1 stderr Error in lines 1-1
         typ, mesg = sagews.recv()
         assert typ == 'json'
@@ -91,7 +91,7 @@ class TestErr:
         code = ("x = " + unichr(8220) + "\nx").encode('utf-8')
         m = conftest.message.execute_code(code = code, id = test_id)
         sagews.send_json(m)
-        # expect 2 messages from worksheet client, including final done:true
+        # expect 2 messages from worksheet client
         # 1 stderr Error in lines 1-1
         typ, mesg = sagews.recv()
         assert typ == 'json'
@@ -99,6 +99,20 @@ class TestErr:
         assert 'stderr' in mesg
         assert 'Error in lines 1-1' in mesg['stderr']
         assert 'should be replaced by < " >' in mesg['stderr']
+        # 2 done
+        conftest.recv_til_done(sagews, test_id)
+    def test_bad_mult(self, test_id, sagews):
+        # warn about possible missing '*' with patterns like 3x^2 and 5(1+x)
+        code = ("x=1\ny=3x^2x")
+        m = conftest.message.execute_code(code = code, id = test_id)
+        sagews.send_json(m)
+        # expect 2 messages from worksheet client
+        # 1 stderr
+        typ, mesg = sagews.recv()
+        assert typ == 'json'
+        assert mesg['id'] == test_id
+        assert 'stderr' in mesg
+        assert 'implicit multiplication' in mesg['stderr']
         # 2 done
         conftest.recv_til_done(sagews, test_id)
 


### PR DESCRIPTION
- 5(1+2) generates TypeError, not SyntaxError; do you want to catch these?
- another case added to end of pytest test_unicode.py
- unrelated, but found during testing: increase sagews pytest timeout because of slow scala launch