### PR TITLE
code-editor: safeguard save_editor_state against called after close

### DIFF
--- a/src/smc-webapp/code-editor/actions.coffee
+++ b/src/smc-webapp/code-editor/actions.coffee
@@ -284,6 +284,8 @@ class exports.Actions extends Actions
         setTimeout(@focus, 1)
 
     save_editor_state: (id, new_editor_state) =>
+        if @_state == 'closed'
+            return
         local  = @store.get('local_view_state')
         if not local?
             return


### PR DESCRIPTION
idea for #2778

but I'm not sure if I understand this correctly ... and there is similar code for the tasks editor, which might need a similar check.