### PR TITLE
mocha mods

### DIFF
--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "test": "(npm run testpg && npm run testapi && npm run testmisc && npm run testkucalc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres/*.coffee",
-    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/api/*.coffee",
+    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/api/*.coffee",
     "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc/*.coffee",
     "testkucalc": "echo 'TEST KUCALC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/kucalc/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",

--- a/src/smc-hub/test/README.md
+++ b/src/smc-hub/test/README.md
@@ -13,9 +13,10 @@ Use separate .term session to start postgresql in the foreground. This command a
 The api tests generate a lot of debug output, which can be filtered out as shown. Also shown is overriding the `progress` reporter.
 
 ```
-cd ~/cocalc/src/smc-hub
+cd ~/cocalc/src
 . smc-env
 . dev/project/postgres-env
+cd smc-hub
 REPORTER=spec BAIL=-b npm run testapi 2>&1 | egrep -v "(debug|deprec|  at )"
 ```
 

--- a/src/smc-hub/test/README.md
+++ b/src/smc-hub/test/README.md
@@ -1,6 +1,15 @@
 # Running mocha tests in smc-hub:
 
-## 1. Start test db instance
+## 1. Development install
+
+Running mocha tests in any of the following directories requires development install, e.g. `cd smc-hub;npm install --only=dev`:
+- cocalc/src/smc-util
+- cocalc/src/smc-util-node
+- cocalc/src/smc-hub
+- cocalc/src/smc-project
+- cocalc/src/smc-webapp
+
+## 2. Start test db instance
 
 Use separate .term session to start postgresql in the foreground. This command also creates the file `postgres-env` used in next step:
 
@@ -8,7 +17,7 @@ Use separate .term session to start postgresql in the foreground. This command a
 ~/cocalc/src/dev/project/start_postgres.py
 ```
 
-### 2. Run the tests
+## 3. Run the tests
 
 The api tests generate a lot of debug output, which can be filtered out as shown. Also shown is overriding the `progress` reporter.
 

--- a/src/smc-hub/test/README.md
+++ b/src/smc-hub/test/README.md
@@ -1,0 +1,21 @@
+# Running mocha tests in smc-hub:
+
+## 1. Start test db instance
+
+Use separate .term session to start postgresql in the foreground. This command also creates the file `postgres-env` used in next step:
+
+```
+~/cocalc/src/dev/project/start_postgres.py
+```
+
+### 2. Run the tests
+
+The api tests generate a lot of debug output, which can be filtered out as shown. Also shown is overriding the `progress` reporter.
+
+```
+cd ~/cocalc/src/smc-hub
+. smc-env
+. dev/project/postgres-env
+REPORTER=spec BAIL=-b npm run testapi 2>&1 | egrep -v "(debug|deprec|  at )"
+```
+

--- a/src/smc-project/jupyter/test/supported-kernels.coffee
+++ b/src/smc-project/jupyter/test/supported-kernels.coffee
@@ -132,7 +132,7 @@ describe 'test the octave kernel --', ->
 
 
 describe 'test the julia kernel --', ->
-    @timeout(20000)
+    @timeout(90000)
     kernel = undefined
     it 'evaluate 4/3', (done) ->
         kernel = common.kernel('julia')
@@ -151,7 +151,7 @@ describe 'test the julia kernel --', ->
 
 
 describe 'test the system-wide R kernel --', ->
-    @timeout(60000)
+    @timeout(90000)
     kernel = undefined
     it 'evaluate sd(c(1,2,5))', (done) ->
         kernel = common.kernel('ir')
@@ -169,7 +169,7 @@ describe 'test the system-wide R kernel --', ->
         kernel.close()
 
 describe 'test the sage R kernel --', ->
-    @timeout(60000)
+    @timeout(90000)
     kernel = undefined
     it 'evaluate sd(c(1,2,5))', (done) ->
         kernel = common.kernel('ir-sage')
@@ -187,7 +187,7 @@ describe 'test the sage R kernel --', ->
         kernel.close()
 
 describe 'test the scala kernel --', ->
-    @timeout(30000)
+    @timeout(90000)
     kernel = undefined
     it 'matchTest', (done) ->
         kernel = common.kernel('scala211')

--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -32,9 +32,9 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "(npm run testproj && npm run testjup",
-    "testproj": "echo 'TEST PROJECT'; node_modules/.bin/mocha --reporter ${REPORTER:-progress} test",
-    "testjup": "echo 'TEST JUPYTER SERVER'; cd jupyter && ../node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test"
+    "test": "npm run testproj && npm run testjup",
+    "testproj": "echo 'TEST PROJECT'; node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/*.coffee",
+    "testjup": "echo 'TEST JUPYTER SERVER'; cd jupyter && ../node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/*.coffee"
   },
   "author": "SageMath, Inc.",
   "contributors": [

--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -32,7 +32,9 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo 'TEST PROJECT'; node_modules/.bin/mocha --reporter progress test && echo 'TEST JUPYTER SERVER'; cd jupyter && ../node_modules/.bin/mocha --reporter  progress  test"
+    "test": "(npm run testproj && npm run testjup",
+    "testproj": "echo 'TEST PROJECT'; node_modules/.bin/mocha --reporter ${REPORTER:-progress} test",
+    "testjup": "echo 'TEST JUPYTER SERVER'; cd jupyter && ../node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test"
   },
   "author": "SageMath, Inc.",
   "contributors": [

--- a/src/smc-util-node/package.json
+++ b/src/smc-util-node/package.json
@@ -4,7 +4,7 @@
   "description": "CoCalc compute server code",
   "main": "index.js",
   "scripts": {
-    "test": "SMC_TEST=true node_modules/.bin/mocha --reporter progress",
+    "test": "SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",
     "lint": "node_modules/.bin/coffeelint -f ../smc-util/coffeelint.json -c *.coffee"
   },

--- a/src/smc-util/package.json
+++ b/src/smc-util/package.json
@@ -4,7 +4,7 @@
   "description": "CoCalc code shared between the frontend and the backend",
   "main": "index.js",
   "scripts": {
-    "test": "export NODE_ENV=mocha-test && SMC_TEST=true node_modules/.bin/mocha --reporter progress test",
+    "test": "export NODE_ENV=mocha-test && SMC_TEST=true node_modules/.bin/mocha --reporter progress test/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",
     "lint": "node_modules/.bin/coffeelint -c *.coffee"
   },

--- a/src/smc-util/package.json
+++ b/src/smc-util/package.json
@@ -4,7 +4,7 @@
   "description": "CoCalc code shared between the frontend and the backend",
   "main": "index.js",
   "scripts": {
-    "test": "export NODE_ENV=mocha-test && SMC_TEST=true node_modules/.bin/mocha --reporter progress test/*.coffee",
+    "test": "export NODE_ENV=mocha-test && SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",
     "lint": "node_modules/.bin/coffeelint -c *.coffee"
   },

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -92,7 +92,9 @@
     "react-addons-perf": "^15.4.2"
   },
   "scripts": {
-    "test": "echo 'TEST WEBAPP'; SMC_TEST=true node_modules/.bin/mocha --reporter progress test && echo 'TEST JUPYTER CLIENT'; cd jupyter && ../node_modules/.bin/mocha  --reporter progress  test",
+    "test": "(npm run testwapp && npm run testjcli)",
+    "testwapp": "echo 'TEST WEBAPP'; SMC_TEST=true node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/*.coffee",
+    "testjcli": "echo 'TEST JUPYTER CLIENT'; cd jupyter && ../node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/*.coffee",
     "lint": "node_modules/.bin/coffeelint -f ../smc-util/coffeelint.json -c *.coffee *.cjsx",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",
     "postinstall": "node_modules/.bin/babel --presets=env  node_modules/prom-client -d node_modules/prom-client-js"

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -592,7 +592,7 @@ exports.ReactDOM = require('react-dom')
 if DEBUG
     smc?.redux = redux  # for convenience in the browser (mainly for debugging)
 
-_internals =
+exports._internals =
         AppRedux                 : AppRedux
         harvest_import_functions : harvest_import_functions
         harvest_own_functions    : harvest_own_functions

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -592,7 +592,7 @@ exports.ReactDOM = require('react-dom')
 if DEBUG
     smc?.redux = redux  # for convenience in the browser (mainly for debugging)
 
-exports._internals =
+_internals =
         AppRedux                 : AppRedux
         harvest_import_functions : harvest_import_functions
         harvest_own_functions    : harvest_own_functions
@@ -600,7 +600,5 @@ exports._internals =
         connect_component        : connect_component
         react_component          : react_component
 
-
-
-
-
+if process?.env?.SMC_TEST
+    exports._internals = _internals


### PR DESCRIPTION
- export `_internals` from src/smc-webapp/smc-react.coffee for use by smc-react-test.coffee
- increase timeouts in src/smc-project/jupyter/test/supported-kernels.coffee for slow-starting kernels (some of these run much faster on second test run immediately after first test)
- modify package.json for easier debugging
  - following precedent in smc-hub, split multi-directory tests in smc-project and smc-webapp
  - more use of --reporter ${REPORTER:-progress}
  - add ${BAIL} to a couple tests; allow `BAIL=-b npm run testapi` etc