### PR TITLE
webapp: improve error message display

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1724,7 +1724,7 @@ class Terminal extends FileEditor
             path       : @filename
             cb         : (err, result) =>
                 if err
-                    alert_message(type:"error", message: "Error connecting to console server -- #{err}")
+                    alert_message(type:"error", message: "Error connecting to console server -- #{misc.to_safe_str(err)}")
                 else
                     # New session or connect to session
                     if result.content? and result.content.length < 36


### PR DESCRIPTION
I saw `Error connecting to console server -- [object Object]` in an error box and well, that's not very informative. This attempts to convert this to a string.