### PR TITLE
webapp: sanitize all window.open commands against popup blockers

### DIFF
--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1779,7 +1779,7 @@ exports.open_popup_window = (url) ->
 exports.open_new_tab = (url, popup=false) ->
     # if popup=true, it opens a small overlay window instead of a new tab
     if popup
-        tab = window.open(url, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=400,width=600')
+        tab = window.open(url, '', 'menubar=yes,toolbar=no,resizable=yes,scrollbars=yes,height=640,width=800')
     else
         tab = window.open(url)
     if(!tab || tab.closed || typeof tab.closed=='undefined')

--- a/src/smc-webapp/project/plain-jupyter-server.cjsx
+++ b/src/smc-webapp/project/plain-jupyter-server.cjsx
@@ -16,7 +16,7 @@ exports.JupyterServerPanel = rclass
 
     render_jupyter_link: ->
         url = jupyter_server_url(@props.project_id)
-        <LinkRetryUntilSuccess href={url} target='_blank'>
+        <LinkRetryUntilSuccess href={url}>
             <Icon name='cc-icon-ipynb' /> Plain Jupyter Server
         </LinkRetryUntilSuccess>
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1555,9 +1555,11 @@ ProjectFilesActionBox = rclass
             if single_file_data.is_public and single_file_data.public?.path isnt single_file
                 parent_is_public = true
         show_social_media = require('./customize').commercial and single_file_data.is_public
+
         url = @construct_public_share_url(single_file)
+        {open_new_tab} = require('smc-webapp/misc_page')
         button_before =
-            <Button bsStyle='default' onClick={=>window.open(url, "_blank")}>
+            <Button bsStyle='default' onClick={=>open_new_tab(url)}>
                 <Icon name='external-link' />
             </Button>
 

--- a/src/smc-webapp/support.cjsx
+++ b/src/smc-webapp/support.cjsx
@@ -250,8 +250,8 @@ exports.SupportPage = rclass
 
     open: (ticket_id) ->
         url = misc.ticket_id_to_ticket_url(ticket_id)
-        tab = window.open(url, '_blank')
-        tab.focus()
+        {open_new_tab} = require('smc-webapp/misc_page')
+        open_new_tab(url, '_blank')
 
     render_body: ->
         for i, ticket of @props.support_tickets

--- a/src/smc-webapp/video-chat.cjsx
+++ b/src/smc-webapp/video-chat.cjsx
@@ -33,7 +33,9 @@ VIDEO_CHAT_LIMIT         = 8       # imposed by free appear.in plan
 
 # The pop-up window for video chat
 video_window = (title, url, cb_closed) ->
-    w = window.open(url, null, "location=yes,resizable=yes,height=640,width=800")
+    {open_new_tab} = require('smc-webapp/misc_page')
+    return open_new_tab(url, popup=true)
+
     # disabled, see https://github.com/sagemathinc/cocalc/issues/1899
     #w.document.write """
     #<html>
@@ -46,7 +48,6 @@ video_window = (title, url, cb_closed) ->
     #    </body>
     #</html>
     #"""
-    return w
 
 video_windows = {}
 

--- a/src/smc-webapp/widgets-misc/link-retry.cjsx
+++ b/src/smc-webapp/widgets-misc/link-retry.cjsx
@@ -9,7 +9,6 @@ exports.LinkRetryUntilSuccess = rclass
 
     propTypes :
         href   : rtypes.string.isRequired
-        target : rtypes.string.isRequired
 
     getInitialState: ->
         working : false
@@ -17,12 +16,9 @@ exports.LinkRetryUntilSuccess = rclass
         error   : false
 
     open: ->
-        w = window.open(@props.href, @props.target)
-        # see https://github.com/sagemathinc/cocalc/issues/2599
-        # Sometimes randomly w isn't defined -- so waiting a little and
-        # failing gracefully if not seems reasonable; user can always manually
-        # switch to the new tab/window.
-        setTimeout((->w?.focus()), 250)
+        # open_new_tab takes care of blocked popups -- https://github.com/sagemathinc/cocalc/issues/2599
+        {open_new_tab} = require('smc-webapp/misc_page')
+        open_new_tab(@props.href)
 
     start: ->
         @setState(loading:true, error:false)


### PR DESCRIPTION
this is a fix for #2599

background: for example, my chrome browser blocks all javascript actions that attempt to open a new tab by default. I have whitelist some pages like cocalc to be allowed to do this, but new users don't have cocalc whitelisted. the result is, that the `window.open` function returns `undefined` or something like that.

this patch takes care of #2599 and also wraps other instances of `window.open` with that function. I've also modified the popup=true case to match  with the config of the video chat. 

test: popup blocking is again active in a private browsing session of my chrome browser. then, these red information bubbles appear and show a link.