### PR TITLE
Enable support for "from __future__ import ..." in sage worksheets

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3630,24 +3630,28 @@ def typeset_mode(on=True, display=True, **args):
     else:
         sys.displayhook = displayhook
 
-def py3print_mode(enable=None):
+
+def python_future_feature(feature=None, enable=None):
     """
-    Enable python3 print syntax.
+    Enable python features from the __future__ system.
 
     EXAMPLES::
 
     Enable python3 printing:
 
-        py3print_mode(True)
-        py3print_mode()   # returns True
+        python_future_feature('print_function', True)
+        python_future_feature('print_function')   # returns True
         print("hello", end="")
 
     Then switch back to python2 printing
-        py3print_mode(False)
+        python_future_feature('print_function', False)
         print "hello"
 
     """
-    return salvus.py3print_mode(enable)
+    return salvus.python_future_feature(feature, enable)
+
+def py3print_mode(enable=None):
+    return python_future_feature('print_function', enable)
 
 def default_mode(mode):
     """

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3651,7 +3651,23 @@ def python_future_feature(feature=None, enable=None):
     return salvus.python_future_feature(feature, enable)
 
 def py3print_mode(enable=None):
-    return python_future_feature('print_function', enable)
+    """
+    Enable python3 print syntax.
+
+    EXAMPLES::
+
+    Enable python3 printing:
+
+        py3print_mode(True)
+        py3print_mode()   # returns True
+        print("hello", end="")
+
+    Then switch back to python2 printing
+        py3print_mode(False)
+        print "hello"
+
+    """
+    return salvus.python_future_feature('print_function', enable)
 
 def default_mode(mode):
     """

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -877,10 +877,8 @@ class Salvus(object):
         if (feature not in future.all_feature_names) or (attr is None) or not isinstance(attr, future._Feature):
             raise RuntimeError("future feature %.50r is not defined" % (feature,))
 
-        wasEnabled = feature in Salvus._py_features
-
         if enable is None:
-            return wasEnabled
+            return feature in Salvus._py_features
 
         if enable:
             Salvus._py_features[feature] = attr
@@ -889,7 +887,6 @@ class Salvus(object):
                 del Salvus._py_features[feature]
             except KeyError:
                 pass
-        return wasEnabled
 
     def default_mode(self, mode=None):
         """

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -28,7 +28,8 @@ For debugging, this may help:
 
 # Add the path that contains this file to the Python load path, so we
 # can import other files from there.
-import os, sys, time
+import os, sys, time, operator
+import __future__ as future
 
 def unicode8(s):
     # I evidently don't understand Python unicode...  Do the following for now:
@@ -544,7 +545,7 @@ class Salvus(object):
     _prefix       = ''
     _postfix      = ''
     _default_mode = 'sage'
-    _py3print_mode = False
+    _py_features = {}
 
     def _flush_stdio(self):
         """
@@ -863,11 +864,32 @@ class Salvus(object):
                 url += u'?download'
             return TemporaryURL(url=url, ttl=mesg.get('ttl',0))
 
-    def py3print_mode(self, enable=None):
+    def python_future_feature(self, feature = None, enable = None):
+        """
+        Allow users to enable, disable, and query the features in the python __future__ module.
+        """
+        if feature is None:
+            if enable is not None:
+                raise ValueError("enable may not be specified when feature is None")
+            return sorted(Salvus._py_features.iterkeys())
+
+        attr = getattr(future, feature, None)
+        if (feature not in future.all_feature_names) or (attr is None) or not isinstance(attr, future._Feature):
+            raise RuntimeError("future feature %.50r is not defined" % (feature,))
+
+        wasEnabled = feature in Salvus._py_features
+
         if enable is None:
