### PR TITLE
Issue/2575

### DIFF
--- a/src/smc-hub/test/mocha.opts
+++ b/src/smc-hub/test/mocha.opts
@@ -1,4 +1,4 @@
 --require coffee-script/register
 --reporter spec
 --recursive
-
+--exit

--- a/src/smc-hub/test/postgres/postgres-user-queries-basic.coffee
+++ b/src/smc-hub/test/postgres/postgres-user-queries-basic.coffee
@@ -110,7 +110,7 @@ describe 'some basic testing of user_queries', ->
             account_id : account_id2
             query      : {projects:[{project_id:project_id, title:null, description:null}]}
             cb         : (err, projects) ->
-                expect(err).toEqual('you do not have read access to this project')
+                expect(err).toEqual('FATAL: you do not have read access to this project')
                 done()
 
     it 'queries the collaborators virtual table before there are any projects for the second user', (done) ->
@@ -236,7 +236,7 @@ describe 'testing file_use -- ', ->
                     path        : 'foo'
                     users       : null
             cb         : (err, result) ->
-                expect(err).toEqual('you do not have read access to this project')
+                expect(err).toEqual('FATAL: you do not have read access to this project')
                 done()
 
     it 'adds second user to first project, then reads and finds one file_use match', (done) ->
@@ -337,7 +337,7 @@ describe 'testing file_use -- ', ->
                     account_id : accounts[0]
                     query      : {file_use : obj}
                     cb         : (err) ->
-                        expect(err).toEqual('user must be an admin')
+                        expect(err).toEqual('FATAL: user must be an admin')
                         cb()
             (cb) ->
                 # now make account 0 an admin
@@ -442,7 +442,7 @@ describe 'test project_log table', ->
             query      :
                 project_log : [{project_id:projects[0], time:null, id:null}]
             cb         : (err, result) ->
-                expect(err).toEqual('you do not have read access to this project')
+                expect(err).toEqual('FATAL: you do not have read access to this project')
                 done()
 
     it 'make third user an admin and verify can read log of first project', (done) ->
@@ -533,7 +533,7 @@ describe 'nonexistent tables', ->
             account_id : account_id
             query      : {nonexistent_table: {foo:'bar'}}
             cb         : (err) ->
-                expect(err).toEqual("table 'nonexistent_table' does not exist")
+                expect(err).toEqual("FATAL: table 'nonexistent_table' does not exist")
                 done(not err)
 
     it 'read from non-existent table (single thing)', (done) ->
@@ -541,7 +541,7 @@ describe 'nonexistent tables', ->
             account_id : account_id
             query      : {nonexistent_table: {foo:null}}
             cb         : (err) ->
-                expect(err).toEqual("get queries not allowed for table 'nonexistent_table'")
+                expect(err).toEqual("FATAL: get queries not allowed for table 'nonexistent_table'")
                 done(not err)
 
     it 'read from non-existent table (multiple)', (done) ->
@@ -549,7 +549,7 @@ describe 'nonexistent tables', ->
             account_id : account_id
             query      : {nonexistent_table: [{foo:null}]}
             cb         : (err) ->
-                expect(err).toEqual("get queries not allowed for table 'nonexistent_table'")
+                expect(err).toEqual("FATAL: get queries not allowed for table 'nonexistent_table'")
                 done(not err)
 
 

--- a/src/smc-hub/test/postgres/postgres-user-queries-changefeeds-2.coffee
+++ b/src/smc-hub/test/postgres/postgres-user-queries-changefeeds-2.coffee
@@ -331,7 +331,7 @@ describe 'test changefeed admin-only access to project', ->
             account_id : accounts[0]
             query      : {projects_admin:{project_id:project_id, title:"Better Title"}}
             cb         : (err) ->
-                expect(err).toEqual("user set queries not allowed for table 'projects_admin'")
+                expect(err).toEqual("FATAL: user set queries not allowed for table 'projects_admin'")
                 done()
 
     it 'tests project title changed properly (so reading as admin)', (done) ->
@@ -347,7 +347,7 @@ describe 'test changefeed admin-only access to project', ->
             account_id : accounts[1]
             query      : {projects:{project_id:project_id, title:"Even Better Title"}}
             cb         : (err) ->
