### PR TITLE
webapp: simple workaround to unmangle katex formulas in RTL contexts

### DIFF
--- a/src/smc-webapp/index.sass
+++ b/src/smc-webapp/index.sass
@@ -350,3 +350,8 @@ footer
   border-right: 30px solid #525659
   border-bottom: 5px solid #525659
   border-top: 5px solid #525659
+
+// issue #2892 -- katex formulas mangled in RTL contexts
+// this here is just a workaround
+span.katex
+  direction: ltr


### PR DESCRIPTION
see issue #2892

This isn't fixing katex, but at least the formulas brackets aren't mixed up.