-            return Salvus._py3print_mode
-        if isinstance(enable, bool):
-            Salvus._py3print_mode = enable
+            return wasEnabled
+
+        if enable:
+            Salvus._py_features[feature] = attr
+        else:
+            try:
+                del Salvus._py_features[feature]
+            except KeyError:
+                pass
+        return wasEnabled
 
     def default_mode(self, mode=None):
         """
@@ -965,10 +987,7 @@ class Salvus(object):
         if pylab is not None:
             pylab.clf()
 
-        compile_flags = 0
-        if self._py3print_mode:
-            import __future__
-            compile_flags = __future__.CO_FUTURE_PRINT_FUNCTION
+        compile_flags = reduce(operator.or_, (feature.compiler_flag for feature in Salvus._py_features.itervalues()), 0)
 
         #code   = sage_parsing.strip_leading_prompts(code)  # broken -- wrong on "def foo(x):\n   print(x)"
         blocks = sage_parsing.divide_into_blocks(code)
@@ -985,7 +1004,6 @@ class Salvus(object):
             pass  # expected behavior usually, since sage.repl.interpreter usually not imported (only used by command line...)
 
         import sage.misc.session
-
         for start, stop, block in blocks:
             # if import sage.repl.interpreter fails, sag_repl_interpreter is unreferenced
             try:
@@ -1022,7 +1040,12 @@ class Salvus(object):
                             # BUGFIX: be careful to *NOT* assign to _!!  see https://github.com/sagemathinc/cocalc/issues/1107
                             block2 = "sage.misc.session.state_at_init = dict(globals());sage.misc.session._dummy=sage.misc.session.show_identifiers();\n"
                             exec compile(block2, '', 'single') in namespace, locals
+                    features = sage_parsing.get_future_features(block, 'single')
+                    if features:
+                        compile_flags = reduce(operator.or_, (feature.compiler_flag for feature in features.itervalues()), compile_flags)
                     exec compile(block+'\n', '', 'single', flags=compile_flags) in namespace, locals
+                    if features:
+                        Salvus._py_features.update(features)
                 sys.stdout.flush()
                 sys.stderr.flush()
             except:
@@ -1877,10 +1900,10 @@ def serve(port, host, extra_imports=False):
                      'default_mode', 'delete_last_output', 'dynamic', 'exercise', 'fork',
                      'fortran', 'go', 'help', 'hide', 'hideall', 'input', 'java', 'javascript', 'julia',
                      'jupyter', 'license', 'load', 'md', 'mediawiki', 'modes', 'octave', 'pandoc',
-                     'perl', 'plot3d_using_matplotlib', 'prun', 'py3print_mode', 'python', 'python3', 'r', 'raw_input',
-                     'reset', 'restore', 'ruby', 'runfile', 'sage_chat', 'sage_eval', 'scala', 'scala211',
-                     'script', 'search_doc', 'search_src', 'sh', 'show', 'show_identifiers', 'singular_kernel',
-                     'time', 'timeit', 'typeset_mode', 'var', 'wiki']:
+                     'perl', 'plot3d_using_matplotlib', 'prun', 'python_future_feature', 'py3print_mode',
+                     'python', 'python3', 'r', 'raw_input', 'reset', 'restore', 'ruby', 'runfile', 'sage_chat',
+                     'sage_eval', 'scala', 'scala211', 'script', 'search_doc', 'search_src', 'sh', 'show', 'show_identifiers',
+                     'singular_kernel', 'time', 'timeit', 'typeset_mode', 'var', 'wiki']:
             namespace[name] = getattr(sage_salvus, name)
 
         namespace['sage_server'] = sys.modules[__name__]    # http://stackoverflow.com/questions/1676835/python-how-do-i-get-a-reference-to-a-module-inside-the-module-itself

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -153,6 +153,65 @@ class TestBasic:
             conftest.recv_til_done(sagews, test_id)
             break
 
+class TestPythonFutureFeatures:
+    def test_pyfutfeats_0(self,exec2):
+        exec2("python_future_feature()", "[]\n")
+
+    def test_pyfutfeats_1(self,exec2):
+        exec2("python_future_feature('division')", "False\n")
+
+    def test_pyfutfeats_2(self,exec2):
+        exec2("python_future_feature('division', True)")
+
+    def test_pyfutfeats_3(self,exec2):
+        exec2("python_future_feature()", "['division']\n")
+
+    def test_pyfutfeats_4(self,exec2):
+        exec2("python_future_feature('division')", "True\n")
+
+    def test_pyfutfeats_5(self,exec2):
+        exec2("print(8r / 5r)", "1.6\n")
+
+    def test_pyfutfeats_6(self,exec2):
+        exec2("python_future_feature('division', False)")
+
+    def test_pyfutfeats_7(self,exec2):
+        exec2("python_future_feature()", "[]\n")
+
+    def test_pyfutfeats_8(self,exec2):
+        exec2("python_future_feature('division')", "False\n")
+
+    def test_pyfutfeats_9(self,exec2):
+        exec2("print(8r / 5r)", "1\n")
+
+class TestPythonFutureImport:
+    def test_pyfutimp_0(self,exec2):
+        code = dedent(r"""
+        for feature in python_future_feature():
+            python_future_feature(feature, False)
+        """)
+        exec2(code)
+
+    def test_pyfutimp_1(self,exec2):
+        exec2("print(8r / 5r)", "1\n")
+
+    def test_pyfutimp_2(self,exec2):
+        code = dedent(r"""
+        from __future__ import division
+        print(8r / 5r)
+        """)
+        output = "1.6\n"
+        exec2(code, output)
+
+    def test_pyfutimp_3(self,exec2):
+        exec2("print(8r / 5r)", "1.6\n")
+
+    def test_pyfutimp_4(self,exec2):
+        exec2("python_future_feature('division', False)")
+
+    def test_pyfutimp_5(self,exec2):
+        exec2("print(8r / 5r)", "1\n")
+
 class TestPy3printMode:
     def test_py3print_mode0(self,exec2):
         exec2("py3print_mode()", "False\n")


### PR DESCRIPTION
Ref: #2868

Add support for python's __future__ statements along with a utility function python_future_feature(feature=None, enable=None) to enable, disable, and query the state of 'future features' like "division" and "print_function".