### PR TITLE
Issue/2510 1

### DIFF
--- a/src/smc-util/upgrade-spec.coffee
+++ b/src/smc-util/upgrade-spec.coffee
@@ -62,7 +62,7 @@ upgrades.max_per_project =
 # is assumed elsewhere.
 upgrades.params =
     disk_quota :
-        display        : 'Disk space'
+        display        : 'Disk Space'
         unit           : 'MB'
         display_unit   : 'MB'
         display_factor : 1
@@ -107,7 +107,7 @@ upgrades.params =
         input_type     : 'number'
         desc           : 'Guaranteed minimum number of CPU cores that are dedicated to your project.'
     mintime :
-        display        : 'Idle timeout'
+        display        : 'Idle Timeout'
         unit           : 'second'
         display_unit   : 'hour'
         display_factor : 1/3600  # multiply internal by this to get what should be displayed
@@ -116,7 +116,7 @@ upgrades.params =
         input_type     : 'number'
         desc           : 'If the project is not used for this long, then it will be automatically stopped.'
     network :
-        display        : 'Internet access'
+        display        : 'Internet Access'
         unit           : 'project'
         display_unit   : 'project'
         display_factor : 1
@@ -125,7 +125,7 @@ upgrades.params =
         input_type     : 'checkbox'
         desc           : 'Full internet access enables a project to connect to the computers outside of CoCalc, download software packages, etc.'
     member_host :
-        display        : 'Member hosting'
+        display        : 'Member Hosting'
         unit           : 'project'
         display_unit   : 'project'
         display_factor : 1

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -671,7 +671,7 @@ ProjectControlPanel = rclass
 
     render_confirm_stop: ->
         if @state.show_stop_confirmation
-            <LabeledRow key='restart' label=''>
+            <LabeledRow key='stop' label=''>
                 <Well>
                     Stopping the project server will kill all processes.
                     After stopping a project, it will not start until a
@@ -697,7 +697,7 @@ ProjectControlPanel = rclass
                 <Icon name={COMPUTE_STATES.starting.icon} /> Restart Project...
             </Button>
             <Button bsStyle='warning' disabled={'stop' not in commands} onClick={(e)=>e.preventDefault(); @setState(show_stop_confirmation:true,restart:false)}>
-                <Icon name={COMPUTE_STATES.stopping.icon} /> Stop Project
+                <Icon name={COMPUTE_STATES.stopping.icon} /> Stop Project...
             </Button>
         </ButtonToolbar>
 

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -241,7 +241,7 @@ QuotaConsole = rclass
                 <Row>
                     <Col sm={6} smOffset={6}>
                         <Button onClick={@start_admin_editing} bsStyle='warning' style={float:'right'}>
-                            <Icon name='pencil' /> Admin edit...
+                            <Icon name='pencil' /> Admin Edit...
                         </Button>
                     </Col>
                 </Row>
@@ -373,7 +373,7 @@ UsagePanel = rclass
         <Row>
             <Col sm={12}>
                 <Button bsStyle='primary' disabled={@state.show_adjustor} onClick={=>@setState(show_adjustor : true)} style={float: 'right', marginBottom : '5px'}>
-                    <Icon name='arrow-circle-up' /> Adjust your quotas...
+                    <Icon name='arrow-circle-up' /> Adjust Quotas...
                 </Button>
             </Col>
         </Row>
@@ -487,7 +487,7 @@ HideDeletePanel = rclass
             </div> if not has_upgrades}
             <ButtonToolbar >
                 <Button bsStyle='danger' onClick={@toggle_delete_project}>
-                    Delete Project
+                    Yes, please delete this project
                 </Button>
                 <Button onClick={@hide_delete_conf}>
                     Cancel
@@ -660,9 +660,28 @@ ProjectControlPanel = rclass
                     <hr />
                     <ButtonToolbar>
                         <Button bsStyle='warning' onClick={(e)=>e.preventDefault(); @setState(restart:false); @restart_project()}>
-                            <Icon name='refresh' /> Restart project server
+                            <Icon name='refresh' /> Restart Project Server
                         </Button>
                         <Button onClick={(e)=>e.preventDefault(); @setState(restart:false)}>
+                             Cancel
+                        </Button>
+                    </ButtonToolbar>
+                </Well>
+            </LabeledRow>
+
+    render_confirm_stop: ->
+        if @state.show_stop_confirmation
+            <LabeledRow key='restart' label=''>
+                <Well>
+                    Stopping the project server will kill all processes.
+                    After stopping a project, it will not start until a
+                    collaborator restarts the project.
+                    <hr />
+                    <ButtonToolbar>
+                        <Button bsStyle='warning' onClick={(e)=>e.preventDefault(); @setState(show_stop_confirmation:false); @stop_project()}>
+                            <Icon name='refresh' /> Stop Project Server
+                        </Button>
+                        <Button onClick={(e)=>e.preventDefault(); @setState(show_stop_confirmation:false)}>
                              Cancel
                         </Button>
                     </ButtonToolbar>
@@ -674,11 +693,11 @@ ProjectControlPanel = rclass
         state = @props.project.get('state')?.get('state')
         commands = COMPUTE_STATES[state]?.commands ? ['save', 'stop', 'start']
         <ButtonToolbar style={marginTop:'10px', marginBottom:'10px'}>
