### PR TITLE
webapp/assistant: log inserts in project log

### DIFF
--- a/src/smc-webapp/assistant/actions.coffee
+++ b/src/smc-webapp/assistant/actions.coffee
@@ -29,8 +29,12 @@ immutable    = require('immutable')
 DATA = null
 
 class exports.ExamplesActions extends Actions
-    _init: (store) ->
+    _init: (store, project_id, path) ->
         @store = store
+        @setState(
+            path       : path
+            project_id : project_id
+        )
 
     get: (key) ->
         @store.get(key)
@@ -85,6 +89,7 @@ class exports.ExamplesActions extends Actions
         prepend_setup_code = @get('prepend_setup_code')
         if (prepend_setup_code) and (setup_code?.length > 0)
             code = "#{setup_code}\n#{code}"
+        @store.log()
         ret =
             code  : code
             lang  : @get('lang')

--- a/src/smc-webapp/assistant/legacy.cjsx
+++ b/src/smc-webapp/assistant/legacy.cjsx
@@ -39,7 +39,7 @@ exports.render_examples_dialog = (opts) ->
     name = redux_name(opts.project_id, opts.path)
     actions = redux.getActions(name)
     if not actions?
-        [actions, store] = init_action_and_store(name)
+        [actions, store] = init_action_and_store(name, opts.project_id, opts.path)
     actions.init(opts.lang)
     actions.set(lang_select:true)
     dialog = <Redux redux={redux}>

--- a/src/smc-webapp/assistant/main.coffee
+++ b/src/smc-webapp/assistant/main.coffee
@@ -48,10 +48,10 @@
 exports.redux_name = (project_id, path) ->
     return "examples-#{project_id}-#{path}"
 
-exports.init_action_and_store = (name) ->
+exports.init_action_and_store = (name, project_id, path) ->
     store   = redux.createStore(makeExamplesStore(name))
     actions = redux.createActions(name, ExamplesActions)
-    actions._init(store)
+    actions._init(store, project_id, path)
     return [actions, store]
 
 ### Public API ###
@@ -61,5 +61,5 @@ exports.instantiate_assistant = (project_id, path) ->
     name = exports.redux_name(project_id, path)
     actions = redux.getActions(name)
     if not actions?
-        [actions, store] = exports.init_action_and_store(name)
+        [actions, store] = exports.init_action_and_store(name, project_id, path)
     return actions

--- a/src/smc-webapp/assistant/store.coffee
+++ b/src/smc-webapp/assistant/store.coffee
@@ -20,16 +20,17 @@
 ###############################################################################
 
 
-_            = require('underscore')
-immutable    = require('immutable')
-{rtypes}     = require('../smc-react')
-{INIT_STATE} = require('./common')
+_                = require('underscore')
+immutable        = require('immutable')
+{rtypes, redux}  = require('../smc-react')
+{INIT_STATE}     = require('./common')
 
 
 exports.makeExamplesStore = (NAME) ->
     name: NAME
 
     stateTypes:
+        project_id          : rtypes.string      # the project_id
         category0           : rtypes.number      # index of selected first category (left)
         category1           : rtypes.number      # index of selected second category (second from left)
         category2           : rtypes.number      # index of selected third category (document titles)
@@ -81,3 +82,19 @@ exports.makeExamplesStore = (NAME) ->
         k0 = @get_category_list0()[@get('category0')]
         k1 = @get_category_list1()[@get('category1')]
         return @data_lang().getIn([k0, k1, 'entries']).map((el) -> el.get(0)).toArray()
+
+    # make an entry about inserting the example in the project log
+    log: () ->
+        lang  = @get('lang')
+        path  = @get('path')
+        c0    = @get_category_list0()[@get('category0')]
+        c1    = @get_category_list1()[@get('category1')]
+        c2    = @get_category_list2()[@get('category2')]
+        entry = [c0, c1, c2]
+        project_actions = redux.getProjectActions(@get('project_id'))
+        project_actions.log
+            event     : 'assistant'
+            action    : 'insert'
+            entry     : entry
+            lang      : lang
+            path      : path

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -216,6 +216,23 @@ LogEntry = rclass
         return if not @props.event.target?
         <span>copied "{@props.event.title}" from the library to {@file_link(@props.event.target, true, 0)}</span>
 
+    render_assistant: ->
+        e = @props.event
+        switch e?.action
+            when 'insert'
+                lang = misc.jupyter_language_to_name(e.lang)
+                <span>used the <i>assistant</i> to insert the "{lang}" example{' '}
+                    {'"'}{e.entry.join(' → ')}{'"'}
+                    {' into '}
+                    <PathLink
+                        path       = {@props.event.path}
+                        full       = {true}
+                        style      = {if @props.cursor then selected_item}
+                        trunc      = {50}
+                        project_id = {@props.project_id}
+                    />
+                </span>
+
     render_upgrade: ->
         params = require('smc-util/schema').PROJECT_UPGRADES.params
         v = []
@@ -276,6 +293,8 @@ LogEntry = rclass
                 return <span>opened this project</span>
             when 'library'
                 return @render_library()
+            when 'assistant'
+                return @render_assistant()
             # ignore unknown -- would just look mangled to user...
             #else
             # FUTURE:


### PR DESCRIPTION
This is a short follow-up for the assistant. This adds entries to the project log in the form of

```
event: {"lang": "python", "path": "empty.ipynb", "entry": ["NumPy", "Indexing", "Get shape of array"], "event": "assistant", "action": "insert"}
event: {"lang": "sage", "path": "empty.sagews", "entry": ["Extras", "Files", "Read CSV data"], "event": "assistant", "action": "insert"}
[...]
```

