### PR TITLE
webapp: switch TimeAgo to alternatively show absolute times

### DIFF
--- a/src/smc-util/db-schema.coffee
+++ b/src/smc-util/db-schema.coffee
@@ -259,6 +259,7 @@ schema.accounts =
                     show_global_info2 : null
                     first_steps       : true
                     newsletter        : true
+                    time_ago_absolute : false
                 first_name      : ''
                 last_name       : ''
                 terminal        :

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -1109,6 +1109,14 @@ OtherSettings = rclass
             Offer to setup the "First Steps" guide (if available).
         </Checkbox>
 
+    render_time_ago_absolute: ->
+        <Checkbox
+            checked  = {@props.other_settings.time_ago_absolute}
+            ref      = 'time_ago_absolute'
+            onChange = {(e)=>@on_change('time_ago_absolute', e.target.checked)}>
+            Display timestamps as absolut points in time – otherwise they are relative to the current time.
+        </Checkbox>
+
     render_confirm: ->
         if not require('./feature').IS_MOBILE
             <Checkbox
@@ -1170,6 +1178,7 @@ OtherSettings = rclass
         <Panel header={<h2> <Icon name='gear' /> Other settings</h2>}>
             {@render_confirm()}
             {@render_first_steps()}
+            {@render_time_ago_absolute()}
             {@render_mask_files()}
             {@render_default_file_sort()}
             {@render_page_size()}

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -1114,7 +1114,7 @@ OtherSettings = rclass
             checked  = {@props.other_settings.time_ago_absolute}
             ref      = 'time_ago_absolute'
             onChange = {(e)=>@on_change('time_ago_absolute', e.target.checked)}>
-            Display timestamps as absolut points in time – otherwise they are relative to the current time.
+            Display timestamps as absolute points in time – otherwise they are relative to the current time.
         </Checkbox>
 
     render_confirm: ->

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -20,7 +20,7 @@
 
 async = require('async')
 
-{React, ReactDOM, rclass, rtypes, is_redux, is_redux_actions, redux, Store, Actions} = require('./smc-react')
+{React, ReactDOM, rclass, rtypes, is_redux, is_redux_actions, redux, Store, Actions, Redux} = require('./smc-react')
 {Alert, Button, ButtonToolbar, Checkbox, Col, FormControl, FormGroup, ControlLabel, InputGroup, OverlayTrigger, Popover, Modal, Tooltip, Row, Well} = require('react-bootstrap')
 {HelpEmailLink, SiteName, CompanyName, PricingUrl, PolicyTOSPageUrl, PolicyIndexPageUrl, PolicyPricingPageUrl} = require('./customize')
 {UpgradeRestartWarning} = require('./upgrade_restart_warning')
@@ -520,8 +520,8 @@ timeago_formatter = (value, unit, suffix, date) ->
 
 TimeAgo = require('react-timeago').default
 
-exports.TimeAgo = rclass
-    displayName : 'Misc-TimeAgo'
+exports.TimeAgoElement = rclass
+    displayName : 'Misc-TimeAgoElement'
 
     propTypes :
         popover   : rtypes.bool
@@ -562,6 +562,54 @@ exports.TimeAgo = rclass
         else
             @render_timeago(d)
 
+TimeAgoWrapper = rclass
+    displayName : 'Misc-TimeAgo'
+
+    propTypes :
+        popover   : rtypes.bool
+        placement : rtypes.string
+        tip       : rtypes.string     # optional body of the tip popover with title the original time.
+        live      : rtypes.bool       # whether or not to auto-update
+
+    reduxProps :
+        account :
+            other_settings : rtypes.object
+
+    render: ->
+        if @props.other_settings.time_ago_absolute ? false
+            try
+                s = new Date(@props.date).toLocaleString()
+                <span>{s}</span>
+            catch
+                <span>Invalid Date</span>
+        else
+            <exports.TimeAgoElement
+                date      = {@props.date}
+                popover   = {@props.popover}
+                placement = {@props.placement}
+                tip       = {@props.tip}
+                live      = {@props.live}
+            />
+
+exports.TimeAgo = rclass
+    displayName : 'Misc-TimeAgo-redux'
+
+    propTypes :
+        popover   : rtypes.bool
+        placement : rtypes.string
+        tip       : rtypes.string     # optional body of the tip popover with title the original time.
+        live      : rtypes.bool       # whether or not to auto-update
+
+    render: ->
+        <Redux redux={redux}>
+            <TimeAgoWrapper
+                date      = {@props.date}
+                popover   = {@props.popover}
+                placement = {@props.placement}
+                tip       = {@props.tip}
+                live      = {@props.live}
+            />
+        </Redux>
 
 # Important:
 # widget can be controlled or uncontrolled -- use default_value for an *uncontrolled* widget

--- a/src/smc-webapp/share/public-paths-browser.cjsx
+++ b/src/smc-webapp/share/public-paths-browser.cjsx
@@ -4,7 +4,7 @@ Share server top-level landing page.
 
 {rclass, React, ReactDOM, rtypes} = require('../smc-react')
 
-{Space, TimeAgo} = require('../r_misc')
+{Space, TimeAgoElement} = require('../r_misc')
 
 INDEX_STYLE =
     margin     : '15px 30px'
@@ -51,7 +51,7 @@ exports.PublicPathsBrowser = rclass
     render_last_edited: (info) ->
         last_edited = info.get('last_edited')
         <span key='last'   style={display:'inline-block', width:'30%'}>
-            {<TimeAgo date={last_edited} live={false} /> if last_edited?}
+            {<TimeAgoElement date={last_edited} live={false} /> if last_edited?}
         </span>
 
     render_public_path_link: (info, bgcolor) ->


### PR DESCRIPTION
This bugged me for a while, too.

However, I'm wondering if there is a better way than this redux-double-wrapping of the element? 