### PR TITLE
webapp: process links should also fix <video> tags

### DIFF
--- a/src/smc-webapp/process-links.coffee
+++ b/src/smc-webapp/process-links.coffee
@@ -79,10 +79,10 @@ $.fn.process_smc_links = (opts={}) ->
                     # make links open in a new tab by default
                     a.attr("target","_blank")
 
-        # part #2: process <img> and <object> tags
+        # part #2: process <img>, <object> and <video>/<source> tags
         # make relative links to images use the raw server
         if opts.project_id and opts.file_path?
-            for [tag, attr] in [['img', 'src'], ['object', 'data']]
+            for [tag, attr] in [['img', 'src'], ['object', 'data'], ['video', 'src'], ['source', 'src']]
                 for x in e.find(tag)
                     y = $(x)
                     src = y.attr(attr)


### PR DESCRIPTION
issue #2725

Testing: upload a small webm video and do this in a chat or a jupyter markdown textarea:

```
<video controls src="video.webm" style="width:50%">
</video>

<video controls style="width:50%">
    <source src="video.webm" >
</video>
```

Of course, other image tags shouldn't break.

There is also similar code buried inside the `sagews/sagews.coffee` file. I tried to fix this in a similar way but then it all broke. That should better be fixed as part of the upcoming rewrite.