### PR TITLE
project: more sensitive memory warning and pointing to out-of-memory wiki page

### DIFF
--- a/src/smc-webapp/project_warnings.cjsx
+++ b/src/smc-webapp/project_warnings.cjsx
@@ -66,9 +66,12 @@ exports.RamWarning = rclass ({name}) ->
             if not rss
                 return <span />
             memory = Math.round(rss/1000)
-        if quotas.memory > memory + 5
+        if quotas.memory > memory + 100
             return <span />
 
         <Alert bsStyle='danger' style={alert_style}>
-            <Icon name='exclamation-triangle' /> WARNING: This project is running low on RAM memory.  Upgrade memory in <a onClick={=>@actions(project_id: @props.project_id).set_active_tab('settings')} style={cursor:'pointer'}>settings</a>, restart your project or kill some processes. (Memory usage is updated about once per minute.)
+            <Icon name='exclamation-triangle' /> WARNING: This project is running low on memory.{' '}
+            Upgrade memory in <a onClick={=>@actions(project_id: @props.project_id).set_active_tab('settings')} style={cursor:'pointer'}>settings</a>,{' '}
+            restart your project or kill some processes.{' '}
+            (<a href={'https://github.com/sagemathinc/cocalc/wiki/My-Project-Is-Running-Out-of-Memory'} target={'_blank'} style={cursor:'pointer'}>more information</a>; memory usage is updated about once per minute.)
         </Alert>


### PR DESCRIPTION
This simply adjusts the memory warning, see #2736

We should check what the memory usage of freshly started jupyter kernels is. python 3 ~80M, while sagemath ~200m? maybe a @DrXyzzy task?
 
Also, being to sensitive and telling users non-stop in a red banner to upgrade memory would be yet another annoyance :roll_eyes: 