### PR TITLE
webapp: special case for logging duplicating files as a copy operation

### DIFF
--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -1113,7 +1113,7 @@ class ProjectActions extends Actions
             src           : required     # Should be an array of source paths
             dest          : required
             id            : undefined
-            only_contents : false
+            only_contents : false        # true for duplicating files
 
         with_slashes = opts.src.map(@_convert_to_displayed_path)
 
@@ -1122,7 +1122,7 @@ class ProjectActions extends Actions
             action : 'copied'
             files  : with_slashes[0...3]
             count  : if opts.src.length > 3 then opts.src.length
-            dest   : opts.dest + '/'
+            dest   : opts.dest + (if opts.only_contents then '' else '/')
 
         if opts.only_contents
             opts.src = with_slashes


### PR DESCRIPTION
See #2728 

testing is easy: copy one or more files to a directory vs. duplicating a file.