### PR TITLE
webapp/course: update state of form box upon changes in supplied props data

### DIFF
--- a/src/smc-webapp/course/common.cjsx
+++ b/src/smc-webapp/course/common.cjsx
@@ -138,6 +138,12 @@ exports.StudentAssignmentInfo = rclass
         edited_grade    : @props.grade ? ''
         edited_comments : @props.comments ? ''
 
+    componentWillReceiveProps: (nextProps) ->
+        @setState(
+            edited_grade    : nextProps.grade ? ''
+            edited_comments : nextProps.comments ? ''
+        )
+
     getDefaultProps: ->
         grade    : ''
         comments : ''


### PR DESCRIPTION
This fixes stale information of the "grade comment" for a student in an assignment.

Test: open the same course assignment twice in two tabs and edit a comment of a student grade. After saving in on of them, the changes should show up in the other instance, too.