-                expect(err).toEqual('user must be an admin')
+                expect(err).toEqual('FATAL: user must be an admin')
                 done()
 
     it 'tests reading from project as non-collab', (done) ->
@@ -355,14 +355,14 @@ describe 'test changefeed admin-only access to project', ->
             account_id : accounts[1]
             query      : {projects:{project_id:project_id, title:null}}
             cb         : (err) ->
-                expect(err).toEqual('you do not have read access to this project')
+                expect(err).toEqual('FATAL: you do not have read access to this project')
                 done()
 
     it 'tests writing to project as anonymous', (done) ->
         db.user_query
             query      : {projects:{project_id:project_id, title:null}}
             cb         : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'projects'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'projects'")
                 done()
 
     it 'tests admin changefeed on projects_admin table', (done) ->
@@ -389,14 +389,14 @@ describe 'test changefeed admin-only access to project', ->
                     cb()
                 ], done)
 
-    it 'tests that user must be an admin to read from (or get changefeed on) projects_admin table', (done) ->
+    it 'tests that FATAL: user must be an admin to read from (or get changefeed on) projects_admin table', (done) ->
         changefeed_id = misc.uuid()
         db.user_query
             account_id : accounts[1]  # NOT admin
             query      : {projects_admin:[{project_id:project_id, title:null}]}
             changes    : changefeed_id
             cb         : (err) ->
-                expect(err).toEqual('user must be an admin')
+                expect(err).toEqual('FATAL: user must be an admin')
                 done()
 
 
@@ -458,7 +458,7 @@ describe 'test public_projects table -- ', ->
             account_id : accounts[0]
             query      : {public_projects:{project_id:null, title:null, description:null}}
             cb         : (err, x) ->
-                expect(err).toEqual('must specify project_id')
+                expect(err).toEqual('FATAL: must specify project_id')
                 done()
 
     tests = (account_id, done) ->
@@ -530,14 +530,14 @@ describe 'test public_paths table -- ', ->
             account_id : accounts[1]
             query      : {public_paths:{project_id:projects[0], path:"bar2.txt"}}
             cb         : (err) ->
-                expect(err).toEqual('user must be an admin')
+                expect(err).toEqual('FATAL: user must be an admin')
                 done()
 
     it 'fail to add a public path when not logged in', (done) ->
         db.user_query
             query      : {public_paths:{project_id:projects[0], path:'foo2.txt'}}
             cb         : (err) ->
-                expect(err).toEqual('no anonymous set queries')
+                expect(err).toEqual('FATAL: no anonymous set queries')
                 done()
 
     read_public_paths = (done) ->
@@ -561,7 +561,7 @@ describe 'test public_paths table -- ', ->
             query      : {public_paths:[{project_id:projects[0], path:null}]}
             changes    : misc.uuid()
             cb         : (err) =>
-                expect(err).toEqual("changefeed MUST include primary key (='id') in query")
+                expect(err).toEqual("FATAL: changefeed MUST include primary key (='id') in query")
                 done()
 
     changefeed_pub_paths = (done) ->
@@ -624,7 +624,7 @@ describe 'test site_settings table -- ', ->
             account_id : accounts[0]
             query : {site_settings:{site_name:'Hacker Site!'}}
             cb    : (err) ->
-                expect(err).toEqual("error setting 'name' -- Error: setting name='undefined' not allowed")
+                expect(err).toEqual("FATAL: error setting 'name' -- Error: setting name='undefined' not allowed")
                 done()
 
     it "check writing to not allowed row", (done) ->
@@ -632,21 +632,21 @@ describe 'test site_settings table -- ', ->
             account_id : accounts[0]
             query : {site_settings:{name:'foobar', value:'stuff'}}
             cb    : (err) ->
-                expect(err).toEqual("error setting 'name' -- Error: setting name='foobar' not allowed")
+                expect(err).toEqual("FATAL: error setting 'name' -- Error: setting name='foobar' not allowed")
                 done()
 
     it "check anon can't write", (done) ->
         db.user_query
             query : {site_settings:{name:'site_name', value:'Hacker Site!'}}
             cb    : (err) ->
