### PR TITLE
webapp/misc: html sanitization stumbles over undefined "this"

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -2145,6 +2145,8 @@ exports.obj_key_subs = (obj, subs) ->
 # * smc-webapp/misc_page    → sanitize_html
 exports.sanitize_html_attributes = ($, node) ->
     $.each node.attributes, ->
+        # sometimes, "this" is undefined -- #2823
+        return if not this?
         attrName  = this.name
         attrValue = this.value
         # remove attribute name start with "on", possible unsafe, e.g.: onload, onerror...


### PR DESCRIPTION
straight forward fix for #2823

testing: the following minimal code for testing causes `this` to be undefined after the second attribute. I have no idea why, it just "happens".

```
<iframe
    id="abc"
    src="javascript:void(0)"
    width="123"
>
</iframe>
```