### PR TITLE
Dealing with Knitr errors

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -17,7 +17,7 @@ import * as synctex from "./synctex";
 import { bibtex } from "./bibtex";
 import { server_time, ExecOutput } from "../generic/client";
 import { clean } from "./clean";
-import { LatexParser, ProcessedLatexLog } from "./latex-log-parser";
+import { LatexParser, IProcessedLatexLog } from "./latex-log-parser";
 import { update_gutters } from "./gutters";
 import { pdf_path } from "./util";
 import { forgetDocument, url_to_pdf } from "./pdfjs-doc-cache";
@@ -34,7 +34,7 @@ import {
 import { IBuildSpecs } from "./build";
 
 export interface BuildLog extends ExecOutput {
-  parse?: ProcessedLatexLog;
+  parse?: IProcessedLatexLog;
 }
 
 export type BuildLogs = Map<string, Map<string, any>>;
@@ -267,12 +267,12 @@ export class Actions extends BaseActions<LatexEditorState> {
       );
     } catch (err) {
       this.set_error(err);
-      this.setState({ knitr_error: true});
+      this.setState({ knitr_error: true });
       return;
     } finally {
       this.set_status("");
     }
-    output.parse = knitr_errors(output);
+    output.parse = knitr_errors(output).toJS();
     this.set_build_logs({ knitr: output });
     this.clear_gutter("Codemirror-latex-errors");
     update_gutters({

--- a/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -273,9 +273,7 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
         {["errors", "typesetting", "warnings"].map(group =>
           this.render_group("latex", group)
         )}
-        {["errors", "typesetting", "warnings"].map(group =>
-          this.render_group("knitr", group)
-        )}
+        {["errors", "warnings"].map(group => this.render_group("knitr", group))}
       </div>
     );
   }

--- a/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -4,7 +4,13 @@ Show errors and warnings.
 
 import { Map } from "immutable";
 import { capitalize, is_different, path_split } from "../generic/misc";
-import { Component, React, rclass, rtypes, Rendered } from "../../app-framework";
+import {
+  Component,
+  React,
+  rclass,
+  rtypes,
+  Rendered
+} from "../../app-framework";
 import { TypedMap } from "../../app-framework/TypedMap";
 
 import { BuildLogs } from "./actions";

--- a/src/smc-webapp/frame-editors/latex-editor/gutters.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/gutters.tsx
@@ -13,11 +13,11 @@ const { Icon, Tip } = require("smc-webapp/r_misc");
 
 import { SPEC, SpecItem } from "./errors-and-warnings";
 
-import { ProcessedLatexLog, Error } from "./latex-log-parser";
+import { IProcessedLatexLog, Error } from "./latex-log-parser";
 
 export function update_gutters(opts: {
   path: string;
-  log: ProcessedLatexLog;
+  log: IProcessedLatexLog;
   set_gutter: Function;
 }): void {
   let path: string = path_split(opts.path).tail;

--- a/src/smc-webapp/frame-editors/latex-editor/knitr.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/knitr.ts
@@ -31,6 +31,29 @@ export async function knitr(
   });
 }
 