-                expect(err).toEqual("no anonymous set queries")
+                expect(err).toEqual("FATAL: no anonymous set queries")
                 done()
 
     it "check anon can't read", (done) ->
         db.user_query
             query : {site_settings:{name:'site_name', value:null}}
             cb    : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'site_settings'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'site_settings'")
                 done()
 
     it "check non-admin can't write", (done) ->
@@ -654,7 +654,7 @@ describe 'test site_settings table -- ', ->
             account_id : accounts[1]
             query : {site_settings:{name:'site_name', value:'Hacker Site!'}}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it "check non-admin can't read", (done) ->
@@ -662,7 +662,7 @@ describe 'test site_settings table -- ', ->
             account_id : accounts[1]
             query : {site_settings:{name:'site_name', value:null}}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it "check admin can write", (done) ->
@@ -739,16 +739,16 @@ describe 'test stats changefeed: ', ->
         db.user_query
             query : {stats:[obj]}
             cb    : (err, x) ->
-                expect(x).toEqual({ stats: [] })
-                done(err)
+                expect(err).toEqual("FATAL: get queries not allowed for table 'stats'")
+                done()
 
     it 'query the stats table as user (get nothing, no error)', (done) ->
         db.user_query
             account_id : account_id
             query      : {stats:[obj]}
             cb         : (err, x) ->
-                expect(x).toEqual({ stats: [] })
-                done(err)
+                expect(err).toEqual("FATAL: get queries not allowed for table 'stats'")
+                done()
 
     it 'insert some entries in the stats table', (done) ->
         db.get_stats(cb:done)
@@ -758,77 +758,15 @@ describe 'test stats changefeed: ', ->
             account_id : account_id
             query      : {stats:[obj]}
             cb         : (err, x) ->
-                expect(x).toEqual({ stats: [ { accounts: 1, accounts_created: { '1d': 1, '1h': 1, '30d': 1, '7d': 1 }, hub_servers: [], id:x.stats[0].id, projects: 0, projects_created: { '1d': 0, '1h': 0, '30d': 0, '7d': 0 }, projects_edited: { '1d': 0, '1h': 0, '30d': 0, '5min': 0, '7d': 0 }, time:x.stats[0].time } ] })
-                done(err)
+                expect(err).toEqual("FATAL: get queries not allowed for table 'stats'")
+                done()
 
     it 'query the stats table as anon and gets the one entry', (done) ->
         db.user_query
             query      : {stats:[obj]}
             cb         : (err, x) ->
