### PR TITLE
db: add "addons" row to project table

### DIFF
--- a/src/smc-util/db-schema.coffee
+++ b/src/smc-util/db-schema.coffee
@@ -792,9 +792,9 @@ schema.projects =
         compute_image :
             type : 'string'
             desc : 'Specify the name of the underlying (kucalc) compute image (default: "latest")'
-        academic :
+        addons :
             type : 'map'
-            desc : 'Configure (kucalc specific) academic related aspects. (available software, environment, ...)'
+            desc : 'Configure (kucalc specific) addons for projects. (e.g. acadmic software, license keys, ...)'
 
     pg_indexes : [
         'last_edited',
@@ -824,7 +824,7 @@ schema.projects =
                 action_request : null   # last requested action -- {action:?, time:?, started:?, finished:?, err:?}
                 course         : null
                 compute_image  : 'latest'
-                academic       : {}
+                addons         : null
         set :
             fields :
                 project_id     : 'project_write'

--- a/src/smc-util/db-schema.coffee
+++ b/src/smc-util/db-schema.coffee
@@ -792,6 +792,9 @@ schema.projects =
         compute_image :
             type : 'string'
             desc : 'Specify the name of the underlying (kucalc) compute image (default: "latest")'
+        academic :
+            type : 'map'
+            desc : 'Configure (kucalc specific) academic related aspects. (available software, environment, ...)'
 
     pg_indexes : [
         'last_edited',
@@ -821,6 +824,7 @@ schema.projects =
                 action_request : null   # last requested action -- {action:?, time:?, started:?, finished:?, err:?}
                 course         : null
                 compute_image  : 'latest'
+                academic       : {}
         set :
             fields :
                 project_id     : 'project_write'


### PR DESCRIPTION
This is just for adding a row like `compute_image` to the projects table. It's a general purpose configuration for "academic" aspects, e.g. additional software, special product keys (for env variables), and whatever we come up in the future. First step is to have a place to store this in a project specific datastructure.

I was also thinking about using the quota system for this, but I fear that's getting too complex.

The associated branch for kucalc is `proj-edu`.