### PR TITLE
Mimic other coupon-promo adders

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1040,7 +1040,14 @@ CouponAdder = rclass
         e?.preventDefault()
         @actions('billing').get_coupon(@state.coupon_id) if @state.coupon_id
 
+    render_well_header: ->
+        if @props.applied_coupons?.size > 0
+            <h5 style={color:'green'}><Icon name='check' /> Coupon added!</h5>
+        else
+            <h5 style={color:'#666'}><Icon name='plus' /> Add a coupon?</h5>
+
     render: ->
+
         # TODO: (Here or elsewhere) Your final cost is:
         #       $2 for the first month
         #       $7/mo after the first
@@ -1055,7 +1062,7 @@ CouponAdder = rclass
             bsStyle = 'primary'
 
         <Well>
-            <h5 style={color:'#666'}><Icon name='plus' /> Add a coupon?</h5>
+            {@render_well_header()}
             {<CouponList applied_coupons={@props.applied_coupons} /> if @props.applied_coupons?.size > 0}
             {<FormGroup style={marginTop:'5px'}>
                 <InputGroup>

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -968,7 +968,11 @@ AddSubscription = rclass
                     {<ConfirmPaymentMethod
                         is_recurring = {@is_recurring()}
                     /> if @props.selected_plan isnt ''}
-                    {<CouponAdder applied_coupons={@props.applied_coupons} coupon_error={@props.coupon_error} />}
+                    <Row>
+                        <Col sm={5} smOffset={7}>
+                            {<CouponAdder applied_coupons={@props.applied_coupons} coupon_error={@props.coupon_error} />}
+                        </Col>
+                    </Row>
                     {@render_create_subscription_buttons()}
                 </Well>
                 <ExplainResources type='shared'/>
@@ -1045,6 +1049,11 @@ CouponAdder = rclass
         else
             placeholder_text = 'Enter your code here...'
 
+        if @state.coupon_id == ''
+            bsStyle = undefined
+        else
+            bsStyle = 'primary'
+
         <Well>
             <h5 style={color:'#666'}><Icon name='plus' /> Add a coupon?</h5>
             {<CouponList applied_coupons={@props.applied_coupons} /> if @props.applied_coupons?.size > 0}
@@ -1058,16 +1067,16 @@ CouponAdder = rclass
                         placeholder = {placeholder_text}
                         onChange    = {(e) => @setState(coupon_id : e.target.value)}
                         onKeyDown   = {@key_down}
+                        onBlur      = {@submit}
                     />
                     <InputGroup.Button>
-                        <Button onClick={@submit} disabled={@state.coupon_id == ''}>
-                            <Icon name='check' />
+                        <Button onClick={@submit} disabled={@state.coupon_id == ''} bsStyle={bsStyle} >
+                            Apply
                         </Button>
                     </InputGroup.Button>
                 </InputGroup>
             </FormGroup> if @props.applied_coupons?.size == 0}
             {<SkinnyError error_text={@props.coupon_error} on_close={@actions('billing').clear_coupon_error} /> if @props.coupon_error}
-            {<div style={color:'rgb(153, 153, 153)', fontWeight:'200'}>No coupons applied</div> if @props.applied_coupons?.size == 0}
         </Well>
 
 CouponList = rclass


### PR DESCRIPTION
Mimic other coupon adders as suggested.

In particular, 
- The button now says `Apply`
- The button is closer to the coupon text. 
- It lights up when you put anything in the box
- It submits onBlur

<img width="417" alt="screen shot 2018-03-05 at 6 12 17 pm" src="https://user-images.githubusercontent.com/618575/37010538-dfa87c00-20a0-11e8-897b-ee15b7851a49.png">
<img width="398" alt="screen shot 2018-03-05 at 6 12 35 pm" src="https://user-images.githubusercontent.com/618575/37010537-df8f45aa-20a0-11e8-84ee-d6158f085205.png">
<img width="412" alt="screen shot 2018-03-05 at 6 12 43 pm" src="https://user-images.githubusercontent.com/618575/37010536-df761e68-20a0-11e8-9253-be94339bfe29.png">