+/**
+Knitr error example:
+
+Testing a few cases, it looks like we should report everything after the line "Error in..."
+In case of multiple errors, only the first error is reported.
+There is not much sense with parsing the lines, because usually they aren't reported.
+Warnings are always below and start with a line ending in "Warning message:".
+
+Loading required package: knitr
+processing file: test2.rnw
+Error in parse(text = code, keep.source = FALSE) :
+  <text>:1:29: unexpected symbol
+1: x <- c(2,3,4,5,1,2,3,3,3,3,4a
+                                ^
+Quitting from lines 26-101 (test2.rnw)
+Error in paste(x, collapse = "+") : object 'x' not found
+Calls: knit ... inline_exec -> hook_eval -> withVisible -> eval -> eval -> paste
+In addition: Warning message:
+In highr::hilight(x, format, prompt = options$prompt, markup = opts$markup) :
+  the syntax of the source code is invalid; the fallback mode is used
+Execution halted
+**/
+
 export function knitr_errors(output: BuildLog): ProcessedLatexLog {
   let i = 0;
 
@@ -40,25 +63,43 @@ export function knitr_errors(output: BuildLog): ProcessedLatexLog {
   const typesetting: Error[] = [];
 
   let file: string = "";
+  let err: Error | undefined = undefined;
+
+  const warnmsg = "Warning message:";
 
   for (let line of output.stderr.split("\n")) {
     console.log(`line ${i}: ${line}`);
     if (line.search("Error") == 0) {
-      let e: Error = {
+      err = {
         line: null,
-        file: `./${file}`,
+        file: `${file}`,
         level: "error",
-        message: "ERROR PROC",
-        content: "test error",
+        message: line,
+        content: "",
         raw: ""
       };
-      file = "";
-      errors.push(e);
-      all.push(e);
+      errors.push(err);
+      all.push(err);
+      continue;
+    }
+    if (line.substring(line.length - warnmsg.length) == warnmsg) {
+      err = {
+        line: null,
+        file: `${file}`,
+        level: "warning",
+        message: line,
+        content: "",
+        raw: ""
+      };
+      warnings.push(err);
+      all.push(err);
       continue;
     }
     if (line.search("processing file:") == 0) {
       file = line.substring("processing file:".length).trim();
+    }
+    if (err != undefined) {
+      err.content += `${line}\n`;
     }
     i += 1;
   }

--- a/src/smc-webapp/frame-editors/latex-editor/knitr.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/knitr.ts
@@ -55,8 +55,6 @@ Execution halted
 **/
 
 export function knitr_errors(output: BuildLog): ProcessedLatexLog {
-  let i = 0;
-
   const all: Error[] = [];
   const errors: Error[] = [];
   const warnings: Error[] = [];
@@ -68,7 +66,6 @@ export function knitr_errors(output: BuildLog): ProcessedLatexLog {
   const warnmsg = "Warning message:";
 
   for (let line of output.stderr.split("\n")) {
-    console.log(`line ${i}: ${line}`);
     if (line.search("Error") == 0) {
       err = {
         line: null,
@@ -101,7 +98,6 @@ export function knitr_errors(output: BuildLog): ProcessedLatexLog {
     if (err != undefined) {
       err.content += `${line}\n`;
     }
-    i += 1;
   }
   return {
     errors,

--- a/src/smc-webapp/frame-editors/latex-editor/knitr.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/knitr.ts
@@ -4,6 +4,8 @@ Run Rweave on rnw files
 
 import { exec, ExecOutput } from "../generic/client";
 import { parse_path } from "../frame-tree/util";
+import { ProcessedLatexLog, Error } from "./latex-log-parser";
+import { BuildLog } from "./actions";
 
 // this still respects the environment variables and init files
 const R_CMD = "R --no-save --no-restore --quiet --no-readline";
@@ -18,15 +20,55 @@ export async function knitr(
   const cmd: string = `echo 'require(knitr); opts_knit$set(concordance = TRUE, progress = FALSE); knit("${filename}")' | ${R_CMD}`;
   status(`running ${cmd}`);
   return exec({
-    allow_post: false, // definitely could take a long time to fully run Rweave
+    allow_post: false, // definitely could take a long time to fully run Knitr
     timeout: 360,
     command: cmd,
     bash: true,
     project_id: project_id,
     path: directory,
     err_on_exit: false,
-    aggregate:time ? { value: time } : undefined // one might think to aggregate on hash, but the output could be random!
+    aggregate: time ? { value: time } : undefined // one might think to aggregate on hash, but the output could be random!
   });
+}
+
+export function knitr_errors(output: BuildLog): ProcessedLatexLog {
+  let i = 0;
+
+  const all: Error[] = [];
+  const errors: Error[] = [];
+  const warnings: Error[] = [];
+  const typesetting: Error[] = [];
+
+  let file: string = "";
+
+  for (let line of output.stderr.split("\n")) {
+    console.log(`line ${i}: ${line}`);
+    if (line.search("Error") == 0) {
+      let e: Error = {
+        line: null,
+        file: `./${file}`,
+        level: "error",
+        message: "ERROR PROC",
+        content: "test error",
+        raw: ""
+      };
+      file = "";
+      errors.push(e);
+      all.push(e);
+      continue;
+    }
+    if (line.search("processing file:") == 0) {
+      file = line.substring("processing file:".length).trim();
+    }
+    i += 1;
+  }
+  return {
+    errors,
+    warnings,
+    typesetting,
+    all,
+    files: []
+  };
 }
 
 export async function patch_synctex(

--- a/src/smc-webapp/frame-editors/latex-editor/knitr.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/knitr.ts
@@ -55,10 +55,7 @@ Execution halted
 **/
 
 export function knitr_errors(output: BuildLog): ProcessedLatexLog {
-  const all: Error[] = [];
-  const errors: Error[] = [];
-  const warnings: Error[] = [];
-  const typesetting: Error[] = [];
+  const pll = new ProcessedLatexLog();
 
   let file: string = "";
   let err: Error | undefined = undefined;
@@ -75,8 +72,8 @@ export function knitr_errors(output: BuildLog): ProcessedLatexLog {
         content: "",
         raw: ""
       };
-      errors.push(err);
-      all.push(err);
+      pll.errors.push(err);
+      pll.all.push(err);
       continue;
     }
     if (line.substring(line.length - warnmsg.length) == warnmsg) {
@@ -88,8 +85,8 @@ export function knitr_errors(output: BuildLog): ProcessedLatexLog {
         content: "",
         raw: ""
       };
-      warnings.push(err);
-      all.push(err);
+      pll.warnings.push(err);
+      pll.all.push(err);
       continue;
     }
     if (line.search("processing file:") == 0) {
@@ -99,13 +96,7 @@ export function knitr_errors(output: BuildLog): ProcessedLatexLog {
       err.content += `${line}\n`;
     }
   }
-  return {
-    errors,
-    warnings,
-    typesetting,
-    all,
-    files: []
-  };
+  return pll;
 }
 
 export async function patch_synctex(

--- a/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
@@ -93,12 +93,12 @@ interface File {
   files: string[];
 }
 
-export interface ProcessedLatexLog {
-  errors: Error[];
-  warnings: Error[];
-  typesetting: Error[];
-  all: Error[];
-  files: string[];
+export class ProcessedLatexLog {
+  errors: Error[] = [];
+  warnings: Error[] = [];
+  typesetting: Error[] = [];
+  all: Error[] = [];
+  files: string[] = [];
 }
 
 export class LatexParser {

--- a/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
@@ -93,12 +93,24 @@ interface File {
   files: string[];
 }
 
-export class ProcessedLatexLog {
+export interface IProcessedLatexLog {
+  errors: Error[];
+  warnings: Error[];
+  typesetting: Error[];
+  all: Error[];
+  files: string[];
+}
+
+export class ProcessedLatexLog implements IProcessedLatexLog {
   errors: Error[] = [];
   warnings: Error[] = [];
   typesetting: Error[] = [];
   all: Error[] = [];
   files: string[] = [];
+
+  toJS(): IProcessedLatexLog {
+    return Object.assign({}, this);
+  }
 }
 
 export class LatexParser {
@@ -124,7 +136,7 @@ export class LatexParser {
     this.openParens = 0;
   }
 
-  parse(): ProcessedLatexLog {
+  parse(): IProcessedLatexLog {
     while ((this.currentLine = this.log.nextLine()) != null) {
       if (this.state === state.NORMAL) {
         if (this.currentLineIsError()) {
@@ -163,7 +175,7 @@ export class LatexParser {
         this.state = state.NORMAL;
       }
     }
-    return this.postProcess(this.data);
+    return this.postProcess(this.data).toJS();
   }
 
   currentLineIsError(): boolean {
@@ -336,12 +348,8 @@ export class LatexParser {
   }
 
   postProcess(data: Error[]): ProcessedLatexLog {
-    const all: Error[] = [];
-    const errors: Error[] = [];
-    const warnings: Error[] = [];
-    const typesetting: Error[] = [];
+    const pll = new ProcessedLatexLog();
     const hashes: string[] = [];
-
     const hashEntry: Function = entry => entry.raw;
 
     let i: number = 0;
@@ -351,22 +359,16 @@ export class LatexParser {
         continue;
       }
       if (data[i].level === "error") {
-        errors.push(data[i]);
+        pll.errors.push(data[i]);
       } else if (data[i].level === "typesetting") {
-        typesetting.push(data[i]);
+        pll.typesetting.push(data[i]);
       } else if (data[i].level === "warning") {
-        warnings.push(data[i]);
+        pll.warnings.push(data[i]);
       }
-      all.push(data[i]);
+      pll.all.push(data[i]);
       hashes.push(hashEntry(data[i]));
       i++;
     }
-    return {
-      errors,
-      warnings,
-      typesetting,
-      all,
-      files: this.rootFileList
-    };
+    return pll;
   }
 }


### PR DESCRIPTION
This patch accomplishes a few details regarding Knitr processing of Rnw files.

* do not continue to compile any latex if there is a knitr problem
* parse the knitr output and try to generate appropriate error and warning messages (there isn't much information to get, but it's still helpful)
* if there are no knitr errors but latex errors, these latex errors are on top
* pure latex processing is not affected.

below are screenshots for various scenarios (R syntax, missing R variable, latex error)

![screenshot-cocalc com-2018 07 02-16-05-57](https://user-images.githubusercontent.com/207405/42169150-3470dfb4-7e13-11e8-8a8c-c6570e2dcb7d.png)


![screenshot-cocalc com-2018 07 02-16-07-26](https://user-images.githubusercontent.com/207405/42169163-3afabbc0-7e13-11e8-869c-4042d291df5a.png)

![screenshot-cocalc com-2018 07 02-16-10-05](https://user-images.githubusercontent.com/207405/42169174-4041ac2e-7e13-11e8-99ed-519d639c94b1.png)

![screenshot-cocalc com-2018 07 02-16-12-52](https://user-images.githubusercontent.com/207405/42169178-447017d6-7e13-11e8-82b5-bc840a10ea2f.png)
