### PR TITLE
webapp and hub/share: same config for macros, etc.

### DIFF
--- a/src/smc-hub/share/mathjax-support.coffee
+++ b/src/smc-hub/share/mathjax-support.coffee
@@ -8,8 +8,24 @@ async   = require('async')
 console.log("loading mathjax-node...")
 mathjax = require('mathjax-node')
 
-# TODO: see
-# mathjax.config(...)
+# Deriving MyMathJaxConfig from the webapp's MathJaxConfig
+# It's the same, execpt for the entries that reference additional .js files
+# Otherwise the rendered page wouldn't even show up, so I assume there is no support for that
+{MathJaxConfig} = require('smc-util/mathjax-config')
+MathJaxConfig = require('smc-util/misc').deep_copy(MathJaxConfig)
+delete MathJaxConfig.TeX.extensions
+
+MyMathJaxConfig =
+    tex2jax     : MathJaxConfig.tex2jax
+    #extensions  : MathJaxConfig.extensions   # commented on purpose, see above
+    TeX         : MathJaxConfig.TeX
+    "HTML-CSS"  : MathJaxConfig["HTML-CSS"]
+    SVG         : MathJaxConfig.SVG
+
+mathjax.config(
+    displayErrors: false
+    MathJax: MyMathJaxConfig
+)
 
 {remove_math} = require('smc-util/mathjax-utils')
 
@@ -33,8 +49,8 @@ replace_scripts = (html) ->
 
 exports.mathjax = (html, cb) ->
     html = replace_scripts(html)
-    [text, math] = remove_math(html)
 
+    [text, math] = remove_math(html)
     f = (i, cb) ->
         s = math[i]
         display = false

--- a/src/smc-util/mathjax-config.coffee
+++ b/src/smc-util/mathjax-config.coffee
@@ -1,0 +1,67 @@
+# mathjax configuration: this could be cleaned up further or even parameterized with some code during startup
+# ATTN: do not use "xypic.js", frequently causes crash!
+
+exports.MathJaxConfig =
+    skipStartupTypeset: true
+    extensions: ["tex2jax.js","asciimath2jax.js"]  # "static/mathjax_extensions/xypic.js"
+    # NOTE: "output/CommonHTML" is the output default: http://docs.mathjax.org/en/latest/output.html
+    # However, **DO NOT** use "output/CommonHTML" for the output JAX; it completely breaks
+    # Sage worksheet output right now.  Maybe when/if worksheets are rewritten
+    # using React, we can change, but not now.  Using "output/SVG" works just fine.
+    #   https://github.com/sagemathinc/cocalc/issues/1962
+    jax: ["input/TeX","input/AsciiMath", "output/SVG"]
+    # http://docs.mathjax.org/en/latest/options/tex2jax.html
+    tex2jax:
+        inlineMath     : [ ['$','$'], ["\\(","\\)"] ]
+        displayMath    : [ ['$$','$$'], ["\\[","\\]"] ]
+        processEscapes : true
+        ignoreClass    : "tex2jax_ignore"
+        skipTags       : ["script","noscript","style","textarea","pre","code"]
+
+    TeX:
+        MAXBUFFER  : 100000  # see https://github.com/mathjax/MathJax/issues/910
+        extensions : ["autoload-all.js", "noUndefined.js", "noErrors.js"]
+        Macros     : # get these from sage/misc/latex.py
+            Bold  : ["\\mathbb{#1}",1]
+            ZZ    : ["\\Bold{Z}",0]
+            NN    : ["\\Bold{N}",0]
+            RR    : ["\\Bold{R}",0]
+            CC    : ["\\Bold{C}",0]
+            FF    : ["\\Bold{F}",0]
+            QQ    : ["\\Bold{Q}",0]
+            QQbar : ["\\overline{\\QQ}",0]
+            CDF   : ["\\Bold{C}",0]
+            CIF   : ["\\Bold{C}",0]
+            CLF   : ["\\Bold{C}",0]
+            RDF   : ["\\Bold{R}",0]
+            RIF   : ["\\Bold{I} \\Bold{R}",0]
+            RLF   : ["\\Bold{R}",0]
+            CFF   : ["\\Bold{CFF}",0]
+            GF    : ["\\Bold{F}_{#1}",1]
+            Zp    : ["\\ZZ_{#1}",1]
+            Qp    : ["\\QQ_{#1}",1]
+            Zmod  : ["\\ZZ/#1\\ZZ",1]
+        noErrors:  # http://docs.mathjax.org/en/latest/tex.html#noerrors
+            inlineDelimiters : ["$","$"]
+            multiLine        : true
+            style:
+                "font-size"  : "85%"
+                "text-align" : "left"
+                "color"      : "red"
+                "padding"    : "1px 3px"
+                "background" : "#FFEEEE"
+                "border"     : "none"
+        noUndefined:  # http://docs.mathjax.org/en/latest/tex.html#noundefined
+            attributes:
+                mathcolor      : "red"
+                mathbackground : "#FFEEEE"
+                mathsize       : "90%"
+
+    # do not use "xypic.js", frequently causes crash!
+    "HTML-CSS":
+        linebreaks:
+            automatic: true
+    SVG:
+        linebreaks:
+            automatic: true
+    showProcessingMessages: false

--- a/src/smc-webapp/last.coffee
+++ b/src/smc-webapp/last.coffee
@@ -55,73 +55,9 @@ if client._connected
     if client._signed_in
         client.emit("signed_in", client._sign_in_mesg)
 
