### PR TITLE
sagews: disable require.ensure for d3 (plotting graphs)

### DIFF
--- a/src/smc-webapp/sagews/sagews.coffee
+++ b/src/smc-webapp/sagews/sagews.coffee
@@ -1526,7 +1526,9 @@ class SynchronizedWorksheet extends SynchronizedDocument2
         if mesg.d3?
             e = $("<div>")
             output.append(e)
-            require.ensure [], () =>
+            # TODO this is a hotfix. Make this loading lazy again -- #2860
+            #require.ensure [], () =>
+            if true
                 require('./d3')  # install the d3 plugin
                 e.d3
                     viewer : mesg.d3.viewer


### PR DESCRIPTION
this is a hotfix for #2860, but only what's in the initial comment. I was able to confirm it by running it through the webpack production build (broken before, fixed after)