### PR TITLE
Change course subscription names

### DIFF
--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -2009,7 +2009,7 @@ class exports.Client extends EventEmitter
             @stripe_error_to_client(id:mesg.id, error:"missing field 'plan'")
             return
 
-        schema = require('smc-util/schema').PROJECT_UPGRADES.membership[mesg.plan.split('-')[0]]
+        schema = require('smc-util/schema').PROJECT_UPGRADES.subscription[mesg.plan.split('-')[0]]
         if not schema?
             @stripe_error_to_client(id:mesg.id, error:"unknown plan -- '#{mesg.plan}'")
             return

--- a/src/smc-util/upgrade-spec.coffee
+++ b/src/smc-util/upgrade-spec.coffee
@@ -144,11 +144,9 @@ upgrades.period_names =
     month4 : '4 months'
     year1  : 'year'
 
-# TODO: change from "membership" to "subscription".
+subscription = upgrades.subscription = {}
 
-membership = upgrades.membership = {}
-
-membership.professional =    # a user that has a professional membership
+subscription.professional =    # a user that has a professional subscription
     icon  : 'battery-full'
     price :
         month  : 99
@@ -164,7 +162,7 @@ membership.professional =    # a user that has a professional membership
         mintime        : 24*3600*20
         network        : 10*20
 
-membership.premium =    # a user that has a premium membership
+subscription.premium =    # a user that has a premium subscription
     icon  : 'battery-three-quarters'
     price :
         month  : 49
@@ -180,7 +178,7 @@ membership.premium =    # a user that has a premium membership
         mintime        : 24*3600*8
         network        : 10*8
 
-membership.standard =   # a user that has a standard membership
+subscription.standard =   # a user that has a standard subscription
     icon  : 'battery-quarter'
     price :
         month  : 7
@@ -197,7 +195,7 @@ membership.standard =   # a user that has a standard membership
         network        : 20
 
 
-membership.large_course =
+subscription.large_course =
     icon  : 'battery-full'
     desc : 'Large course\n(250 students)'
     price :
@@ -214,7 +212,7 @@ membership.large_course =
         network        : 250
 
 
-membership.large_course2 =
+subscription.large_course2 =
     icon  : 'battery-full'
     desc : 'Large compute heavy course\n(250 students)'
     price :
@@ -231,7 +229,7 @@ membership.large_course2 =
         member_host    : 250
         network        : 250
 
-membership.medium_course =
+subscription.medium_course =
     icon  : 'battery-three-quarters'
     desc  : 'Medium course\n(70 students)'
     price :
@@ -247,7 +245,7 @@ membership.medium_course =
         member_host    : 70
         network        : 70
 
-membership.medium_course2 =
+subscription.medium_course2 =
     icon  : 'battery-three-quarters'
     desc  : 'Medium compute heavy course\n(70 students)'
     price :
@@ -264,7 +262,7 @@ membership.medium_course2 =
         member_host    : 70
         network        : 70
 
-membership.small_course =
+subscription.small_course =
     icon  : 'battery-quarter'
     desc  : 'Small course\n(25 students)'
     price :
@@ -280,7 +278,7 @@ membership.small_course =
         member_host    : 25
         network        : 25
 
-membership.small_course2 =
+subscription.small_course2 =
     icon  : 'battery-quarter'
     desc  : 'Small compute heavy course\n(25 students)'
     price :
@@ -297,7 +295,7 @@ membership.small_course2 =
         member_host    : 25
         network        : 25
 
-membership.student_course =
+subscription.student_course =
     icon  : 'graduation-cap'
     price :
         month4 : 14
@@ -313,7 +311,7 @@ membership.student_course =
         network        : 2
 
 ###
-membership.student_course2 =
+subscription.student_course2 =
     icon  : 'graduation-cap'
     price :
         month4 : 28

--- a/src/smc-util/upgrade-spec.coffee
+++ b/src/smc-util/upgrade-spec.coffee
@@ -197,7 +197,7 @@ subscription.standard =   # a user that has a standard subscription
 
 subscription.large_course =
     icon  : 'battery-full'
