### PR TITLE
webapp: fix/adjust new icon set for sagews %md

### DIFF
--- a/src/smc-webapp/buttonbar.coffee
+++ b/src/smc-webapp/buttonbar.coffee
@@ -1636,7 +1636,7 @@ initialize_sage_python_r_toolbar = () ->
 
     # -- python specific --
     pybar    = make_bar("webapp-editor-codeedit-buttonbar-python")
-    add_icon(pybar, "<i class='fa'>#</i>", "#comment", "Comment selected text")
+    add_icon(pybar, "#", "#comment", "Comment selected text")
 
     py_control = ["Data", "Basic Data Types",
            [["Construction"],

--- a/src/smc-webapp/code-editor/frame-title-bar.cjsx
+++ b/src/smc-webapp/code-editor/frame-title-bar.cjsx
@@ -348,7 +348,7 @@ exports.FrameTitleBar = rclass
                 disabled = {@props.read_only}
                 bsSize   = {@button_size()}
             >
-                <Icon name='magic' />
+                <Icon name='indent' />
             </Button>
         </ButtonGroup>
 

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1418,6 +1418,9 @@ class CodeMirrorEditor extends FileEditor
 
             # Save for next time
             @_last_layout = @_layout
+        else
+            layout = @_layout ? 0
+            btn.find(".webapp-editor-layout-#{layout}").show()
 
         # Workaround a major and annoying bug in Safari:
         #     https://github.com/philipwalton/flexbugs/issues/132

--- a/src/smc-webapp/editor.html
+++ b/src/smc-webapp/editor.html
@@ -121,7 +121,7 @@ Editor for files in a project
                         <a href="#paste" class="btn btn-default btn-history webapp-editor-write-only" data-toggle="tooltip" data-placement="bottom" title="Paste"><i class="fa fa-paste"> </i> </a>
                         <a href="#sagews2pdf" class="btn btn-default webapp-editor-write-only hide" data-toggle="tooltip" data-placement="bottom" title="Convert to PDF"><i class="fa fa-file-pdf-o"> </i> </a>
                         <a href="#print" class="btn btn-default webapp-editor-write-only hide" data-toggle="tooltip" data-placement="bottom" title="Print"><i class="fa fa-print"> </i> </a>
-                        <a href="#sagews2ipynb" class="btn btn-default webapp-editor-write-only hide" data-toggle="tooltip" data-placement="bottom" title="Convert to ipynb"><i class="fa cc-icon-ipynb"> </i> <span class="hidden-sm">Jupyter</span></a>
+                        <a href="#sagews2ipynb" class="btn btn-default webapp-editor-write-only hide" data-toggle="tooltip" data-placement="bottom" title="Convert to ipynb"><i class="cc-icon-ipynb"> </i> <span class="hidden-sm">Jupyter</span></a>
                     </span>
 
                     <span class="btn-group webapp-editor-read-only hide">
@@ -1065,8 +1065,8 @@ Editor for files in a project
             <a href="#link" data-args="special" class="btn btn-default"  data-toggle="tooltip" data-placement="bottom" title="Insert link..."><i class="fa fa-link"></i></a>
             <a href="#image" data-args="special" class="btn btn-default"  data-toggle="tooltip" data-placement="bottom" title="Insert image..."><i class="fa fa-image"></i></a>
             <a href="#table" data-args="special" class="btn btn-default"  data-toggle="tooltip" data-placement="bottom" title="Insert table"><i class="fa fa-table"></i></a>
-            <a href="#horizontalRule" data-args="special" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Insert horizontal line"><i class="fa">&mdash;</i></a>
-            <a href="#SpecialChar" data-args="special" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Insert Special Character ..."><i class="fa">&Omega;</i></a>
+            <a href="#horizontalRule" data-args="special" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Insert horizontal line">&mdash;</a>
+            <a href="#SpecialChar" data-args="special" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Insert Special Character ...">&Omega;</a>
         </span>
         <span class="btn-group">
             <a href="#justifyleft" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Left justify"><i class="fa fa-align-left"></i></a>


### PR DESCRIPTION
In sagews, a `%md` block, I noticed that there are 3 undefined icons. Sometimes, this split-view icon was also empty, hence I added a fallback in case `@_layout` isn't defined. (heisenbuggy)

The "#" sign for comments in code is also broken.

Finally, the "magic" icon is used by the assistant and it might not be great to use that icon for code formatting as well. Using "indent" seems like a fine choice to me.

![screenshot-cocalc com-2018 04 15-18-41-13](https://user-images.githubusercontent.com/207405/38780863-3cd86ea6-40dd-11e8-8cf4-765fc026e8a7.png)
