### PR TITLE
syncdoc: skip undefined codemirrors in close

### DIFF
--- a/src/smc-webapp/syncdoc.coffee
+++ b/src/smc-webapp/syncdoc.coffee
@@ -542,6 +542,7 @@ class SynchronizedDocument2 extends SynchronizedDocument
         @_syncstring?.close()
         # TODO -- this doesn't work...
         for cm in [@codemirror, @codemirror1]
+            continue if not cm?
             cm.setOption("mode", "text/x-csrc")
             cmElem = cm.getWrapperElement()
             cmElem.parentNode.removeChild(cmElem)


### PR DESCRIPTION
This is hopefully harmless until this is fixed properly