### PR TITLE
make "something bad" message more useful

### DIFF
--- a/src/webapp-lib/app.pug
+++ b/src/webapp-lib/app.pug
@@ -16,7 +16,7 @@ html(lang="en")
         div.message
           | Timeout while loading CoCalc.
           br/
-          | If the problem persists, click <a href="https://github.com/sagemathinc/cocalc/wiki/Troubleshooting">Troubleshooting</a> for more information.
+          | If the problem persists, click <a href="https://github.com/sagemathinc/cocalc/wiki/Connection-Timeout">Connection Timeout</a> for more information.
     div#smc-startup-banner-status
       | Initializing ...
 

--- a/src/webapp-lib/app.pug
+++ b/src/webapp-lib/app.pug
@@ -14,9 +14,11 @@ html(lang="en")
         img(src=require('!url-loader?mimetype=image/svg+xml!cocalc-icon-white-transparent.svg'))
       div.banner-error
         div.message
-          | Something bad must have happened.
+          | Timeout while loading CoCalc.
           br/
           | Try <a href="javascript:location.reload(true);">reloading the page</a> while holding your shift-key.
+          br/
+          | Or disable browser extensions blocking external sites, or try a different browser.
     div#smc-startup-banner-status
       | Initializing ...
 

--- a/src/webapp-lib/app.pug
+++ b/src/webapp-lib/app.pug
@@ -16,9 +16,7 @@ html(lang="en")
         div.message
           | Timeout while loading CoCalc.
           br/
-          | Try <a href="javascript:location.reload(true);">reloading the page</a> while holding your shift-key.
-          br/
-          | Or disable browser extensions blocking external sites, or try a different browser.
+          | If the problem persists, click <a href="https://github.com/sagemathinc/cocalc/wiki/Troubleshooting">Troubleshooting</a> for more information.
     div#smc-startup-banner-status
       | Initializing ...
 


### PR DESCRIPTION
Replace `Something bad must have happened.` message with text that
- identifies CoCalc as source of the message
- offers information on the nature of the error

@haraldschilly  please review for correctness. Also, can you suggest a quick way to simulate the error in testing?

If merged, also update [this wiki entry](https://github.com/sagemathinc/cocalc/wiki/Troubleshooting#load-timeout)