### PR TITLE
webapp/latex: immediately remove temporary pdf after creating preview images

### DIFF
--- a/src/smc-webapp/latex/document.coffee
+++ b/src/smc-webapp/latex/document.coffee
@@ -574,6 +574,15 @@ patchSynctex(\"#{@filename_tex}\");' | R --no-save"
                     cb      : (err, output) ->
                         cb(err)
 
+            # delete the copied PDF file, we no longer need it (might use up a lot of disk/memory space)
+            (cb) =>
+                @_exec
+                    command : 'rm'
+                    args    : [pdf]
+                    timeout : 15
+                    err_on_exit : true
+                    cb      : cb
+
             # get the new sha1 hashes
             (cb) =>
                 @_exec


### PR DESCRIPTION
reason: the pdf file could be huge and this eats up /tmp (memory) quickly

test: 

* PDF previews work
*  there shouldn't be any PDFs in `ls -l /tmp/latex-preview/*` (maybe briefly, but that's all)