-                expect(x).toEqual({ stats: [ { accounts: 1, accounts_created: { '1d': 1, '1h': 1, '30d': 1, '7d': 1 }, hub_servers: [], id:x.stats[0].id, projects: 0, projects_created: { '1d': 0, '1h': 0, '30d': 0, '7d': 0 }, projects_edited: { '1d': 0, '1h': 0, '30d': 0, '5min': 0, '7d': 0 }, time:x.stats[0].time } ] })
-                done(err)
-
-    it 'creates some more accounts and projects and add another stats entry', (done) ->
-        async.series([
-            (cb) ->
-                create_accounts 100, 1, (err, x) -> account_id=x[0]; cb(err)
-            (cb) ->
-                create_projects 100, account_id, cb
-            (cb) ->
-                db.get_stats(cb:cb, ttl:-1)
-            (cb) ->
-                db.user_query
-                    query      : {stats:[obj]}
-                    cb         : (err, x) ->
-                        expect(x.stats[0]).toEqual({ accounts: 101, accounts_created: { '1d': 101, '1h': 101, '30d': 101, '7d': 101 }, hub_servers: [], id:x.stats[0].id, projects: 100, projects_created: { '1d': 100, '1h': 100, '30d': 100, '7d': 100 }, projects_edited: { '1d': 100, '1h': 100, '30d': 100, '5min': 100, '7d': 100 }, time:x.stats[0].time })
-                        cb(err)
-        ], done)
-
-    it 'create anonymous changefeed on stats and see new entry appear', (done) ->
-        changefeed_id = misc.uuid()
-        remove_id = undefined
-        db.user_query
-            query      : {stats:[obj]}
-            changes    : changefeed_id
-            cb         : changefeed_series([
-                (x, cb) ->
-                    expect(x.stats.length).toEqual(2)
-                    async.series([
-                        (cb) ->
-                            create_projects(10, account_id, cb)
-                        (cb) ->
-                            db.get_stats(ttl:0, ttl_db:0, ttl_dt:0, cb:cb)
-                    ], cb)
-                (x, cb) ->
-                    expect(x).toEqual({ action: 'insert', new_val: { accounts: 101, accounts_created: { '1d': 101, '1h': 101, '30d': 101, '7d': 101 }, hub_servers: [], id:x.new_val.id, projects: 110, projects_created: { '1d': 110, '1h': 110, '30d': 110, '7d': 110 }, projects_edited: { '1d': 110, '1h': 110, '30d': 110, '5min': 110, '7d': 110 }, time: x.new_val.time } })
-
-                    db._query
-                        query : "UPDATE stats"
-                        set   : {projects:150}
-                        where : {id:x.new_val.id}
-                        cb    : cb
-
-                (x, cb) ->
-                    expect(x).toEqual({ action: 'update', new_val: { accounts: 101, accounts_created: { '1d': 101, '1h': 101, '30d': 101, '7d': 101 }, hub_servers: [], id:x.new_val.id, projects: 150, projects_created: { '1d': 110, '1h': 110, '30d': 110, '7d': 110 }, projects_edited: { '1d': 110, '1h': 110, '30d': 110, '5min': 110, '7d': 110 }, time: x.new_val.time } })
-
-                    # remove something from the changefeed by editing its timestamp to be old
-                    remove_id = x.new_val.id
-                    db._query
-                        query : "UPDATE stats"
-                        set   : {time:misc.hours_ago(2)}
-                        where : {id:remove_id}
-                        cb    : cb
-                (x, cb) ->
-                    expect(x.action).toEqual('delete')
-                    expect(x.old_val.id).toEqual(remove_id)
-                    expect(x.new_val).toEqual(undefined)
-
-                    db.user_query_cancel_changefeed(id:changefeed_id, cb:cb)
-                (x, cb) ->
-                    expect(x).toEqual({action:'close'})
-
-                    cb()
-            ], done)
+                expect(err).toEqual("FATAL: get queries not allowed for table 'stats'")
+                done()
 
 
 describe 'test system_notifications ', ->
@@ -865,7 +803,7 @@ describe 'test system_notifications ', ->
                 cb         : (err, result) ->
                     expect(err).toEqual(x.err)
                     cb()
-        async.map([{account_id:accounts[0]}, {account_id:accounts[1], err:'user must be an admin'}, {err:'no anonymous set queries'}], f, done)
+        async.map([{account_id:accounts[0]}, {account_id:accounts[1], err:'FATAL: user must be an admin'}, {err:'FATAL: no anonymous set queries'}], f, done)
 
     it 'reads non-empty table as admin, non-admin, and anon', (done) ->
         # fill in the defaults from the schema

--- a/src/smc-hub/test/postgres/postgres-user-queries-cursors.coffee
+++ b/src/smc-hub/test/postgres/postgres-user-queries-cursors.coffee
@@ -127,7 +127,7 @@ describe 'access control tests on cursors table -- ', ->
             project_id : projects[0]
             query      : {cursors:{string_id:string_id, user_id:0, time:t[0], locs:null}}
             cb         : (err, x) ->
-                expect(err).toEqual("get queries not allowed for table 'cursors'")
+                expect(err).toEqual("FATAL: get queries not allowed for table 'cursors'")
                 done()
 
     it 'fails to reads back as user not on project', (done) ->
@@ -135,21 +135,21 @@ describe 'access control tests on cursors table -- ', ->
             account_id : accounts[1]
             query      : {cursors:{string_id:string_id, user_id:0, time:t[0], locs:null}}
             cb         : (err, x) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it 'tries to read as anon and fails', (done) ->
         db.user_query
             query : {cursors:{string_id:string_id, time:t[0], user_id:0, locs:null}}
             cb    : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'cursors'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'cursors'")
                 done()
 
     it 'tries to write as anon and fails', (done) ->
         db.user_query
             query : {cursors:{string_id:string_id, time:new Date(), user_id:0, locs:[{x:1, y:2}]}}
             cb    : (err) ->