-    desc : 'Large course\n(250 students)'
+    desc : 'Basic large course\n(250 students)'
     price :
         month4 : 999
         year1  : 2499
@@ -214,7 +214,7 @@ subscription.large_course =
 
 subscription.large_course2 =
     icon  : 'battery-full'
-    desc : 'Large compute heavy course\n(250 students)'
+    desc : 'Standard large course\n(250 students)'
     price :
         month4 : 1999
         year1  : 4999
@@ -231,7 +231,7 @@ subscription.large_course2 =
 
 subscription.medium_course =
     icon  : 'battery-three-quarters'
-    desc  : 'Medium course\n(70 students)'
+    desc  : 'Basic medium course\n(70 students)'
     price :
         month4 : 399
         year1  : 999
@@ -247,7 +247,7 @@ subscription.medium_course =
 
 subscription.medium_course2 =
     icon  : 'battery-three-quarters'
-    desc  : 'Medium compute heavy course\n(70 students)'
+    desc  : 'Standard medium course\n(70 students)'
     price :
         month4 : 799
         year1  : 1999
@@ -264,7 +264,7 @@ subscription.medium_course2 =
 
 subscription.small_course =
     icon  : 'battery-quarter'
-    desc  : 'Small course\n(25 students)'
+    desc  : 'Basic small course\n(25 students)'
     price :
         month4 : 199
         year1  : 499
@@ -280,7 +280,7 @@ subscription.small_course =
 
 subscription.small_course2 =
     icon  : 'battery-quarter'
-    desc  : 'Small compute heavy course\n(25 students)'
+    desc  : 'Standard small course\n(25 students)'
     price :
         month4 : 399
         year1  : 999

--- a/src/smc-util/upgrade-spec.coffee
+++ b/src/smc-util/upgrade-spec.coffee
@@ -135,8 +135,8 @@ upgrades.field_order = ['member_host', 'network', 'mintime', 'disk_quota',
 # live_subscriptions is an array of arrays.  Each array should have length a divisor of 12.
 # The subscriptions will be displayed one row at a time.
 upgrades.live_subscriptions = [['standard', 'premium', 'professional'],
-                               ['small_course', 'medium_course', 'large_course'],
-                               ['small_course2', 'medium_course2', 'large_course2']]
+                               ['small_course2', 'medium_course2', 'large_course2'],
+                               ['small_course', 'medium_course', 'large_course']]
 
 upgrades.period_names =
     month  : 'month'

--- a/src/smc-util/upgrades.coffee
+++ b/src/smc-util/upgrades.coffee
@@ -33,12 +33,12 @@ exports.get_total_upgrades = get_total_upgrades = (stripe_subscriptions_data) ->
     total = {}
     for sub in subs
         for q in [0...sub.quantity]
-            total = misc.map_sum(total, PROJECT_UPGRADES.membership[sub.plan.id.split('-')[0]].benefits)
+            total = misc.map_sum(total, PROJECT_UPGRADES.subscription[sub.plan.id.split('-')[0]].benefits)
     return total
 
 #
 # INPUT:
-#    memberships = {standard:2, premium:1, course:2, ...}
+#    subscriptions = {standard:2, premium:1, course:2, ...}
 #    projects = {project_id:{cores:1, network:1, ...}, ...}
 #
 # OUTPUT:

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1114,7 +1114,7 @@ exports.SubscriptionGrid = SubscriptionGrid = rclass
         is_static : false
 
     is_selected: (plan, period) ->
-        if @props.period is 'year'
+        if @props.period?.slice(0, 4) is 'year'
             return @props.selected_plan is "#{plan}-year"
         else
             return @props.selected_plan is plan

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -32,7 +32,7 @@ _             = require('underscore')
 
 {PROJECT_UPGRADES} = require('smc-util/schema')
 
-STUDENT_COURSE_PRICE = require('smc-util/upgrade-spec').upgrades.membership.student_course.price.month4
+STUDENT_COURSE_PRICE = require('smc-util/upgrade-spec').upgrades.subscription.student_course.price.month4
 
 load_stripe = (cb) ->
     if Stripe?
