### PR TITLE
Simplify share rendering

### DIFF
--- a/src/smc-hub/share/render-public-path.cjsx
+++ b/src/smc-hub/share/render-public-path.cjsx
@@ -95,6 +95,7 @@ exports.render_public_path = (opts) ->
             else
                 fs.readFile locals.path_to_file, (err, data) ->
                     if err
+                        dbg("file read error")
                         cb(err)
                     else
                         locals.content = data.toString()

--- a/src/smc-webapp/share/page.cjsx
+++ b/src/smc-webapp/share/page.cjsx
@@ -85,19 +85,15 @@ exports.Page = rclass
                 {@render_google_analytics()}
             </head>
             <body>
-                <div style={display: 'flex', flexDirection: 'column', height: '100vh', width: '100vw', overflow: 'auto'}>
-                    <TopBar
-                        viewer       = @props.viewer
-                        path         = @props.path
-                        project_id   = @props.project_id
-                        base_url     = @props.base_url
-                        site_name    = @props.site_name
-                        is_public    = @props.is_public
-                    />
-                    <div key='index' style={display: 'flex', flexDirection: 'column', flex:1}>
-                        {@props.children}
-                    </div>
-                </div>
+                <TopBar
+                    viewer       = @props.viewer
+                    path         = @props.path
+                    project_id   = @props.project_id
+                    base_url     = @props.base_url
+                    site_name    = @props.site_name
+                    is_public    = @props.is_public
+                />
+                {@props.children}
             </body>
         </html>
 

--- a/src/smc-webapp/share/public-path.cjsx
+++ b/src/smc-webapp/share/public-path.cjsx
@@ -111,7 +111,7 @@ exports.PublicPath = rclass
 
         <div style={display: 'flex', flexDirection: 'column', flex:1} has_mathjax={if mathjax then "true"}>
             <PublicPathInfo path={@props.path} info={@props.info} />
-            <div style={background: 'white', overflow:'auto', flex:1}>
+            <div style={background: 'white', flex:1}>
                 {elt}
             </div>
         </div>

--- a/src/smc-webapp/share/public-paths-browser.cjsx
+++ b/src/smc-webapp/share/public-paths-browser.cjsx
@@ -8,8 +8,6 @@ misc = require('smc-util/misc')
 
 INDEX_STYLE =
     margin     : '0px 30px 15px 30px'
-    overflow   : 'auto'
-    height     : '100%'
     background : 'white'
 
 exports.PublicPathsBrowser = rclass
@@ -97,7 +95,7 @@ exports.PublicPathsBrowser = rclass
             @render_public_path_link(info, bgcolor)
 
     render: ->
-        <div style={display:'flex', flexDirection:'column'}>
+        <div>
             <div key='top' style={paddingLeft: '30px', background: '#dfdfdf'}>
                 {@render_overview()}
                 <Space />


### PR DESCRIPTION
>[ws] A concern I just had. All editors in normal Cocalc assume they are in a fixed height div with flex column layout. That's basically why the share server is that way -- so they can keep that assumpion. Just a thought.

I think this is mostly for scroll position reasons. But on the share server, the whole page scrolls. Anyways, for the implemented editors so far it doesn't seem to be an issue.