### PR TITLE
static/landingpage: show warning to firefox users about issue #2875

### DIFF
--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -40,6 +40,10 @@ block content
           img(src=require('!url-loader?mimetype=image/svg+xml!cocalc-logo.svg'))
       div.col-sm-12.center.descr.
         #{htmlWebpackPlugin.options.description}
+      div.col-sm-12.center.ff-only
+        div.alert.alert-danger.
+          WARNING: There is #[a.alert-link(href="https://github.com/sagemathinc/cocalc/issues/2875") a serious issue for Firefox].
+          Working on #{NAME} is severely impaired, because Firefox disconnects you due to this bug.
       div.col-sm-12.center
         +start_button
 
@@ -370,3 +374,8 @@ block content
           white-space    : nowrap
       #included > div
         padding          : 0
+      .ff-only
+        display: none
+      @supports (-moz-appearance:none)
+        .ff-only
+          display: block


### PR DESCRIPTION
This adds a red box warning about firefox (and only for firefox). The text sounds a bit weird, but I think it gets the point across.

![screenshot from 2018-05-25 17-44-49](https://user-images.githubusercontent.com/207405/40553784-008f3782-6044-11e8-963e-018429c61a11.png)
