### PR TITLE
Issue/2124

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2649,6 +2649,7 @@ def show(*objs, **kwds):
         elif is_dataframe(obj):
             html(obj.to_html(), hide=False)
         else:
+            __builtins__['_'] = obj
             s = str(sage.misc.latex.latex(obj))
             if r'\text{\texttt' in s and 'tikzpicture' not in s:
                 # In this case the mathjax latex mess is so bad, it is better to just print and give up!

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -153,12 +153,21 @@ class TestBasic:
             conftest.recv_til_done(sagews, test_id)
             break
 
+class TestUnderscore:
     # https://github.com/sagemathinc/cocalc/issues/1107
     def test_sage_underscore_1(self, exec2):
         exec2("2/5","2/5\n")
     def test_sage_underscore_2(self, exec2):
         exec2("_","2/5\n")
+    # https://github.com/sagemathinc/cocalc/issues/2124
+    def test_sage_underscore_3(self, exec2):
+        exec2("typeset_mode(True)\n_", html_pattern=r'\\frac\{2\}\{5\}')
+    def test_sage_underscore_4(self, exec2):
+        exec2("3*7",html_pattern="21\$")
+    def test_sage_underscore_5(self, exec2):
+        exec2("typeset_mode(False)\n_","21\n")
 
+class TestModeComments:
     # https://github.com/sagemathinc/cocalc/issues/978
     def test_mode_comments_1(self, exec2):
         exec2(dedent("""
@@ -175,6 +184,7 @@ class TestBasic:
         456'
         """).lstrip())
 
+class TestBlockParser:
     def test_block_parser(self, execbuf):
         """
         .. NOTE::

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -236,7 +236,7 @@ class TestOctaveDefaultMode:
     def test_octave_capture3(self, exec2):
         exec2("%sage\nprint(output)", pattern = "   1   2")
     def test_octave_version(self, exec2):
-        exec2("version()", pattern="4.2.1")
+        exec2("version()", pattern="4.2.2")
 
 class TestAnaconda3Mode:
     def test_start_a3(self, exec2):

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -56,7 +56,7 @@ class TestScala211Mode:
 
 class TestPython3Mode:
     def test_p3_max(self, exec2):
-        exec2("%python3\nmax([],default=9)", "9")
+        exec2("%python3\nmax([],default=9)", "9", timeout=30)
 
     def test_p3_version(self, exec2):
         exec2("%python3\nimport sys\nprint(sys.version)", pattern=r"^3\.5\.\d+ ")


### PR DESCRIPTION
Ref: #2124

One line added to set '_' in sage_salvus.py when code executes with typeset_mode enabled.

Pytest suite updated, all tests pass. To verify:

```
# apply patch for this PR
cd ~/cocalc/src/smc_sagews/smc_sagews/tests
python -m pytest
...
== 145 passed, 5 skipped in 367.08 seconds ==
```

