### PR TITLE
db user search: search all users, not just active ones -- #2991

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -906,12 +906,13 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
     #     OR
     #     (created >= NOW() - $3::INTERVAL)
     #   )
+    #   ORDER BY last_active DESC NULLS LAST
     #   LIMIT $4::INTEGER
     user_search: (opts) =>
         opts = defaults opts,
             query  : required     # comma separated list of email addresses or strings such as 'foo bar' (find everything where foo and bar are in the name)
             limit  : 50           # limit on string queries; email query always returns 0 or 1 result per email address
-            active : '13 months'  # for name search (not email), only return users active this recently. -- upped b/c of #2991
+            active : undefined    # for name search (not email), only return users active this recently. -- disabled b/c of #2991
             admin  : false
             cb     : required     # cb(err, list of {id:?, first_name:?, last_name:?, email_address:?}), where the
                                   # email_address *only* occurs in search queries that are by email_address -- we do not reveal
@@ -986,6 +987,8 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     # name search only includes active users
                     query += " AND ((last_active >= NOW() - $#{i}::INTERVAL) OR (created >= NOW() - $#{i}::INTERVAL)) "
                     i += 1
+                # recently active users are much more relevant than old ones -- #2991
+                query += " ORDER BY last_active DESC NULLS LAST"
                 query += " LIMIT $#{i}::INTEGER"; i += 1
                 params.push(opts.limit)
                 @_query

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -880,11 +880,38 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                         f(account_id, username)
                     opts.cb(undefined, usernames)
 
+    # This searches for users. In case someone has to debug this, the "clear text" for the user search by name (tokens) is
+    # SELECT account_id, first_name, last_name, last_active, created
+    # FROM accounts
+    # WHERE deleted IS NOT TRUE
+    #   AND (
+    #     (
+    #       (
+    #         lower(first_name) LIKE $1::TEXT
+    #         OR
+    #         lower(last_name) LIKE $1::TEXT
+    #       )
+    #       AND
+    #       (
+    #         lower(first_name) LIKE $2::TEXT
+    #         OR
+    #         lower(last_name) LIKE $2::TEXT
+    #       )
+    #       AND
+    #          ...
+    #     )
+    #   )
+    #   AND (
+    #     (last_active >= NOW() - $3::INTERVAL)
+    #     OR
+    #     (created >= NOW() - $3::INTERVAL)
+    #   )
+    #   LIMIT $4::INTEGER
     user_search: (opts) =>
         opts = defaults opts,
             query  : required     # comma separated list of email addresses or strings such as 'foo bar' (find everything where foo and bar are in the name)
             limit  : 50           # limit on string queries; email query always returns 0 or 1 result per email address
-            active : '6 months'   # for name search (not email), only return users active this recently.
+            active : '13 months'  # for name search (not email), only return users active this recently. -- upped b/c of #2991
             admin  : false
             cb     : required     # cb(err, list of {id:?, first_name:?, last_name:?, email_address:?}), where the
                                   # email_address *only* occurs in search queries that are by email_address -- we do not reveal

--- a/src/smc-util/db-schema.coffee
+++ b/src/smc-util/db-schema.coffee
@@ -222,7 +222,7 @@ schema.accounts =
         'created_by',
         'created',
         'api_key',
-        'last_active'
+        'last_active DESC NULLS LAST'
         ]
     user_query :
         get :

--- a/src/smc-webapp/admin/users/user-search.tsx
+++ b/src/smc-webapp/admin/users/user-search.tsx
@@ -65,7 +65,7 @@ export class UserSearch extends Component<{}, UserSearchState> {
       query: this.state.query,
       admin: true,
       limit: 100,
-      active: "1 year"
+      active: "20 months"
     });
     if (!this.mounted) {
       return;

--- a/src/smc-webapp/admin/users/user-search.tsx
+++ b/src/smc-webapp/admin/users/user-search.tsx
@@ -4,12 +4,7 @@ Functionality and UI to ensure a user with given email (or account_id) is sync'd
 
 import { Row, Col, FormGroup, FormControl, Button } from "react-bootstrap";
 
-import {
-  React,
-  Component,
-  Rendered,
-  ReactDOM
-} from "smc-webapp/app-framework";
+import { React, Component, Rendered, ReactDOM } from "smc-webapp/app-framework";
 
 import { user_search, User } from "smc-webapp/frame-editors/generic/client";
 
@@ -24,14 +19,14 @@ interface UserSearchState {
   result: User[];
 }
 
-function user_sort_key(user: User) : string {
-  if(user.last_active) {
+function user_sort_key(user: User): string {
+  if (user.last_active) {
     return user.last_active;
   }
-  if(user.created) {
+  if (user.created) {
     return user.created;
   }
-  return '';
+  return "";
 }
 
 export class UserSearch extends Component<{}, UserSearchState> {
@@ -64,8 +59,7 @@ export class UserSearch extends Component<{}, UserSearchState> {
     const result: User[] = await user_search({
       query: this.state.query,
       admin: true,
-      limit: 100,
-      active: "20 months"
+      limit: 100
     });
     if (!this.mounted) {
       return;


### PR DESCRIPTION
did three test searches directly on the db in prod, which all were below 3 ms. 