### PR TITLE
course: adding all students button (small usability aspect)

### DIFF
--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -153,6 +153,20 @@ exports.StudentsPanel = rclass ({name}) ->
         @actions(@props.name).add_students(students)
         @setState(err:undefined, add_select:undefined, selected_option_nodes:undefined, add_search:'')
 
+    add_all_students: (options) ->
+        students = []
+        for entry in @state.add_select
+            account_id = entry.account_id
+            if misc.is_valid_uuid_string(account_id)
+                students.push(
+                    account_id    : account_id
+                    email_address : entry.email_address
+                )
+            else
+                students.push(email_address : entry.email_address)
+        @actions(@props.name).add_students(students)
+        @setState(err:undefined, add_select:undefined, selected_option_nodes:undefined, add_search:'')
+
     get_add_selector_options: ->
         v = []
         seen = {}
@@ -174,6 +188,7 @@ exports.StudentsPanel = rclass ({name}) ->
                 {options}
             </FormControl>
             {@render_add_selector_button(options)}
+            {@render_add_all_students_button(options)}
         </FormGroup>
 
     render_add_selector_button: (options) ->
@@ -194,6 +209,16 @@ exports.StudentsPanel = rclass ({name}) ->
                 else "Add #{nb_selected} students"
         disabled = options.length == 0 or (options.length >= 2 and nb_selected == 0)
         <Button onClick={=>@add_selected_students(options)} disabled={disabled}><Icon name='user-plus' /> {btn_text}</Button>
+
+    render_add_all_students_button: (options) ->
+        disabled = (options.length == 0)
+        disabled or= ((@state.selected_option_nodes?.length ? 0) > 0)
+        <Button
+            onClick  = {=>@add_all_students(options)}
+            disabled = {disabled}
+        >
+            <Icon name={'user-plus'} /> Add all students
+        </Button>
 
     render_error: ->
         ed = null


### PR DESCRIPTION
This simply adds a button to the "student add" form to add all students in one go (if none are selected).

Test: make a course and add `student+1000@cocalc.com, student+1001@cocalc.com, student+1002@cocalc.com` into the input box and search.

![screenshot from 2018-03-27 13-38-30](https://user-images.githubusercontent.com/207405/37965105-3407d2f8-31c4-11e8-8c0a-8eb82f8c11ea.png)
