### PR TITLE
Fix state types

### DIFF
--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -254,6 +254,8 @@ redux.createStore
         local_storage_warning : rtypes.bool
         show_file_use         : rtypes.bool
         num_ghost_tabs        : rtypes.number
+        session               : rtypes.string # session query in the url bar
+        last_status_time      : rtypes.string
 
 recent_disconnects = []
 record_disconnect = () ->

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -110,9 +110,6 @@ class ProjectActions extends Actions
     get_store: =>
         return @redux.getStore(@name)
 
-    get_state: (key) =>
-        return @get_store()[key]
-
     clear_all_activity: =>
         @setState(activity:undefined)
 
@@ -1187,9 +1184,6 @@ class ProjectActions extends Actions
 
     show_upload : (show) =>
         @setState(show_upload : show)
-
-    toggle_upload: =>
-        @show_upload(not @get_state('show_upload'))
 
     # Compute the absolute path to the file with given name but with the
     # given extension added to the file (e.g., "md") if the file doesn't have

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -111,7 +111,7 @@ class ProjectActions extends Actions
         return @redux.getStore(@name)
 
     get_state: (key) =>
-        return @get_store().get(key)
+        return @get_store()[key]
 
     clear_all_activity: =>
         @setState(activity:undefined)

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -77,6 +77,10 @@ class Actions
     setState: (obj, nothing_else) =>
         if nothing_else?
             throw Error("setState takes exactly one argument, which must be an object")
+        if DEBUG and @redux.getStore(@name).__converted
+            for key of obj
+                if not Object.getOwnPropertyDescriptor(@redux.getStore(@name), key)?.get?
+                    console.warn("`#{key}` is not declared in stateTypes of store name `#{@name}`")
         @redux._set_state({"#{@name}": obj})
         return
 
@@ -444,6 +448,10 @@ connect_component = (spec) =>
             for prop, type of info
                 if redux.getStore(store_name).__converted?
                     val = redux.getStore(store_name)[prop]
+                    if not Object.getOwnPropertyDescriptor(redux.getStore(store_name), prop)?.get?
+                        if DEBUG
+                            console.warn("Requested reduxProp `#{prop}` from store `#{store_name}` but it is not defined in its stateTypes nor reduxProps")
+                        val = state.getIn([store_name, prop])
                 else # TODOJ: remove when all stores are converted
                     val = state.getIn([store_name, prop])
                 if type.category == "IMMUTABLE"


### PR DESCRIPTION
Addresses #2518
Warns you if you're accessing state that isn't declared or if you're setting state that isn't declared.

Let's you use it anyways. 

# Testing
Inside project actions or page actions, call `@setState` with a property not defined in stateTypes.
Use that property in a component with reduxProps. See both warnings and that passing down the prop still works.