### PR TITLE
webapp/courses: mismatching keys when checking payment config choices

### DIFF
--- a/src/smc-webapp/course/actions.coffee
+++ b/src/smc-webapp/course/actions.coffee
@@ -150,7 +150,7 @@ exports.CourseActions = class CourseActions extends Actions
         store = @get_store()
         return if not store?
         settings = store.get('settings')
-        if settings.get('student') or settings.get('institute')
+        if settings.get('institute_pay') or settings.get('student_pay')
             # already done
             return
         @set_pay_choice('institute', false)


### PR DESCRIPTION
The mentioned mismatch is with [set_pay_method](https://github.com/sagemathinc/cocalc/blob/master/src/smc-webapp/course/actions.coffee#L224)