-                expect(err).toEqual("no anonymous set queries")
+                expect(err).toEqual("FATAL: no anonymous set queries")
                 done()
 
     it 'tries to write as user not on the project and fails', (done) ->
@@ -157,7 +157,7 @@ describe 'access control tests on cursors table -- ', ->
             account_id : accounts[1]
             query : {cursors:{string_id:string_id, time:t[1], user_id:0, locs:null}}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it 'tries to write as different project and fails', (done) ->
@@ -165,7 +165,7 @@ describe 'access control tests on cursors table -- ', ->
             project_id : projects[1]
             query : {cursors:{string_id:string_id, time:t[1], user_id:0, locs:[{x:5,y:10}]}}
             cb    : (err) ->
-                expect(err).toEqual("user set queries not allowed for table 'cursors'")
+                expect(err).toEqual("FATAL: user set queries not allowed for table 'cursors'")
                 done()
 
     it 'makes account1 an admin', (done) ->
@@ -203,7 +203,7 @@ describe 'access control tests on cursors table -- ', ->
             project_id : projects[0]
             query      : {cursors:{string_id:string_id, time:t[3], user_id:2, locs:[{x:20,y:25}]}}
             cb         : (err) ->
-                expect(err).toEqual("user set queries not allowed for table 'cursors'")
+                expect(err).toEqual("FATAL: user set queries not allowed for table 'cursors'")
                 done()
 
     it 'tries to write non-array locs and fail', (done) ->
@@ -219,7 +219,7 @@ describe 'access control tests on cursors table -- ', ->
             account_id : accounts[0]
             query : {cursors:{string_id:'sage', time:t[4], user_id:2, locs:[{x:20,y:25}]}}
             cb    : (err) ->
-                expect(err).toEqual("string_id (='sage') must be a string of length 40")
+                expect(err).toEqual("FATAL: string_id (='sage') must be a string of length 40")
                 done()
 
     it 'tries to write with missing locs and fail', (done) ->

--- a/src/smc-hub/test/postgres/postgres-user-queries-patches.coffee
+++ b/src/smc-hub/test/postgres/postgres-user-queries-patches.coffee
@@ -122,14 +122,14 @@ describe 'access control tests on patches table -- ', ->
         db.user_query
             query : {patches:{string_id:null, time:null, user_id:null, patch:null}}
             cb    : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'patches'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'patches'")
                 done()
 
     it 'tries to write as anon to patches table and fails', (done) ->
         db.user_query
             query : {patches:{string_id:string_id, time:new Date(), user_id:0, patch:patch0}}
             cb    : (err) ->
-                expect(err).toEqual("no anonymous set queries")
+                expect(err).toEqual("FATAL: no anonymous set queries")
                 done()
 
     it 'tries to write as user not on the project and fails', (done) ->
@@ -137,7 +137,7 @@ describe 'access control tests on patches table -- ', ->
             account_id : accounts[1]
             query : {patches:{string_id:string_id, time:new Date(), user_id:0, patch:patch0}}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it 'tries to write as different project and fails', (done) ->
@@ -145,7 +145,7 @@ describe 'access control tests on patches table -- ', ->
             project_id : projects[1]
             query : {patches:{string_id:string_id, time:new Date(), user_id:0, patch:patch0}}
             cb    : (err) ->
-                expect(err).toEqual("project not allowed to write to syncstring in different project")
+                expect(err).toEqual("FATAL: project not allowed to write to syncstring in different project")
                 done()
 
     it 'makes account1 an admin', (done) ->
@@ -199,7 +199,7 @@ describe 'access control tests on patches table -- ', ->
             project_id : projects[0]
             query : {patches:{string_id:'sage', time:misc.minutes_ago(4), user_id:0, patch:patch0}}
             cb    : (err) ->
-                expect(err).toEqual("string_id (='sage') must be a string of length 40")
+                expect(err).toEqual("FATAL: string_id (='sage') must be a string of length 40")
                 done()
 
     it 'tries to write invalid time and fails', (done) ->
@@ -239,7 +239,7 @@ describe 'access control tests on patches table -- ', ->
             account_id : accounts[1]
             query      : {patches:{string_id:string_id, user_id:1, patch:patch0}}
             cb         : (err) ->
