### PR TITLE
change 'invite' to 'add' in text

### DIFF
--- a/src/smc-webapp/collaborators/add-to-project.cjsx
+++ b/src/smc-webapp/collaborators/add-to-project.cjsx
@@ -88,7 +88,7 @@ exports.AddCollaborators = rclass
         replyto      = redux.getStore('account').get_email_address()
         replyto_name = redux.getStore('account').get_fullname()
         if replyto_name?
-            subject = "#{replyto_name} invites you to project #{@props.project.get('title')}"
+            subject = "#{replyto_name} added you to project #{@props.project.get('title')}"
         else
             subject = "CoCalc Invitation to project #{@props.project.get('title')}"
         @actions('projects').invite_collaborator(
@@ -127,7 +127,7 @@ exports.AddCollaborators = rclass
         replyto      = redux.getStore('account').get_email_address()
         replyto_name = redux.getStore('account').get_fullname()
         if replyto_name?
-            subject = "#{replyto_name} invites you to project #{@props.project.get('title')}"
+            subject = "#{replyto_name} added you to project #{@props.project.get('title')}"
         else
             subject = "CoCalc Invitation to project #{@props.project.get('title')}"
         @actions('projects').invite_collaborators_by_email(@props.project.get('project_id'),

--- a/src/smc-webapp/collaborators/add-to-project.cjsx
+++ b/src/smc-webapp/collaborators/add-to-project.cjsx
@@ -88,9 +88,9 @@ exports.AddCollaborators = rclass
         replyto      = redux.getStore('account').get_email_address()
         replyto_name = redux.getStore('account').get_fullname()
         if replyto_name?
-            subject = "#{replyto_name} added you to project #{@props.project.get('title')}"
+            subject = "#{replyto_name} added you to CoCalc project #{@props.project.get('title')}"
         else
-            subject = "CoCalc Invitation to project #{@props.project.get('title')}"
+            subject = "You've been added to CoCalc project #{@props.project.get('title')}"
         @actions('projects').invite_collaborator(
             @props.project.get('project_id'),
             account_id,

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -540,7 +540,7 @@ Student = rclass
         else
             <Tip placement='right'
                  title='Create the student project'
-                 tip='Create a new project for this student, then add (or invite) the student as a collaborator, and also add any collaborators on the project containing this course.'>
+                 tip='Create a new project for this student, then add the student as a collaborator, and also add any collaborators on the project containing this course.'>
                 <Button onClick={@create_project}>
                     <Icon name="plus-circle" /> Create student project
                 </Button>


### PR DESCRIPTION
This should fix #2873 unless I am missing an "invite" somewhere, but my very-quick grep search found one other instance in billing here: https://github.com/sagemathinc/cocalc/blob/invite_to_add/src/smc-webapp/billing.cjsx#L1212

```
You can also invite collaborators to work with you inside a project
```

I thought this was an ok use for the word "invite" so I left it, but maybe for consistency it might be better to switch it also.