### PR TITLE
webapp: log project stop/restart requests by a user

### DIFF
--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -119,8 +119,13 @@ LogEntry = rclass
         </span>
 
     render_start_project: ->
-        <span>started this project {@render_took()}
-        </span>
+        <span>started this project {@render_took()}</span>
+
+    render_project_restart_requested: ->
+        <span>requested to restart this project</span>
+
+    render_project_stop_requested: ->
+        <span>requested to stop this project</span>
 
     render_miniterm_command: (cmd) ->
         if cmd.length > 50
@@ -228,6 +233,10 @@ LogEntry = rclass
         switch @props.event?.event
             when 'start_project'
                 return @render_start_project()
+            when 'project_stop_requested'
+                return @render_project_stop_requested()
+            when 'project_restart_requested'
+                return @render_project_restart_requested()
             when 'open' # open a file
                 return @render_open_file()
             when 'set'

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -42,6 +42,20 @@ LogMessage = rclass
             This is a log message
         </div>
 
+# This is used for these cases, where `account_id` isn't set. This means, a back-end system process is responsible.
+# In the case of stopping a project, the name is recorded in the event.by field.
+SystemProcess = rclass
+    displayName : 'ProjectLog-SystemProcess'
+
+    propTypes :
+        event : rtypes.any
+
+    render: ->
+        if @props.event.by?
+            <span>System service <code>{@props.event.by}</code></span>
+        else
+            <span>A system service</span>
+
 LogSearch = rclass
     displayName : 'ProjectLog-LogSearch'
 
@@ -126,6 +140,9 @@ LogEntry = rclass
 
     render_project_stop_requested: ->
         <span>requested to stop this project</span>
+
+    render_project_stopped: ->
+        <span>stopped this project</span>
 
     render_miniterm_command: (cmd) ->
         if cmd.length > 50
@@ -237,6 +254,8 @@ LogEntry = rclass
                 return @render_project_stop_requested()
             when 'project_restart_requested'
                 return @render_project_restart_requested()
+            when 'project_stopped'
+                return @render_project_stopped()
             when 'open' # open a file
                 return @render_open_file()
             when 'set'
@@ -263,10 +282,16 @@ LogEntry = rclass
             #    return <span>{misc.to_json(@props.event)}</span>
 
     render_user: ->
-        <User user_map={@props.user_map} account_id={@props.account_id} />
+        if @props.account_id?
+            <User user_map={@props.user_map} account_id={@props.account_id} />
+        else
+            <SystemProcess event={@props.event} />
 
     icon: ->
-        switch @props.event?.event
+        if not @props.event?.event
+            return 'dot-circle-o'
+
+        switch @props.event.event
             when 'open_project'
                 return 'folder-open-o'
             when 'open' # open a file
@@ -288,8 +313,11 @@ LogEntry = rclass
                 return 'user'
             when 'invite_nonuser'
                 return 'user'
-            else
-                return 'dot-circle-o'
+
+        if @props.event.event.indexOf('project') != -1
+            return 'edit'
+        else
+            return 'dot-circle-o'
 
     render: ->
         style = if @props.cursor then selected_item else @props.backgroundStyle

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -451,6 +451,8 @@ class ProjectsActions extends Actions
         @redux.getTable('projects').set
             project_id     : project_id
             action_request : {action:'stop', time:webapp_client.server_time()}
+        @redux.getProjectActions(project_id).log
+            event : 'project_stop_requested'
 
     close_project_on_server: (project_id) =>  # not used by UI yet - dangerous
         @redux.getTable('projects').set
@@ -461,6 +463,8 @@ class ProjectsActions extends Actions
         @redux.getTable('projects').set
             project_id     : project_id
             action_request : {action:'restart', time:webapp_client.server_time()}
+        @redux.getProjectActions(project_id).log
+            event : 'project_restart_requested'
 
     # Explcitly set whether or not project is hidden for the given account (state=true means hidden)
     set_project_hide: (account_id, project_id, state) =>


### PR DESCRIPTION
this isn't finished, but could still be merged right now. it only logs the *requests* to stop/restart a project. more work needs to be done to then actually log the "stop" by the backend. the only tiny complication is that the backend has no `account_id`. hence, the front-end part needs to deal with that, too.