-                expect("#{err}").toEqual("query must specify (primary) key 'time'")
+                expect("#{err}").toEqual("FATAL: query must specify (primary) key 'time'")
                 done()
 
     it 'tries to write without including string field at all (and fails)', (done) ->
@@ -247,7 +247,7 @@ describe 'access control tests on patches table -- ', ->
             account_id : accounts[1]
             query      : {patches:{time:t0, user_id:1, patch:patch0}}
             cb         : (err) ->
-                expect(err).toEqual("string_id (='undefined') must be a string of length 40")
+                expect(err).toEqual("FATAL: string_id (='undefined') must be a string of length 40")
                 done()
 
 

--- a/src/smc-hub/test/postgres/postgres-user-queries-syncstring-eval.coffee
+++ b/src/smc-hub/test/postgres/postgres-user-queries-syncstring-eval.coffee
@@ -56,14 +56,14 @@ describe 'use of eval_inputs table --', ->
         db.user_query
             query : {eval_inputs:{string_id:string_id, time:t0, user_id:0, input:input}}
             cb    : (err) ->
-                expect(err).toEqual("no anonymous set queries")
+                expect(err).toEqual("FATAL: no anonymous set queries")
                 done()
 
     it 'verifies anonymous get queries are not allowed', (done) ->
         db.user_query
             query : {eval_inputs:[{string_id:string_id, time:null, user_id:null, input:null}]}
             cb    : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'eval_inputs'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'eval_inputs'")
                 done()
 
     it 'verifies set query by user not on syncstring is not allowed', (done) ->
@@ -71,7 +71,7 @@ describe 'use of eval_inputs table --', ->
             account_id : accounts[2]
             query : {eval_inputs:{string_id:string_id, time:t0, user_id:0, input:input}}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it 'verifies get query by user not on project not allowed', (done) ->
@@ -79,7 +79,7 @@ describe 'use of eval_inputs table --', ->
             account_id : accounts[2]
             query : {eval_inputs:[{string_id:string_id, time:null, user_id:null, input:null}]}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it 'make that user an admin', (done) ->
@@ -115,7 +115,7 @@ describe 'use of eval_inputs table --', ->
 
     it 'verifies set/get FAILS by user who is listed on syncstring, but is actually not on project', (done) ->
         test_write_and_read accounts[1], undefined, (err) ->
-            expect(err).toEqual('user must be an admin')
+            expect(err).toEqual('FATAL: user must be an admin')
             done()
 
     it 'adds other user to project', (done) ->
@@ -126,7 +126,7 @@ describe 'use of eval_inputs table --', ->
 
     it 'verifies set/get by other project fails', (done) ->
         test_write_and_read undefined, projects[1], (err) ->
-            expect(err).toEqual('project not allowed to write to syncstring in different project')
+            expect(err).toEqual('FATAL: project not allowed to write to syncstring in different project')
             done()
 
     # one that succeeds should be done last, since this is used below.
@@ -161,7 +161,7 @@ describe 'use of eval_inputs table --', ->
             account_id : accounts[0]
             query : {eval_inputs:[{string_id:null, time:null, user_id:null, input:null}]}
             cb    : (err, x) ->
-                expect(err).toEqual("string_id (='null') must be a string of length 40")
+                expect(err).toEqual("FATAL: string_id (='null') must be a string of length 40")
                 done()
 
     it 'verifies that user_id must be nonnegative', (done) ->
@@ -260,14 +260,14 @@ describe 'use of eval_outputs table --', ->
         db.user_query
             query : {eval_outputs:{string_id:string_id, time:t0, number:0, output:output}}
             cb    : (err) ->
-                expect(err).toEqual("no anonymous set queries")
+                expect(err).toEqual("FATAL: no anonymous set queries")
                 done()
 
     it 'verifies anonymous get queries are not allowed', (done) ->
         db.user_query
             query : {eval_outputs:[{string_id:string_id, time:null, number:null, output:null}]}
             cb    : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'eval_outputs'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'eval_outputs'")
                 done()
 
     it 'verifies set query by user not on syncstring is not allowed', (done) ->
