### PR TITLE
Use babel-loader for .js and .jsx

### DIFF
--- a/src/webpack.config.coffee
+++ b/src/webpack.config.coffee
@@ -539,6 +539,7 @@ module.exports =
                     { loader: 'coffee-loader' }
                 ]
             },
+            { test: /\.(js|jsx)$/, loader: 'babel-loader' }
             { test: /\.less$/,   use: ["style-loader", "css-loader", "less-loader?#{cssConfig}"] },
             { test: /\.scss$/,   use: ["style-loader", "css-loader", "sass-loader?#{cssConfig}"] },
             { test: /\.sass$/,   use: ["style-loader", "css-loader", "sass-loader?#{cssConfig}&indentedSyntax"] },


### PR DESCRIPTION
I remembered to polyfill es2015+ but not transpile it. Oops.