### PR TITLE
webapp/ui: remove duplicate (disabled) scrollbar when viewing an editor content

### DIFF
--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -419,7 +419,7 @@ ProjectContentViewer = rclass
                 <div
                     style = {position: 'absolute', height:'100%', width:'100%', display:'flex'}
                     ref   = 'editor_container'
-                    >
+                >
                     <div style={flex:1, overflow:'hidden', height:'100%', width:'100%'}>
                         {editor}
                     </div>
@@ -458,7 +458,7 @@ ProjectContentViewer = rclass
                     @render_editor_tab()
 
     render: ->
-        <div style={overflowY:'scroll', overflowX:'hidden', flex:1, height:0, position:'relative'}>
+        <div style={overflowY:'auto', overflowX:'hidden', flex:1, height:0, position:'relative'}>
             {@render_tab_content()}
         </div>
 


### PR DESCRIPTION
There is a second scrollbar for editor content, see screenshot. This simply makes it show up only when necessary …

![cocalc-double-scrollbar](https://user-images.githubusercontent.com/207405/37286673-ed294910-2602-11e8-8beb-cb7bd8a4a73f.png)