@@ -275,7 +275,7 @@ describe 'use of eval_outputs table --', ->
             account_id : accounts[2]
             query : {eval_outputs:{string_id:string_id, time:t0, number:0, output:output}}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it 'verifies get query by user not on project not allowed', (done) ->
@@ -283,7 +283,7 @@ describe 'use of eval_outputs table --', ->
             account_id : accounts[2]
             query : {eval_outputs:[{string_id:string_id, time:null, number:null, output:null}]}
             cb    : (err) ->
-                expect(err).toEqual("user must be an admin")
+                expect(err).toEqual("FATAL: user must be an admin")
                 done()
 
     it 'make that user an admin', (done) ->
@@ -319,7 +319,7 @@ describe 'use of eval_outputs table --', ->
 
     it 'verifies set/get FAILS by user who is listed on syncstring, but is actually not on project', (done) ->
         test_write_and_read accounts[1], undefined, (err) ->
-            expect(err).toEqual('user must be an admin')
+            expect(err).toEqual('FATAL: user must be an admin')
             done()
 
     it 'adds other user to project', (done) ->
@@ -330,7 +330,7 @@ describe 'use of eval_outputs table --', ->
 
     it 'verifies set/get by other project fails', (done) ->
         test_write_and_read undefined, projects[1], (err) ->
-            expect(err).toEqual('project not allowed to write to syncstring in different project')
+            expect(err).toEqual('FATAL: project not allowed to write to syncstring in different project')
             done()
 
     # one that succeeds should be done last, since this is used below.
@@ -365,7 +365,7 @@ describe 'use of eval_outputs table --', ->
             account_id : accounts[0]
             query : {eval_outputs:[{string_id:null, time:null, number:null, output:null}]}
             cb    : (err, x) ->
-                expect(err).toEqual("string_id (='null') must be a string of length 40")
+                expect(err).toEqual("FATAL: string_id (='null') must be a string of length 40")
                 done()
 
     it 'verifies that number must be nonnegative', (done) ->

--- a/src/smc-hub/test/postgres/postgres-user-queries-syncstring.coffee
+++ b/src/smc-hub/test/postgres/postgres-user-queries-syncstring.coffee
@@ -31,14 +31,14 @@ describe 'basic use of syncstring table from user -- ', ->
         db.user_query
             query : {syncstrings:{project_id:projects[0], path:path, users:accounts}}
             cb    : (err) ->
-                expect(err).toEqual("no anonymous set queries")
+                expect(err).toEqual("FATAL: no anonymous set queries")
                 done()
 
     it 'verifies anonymous get queries are not allowed', (done) ->
         db.user_query
             query : {syncstrings:{project_id:projects[0], path:path, users:null}}
             cb    : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'syncstrings'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'syncstrings'")
                 done()
 
     it 'creates a syncstring entry', (done) ->
@@ -61,7 +61,7 @@ describe 'basic use of syncstring table from user -- ', ->
             account_id : accounts[1]
             query : {syncstrings:{project_id:projects[0], path:'b.txt'}}
             cb    : (err) ->
-                expect(err).toEqual('user must be an admin')
+                expect(err).toEqual('FATAL: user must be an admin')
                 done()
 
     it 'makes account1 an admin', (done) ->
@@ -127,7 +127,7 @@ describe 'basic use of syncstring table from user -- ', ->
             account_id : accounts[0]
             query      : {syncstrings:{path:path, read_only:true}}
             cb         : (err) ->
-                expect(err).toEqual("project_id (='undefined') must be a valid uuid")
+                expect(err).toEqual("FATAL: project_id (='undefined') must be a valid uuid")
                 done()
 
     it 'confirms that path does NOT have to be given (this would be the project-wide syncstring)', (done) ->
@@ -141,7 +141,7 @@ describe 'basic use of syncstring table from user -- ', ->
             account_id : accounts[0]
             query      : {syncstrings:{path:path, read_only:null}}
             cb         : (err) ->
-                expect(err).toEqual("project_id (='undefined') must be a valid uuid")
+                expect(err).toEqual("FATAL: project_id (='undefined') must be a valid uuid")
                 done()
 
     it 'confirms that path does NOT have to be given in get query either', (done) ->
