### PR TITLE
handle ansi codes in stderr

### DIFF
--- a/src/smc-webapp/jupyter/cell-output-message.cjsx
+++ b/src/smc-webapp/jupyter/cell-output-message.cjsx
@@ -58,9 +58,16 @@ exports.Stderr = Stderr = rclass
     mixins: [ImmutablePureRenderMixin]
 
     render: ->
-        # span below?  what? -- See https://github.com/sagemathinc/cocalc/issues/1958
-        <div style={STDERR_STYLE}><span>{@props.message.get('text')}</span>
-        </div>
+        value = @props.message.get('text')
+        if is_ansi(value)
+            <div style={STDERR_STYLE}>
+                <Ansi>{value}</Ansi>
+            </div>
+        else
+            # span below?  what? -- See https://github.com/sagemathinc/cocalc/issues/1958
+            <div style={STDERR_STYLE}>
+                <span>{value}</span>
+            </div>
 
 Image = rclass
     propTypes:


### PR DESCRIPTION
Ref: #2889.

Here is what is displayed with the new code. Ugly ansi codes no longer appear, and foreground color seems to match the output of JuliaBox.

CoCalc with Julia 0.6.2 kernel:

<img width="601" alt="jlog-cocalc" src="https://user-images.githubusercontent.com/528072/41362458-0e28a074-6ef7-11e8-81c9-dfcfd04ce10c.png">

JuliaBox with Julia 0.6.2 kernel:

![jlog-jbox](https://user-images.githubusercontent.com/528072/41362474-17edddea-6ef7-11e8-9d72-f50931ebd6ba.png)