-# mathjax configuration: this could be cleaned up further or even parameterized with some code during startup
-
-# ATTN: do not use "xypic.js", frequently causes crash!
-window.MathJax = exports.MathJaxConfig =
-    skipStartupTypeset: true
-    extensions: ["tex2jax.js","asciimath2jax.js"]  # "static/mathjax_extensions/xypic.js"
-    # NOTE: "output/CommonHTML" is the output default: http://docs.mathjax.org/en/latest/output.html
-    # However, **DO NOT** use "output/CommonHTML" for the output JAX; it completely breaks
-    # Sage worksheet output right now.  Maybe when/if worksheets are rewritten
-    # using React, we can change, but not now.  Using "output/SVG" works just fine.
-    #   https://github.com/sagemathinc/cocalc/issues/1962
-    jax: ["input/TeX","input/AsciiMath", "output/SVG"]
-    # http://docs.mathjax.org/en/latest/options/tex2jax.html
-    tex2jax:
-        inlineMath     : [ ['$','$'], ["\\(","\\)"] ]
-        displayMath    : [ ['$$','$$'], ["\\[","\\]"] ]
-        processEscapes : true
-        ignoreClass    : "tex2jax_ignore"
-        skipTags       : ["script","noscript","style","textarea","pre","code"]
-
-    TeX:
-        MAXBUFFER  : 100000  # see https://github.com/mathjax/MathJax/issues/910
-        extensions : ["autoload-all.js", "noUndefined.js", "noErrors.js"]
-        Macros     : # get these from sage/misc/latex.py
-            Bold  : ["\\mathbb{#1}",1]
-            ZZ    : ["\\Bold{Z}",0]
-            NN    : ["\\Bold{N}",0]
-            RR    : ["\\Bold{R}",0]
-            CC    : ["\\Bold{C}",0]
-            FF    : ["\\Bold{F}",0]
-            QQ    : ["\\Bold{Q}",0]
-            QQbar : ["\\overline{\\QQ}",0]
-            CDF   : ["\\Bold{C}",0]
-            CIF   : ["\\Bold{C}",0]
-            CLF   : ["\\Bold{C}",0]
-            RDF   : ["\\Bold{R}",0]
-            RIF   : ["\\Bold{I} \\Bold{R}",0]
-            RLF   : ["\\Bold{R}",0]
-            CFF   : ["\\Bold{CFF}",0]
-            GF    : ["\\Bold{F}_{#1}",1]
-            Zp    : ["\\ZZ_{#1}",1]
-            Qp    : ["\\QQ_{#1}",1]
-            Zmod  : ["\\ZZ/#1\\ZZ",1]
-        noErrors:  # http://docs.mathjax.org/en/latest/tex.html#noerrors
-            inlineDelimiters : ["$","$"]
-            multiLine        : true
-            style:
-                "font-size"  : "85%"
-                "text-align" : "left"
-                "color"      : "red"
-                "padding"    : "1px 3px"
-                "background" : "#FFEEEE"
-                "border"     : "none"
-        noUndefined:  # http://docs.mathjax.org/en/latest/tex.html#noundefined
-            attributes:
-                mathcolor      : "red"
-                mathbackground : "#FFEEEE"
-                mathsize       : "90%"
-
-    # do not use "xypic.js", frequently causes crash!
-    "HTML-CSS":
-        linebreaks:
-            automatic: true
-    SVG:
-        linebreaks:
-            automatic: true
-    showProcessingMessages: false
+# load the mathjax configuration before mathjax starts up
+{MathJaxConfig} = require('smc-util/mathjax-config')
+window.MathJax = MathJaxConfig
 
 $ = window.$
 $("#smc-startup-banner")?.remove()
@@ -129,11 +65,12 @@ $('#smc-startup-banner-status')?.remove()
 $ ->
     $(parent).trigger('initialize:frame')
 
-    # dynamically inserting the mathjax script URL
+    # mathjax startup. config is set above, now we dynamically insert the mathjax script URL
     mjscript = document.createElement("script")
     mjscript.type = "text/javascript"
     mjscript.src  = MATHJAX_URL
     mjscript.onload = ->
+        # once loaded, we finalize the configuration and process pending rendering requests
         {mathjax_finish_startup} = require('./misc_page')
         MathJax.Hub?.Queue([mathjax_finish_startup])
     document.getElementsByTagName("head")[0].appendChild(mjscript)

--- a/src/smc-webapp/printing.coffee
+++ b/src/smc-webapp/printing.coffee
@@ -137,7 +137,7 @@ class SagewsPrinter extends Printer
     generate_html: (data) ->
         if not @_html_tmpl?
             # recycle our mathjax config from last.coffee
-            {MathJaxConfig} = require('./last')
+            {MathJaxConfig} = require('smc-util/mathjax-config')
             MathJaxConfig = _.clone(MathJaxConfig)
             MathJaxConfig.skipStartupTypeset = false
             MathJaxConfig.showProcessingMessages = true


### PR DESCRIPTION
This reuses the existing webapp mathjax configuration for the static renderer in shared.Not all settings can be used, though ,and well, no idea how to fix all the remaining erroneous attempts to render a formula in the codemirror boxes.

screenshot for the QQbar macro:

![screenshot from 2017-11-24 15-29-00](https://user-images.githubusercontent.com/207405/33214437-381834a8-d12c-11e7-99b7-cd16b37c181c.png)
