### PR TITLE
Issue/2906

### DIFF
--- a/src/smc-webapp/jupyter/cell-output-message.cjsx
+++ b/src/smc-webapp/jupyter/cell-output-message.cjsx
@@ -203,7 +203,8 @@ Data = rclass
     render: ->
         type  = undefined
         value = undefined
-        @props.message.get('data').forEach (v, k) ->
+        data = @props.message.get('data')
+        data?.forEach? (v, k) ->
             type  = k
             value = v
             return false


### PR DESCRIPTION
see #2906 

With that fix, the "data" is a string, a weird one: `Unsupported message: {"found":"true","data":"Spass hassen spass"}`