### PR TITLE
Issue/2903

### DIFF
--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -37,7 +37,7 @@ misc      = require('smc-util/misc')
 
 misc_page = require('./misc_page')
 
-{Actions, rtypes, computed, depends, project_redux_name, Table, register_project_store, redux}  = require('./smc-react')
+{Actions, rtypes, computed, depends, project_redux_name, Table, redux}  = require('./smc-react')
 
 exports.file_actions = file_actions =
     compress  :
@@ -124,23 +124,16 @@ must_define = (redux) ->
     if not redux?
         throw Error('you must explicitly pass a redux object into each function in project_store')
 
-# Name used by the project_store for the sub-stores corresponding to that project.
-exports.redux_name = key = (project_id, name) ->
-    s = "project-#{project_id}"
-    if name?
-        s += "-#{name}"
-    return s
-
 _init_library_index_ongoing = {}
 _init_library_index_cache   = {}
 
 class ProjectActions extends Actions
     destroy: =>
         must_define(@redux)
-        name = key(@project_id)
+        name = project_redux_name(@project_id)
         @close_all_files()
         for table, _ of QUERIES
-            @redux.removeTable(key(@project_id, table))
+            @redux.removeTable(project_redux_name(@project_id, table))
 
     _ensure_project_is_open: (cb, switch_to) =>
         s = @redux.getStore('projects')
@@ -2124,76 +2117,3 @@ get_directory_listing = (opts) ->
                 redux.getProjectActions(opts.project_id).log
                     event : 'start_project'
                     time  : misc.server_time() - time0
-
-###
-!!!ATTENTION!!!
-
-When you rewrite the code below, do NOT change the semantics!!
-
-In particular, calling getProjectStore or getProjectActions or getProjectTable
-from the main redux object at any time is allowed, and should return something
-that is defined.  And calling any one must result in all of actions, store,
-and the table being defined.
-###
-
-exports.getStore = getStore = (project_id, redux) ->
-    must_define(redux)
-    name  = key(project_id)
-    store = redux.getStore(name)
-    if store?
-        return store
-
-    # Initialize everything
-    actions = redux.createActions(name, ProjectActions)
-    actions.project_id = project_id  # so actions can assume this is available on the object
-    store = redux.createStore(create_project_store_def(name, project_id))
-
-    queries = misc.deep_copy(QUERIES)
-    create_table = (table_name, q) ->
-        #console.log("create_table", table_name)
-        class P extends Table
-            query: =>
-                return "#{table_name}":q.query
-            options: =>
-                return q.options
-            _change: (table, keys) =>
-                actions.setState("#{table_name}": table.get())
-
-    for table_name, q of queries
-        for k, v of q
-            if typeof(v) == 'function'
-                q[k] = v()
-        q.query.project_id = project_id
-        T = redux.createTable(key(project_id, table_name), create_table(table_name, q))
-
-    return store
-
-exports.getActions = (project_id, redux) ->
-    must_define(redux)
-    if not getStore(project_id, redux)?
-        getStore(project_id, redux)
-    return redux.getActions(key(project_id))
-
-exports.getTable = (project_id, name, redux) ->
-    must_define(redux)
-    if not getStore(project_id, redux)?
-        getStore(project_id, redux)
-    return redux.getTable(key(project_id, name))
-
-exports.deleteStoreActionsTable = (project_id, redux) ->
-    must_define(redux)
-    name = key(project_id)
-
-    store = redux.getStore(name)
-    if store?
-        store.destroy()
-    actions = redux.getActions(name)
-    if actions?
-        actions.close_all_files()
-        redux.removeActions(name)
-    for table,_ of QUERIES
-        redux.removeTable(key(project_id, table))
-    redux.removeStore(name)
-
-# Register this module with the redux module, so it can be used by the rest of SMC easily.
-register_project_store(exports)

--- a/src/smc-webapp/smc-react-ts.ts
+++ b/src/smc-webapp/smc-react-ts.ts
@@ -229,16 +229,19 @@ export class AppRedux {
     return this._actions[name];
   }
 
