### PR TITLE
webapp/global banner: reactivate for K2 announcement

### DIFF
--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -32,9 +32,13 @@ misc = require('smc-util/misc')
 {AccountPage} = require('./account_page')
 {FileUsePage} = require('./file_use')
 {AdminPage} = require('admin/page')
+{show_announce_end} = require('./redux_account')
 
 ACTIVE_BG_COLOR = COLORS.TOP_BAR.ACTIVE
 feature = require('./feature')
+
+# same as nav bar height?
+exports.announce_bar_offset = announce_bar_offset = 40
 
 exports.ActiveAppContent = ({active_top_tab, render_small}) ->
     switch active_top_tab
@@ -384,9 +388,11 @@ exports.FullscreenButton = rclass
     reduxProps :
         page :
             fullscreen : rtypes.oneOf(['default', 'kiosk'])
+        account :
+            show_global_info       : rtypes.bool
 
     shouldComponentUpdate: (next) ->
-        return @props.fullscreen != next.fullscreen
+        return misc.is_different(@props, next, ['fullscreen', 'show_global_info'])
 
     on_fullscreen: (ev) ->
         if ev.shiftKey
@@ -396,13 +402,14 @@ exports.FullscreenButton = rclass
 
     render: ->
         icon = if @props.fullscreen then 'compress' else 'expand'
+        top_px = if @props.show_global_info then "#{announce_bar_offset + 1}px" else '1px'
 
         tip_style =
-            position   : 'fixed'
-            zIndex     : 10000
-            right      : 0
-            top        : '1px'
-            borderRadius: '3px'
+            position     : 'fixed'
+            zIndex       : 10000
+            right        : 0
+            top          : top_px
+            borderRadius : '3px'
 
 
         icon_style =
@@ -541,6 +548,7 @@ exports.LocalStorageWarning = rclass
 # for other global announcements.
 # For now, it just has a simple dismiss button backed by the account → other_settings, though.
 # 20171013: disabled, see https://github.com/sagemathinc/cocalc/issues/1982
+# 20180713: enabled again, we need it to announce the K2 switch
 exports.GlobalInformationMessage = rclass
     displayName: 'GlobalInformationMessage'
 
@@ -548,7 +556,8 @@ exports.GlobalInformationMessage = rclass
         redux.getTable('account').set(other_settings:{show_global_info2:webapp_client.server_time()})
 
     render: ->
-        more_url = 'https://github.com/sagemathinc/cocalc/wiki/KubernetesMigration'
+        more_url = 'https://github.com/sagemathinc/cocalc/wiki/Maintenance2018'
+        local_time = show_announce_end.toLocaleString()
         bgcol = COLORS.YELL_L
         style =
             padding         : '5px 0 5px 5px'
@@ -562,12 +571,11 @@ exports.GlobalInformationMessage = rclass
 
         <Row style={style}>
             <Col sm={9} style={paddingTop: 3}>
-                <p><b>CoCalc <a target='_blank' href={more_url}>migrated to Kubernetes</a></b>.
-                {' '}Please report any issues.
+                <p><b>On {local_time} there will be a <a target='_blank' href={more_url}>scheduled downtime</a> for system maintenance.</b>
                 {' '}<a target='_blank' href={more_url}>More information...</a></p>
             </Col>
             <Col sm={3}>
-                <Button bsStyle='danger' bsSize="small" className='pull-right' style={marginRight:'20px'}
+                <Button bsStyle='danger' bsSize="small" className='pull-right' style={marginRight:'10px'}
                     onClick={@dismiss}>Close</Button>
             </Col>
         </Row>

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -42,7 +42,7 @@
 misc = require('smc-util/misc')
 
 {ProjectsNav} = require('./projects_nav')
-{ActiveAppContent, CookieWarning, GlobalInformationMessage, LocalStorageWarning, ConnectionIndicator, ConnectionInfo, FullscreenButton, NavTab, NotificationBell, AppLogo, VersionWarning} = require('./app_shared')
+{ActiveAppContent, CookieWarning, GlobalInformationMessage, LocalStorageWarning, ConnectionIndicator, ConnectionInfo, FullscreenButton, NavTab, NotificationBell, AppLogo, VersionWarning, announce_bar_offset} = require('./app_shared')
 
 nav_class = 'hidden-xs'
 
@@ -245,6 +245,8 @@ Page = rclass
             width         : '100vw'
             overflow      : 'hidden'
 
+        top = if @props.show_global_info then "#{announce_bar_offset}px" else 0
+
         style_top_bar =
             display       : 'flex'
             marginBottom  : 0
@@ -254,9 +256,10 @@ Page = rclass
             right         : 0
             zIndex        : '100'
             borderRadius  : 0
-            top           : if @props.show_global_info then '40px' else 0
+            top           : top
 
-        positionHackHeight = (40 + if @props.show_global_info then 40 else 0) + 'px'
+        positionHackOffset = if @props.show_global_info then announce_bar_offset else 0
+        positionHackHeight = (40 + positionHackOffset) + 'px'
 
         <div ref="page" style={style} onDragOver={(e) -> e.preventDefault()} onDrop={@drop}>
             {<FileUsePageWrapper /> if @props.show_file_use}

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -1118,7 +1118,7 @@ OtherSettings = rclass
 
     toggle_global_banner: (val) ->
         if val
