### PR TITLE
make sagews pytest suite work with python 3.5

### DIFF
--- a/src/smc_sagews/smc_sagews/tests/test_00_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_00_timing.py
@@ -22,7 +22,7 @@ class TestSageTiming:
         assert result == 0
         tick = time.time()
         elapsed = tick - start
-        assert 1.0 == pytest.approx(elapsed, abs = 0.1)
+        assert 1.0 == pytest.approx(elapsed, abs = 0.2)
 
     def test_load_sage(self):
         start = time.time()
@@ -98,7 +98,7 @@ class TestStartSageServer:
         print("socket unlocked")
         conn = conftest.ConnectionJSON(sock)
         c_ack = conn._recv(1)
-        assert c_ack == 'y',"expect ack for token, got %s"%c_ack
+        assert c_ack == b'y',"expect ack for token, got %s"%c_ack
 
         # start session
         msg = conftest.message.start_session()

--- a/src/smc_sagews/smc_sagews/tests/test_graphics.py
+++ b/src/smc_sagews/smc_sagews/tests/test_graphics.py
@@ -108,7 +108,7 @@ for i in range(2):
                     continue
             else:
                 blob_wanted -= 1
-                file_uuid = mesg[:SHA_LEN]
+                file_uuid = mesg[:SHA_LEN].decode()
                 assert file_uuid == conftest.uuidsha1(mesg[SHA_LEN:])
                 m = conftest.message.save_blob(sha1 = file_uuid)
                 sagews.send_json(m)

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -250,8 +250,8 @@ class TestAnaconda3Mode:
 
 class TestJuliaMode:
     def test_julia_quadratic(self, exec2):
-        exec2('%julia\nquadratic(a, sqr_term, b) = (-b + sqr_term) / 2a\nquadratic(2.0, -2.0, -12.0)', '2.5')
+        exec2('%julia\nquadratic(a, sqr_term, b) = (-b + sqr_term) / 2a\nquadratic(2.0, -2.0, -12.0)', '2.5', timeout=40)
 
     def test_julia_version(self, exec2):
-        exec2("%julia\nVERSION", pattern='"0.6.3"')
+        exec2("%julia\nVERSION", pattern='"0.6.3"', timeout=40)
 

--- a/src/smc_sagews/smc_sagews/tests/test_unicode.py
+++ b/src/smc_sagews/smc_sagews/tests/test_unicode.py
@@ -26,8 +26,8 @@ class TestUnicode:
         test for cell with input u"äöüß"
         """
         ustr = 'u"äöüß"'
-        uout = ustr[2:-1].decode('utf8').__repr__().decode('utf8')
-        exec2(ustr, uout)
+        x = r'\xe4\xf6\xfc\xdf'
+        exec2(ustr, x)
     def test_unicode_2(self, exec2):
         r"""
         Test for cell with input u"ááá".
@@ -40,9 +40,8 @@ class TestUnicode:
           "stdout": "u\'\\\\xe1\\\\xe1\\\\xe1\'\\n"
         """
         ustr = 'u"ááá"'
-        # same as below: uout = u"u'\\xe1\\xe1\\xe1'\n"
-        uout = ustr[2:-1].decode('utf8').__repr__().decode('utf8')
-        exec2(ustr, uout)
+        x = r'\xe1\xe1\xe1'
+        exec2(ustr, x)
     def test_unicode_3(self, exec2):
         r"""
         Test for cell with input "ááá".
@@ -54,15 +53,15 @@ class TestUnicode:
           "stdout": "\'\\\\xc3\\\\xa1\\\\xc3\\\\xa1\\\\xc3\\\\xa1\'\\n"
         """
         ustr = '"ááá"'
-        uout = ustr[1:-1].decode('utf8').encode('utf8').__repr__().decode('utf8')
-        exec2(ustr, uout)
+        x = r'\xc3\xa1\xc3\xa1\xc3\xa1'
+        exec2(ustr, x)
     def test_unicode_4(self, exec2):
         r"""
         test for cell with input "öäß"
         """
         ustr = '"öäß"'
-        uout = ustr[1:-1].decode('utf8').encode('utf8').__repr__().decode('utf8')
-        exec2(ustr, uout)
+        x = r'\xc3\xb6\xc3\xa4\xc3\x9f'
+        exec2(ustr, x)
 
 class TestOutputReplace:
     def test_1865(self,exec2):
@@ -72,8 +71,8 @@ class TestOutputReplace:
 
 class TestErr:
     def test_non_ascii(self, test_id, sagews):
-        # assign x to hbar to trigger non-ascii warning
-        code = ("x = " + unichr(295) + "\nx").encode('utf-8')
+        # assign to hbar to trigger non-ascii warning
+        code = "ħ = 9"
         m = conftest.message.execute_code(code = code, id = test_id)
         sagews.send_json(m)
         # expect 2 messages from worksheet client
@@ -87,8 +86,8 @@ class TestErr:
         # 2 done
         conftest.recv_til_done(sagews, test_id)
     def test_bad_quote(self, test_id, sagews):
-        # assign x to one of U+201C or U+201D to trigger bad quote warning
-        code = ("x = " + unichr(8220) + "\nx").encode('utf-8')
+        # assign x to U+201C (could use U+201D) to trigger bad quote warning
+        code = "“"
         m = conftest.message.execute_code(code = code, id = test_id)
         sagews.send_json(m)
         # expect 2 messages from worksheet client


### PR DESCRIPTION
- explicit use of encode()/decode()/chr() when going between bytes and strings
- dict.items() instead of dict.iteritems()
- allow more time for some tests to complete

to test, apply this patch, then
```
cd ~/cocalc/src/smc_sagews/smc_sagews/tests
python -m pytest
==>
== 167 passed, 5 skipped in 332.97 seconds ==
```