-            <Button bsStyle='warning' disabled={'start' not in commands and 'stop' not in commands} onClick={(e)=>e.preventDefault(); @setState(restart:true)}>
-                <Icon name={COMPUTE_STATES.starting.icon} /> Restart project...
+            <Button bsStyle='warning' disabled={'start' not in commands and 'stop' not in commands} onClick={(e)=>e.preventDefault(); @setState(show_stop_confirmation:false,restart:true)}>
+                <Icon name={COMPUTE_STATES.starting.icon} /> Restart Project...
             </Button>
-            <Button bsStyle='warning' disabled={'stop' not in commands} onClick={(e)=>e.preventDefault(); @stop_project()}>
-                <Icon name={COMPUTE_STATES.stopping.icon} /> Stop
+            <Button bsStyle='warning' disabled={'stop' not in commands} onClick={(e)=>e.preventDefault(); @setState(show_stop_confirmation:true,restart:false)}>
+                <Icon name={COMPUTE_STATES.stopping.icon} /> Stop Project
             </Button>
         </ButtonToolbar>
 
@@ -740,6 +759,7 @@ ProjectControlPanel = rclass
                 {@render_action_buttons()}
             </LabeledRow>
             {@render_confirm_restart()}
+            {@render_confirm_stop()}
             <LabeledRow key='project_id' label='Project id'>
                 <pre>{@props.project.get('project_id')}</pre>
             </LabeledRow>

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -180,9 +180,9 @@ EmailAddressSetting = rclass
 
     change_button: ->
         if @is_submittable()
-            <Button onClick={@save_editing} bsStyle='success'>Change email address</Button>
+            <Button onClick={@save_editing} bsStyle='success'>Change Email Address</Button>
         else
-            <Button disabled bsStyle='success'>Change email address</Button>
+            <Button disabled bsStyle='success'>Change Email Address</Button>
 
     render_error: ->
         if @state.error
@@ -230,7 +230,7 @@ EmailAddressSetting = rclass
         <LabeledRow label='Email address'  style={marginBottom: '15px'}>
             <div>
                 {@props.email_address}
-                <Button className='pull-right'  disabled={@state.state != 'view'} onClick={@start_editing}>Change email...</Button>
+                <Button className='pull-right'  disabled={@state.state != 'view'} onClick={@start_editing}>Change Email...</Button>
             </div>
             {@render_edit() if @state.state != 'view'}
         </LabeledRow>
@@ -332,10 +332,10 @@ PasswordSetting = rclass
     change_button: ->
         if @is_submittable()
             <Button onClick={@save_new_password} bsStyle='success'>
-                Change password
+                Change Password
             </Button>
         else
-            <Button disabled bsStyle='success'>Change password</Button>
+            <Button disabled bsStyle='success'>Change Password</Button>
 
     render_error: ->
         if @state.error
@@ -392,7 +392,7 @@ PasswordSetting = rclass
         <LabeledRow label='Password' style={marginBottom: '15px'}>
             <div style={height:'30px'}>
                 <Button className='pull-right' disabled={@state.state != 'view'} onClick={@change_password}>
-                    Change password...
+                    Change Password...
                 </Button>
             </div>
             {@render_edit() if @state.state != 'view'}
@@ -522,7 +522,7 @@ AccountSettings = rclass
             {text}
             <ButtonToolbar style={textAlign: 'center', marginTop: '15px'}>
                 <Button bsStyle="primary" onClick={=>@actions('account').sign_out(@props.everywhere)}>
-                    <Icon name="external-link" /> Sign out
+                    <Icon name="external-link" /> Sign Out
                 </Button>
                 <Button onClick={=>@actions('account').setState(show_sign_out : false)}>
                     Cancel
@@ -535,11 +535,11 @@ AccountSettings = rclass
         <ButtonToolbar className='pull-right'>
             <Button bsStyle='warning' disabled={@props.show_sign_out and not @props.everywhere}
                 onClick={=>@actions('account').setState(show_sign_out : true, everywhere : false, sign_out_error:undefined)}>
-                <Icon name='sign-out'/> Sign out...
+                <Icon name='sign-out'/> Sign Out...
             </Button>
             <Button bsStyle='warning' disabled={@props.show_sign_out and @props.everywhere}
                 onClick={=>@actions('account').setState(show_sign_out : true, everywhere : true, sign_out_error:undefined)}>
-                <Icon name='sign-out'/> Sign out everywhere...
+                <Icon name='sign-out'/> Sign Out Everywhere...
             </Button>
         </ButtonToolbar>
 

--- a/src/smc-webapp/widget-ssh-keys/main.cjsx
+++ b/src/smc-webapp/widget-ssh-keys/main.cjsx
@@ -168,9 +168,9 @@ DeleteConfirmation = rclass
             <hr />
             <ButtonToolbar>
                 <Button bsStyle='danger' onClick={@props.confirm}>
-                    Yes, delete this key.
+                    Yes, please delete this SSH key
                 </Button>
-                <Button bsStyle='primary' onClick={@props.cancel}>
+                <Button onClick={@props.cancel}>
                     Cancel
                 </Button>
             </ButtonToolbar>


### PR DESCRIPTION
This works on some of the issues raised in #2510. It attempts to make many of the buttons consistently capitalized. The main exception to this is "irreversible" dangerous options such as "delete project" or "delete ssh key". These buttons have a more descriptive explanation of their consequences, but they do not contain punctuation.