### PR TITLE
kernel selection suggestion for jupyter notebooks

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -2189,3 +2189,51 @@ exports.jupyter_language_to_name = (lang) ->
         return 'SageMath'
     else
         return lang.charAt(0).toUpperCase() + lang[1..]
+
+# Find the kernel whose name is closest to the given name.
+exports.closest_kernel_match = (name,kernel_list) ->
+    name = name.toLowerCase().replace("matlab","octave")
+    bestValue = -1
+    bestMatch = null
+    for i in [0..kernel_list.size-1]
+        k = kernel_list.get(i)
+        kernel_name = k.get("name").toLowerCase()
+        v = 0
+        for j in [0..name.length-1]
+            if name[j] == kernel_name[j]
+                v++
+            else
+                break
+        # TODO: don't use regular name comparison, use compareVersionStrings
+        if v > bestValue or (v == bestValue and bestMatch and compareVersionStrings(k.get("name"),bestMatch.get("name")) == 1)
+            bestValue = v
+            bestMatch = k
+    return bestMatch
+
+# compareVersionStrings takes two strings "a","b"
+# and returns 1 is "a" is bigger, 0 if they are the same, and -1 if "a" is smaller.
+# By "bigger" we compare the integer and non-integer parts of the strings separately.
+# Examples:
+#     - "sage.10" is bigger than "sage.9" (because 10 > 9)
+#     - "python.1" is bigger than "sage.9" (because "python" > "sage")
+#     - "sage.1.23" is bigger than "sage.0.456" (because 1 > 0)
+#     - "sage.1.2.3" is bigger than "sage.1.2" (because "." > "")
+compareVersionStrings = (a, b) ->
+  a = a.split(/(\d+)/)
+  b = b.split(/(\d+)/)
+  for i in [0..Math.max(a.length, b.length)-1]
+    l = a[i] or ""
+    r = b[i] or ""
+    if /\d/.test(l) and /\d/.test(r)
+      vA = parseInt(l)
+      vB = parseInt(r)
+      if vA > vB
+        return 1
+      if vA < vB
+        return -1
+    else
+      if l > r
+        return 1
+      if l < r
+        return -1
+  return 0

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -10,6 +10,7 @@ require('coffee-cache')
 
 misc = require('../misc')
 underscore = require('underscore')
+immutable = require('immutable')
 
 # ATTN: the order of these require statements is important,
 # such that should & sinon work well together
@@ -1470,3 +1471,16 @@ describe 'misc.transform_get_url mangles some URLs or "understands" what action 
 
 
 
+describe 'test closest kernel matching method', ->
+    octave   = immutable.fromJS {name:"octave", display_name:"Octave", language:"octave"}
+    python2  = immutable.fromJS {name:"python2", display_name:"Python 2", language:"python"}
+    python3  = immutable.fromJS {name:"python3", display_name:"Python 3", language:"python"}
+    sage8_2  = immutable.fromJS {name:"sage8.2", display_name:"Sagemath 8.2", language:"python"}
+    sage8_10 = immutable.fromJS {name:"sage8.10", display_name:"Sagemath 8.10", language:"python"}
+    kernels = immutable.fromJS([octave,python3,python3,sage8_2,sage8_10])
+    it 'thinks python8 should be python3', ->
+        expect(misc.closest_kernel_match("python8",kernels)).toEqual(python3)
+    it 'replaces "matlab" with "octave"', ->
+        expect(misc.closest_kernel_match("matlabe",kernels)).toEqual(octave)
+    it 'suggests sage8.10 over sage8.2', ->
+        expect(misc.closest_kernel_match("sage8",kernels)).toEqual(sage8_10)

--- a/src/smc-webapp/jupyter/status.cjsx
+++ b/src/smc-webapp/jupyter/status.cjsx
@@ -4,9 +4,7 @@ Kernel display
 
 {React, ReactDOM, rclass, rtypes}  = require('../smc-react')
 {Icon, Loading, Tip} = require('../r_misc')
-
-misc = require('smc-util/misc')
-
+{closest_kernel_match} = require('smc-util/misc')
 {Logo} = require('./logo')
 
 exports.Mode = rclass ({name}) ->
@@ -87,9 +85,13 @@ exports.Kernel = rclass ({name}) ->
     render_name: ->
         display_name = @props.kernel_info?.get('display_name')
         if not display_name? and @props.kernels?
+            console.log(@props.kernels.toJS())
             # Definitely an unknown kernel
-            <span style={KERNEL_ERROR_STYLE}>
-                Unknown kernel <span style={fontWeight:'bold'}>{@props.kernel}</span> (select a valid kernel from the Kernel menu)
+            closestKernel = closest_kernel_match(@props.kernel,@props.kernels)
+            closestKernelDisplayName = closestKernel.get("display_name")
+            closestKernelName = closestKernel.get("name")
+            <span style={KERNEL_ERROR_STYLE} onClick={() => @props.actions.set_kernel(closestKernelName)}>
+                Unknown kernel <span style={fontWeight:'bold'}>{@props.kernel}</span>, click here to use {closestKernelDisplayName} instead.
             </span>
         else
             # List of known kernels just not loaded yet.
@@ -230,4 +232,3 @@ exports.Kernel = rclass ({name}) ->
             {@render_logo()}
             {@render_tip(title, body)}
         </span>
-


### PR DESCRIPTION
This PR changes the error message for a jupyter notebook with unknown kernel to a message that suggests an existing kernel and allows a user to click and for that kernel to be automatically selected.

I changed the wording of the message to include the word "click" to emphasize that it is actionable.

The suggested kernel is determined by the `closest_kernel_match` function. It basically looks at kernels which have the longest matching prefix with the given kernel. The results are sorted using a custom string comparison that makes things like "sage8.10" bigger than "sage8.9". This way, given the string "sage", this function should usually recommend the latest version of the Sage kernel.