### PR TITLE
webapp/latex: timing issue when opening a tex file that does not need to be compiled again

### DIFF
--- a/src/smc-webapp/latex/document.coffee
+++ b/src/smc-webapp/latex/document.coffee
@@ -402,7 +402,7 @@ patchSynctex(\"#{@filename_tex}\");' | R --no-save"
             err_on_exit : true
             cb          : (err, output) =>
                 if err
-                    console.log("Make sure pdfinfo is installed!  sudo apt-get install poppler-utils.")
+                    console.warn("Make sure pdfinfo is installed!  sudo apt-get install poppler-utils.")
                     cb(err)
                     return
                 v = {}
@@ -416,6 +416,7 @@ patchSynctex(\"#{@filename_tex}\");' | R --no-save"
         before = @num_pages
         @pdfinfo (err, info) =>
             # if err maybe no pdf yet -- just don't do anything
+            @dbg("update_number_of_pdf_pages: #{err}, #{info?.Pages}")
             if not err and info?.Pages?
                 @num_pages = info.Pages
                 # Delete trailing removed pages from our local view of things; otherwise, they won't properly

--- a/src/smc-webapp/latex/editor.coffee
+++ b/src/smc-webapp/latex/editor.coffee
@@ -583,14 +583,14 @@ class exports.LatexEditor extends editor.FileEditor
                 if @latex_editor.has_uncommitted_changes()
                     delete @_last_update_preview  # running latex on stale version
                     @get_rnw_concordance_error = false
-                #@dbg("update_preview(#{misc.to_json(opts)}): run_latex")
+                #@dbg("update_preview(#{misc.to_json(force:force, only_compile:only_compile)}): run_latex")
                 @run_latex
                     command      : @load_conf_doc().latex_command
                     cb           : cb
             (cb) =>
                 if only_compile
                     cb(); return
-                #@dbg("update_preview(#{misc.to_json(opts)}): preview update")
+                #@dbg("update_preview(#{misc.to_json(force:force, only_compile:only_compile)}): preview update")
                 preview_button.icon_spin(true, disable=true)
                 @preview.update
                     cb: cb

--- a/src/smc-webapp/latex/editor.coffee
+++ b/src/smc-webapp/latex/editor.coffee
@@ -88,14 +88,16 @@ class exports.LatexEditor extends editor.FileEditor
         latex_buttonbar.show()
 
         @latex_editor.on 'saved', () =>
-            @update_preview () =>
+            saved_cb = =>
                 if @_current_page == 'pdf-preview'
                     @preview_embed?.update()
+            @update_preview(saved_cb)
             @spell_check()
 
         @latex_editor.syncdoc.on 'connect', () =>
+            #if DEBUG then console.log("LatexEditor. syncdoc.on 'connect'")
             @preview.zoom_width = @load_conf().zoom_width ? 100
-            @update_preview()
+            setTimeout((=> @update_preview(undefined, false, false)), 1000)
             @spell_check()
 
         @latex_editor.print = () =>
@@ -108,7 +110,7 @@ class exports.LatexEditor extends editor.FileEditor
         @_target = v.tail
 
         # initialize the previews
-        n = @filename.length
+        #n = @filename.length
 
         # The pdf preview.
         {PNG_Preview} = require('./png_preview')
@@ -466,7 +468,7 @@ class exports.LatexEditor extends editor.FileEditor
                     @preview.pdflatex.trash_aux_files (err, _log) =>
                         cb(err)
                 (cb) =>
-                    @update_preview(cb, force=true, only_compile=true)
+                    @update_preview(cb, true, true)
             ], (err) =>
                 run_recompile.icon_spin(false, disable=true)
             )
@@ -513,16 +515,20 @@ class exports.LatexEditor extends editor.FileEditor
 
     # This function isn't called on save
     # @latex_editor.save is called instead for some reason
-    save: (cb, force=false) =>
+    save: (cb, force) =>
+        force ?= false
         @latex_editor.save (err) =>
             cb?(err)
             if not err
-                @update_preview (force=force) =>
+                sf =  =>
                     if @_current_page == 'pdf-preview'
                         @preview_embed?.update()
+                @update_preview(sf, force)
                 @spell_check()
 
-    update_preview: (cb, force=false, only_compile=false) =>
+    update_preview: (cb, force, only_compile) =>
+        force        ?= false
+        only_compile ?= false
         # force: continue, even when content hasn't changed
         # only_compile: avoid the preview rendering
         # obvious TODO: untangle preview update and run_latex
@@ -575,12 +581,14 @@ class exports.LatexEditor extends editor.FileEditor
                 if @latex_editor.has_uncommitted_changes()
                     delete @_last_update_preview  # running latex on stale version
                     @get_rnw_concordance_error = false
+                #@dbg("update_preview(force=#{force}, only_compile=#{only_compile}): run_latex")
                 @run_latex
                     command      : @load_conf_doc().latex_command
                     cb           : cb
             (cb) =>
                 if only_compile
                     cb(); return
+                #@dbg("update_preview(force=#{force}, only_compile=#{only_compile}): preview update")
                 preview_button.icon_spin(true, disable=true)
                 @preview.update
                     cb: cb

--- a/src/smc-webapp/latex/png_preview.coffee
+++ b/src/smc-webapp/latex/png_preview.coffee
@@ -11,6 +11,7 @@ templates = $("#webapp-editor-templates")
 class exports.PNG_Preview extends FileEditor
     constructor: (@project_id, @filename, contents, opts) ->
         super(@project_id, @filename)
+        @dbg("PNG_Preview constructor called with #{misc.to_json(opts)}")
         @pdflatex = new PDFLatexDocument(project_id:@project_id, filename:@filename, image_type:"png")
         @opts = opts
         @_updating = false
@@ -33,9 +34,10 @@ class exports.PNG_Preview extends FileEditor
         @_needs_update = true
         @_dragpos = null
         @_init_dragging()
+        #if DEBUG then window.png_preview = @
 
     dbg: (mesg) =>
-        #console.log("PDF_Preview: #{mesg}")
+        #if DEBUG then console.log("PDF_Preview: #{mesg}")
 
     # TODO refactor this into misc_page
     _init_dragging: =>
@@ -214,6 +216,7 @@ class exports.PNG_Preview extends FileEditor
         @dbg("update: current_page=#{n}")
 
         f = (opts, cb) =>
+            @dbg("update/f: opts=#{misc.to_json(opts)}")
             opts.cb = (err, changed_pages) =>
                 if err
                     cb(err)
@@ -272,6 +275,7 @@ class exports.PNG_Preview extends FileEditor
         p          = @pdflatex.page(n)
         url        = p.url
         resolution = p.resolution
+        @dbg("PNG_Preview._update_page: last_page = #{@last_page}")
         if not url?
             # delete page and all following it from DOM
             for m in [n .. @last_page]


### PR DESCRIPTION
see issue #2534, this did bug me again and again when testing in the past few days.

In the end, all this does is delay the update rendering by 1 second after the syncdoc says that it is connected. I suspect this bug started when opening files was speeded up. I am also aware that this is not a perfect fix, but let's postpone this after a rewrite...

Testing: I checked with a normal document and upon Rnw documents.

Here is a document with a couple of pages for testing. The way to reproduce the problem in prod is to open it, wait until compiled, close the tab, wait a few secs, then open the tab again. The .tex file is saved while closed and there is no need to re-render it when opening. And without that additional rendering, it is somehow not properly initialized. That's why it's a "heisenbug".

```
\documentclass{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{lmodern}
\usepackage[english]{babel}
\usepackage{blindtext}
\begin{document}
\Blinddocument[1]
\end{document}
```