@@ -811,7 +811,7 @@ PlanInfo = rclass
         </div>
 
     render: ->
-        plan_data = PROJECT_UPGRADES.membership[@props.plan]
+        plan_data = PROJECT_UPGRADES.subscription[@props.plan]
         if not plan_data?
             return <div>Unknown plan type: {@props.plan}</div>
 
@@ -857,7 +857,7 @@ AddSubscription = rclass
         selected_button : 'month'
 
     is_recurring: ->
-        not PROJECT_UPGRADES.membership[@props.selected_plan.split('-')[0]].cancel_at_period_end
+        not PROJECT_UPGRADES.subscription[@props.selected_plan.split('-')[0]].cancel_at_period_end
 
     submit_create_subscription: ->
         plan = @props.selected_plan
@@ -900,7 +900,7 @@ AddSubscription = rclass
 
     render_renewal_info: ->
         if @props.selected_plan
-            renews = not PROJECT_UPGRADES.membership[@props.selected_plan.split('-')[0]].cancel_at_period_end
+            renews = not PROJECT_UPGRADES.subscription[@props.selected_plan.split('-')[0]].cancel_at_period_end
             length = PROJECT_UPGRADES.period_names[@state.selected_button]
             <p style={marginBottom:'1ex', marginTop:'1ex'}>
                 {<span>This subscription will <b>automatically renew</b> every {length}.  You can cancel automatic renewal at any time.</span> if renews}
@@ -1143,7 +1143,7 @@ exports.SubscriptionGrid = SubscriptionGrid = rclass
         for row in PROJECT_UPGRADES.live_subscriptions
             v = []
             for x in row
-                price_keys = _.keys(PROJECT_UPGRADES.membership[x].price)
+                price_keys = _.keys(PROJECT_UPGRADES.subscription[x].price)
                 if _.intersection(periods, price_keys).length > 0
                     v.push(x)
             if v.length > 0
@@ -1328,10 +1328,10 @@ exports.ExplainPlan = ExplainPlan = rclass
 # ~~~ FAQ START
 
 # some variables used in the text below
-faq_course_120 = 2 * PROJECT_UPGRADES.membership.medium_course.benefits.member_host
-faq_academic_students =  PROJECT_UPGRADES.membership.small_course.benefits.member_host
-faq_academic_nb_standard = Math.ceil(faq_academic_students / PROJECT_UPGRADES.membership.standard.benefits.member_host)
-faq_academic_full = faq_academic_nb_standard * 4 * PROJECT_UPGRADES.membership.standard.price.month
+faq_course_120 = 2 * PROJECT_UPGRADES.subscription.medium_course.benefits.member_host
+faq_academic_students =  PROJECT_UPGRADES.subscription.small_course.benefits.member_host
+faq_academic_nb_standard = Math.ceil(faq_academic_students / PROJECT_UPGRADES.subscription.standard.benefits.member_host)
+faq_academic_full = faq_academic_nb_standard * 4 * PROJECT_UPGRADES.subscription.standard.price.month
 faq_idle_time_free_h = require('smc-util/schema').DEFAULT_QUOTAS.mintime / 60 / 60
 
 # the structured react.js FAQ text

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1311,6 +1311,13 @@ exports.ExplainPlan = ExplainPlan = rclass
 
                 <br/>
 
+                <h4>Basic or Standard?</h4>
+                Our basic plans work well for cases where you are only doing
+                small computations or just need internet access and better hosting uptime.
+
+                However, we find that many data science and computational science courses
+                run much smoother with the additional RAM and CPU found in the standard plan.
+
                 <br/>
 
             </div>

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -904,7 +904,7 @@ AddSubscription = rclass
             length = PROJECT_UPGRADES.period_names[@state.selected_button]
             <p style={marginBottom:'1ex', marginTop:'1ex'}>
                 {<span>This subscription will <b>automatically renew</b> every {length}.  You can cancel automatic renewal at any time.</span> if renews}
