### PR TITLE
webapp: load stats from the /stats endpoint

### DIFF
--- a/src/smc-webapp/r_help.cjsx
+++ b/src/smc-webapp/r_help.cjsx
@@ -395,7 +395,7 @@ exports.HelpPage = HelpPage = rclass
                 </Row>
                 <Row style={marginTop:'20px'}>
                     <ThirdPartySoftware />
-                    {# <HelpPageUsageSection /> }
+                    <HelpPageUsageSection />
                 </Row>
                 <Row>
                     {<LinkList title='About' icon='info-circle' links={ABOUT_LINKS} width={12} /> if require('./customize').commercial}

--- a/src/smc-webapp/redux_server_stats.coffee
+++ b/src/smc-webapp/redux_server_stats.coffee
@@ -8,19 +8,32 @@ name    = 'server_stats'
 actions = redux.createActions(name)
 store   = redux.createStore(name, {loading:true})
 
-class StatsTable extends Table
-    query: ->
-        return 'stats'
+$ = window.$
+{BASE_URL} = require('misc_page')
+get_stats = ->
+    $.getJSON "#{BASE_URL}/stats", (data) ->
+        data.time = new Date(data.time)
+        data.loading = false
+        actions.setState(data)
+    setTimeout(get_stats, 90 * 1000)
 
-    _change: (table, keys) =>
-        newest = undefined
-        for obj in table.get(keys).toArray()
-            if obj? and (not newest? or obj.get('time') > newest.get('time'))
-                newest = obj
-        if newest?
-            newest = newest.toJS()
-            newest.time = new Date(newest.time)
-            newest.loading = false
-            actions.setState(newest)
+get_stats()
 
-redux.createTable(name, StatsTable)
+#class StatsTable extends Table
+
+#    query: ->
+#        return 'stats'
+#
+#    _change: (table, keys) =>
+#        newest = undefined
+#        for obj in table.get(keys).toArray()
+#            if obj? and (not newest? or obj.get('time') > newest.get('time'))
+#                newest = obj
+#        if newest?
+#            newest = newest.toJS()
+#            newest.time = new Date(newest.time)
+#            newest.loading = false
+#            actions.setState(newest)
+#
+
+#redux.createTable(name, StatsTable)


### PR DESCRIPTION
I'm not even sure what I'm doing here. This is an ugly proof of concept for loading the "stats" data from the dedicated /stats http-endpoint. 