@@ -257,7 +257,7 @@ describe 'basic use of syncstring table from project -- ', ->
             project_id : projects[1]
             query : {syncstrings:{project_id:projects[0], path:'b.txt'}}
             cb    : (err) ->
-                expect(err).toEqual('projects can only access their own syncstrings')
+                expect(err).toEqual('FATAL: projects can only access their own syncstrings')
                 done()
 
     ss_every = undefined
@@ -312,7 +312,7 @@ describe 'basic use of syncstring table from project -- ', ->
             project_id : projects[1]
             query      : {syncstrings:{path:path, read_only:true}}
             cb         : (err) ->
-                expect(err).toEqual("project_id (='undefined') must be a valid uuid")
+                expect(err).toEqual("FATAL: project_id (='undefined') must be a valid uuid")
                 done()
 
     it 'confirms that path does NOT have to be given (this would be the project-wide syncstring)', (done) ->
@@ -326,7 +326,7 @@ describe 'basic use of syncstring table from project -- ', ->
             project_id : projects[1]
             query      : {syncstrings:{path:path, read_only:null}}
             cb         : (err) ->
-                expect(err).toEqual("project_id (='undefined') must be a valid uuid")
+                expect(err).toEqual("FATAL: project_id (='undefined') must be a valid uuid")
                 done()
 
     it 'confirms that path does NOT have to be given in get query either', (done) ->
@@ -425,7 +425,7 @@ describe 'test syncstrings_delete -- ', ->
             account_id : accounts[0]
             query : {syncstrings_delete:{project_id:projects[0], path:path}}
             cb    : (err) ->
-                expect(err).toEqual('user must be an admin')
+                expect(err).toEqual('FATAL: user must be an admin')
                 done()
 
     it 'makes account an admin', (done) ->
@@ -460,14 +460,14 @@ describe 'test access roles for recent_syncstrings_in_project', ->
         db.user_query
             query : {recent_syncstrings_in_project:{project_id:projects[0], path:'foo.txt'}}
             cb    : (err) ->
-                expect(err).toEqual("no anonymous set queries")
+                expect(err).toEqual("FATAL: no anonymous set queries")
                 done()
 
     it 'verifies anonymous get queries are not allowed', (done) ->
         db.user_query
             query : {recent_syncstrings_in_project:{project_id:projects[0], max_age_m:15, string_id:null}}
             cb    : (err) ->
-                expect(err).toEqual("anonymous get queries not allowed for table 'recent_syncstrings_in_project'")
+                expect(err).toEqual("FATAL: anonymous get queries not allowed for table 'recent_syncstrings_in_project'")
                 done()
 
     it 'account do a valid get query and confirms no recent syncstrings', (done) ->
@@ -491,7 +491,7 @@ describe 'test access roles for recent_syncstrings_in_project', ->
             project_id : projects[1]
             query : {recent_syncstrings_in_project:{project_id:projects[0], max_age_m:15, string_id:null}}
             cb    : (err, result) ->
-                expect(err).toEqual('projects can only access their own syncstrings')
+                expect(err).toEqual('FATAL: projects can only access their own syncstrings')
                 done()
 
     it 'account do invalid get query and error', (done) ->
@@ -499,7 +499,7 @@ describe 'test access roles for recent_syncstrings_in_project', ->
             account_id : accounts[1]
             query : {recent_syncstrings_in_project:{project_id:projects[0], max_age_m:15, string_id:null}}
             cb    : (err, result) ->
-                expect(err).toEqual('user must be an admin')
+                expect(err).toEqual('FATAL: user must be an admin')
                 done()
 
     it 'makes account1 an admin', (done) ->


### PR DESCRIPTION
Ref: #2575 

- add `--exit` to mocha opts for mocha 4 compatibility
- fixes for 'FATAL ' prefix on some errors
- get queries not allowed on 'stats' table'

To test, apply patch for this PR, then:
```
cd ~/cocalc/src/smc-hub
npm run testpg
# sample output:
TEST POSTGRES
 
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
 
  401 passing (18s)
 
4.24user 0.55system 0:18.93elapsed 25%CPU (0avgtext+0avgdata 102312maxresident)k
7822inputs+0outputs (9major+55513minor)pagefaults 0swaps
```

