### PR TITLE
api doc for get_available_upgrades

### DIFF
--- a/src/smc-hub/test/api/messages.coffee
+++ b/src/smc-hub/test/api/messages.coffee
@@ -41,4 +41,6 @@ describe 'checking message2 documentation', ->
         expect(messages.documentation.events.create_support_ticket.fields.body).toMatch('required')
     it "get_support_tickets", ->
         expect(messages.documentation.events.get_support_tickets.description).toInclude("/api/v1/get_support_tickets")
+    it "get_available_upgrades", ->
+        expect(messages.documentation.events.get_available_upgrades.description).toInclude("/api/v1/get_available_upgrades")
 

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -2450,6 +2450,41 @@ API message2
         id:
            init  : undefined
            desc  : 'A unique UUID for the query'
+    desc         : """
+This request returns information on project upgrdes for the user
+whose API key appears in the request.
+Two objects are returned, total upgrades and available upgrades.
+Values for `mintime` are in units of seconds.
+Values for `cpu shares` correspond the number of CPU shares shown
+in the web UI in 'Account Settings / Upgrades' multiplied by 256.
+
+Example:
+```
+  curl -X POST -u sk_abcdefQWERTY090900000000: https://cocalc.com/api/v1/get_available_upgrades
+  ==>
+  {"id":"57fcfd71-b50f-44ef-ba66-1e37cac858ef",
+   "event":"available_upgrades",
+   "total":{
+     "cores":10,
+     "cpu_shares":2048,
+     "disk_quota":200000,
+     "member_host":80,
+     "memory":120000,
+     "memory_request":8000,
+     "mintime":3456000,
+     "network":400},
+     "excess":{},
+   "available":{
+     "cores":6,
+     "cpu_shares":512,
+     "disk_quota":131000,
+     "member_host":51,
+     "memory":94000,
+     "memory_request":8000,
+     "mintime":1733400,
+     "network":372}}
+```
+"""
 
 # client <-- hub
 


### PR DESCRIPTION
See: #2672

- update api.html for get_available_upgrades
- add syntax check for get_available_upgrades message2 def

I didn't add a mocha test for get_available_upgrades at this time because I didn't want to get into mocking the stripe interface.