-                {<span>You will be <b>charged only once</b> for the course package, which lasts {length}.  It does <b>not automatically renew</b>.</span> if not renews}
+                {<span>You will be <b>charged only once</b> for the course package, which lasts {if length == 'year' then 'a '}{length}.  It does <b>not automatically renew</b>.</span> if not renews}
             </p>
 
     render_subscription_grid: ->
@@ -928,12 +928,13 @@ AddSubscription = rclass
             {@render_dedicated_resources() if @state.selected_button is 'dedicated_resources'}
         ###
 
-    render_create_subscription_confirm: ->
+    render_create_subscription_confirm: (plan_data) ->
         if @is_recurring()
             subscription = " and you will be signed up for a recurring subscription"
+        name = plan_data.desc ? misc.capitalize(@props.selected_plan).replace(/_/g,' ') + ' plan'
         <Alert>
             <h4><Icon name='check' /> Confirm your selection </h4>
-            <p>You have selected the <span style={fontWeight:'bold'}>{misc.capitalize(@props.selected_plan).replace(/_/g,' ')} subscription</span>.</p>
+            <p>You have selected the <span style={fontWeight:'bold'}>{name} subscription</span>.</p>
             {@render_renewal_info()}
             <p>By clicking 'Add Subscription' your payment card will be immediately charged{subscription}.</p>
         </Alert>
@@ -959,11 +960,12 @@ AddSubscription = rclass
         </Row>
 
     render: ->
+        plan_data = PROJECT_UPGRADES.subscription[@props.selected_plan.split('-')[0]]
         <Row>
             <Col sm=10 smOffset=1>
                 <Well style={boxShadow:'5px 5px 5px lightgray', zIndex:1}>
                     {@render_create_subscription_options()}
-                    {@render_create_subscription_confirm() if @props.selected_plan isnt ''}
+                    {@render_create_subscription_confirm(plan_data) if @props.selected_plan isnt ''}
                     {<ConfirmPaymentMethod
                         is_recurring = {@is_recurring()}
                     /> if @props.selected_plan isnt ''}

--- a/src/smc-webapp/course/settings_panel.cjsx
+++ b/src/smc-webapp/course/settings_panel.cjsx
@@ -39,7 +39,7 @@ misc = require('smc-util/misc')
 {HelpBox} = require('./help_box')
 {DeleteStudentsPanel} = require('./delete_students')
 
-STUDENT_COURSE_PRICE = require('smc-util/upgrade-spec').upgrades.membership.student_course.price.month4
+STUDENT_COURSE_PRICE = require('smc-util/upgrade-spec').upgrades.subscription.student_course.price.month4
 
 StudentProjectsStartStopPanel = rclass ({name}) ->
     displayName : "CourseEditorSettings-StudentProjectsStartStopPanel"

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -254,7 +254,7 @@ class AccountStore extends Store
     get_confirm_close: =>
         return @getIn(['other_settings', 'confirm_close'])
 
-    # Total ugprades this user is paying for (sum of all upgrades from memberships)
+    # Total ugprades this user is paying for (sum of all upgrades from subscriptions)
     get_total_upgrades: =>
         require('upgrades').get_total_upgrades(@getIn(['stripe_customer','subscriptions', 'data'])?.toJS())
 

--- a/src/smc-webapp/support.cjsx
+++ b/src/smc-webapp/support.cjsx
@@ -184,7 +184,7 @@ class SupportActions extends Actions
         tags = []
 
         # all upgrades the user has available
-        # that's a sum of membership benefits (see schema.coffee)
+        # that's a sum of subscription benefits (see schema.coffee)
         upgrades = account.get_total_upgrades()
         if upgrades? and misc.sum(_.values(upgrades)) > 0
             tags.push('member')


### PR DESCRIPTION
UI Changes:
- Change the course plan names to Basic/Standard
- Add a section `Basic or Standard?` in the plan explanation section
- List the Standard plan on the first row instead of the second

Bug Fixes:
- Change grammar of the confirmation to say "lasts a year" instead "lasts year"
- Fix highlighting bug where an annual course subscription panel would not highlight upon selection.

Misc:
- Change code to use `subscription` instead of `membership`