### PR TITLE
matplotlib backend selection in salvus server

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -12,6 +12,9 @@
 #                  http://www.gnu.org/licenses/                                         #
 #########################################################################################
 
+# set backend of matplot lib before any other module is loaded
+import matplotlib
+matplotlib.use('Agg')
 
 import copy, os, sys, types, re
 

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -4,8 +4,9 @@ sage_server.py -- unencrypted forking TCP server.
 
 Note: I wrote functionality so this can run as root, create accounts on the fly,
 and serve sage as those accounts.  Doing this is horrendous from a security point of
-view, and I'm definitely not doing this.  None of that functionality is actually
-used in https://cloud.sagemath.com!
+view, and I'm definitely not doing this.
+
+None of that functionality is actually used in https://cocalc.com!
 
 For debugging, this may help:
 


### PR DESCRIPTION
This is work in progress, but right now it is at least in state where sagews worksheets produce some output in ubuntu 18.04 again.

The background is that matplotlib config files or env variables might set the backend of matplotlib to one of such a type, where it tries to open a graphical window. e.g. configs like that

```
$ grep ^backend /etc/matplotlibrc
backend      : TkAgg
```

This change here makes this robust against that and selects "Agg" regardless of what the configuration says.

Loading speed? Since in that file pylab is getting imported globally, and also some other parts of matplotlib, I can't imagine how this can have any impact.

Testing: ~~what's missing is to double check with the current ubuntu 16.04 environment.~~ ok, this works in the current software environment, too (no surprise)