### PR TITLE
project page: fixing scrollTop restoration after using smc-vfill flex  layout for the "editor_inner_container" element 

### DIFF
--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -19,6 +19,8 @@
 #
 ###############################################################################
 
+$ = window.$
+
 ###
 project page react component
 ###
@@ -242,11 +244,11 @@ ProjectContentViewer = rclass
     restore_scroll_position: ->
         saved_scroll = @props.opened_file?.get('component')?.scroll_position
         if saved_scroll?
-            @refs.editor_inner_container.scrollTop = saved_scroll
+            $(@refs.editor_inner_container).children()[0].scrollTop = saved_scroll
 
     save_scroll_position: ->
         if @refs.editor_inner_container? and @props.save_scroll?
-            val = @refs.editor_inner_container.scrollTop
+            val = $(@refs.editor_inner_container).children()[0].scrollTop
             @props.save_scroll(val)
 
     render_editor: (path) ->


### PR DESCRIPTION
see #2780

This fix does work for #2780, but it is something I don't really want to go with (because of jquery) … but it is at least a proof of concept how to address this.

(or, we do this as a hotfix for now and update the ticket with a good idea how to do this)