-            # this must be null, not undefined. no idea why...
+            # this must be "null", not "undefined" – otherwise the data isn't stored in the DB.
             @on_change('show_global_info2', null)
         else
             @on_change('show_global_info2', webapp_client.server_time())

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -1116,19 +1116,37 @@ OtherSettings = rclass
     on_change: (name, value) ->
         @props.redux.getTable('account').set(other_settings:{"#{name}":value})
 
+    toggle_global_banner: (val) ->
+        if val
+            # this must be null, not undefined. no idea why...
+            @on_change('show_global_info2', null)
+        else
+            @on_change('show_global_info2', webapp_client.server_time())
+
     render_first_steps: ->
         <Checkbox
             checked  = {!!@props.other_settings.get('first_steps')}
             ref      = 'first_steps'
-            onChange = {(e)=>@on_change('first_steps', e.target.checked)}>
+            onChange = {(e)=>@on_change('first_steps', e.target.checked)}
+        >
             Offer to setup the "First Steps" guide (if available).
+        </Checkbox>
+
+    render_global_banner: ->
+        <Checkbox
+            checked  = {!@props.other_settings.get('show_global_info2')}
+            ref      = 'global_banner'
+            onChange = {(e)=>@toggle_global_banner(e.target.checked)}
+        >
+            Show announcement banner (only shows up if there is a message)
         </Checkbox>
 
     render_time_ago_absolute: ->
         <Checkbox
             checked  = {!!@props.other_settings.get('time_ago_absolute')}
             ref      = 'time_ago_absolute'
-            onChange = {(e)=>@on_change('time_ago_absolute', e.target.checked)}>
+            onChange = {(e)=>@on_change('time_ago_absolute', e.target.checked)}
+        >
             Display timestamps as absolute points in time – otherwise they are relative to the current time.
         </Checkbox>
 
@@ -1136,7 +1154,8 @@ OtherSettings = rclass
         <Checkbox
             checked  = {!!@props.other_settings.get('katex')}
             ref      = 'katex'
-            onChange = {(e)=>@on_change('katex', e.target.checked)}>
+            onChange = {(e)=>@on_change('katex', e.target.checked)}
+        >
             KaTeX: render using <a href="https://khan.github.io/KaTeX/" target="_blank">KaTeX</a> when possible, instead of <a href="https://www.mathjax.org/" target="_blank">MathJax</a>
         </Checkbox>
 
@@ -1145,7 +1164,8 @@ OtherSettings = rclass
             <Checkbox
                 checked  = {!!@props.other_settings.get('confirm_close')}
                 ref      = 'confirm_close'
-                onChange = {(e)=>@on_change('confirm_close', e.target.checked)}>
+                onChange = {(e)=>@on_change('confirm_close', e.target.checked)}
+            >
                 Confirm: always ask for confirmation before closing the browser window
             </Checkbox>
 
@@ -1215,6 +1235,7 @@ OtherSettings = rclass
         <Panel header={<h2> <Icon name='gear' /> Other settings</h2>}>
             {@render_confirm()}
             {@render_first_steps()}
+            {@render_global_banner()}
             {@render_time_ago_absolute()}
             {### @render_katex() ###}
             {@render_mask_files()}

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -20,6 +20,9 @@ help = ->
 {webapp_client} = require('./webapp_client')
 remember_me = webapp_client.remember_me_key()
 
+exports.show_announce_start = new Date('2018-06-12T00:00:00.000Z')
+exports.show_announce_end = new Date('2018-07-21T14:00:00.000Z')
+
 # Define account actions
 class AccountActions extends Actions
     _init: (store) =>
@@ -32,17 +35,22 @@ class AccountActions extends Actions
         # unknown state, right after opening the application
         if sgi2 == 'loading'
             show = false
-        # not set means there is no timestamp → show banner
+        # value not set means there is no timestamp → show banner
         else
+            # ... if it is inside the scheduling window
+            start = exports.show_announce_start
+            end = exports.show_announce_end
+            in_window = start < webapp_client.server_time() < end
+
             if not sgi2?
-                show = true
+                show = in_window
             # 3rd case: a timestamp is set
             # show the banner only if its start_dt timetstamp is earlier than now
             # *and* when the last "dismiss time" by the user is prior to it.
             else
                 sgi2_dt = new Date(sgi2)
-                start_dt = new Date('2018-07-01T19:00:00.000Z')
-                show = start_dt < webapp_client.server_time() and sgi2_dt < start_dt
+                dismissed_before_start = sgi2_dt < start
+                show = in_window and dismissed_before_start
         @setState(show_global_info: show)
 
     set_user_type: (user_type) =>


### PR DESCRIPTION
I'm trying to make this work again. There is a comment I don't understand, though

> We need to delete this function and instead do like in the _init of actions, i.e.,
>    set derived state based on changes to account store in AccountActions.  -- william

When I add a `_init` function to the account actions, it isn't called at all. Is such a call supposed to happen by the framework? Is this documented anywhere? If so, I haven't found it in the app-framework examples. 

So, what I ended up doing is just calling it right where it is created, in order to make it do anything.