### PR TITLE
Sharing improvements

### DIFF
--- a/src/s
+++ b/src/s
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import os,time
+
+s = "dev/project/start_share.py"
+while True:
+    print(s)
+    os.system(s)
+    time.sleep(1)

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1533,11 +1533,6 @@ ProjectFilesActionBox = rclass
             display_url += '/'
         return display_url
 
-    render_public_share_url: (url, copyable) ->
-        <CopyToClipBoard
-            value = url
-        />
-
     render_public_link_header: (url, as_link) ->
         if as_link
             <h4><a href={url} target="_blank">Public link</a></h4>
@@ -1561,6 +1556,11 @@ ProjectFilesActionBox = rclass
                 parent_is_public = true
         show_social_media = require('./customize').commercial and single_file_data.is_public
         url = @construct_public_share_url(single_file)
+        button_before =
+            <Button bsStyle='default' onClick={=>console.log "TODO OPEN"}>
+                <Icon name='external-link' />
+            </Button>
+
         <div>
             <Row>
                 <Col sm=8 style={color:'#666', fontSize:'12pt'}>
@@ -1584,27 +1584,31 @@ ProjectFilesActionBox = rclass
                     </FormGroup>
                     {@render_share_warning() if parent_is_public}
                 </Col>
+                {<Col sm=4 style={color:'#666'}>
+                    <h4>Shared publicly</h4>
+                    <CopyToClipBoard
+                        value         = url
+                        button_before = {button_before}
+                        hide_after    = {true}
+                    />
+                </Col> if single_file_data.is_public}
                 <Col sm=4 style={color:'#666'}>
-                    <h4>Share this publicly</h4>
+                    <h4>Items</h4>
                     {@render_selected_files_list()}
-                </Col>
-                <Col sm=4 style={color:'#666'}>
-                    {@render_public_link_header(url, single_file_data.is_public)}
-                    {@render_public_share_url(url)}
                 </Col>
             </Row>
             <Row>
-                <Col sm=8>
+                <Col sm=4>
                     <ButtonToolbar>
                         <Button bsStyle='primary' onClick={@share_click} disabled={parent_is_public}>
                             <Icon name='share-square-o' /><Space/>
-                            {if single_file_data.is_public then 'Change description' else 'Make item public'}
+                            {if single_file_data.is_public then 'Update description' else 'Make item public'}
                         </Button>
                         <Button bsStyle='warning' onClick={@stop_sharing_click} disabled={not single_file_data.is_public or parent_is_public}>
-                            <Icon name='shield' /> Stop sharing item publicly
+                            <Icon name='shield' /> Make item private
                         </Button>
                         <Button onClick={@cancel_action}>
-                            Close
+                            Cancel
                         </Button>
                     </ButtonToolbar>
                 </Col>

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -146,17 +146,6 @@ ListingHeader = rclass
                 {@render_sort_link("name", "Name")}
             </Col>
         </Row>
-ShareButton = ({on_click}) ->
-    <span><Space/>
-        <Button
-            bsSize  = 'xsmall'
-            onClick = {on_click}
-            style   = {color:'rgb(102, 102, 102)'}
-        >
-            <Icon name='share-o' /> <span className='hidden-xs'>Share...</span>
-        </Button>
-    </span>
-
 PublicButton = ({on_click}) ->
     <span><Space/>
         <Button
@@ -267,10 +256,6 @@ FileRow = rclass
             />
         else if @props.is_public
             <PublicButton
-                on_click = {generate_click_for('share', @full_path(), @props.actions)}
-            />
-        else
-            <ShareButton
                 on_click = {generate_click_for('share', @full_path(), @props.actions)}
             />
 
@@ -403,10 +388,6 @@ DirectoryRow = rclass
             />
         else if @props.is_public
             <PublicButton
-                on_click = {generate_click_for('share', @full_path(), @props.actions)}
-            />
-        else
-            <ShareButton
                 on_click = {generate_click_for('share', @full_path(), @props.actions)}
             />
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1557,7 +1557,7 @@ ProjectFilesActionBox = rclass
         show_social_media = require('./customize').commercial and single_file_data.is_public
         url = @construct_public_share_url(single_file)
         button_before =
-            <Button bsStyle='default' onClick={=>console.log "TODO OPEN"}>
+            <Button bsStyle='default' onClick={=>window.open(url, "_blank")}>
                 <Icon name='external-link' />
             </Button>
 

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1732,9 +1732,14 @@ exports.UpgradeAdjustor = rclass
                 </ButtonToolbar>
             </Alert>
 
+# Takes a value and makes it highlight on click
+# Has a copy to clipboard button by default on the end
+# See prop descriptions for more details
 exports.CopyToClipBoard = rclass
     propTypes:
-        value : rtypes.string
+        value         : rtypes.string
+        button_before : rtypes.element # Optional button to place before the copy text
+        hide_after    : rtypes.bool    # Hide the default after button
 
     getInitialState: ->
         show_tooltip : false
@@ -1748,9 +1753,29 @@ exports.CopyToClipBoard = rclass
         return if not @state.show_tooltip
         @setState(show_tooltip : false)
 
+    render_button_after: ->
+        <InputGroup.Button>
+            <Overlay
+                show      = {@state.show_tooltip}
+                target    = {() => ReactDOM.findDOMNode(@refs.clipboard_button)}
+                placement = 'bottom'
+            >
+                <Tooltip id='copied'>Copied!</Tooltip>
+            </Overlay>
+            <Button
+                ref     = "clipboard_button"
+                onClick = {@on_button_click}
+            >
+                <Icon name='clipboard'/>
+            </Button>
+        </InputGroup.Button>
+
     render: ->
         <FormGroup>
             <InputGroup>
+                {<InputGroup.Button>
+                    {@props.button_before}
+                </InputGroup.Button> if @props.button_before?}
                 <FormControl
                     type     = "text"
                     readOnly = {true}
@@ -1758,20 +1783,6 @@ exports.CopyToClipBoard = rclass
                     onClick  = {(e)=>e.target.select()}
                     value    = {@props.value}
                 />
-                <InputGroup.Button>
-                    <Overlay
-                        show      = {@state.show_tooltip}
-                        target    = {() => ReactDOM.findDOMNode(@refs.clipboard_button)}
-                        placement = 'bottom'
-                    >
-                        <Tooltip id='copied'>Copied!</Tooltip>
-                    </Overlay>
-                    <Button
-                        ref     = "clipboard_button"
-                        onClick = {@on_button_click}
-                    >
-                        <Icon name='clipboard'/>
-                    </Button>
-                </InputGroup.Button>
+                {@render_button_after() unless @props.hide_after}
             </InputGroup>
         </FormGroup>


### PR DESCRIPTION
- Removes `Share` button from listing entries
- Improves sharing workflow
- Rename `Close` to `Cancel` for consistency
- Rename `Stop sharing item publicly` to `Make item private`

<img width="1422" alt="screen shot 2017-11-30 at 4 23 24 pm" src="https://user-images.githubusercontent.com/618575/33462260-67373cd4-d5eb-11e7-8977-8d933004397c.png">

Only see the link after sharing. 
<img width="1433" alt="screen shot 2017-11-30 at 4 23 37 pm" src="https://user-images.githubusercontent.com/618575/33462261-674e688c-d5eb-11e7-8642-f45f415a93f8.png">
List of items is less important at this point (esp since you can't share more than one item yet).
