### PR TITLE
Issue/2646

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3102,7 +3102,8 @@ def reset(vars=None, attached=False):
     for k in G.keys():
         if k[0] != '_' and type(k) != T:
             try:
-                del G[k]
+                if k != 'salvus':
+                    del G[k]
             except KeyError:
                 pass
     restore()

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -50,6 +50,17 @@ class TestDecorators:
         f(2)""")
         exec2(code, "5\n")
 
+class TestSageCommands:
+    def test_reset(self, exec2):
+        "issue 2646 do not clear salvus fns with sage reset"
+        code = dedent(r"""
+        a = EllipticCurve('123a')
+        save(a, 'load-save-test.sobj')
+        reset()
+        b = load('load-save-test.sobj')
+        b == EllipticCurve('123a')""")
+        exec2(code, "True\n")
+
 class TestLinearAlgebra:
     def test_solve_right(self, exec2):
         code = dedent(r"""


### PR DESCRIPTION
If I understand the `reset()` code in sage_salvus.py starting around line 3100, this PR is consistent with the intent.

Also added pytest for the issue, which fails without the patch and succeeds with it.

With patch applied, all pytest tests pass.
```
~/cocalc/src/smc_sagews/smc_sagews$ python -m pytest
...
= 142 passed, 5 skipped in 524.71 seconds =
```