### PR TITLE
set initial aspect ratio/crop after image is loaded

### DIFF
--- a/src/smc-webapp/r_profile_image.tsx
+++ b/src/smc-webapp/r_profile_image.tsx
@@ -313,7 +313,20 @@ export class ProfileImageSelector extends Component<
           onChange={(crop: any, pixelCrop: any) =>
             this.setState({ crop, pixelCrop })
           }
-          crop={this.state.crop || { x: 10, y: 10, width: 30, height: 30 }}
+          onImageLoaded={image => {
+            this.setState({
+              crop: ReactCrop.makeAspectCrop(
+                {
+                  x: 0,
+                  y: 0,
+                  aspect: 1,
+                  width: 30
+                },
+                image.width / image.height
+              )
+            });
+          }}
+          crop={this.state.crop}
         />
         <br />
         <ButtonToolbar>


### PR DESCRIPTION
This makes it so that the cropping tool is always a square. Fixes #2971.