### PR TITLE
sagews: skip init_hide_show_gutter for undefined codemirrors

### DIFF
--- a/src/smc-webapp/sagews/sagews.coffee
+++ b/src/smc-webapp/sagews/sagews.coffee
@@ -200,6 +200,7 @@ class SynchronizedWorksheet extends SynchronizedDocument2
     init_hide_show_gutter: () =>
         gutters = ["CodeMirror-linenumbers", "CodeMirror-foldgutter", "smc-sagews-gutter-hide-show"]
         for cm in [@codemirror, @codemirror1]
+            continue if not cm?
             cm.setOption('gutters', gutters)
             cm.on 'gutterClick', @_handle_input_hide_show_gutter_click
 


### PR DESCRIPTION
this is a one-line fix for #2830

although I'm wondering why this is can even happen at all.