+  hasActions(name:string):boolean {
+    return !!this._actions[name];
+  }
+
   getActions<T, C extends Actions<T>>(
     name: string | { project_id: string }
-  ): C | undefined {
-    if (name == null) {
-      throw Error(
-        "name must be a string or an object with a project_id attribute, but is undefined"
-      );
-    }
+  ): C {
     if (typeof name === "string") {
-      return this._actions[name];
+      if (!this.hasActions(name)) {
+        throw Error(`getActions: actions ${name} not registered`);
+      } else {
+        return this._actions[name];
+      }
     } else {
       if (name.project_id == null) {
         throw Error("Object must have project_id attribute");

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -47,12 +47,6 @@ exports.COLOR =
     FG_RED  : '#c9302c' # red used for text
     FG_BLUE : '#428bca' # blue used for text
 
-# We do this so this module can be used without having to include all the
-# project-store related functionality.  When it gets loaded, it will set the
-# project_store module below.  This is purely a potential lazy loading optimization.
-project_store = undefined
-exports.register_project_store = (x) -> project_store = x
-
 class Table
     constructor: (@name, @redux) ->
         if not Primus?  # hack for now -- not running in browser (instead in testing server)
@@ -360,6 +354,7 @@ class AppRedux
                 S._init?()
         return S
 
+    # Returns undefined if the store is not created
     getStore: (name) =>
         if not name?
             throw Error("name must be a string")
@@ -410,32 +405,45 @@ class AppRedux
             throw Error("getTable: table #{name} not registered")
         return @_tables[name]
 
-    # getProject[...] only works if the project_store has been
-    # initialized by calling register_project_store.  This
-    # happens when project_store is require'd.
+    projectStoreExists: (project_id) =>
+        return !!this.getStore(project_redux_name(project_id))
+
+    # getProject... is safe to call any time. All structures will be created if they don't exist
+    # Thus use getStore(...) to check for existence.
     getProjectStore: (project_id) =>
         if not misc.is_valid_uuid_string(project_id)
             console.trace()
             console.warn("getProjectStore: INVALID project_id -- #{project_id}")
-        return project_store.getStore(project_id, @)
+        if not projectStoreExists(project_id)
+            require("project_store").init(project_id)
+        return @getStore(project_redux_name(project_id))
 
     getProjectActions: (project_id) =>
         if not misc.is_valid_uuid_string(project_id)
             console.trace()
             console.warn("getProjectActions: INVALID project_id -- #{project_id}")
-        return project_store.getActions(project_id, @)
+        if not projectStoreExists(project_id)
+            require("project_store").init(project_id)
+        return @getActions(project_redux_name(project_id))
 
     getProjectTable: (project_id, name) =>
         if not misc.is_valid_uuid_string(project_id)
             console.trace()
             console.warn("getProjectTable: INVALID project_id -- #{project_id}")
-        return project_store.getTable(project_id, name, @)
+        if not projectStoreExists(project_id)
+            require("project_store").init(project_id)
+        return @getTable(project_redux_name(project_id, name))
 
     removeProjectReferences: (project_id) =>
         if not misc.is_valid_uuid_string(project_id)
             console.trace()
             console.warn("getProjectReferences: INVALID project_id -- #{project_id}")
-        project_store.deleteStoreActionsTable(project_id, @)
+        name = project_redux_name(project_id);
+        store = @getStore(name)
+        if store? and typeof store.destroy == "function"
+            store.destroy()
+        @removeActions(name)
+        @removeStore(name)
 
     getEditorStore: (project_id, path, is_public) =>
         if not misc.is_valid_uuid_string(project_id)

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -405,7 +405,7 @@ class AppRedux
             throw Error("getTable: table #{name} not registered")
         return @_tables[name]
 
-    projectStoreExists: (project_id) =>
+    hasProjectStore: (project_id) =>
         return !!this.getStore(project_redux_name(project_id))
 
     # getProject... is safe to call any time. All structures will be created if they don't exist
@@ -414,7 +414,7 @@ class AppRedux
         if not misc.is_valid_uuid_string(project_id)
             console.trace()
             console.warn("getProjectStore: INVALID project_id -- #{project_id}")
-        if not projectStoreExists(project_id)
+        if not @hasProjectStore(project_id)
             require("project_store").init(project_id)
         return @getStore(project_redux_name(project_id))
 
@@ -422,7 +422,7 @@ class AppRedux
         if not misc.is_valid_uuid_string(project_id)
             console.trace()
             console.warn("getProjectActions: INVALID project_id -- #{project_id}")
-        if not projectStoreExists(project_id)
+        if not @hasProjectStore(project_id)
             require("project_store").init(project_id)
         return @getActions(project_redux_name(project_id))
 
@@ -430,7 +430,7 @@ class AppRedux
         if not misc.is_valid_uuid_string(project_id)
             console.trace()
             console.warn("getProjectTable: INVALID project_id -- #{project_id}")
-        if not projectStoreExists(project_id)
+        if not @hasProjectStore(project_id)
             require("project_store").init(project_id)
         return @getTable(project_redux_name(project_id, name))
 


### PR DESCRIPTION
Fixing #2903 Revert getProjectStore/Actions/Table to old semantics. 

Also enforce that stores and actions are defined when calling getStore and getActions when using Typescript.

Note: This creates a semantic difference between the typescript and coffeescript interfaces for our global redux object! 

@williamstein I don't want to change the coffeescript behavior because I'm guessing a lot of code relies on checking if `redux.getStore` is undefined and refactoring all of that sounds unnecessarily dangerous. You mentioned that you'd like things to be guaranteed to be defined when possible for typescript so this is my solution.