### PR TITLE
spellcheck special cases for rtex/rnw files

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -225,7 +225,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
         );
         return;
       }
-      if (!this._syncstring || this._state == 'closed') {
+      if (!this._syncstring || this._state == "closed") {
         // the doc could perhaps be closed by the time this init is fired, in which case just bail -- no point in trying to initialize anything.
         return;
       }
@@ -264,7 +264,11 @@ export class Actions<T = CodeEditorState> extends BaseActions<
   // This is currently NOT used in this base class.  It's used in other
   // editors to store shared configuration or other information.  E.g., it's
   // used by the latex editor to store the build command, master file, etc.
-  _init_syncdb(primary_keys: string[], string_cols?: string[], path?: string): void {
+  _init_syncdb(
+    primary_keys: string[],
+    string_cols?: string[],
+    path?: string
+  ): void {
     const aux = aux_file(path || this.path, "syncdb");
     this._syncdb = syncdb({
       project_id: this.project_id,
@@ -291,7 +295,8 @@ export class Actions<T = CodeEditorState> extends BaseActions<
 
   // Reload the document.  This is used mainly for *public* viewing of
   // a file.
-  reload(_ : string): void {  // id not used here...
+  reload(_: string): void {
+    // id not used here...
     if (!this.store.get("is_loaded")) {
       // currently in the process of loading
       return;
@@ -812,7 +817,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
   // so the information can propogate to other users via the syncstring.
   set_cursor_locs(locs: any[]): void {
     if (!this._syncstring) {
-      return;  // not currently valid.
+      return; // not currently valid.
     }
     if (locs.length === 0) {
       // don't remove on blur -- cursor will fade out just fine
@@ -1312,6 +1317,12 @@ export class Actions<T = CodeEditorState> extends BaseActions<
     return cm.focus();
   }
 
+  // returns the path, unless we aim to spellcheck for a related file (e.g. rnw, rtex)
+  // overwritten in derived classes
+  get_spellcheck_path(): string {
+    return this.path;
+  }
+
   // Runs spellchecker on the backend last saved file, then
   // sets the mispelled_words part of the state to the immutable
   // Set of those words.  They can then be rendered by any editor/view.
@@ -1332,7 +1343,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
     try {
       const words: string[] = await misspelled_words({
         project_id: this.project_id,
-        path: this.path,
+        path: this.get_spellcheck_path(),
         lang,
         time
       });

--- a/src/smc-webapp/frame-editors/code-editor/spell-check.ts
+++ b/src/smc-webapp/frame-editors/code-editor/spell-check.ts
@@ -22,11 +22,13 @@ export async function misspelled_words(opts: Options): Promise<string[]> {
   }
 
   let mode: string;
-  switch (filename_extension(opts.path)) {
+  switch (filename_extension(opts.path).toLowerCase()) {
     case "html":
       mode = "--mode=html";
       break;
     case "tex":
+    case "rtex":
+    case "rnw":
       mode = "--mode=tex";
       break;
     default:

--- a/src/smc-webapp/frame-editors/code-editor/spell-check.ts
+++ b/src/smc-webapp/frame-editors/code-editor/spell-check.ts
@@ -5,6 +5,7 @@ Backend spell checking support
 import { filename_extension } from "../generic/misc";
 import { exec, ExecOutput } from "../generic/client";
 import { language } from "../generic/misc-page";
+import { KNITR_EXTS } from "../latex-editor/util.ts";
 
 interface Options {
   project_id: string;
@@ -22,31 +23,27 @@ export async function misspelled_words(opts: Options): Promise<string[]> {
   }
 
   let mode: string;
-  switch (filename_extension(opts.path).toLowerCase()) {
-    case "html":
-      mode = "--mode=html";
-      break;
-    case "tex":
-    case "rtex":
-    case "rnw":
-      mode = "--mode=tex";
-      break;
-    default:
-      mode = "--mode=none";
+  const ext = filename_extension(opts.path).toLowerCase();
+  if (ext == "html") {
+    mode = "--mode=html";
+  } else if (ext == "tex" || KNITR_EXTS.includes(ext)) {
+    mode = "--mode=tex";
+  } else {
+    mode = "--mode=none";
   }
+
   let lang;
-  switch(opts.lang) {
-    case 'default':
+  switch (opts.lang) {
+    case "default":
       lang = `--lang=${language()}`;
       break;
-    case 'disabled':
-      lang = '';
+    case "disabled":
+      lang = "";
       break;
     default:
       lang = `--lang=${opts.lang}`;
-
   }
-  const command = `cat '${opts.path}'|aspell ${mode} ${lang} list|sort|uniq`;
+  const command = `cat '${opts.path}' | aspell ${mode} ${lang} list | sort -u`;
   //console.log(command);
 
   const output: ExecOutput = await exec({

--- a/src/smc-webapp/frame-editors/latex-editor/register.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/register.ts
@@ -1,17 +1,17 @@
 /*
 Register the LaTeX file editor
-
 */
 
 import { Editor } from "./editor";
 import { Actions } from "./actions";
+import { KNITR_EXTS } from "./util.ts";
 
 import { register_file_editor } from "../frame-tree/register";
 
 // Load plugin so that codemirror can automatically close latex environments.
 import "./codemirror-autoclose-latex";
 
-for (let ext of ["tex", "rnw", "rtex"]) {
+for (let ext of KNITR_EXTS.concat(["tex"])) {
   register_file_editor({
     ext: ext,
     component: Editor,

--- a/src/smc-webapp/frame-editors/latex-editor/util.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/util.ts
@@ -1,5 +1,5 @@
 /*
-Utility functions specific to the latex editor.
+data and functions specific to the latex editor.
 */
 
 import { change_filename_extension } from "../generic/misc";
@@ -7,3 +7,5 @@ import { change_filename_extension } from "../generic/misc";
 export function pdf_path(path: string): string {
   return change_filename_extension(path, "pdf");
 }
+
+export const KNITR_EXTS: ReadonlyArray<string> = ["rnw", "rtex"];


### PR DESCRIPTION
**depends on #3031** ← review that one first

ref: #3026 

test: create a file `test.Rtex` with content, e.g.

```
cat <<EOF > test.Rtex
\documentclass{scrartcl}

\begin{document}

tesst

%% a chunk with default options
%% begin.rcode
% 1+1
%
% x=rnorm(5); t(t(x))
%% end.rcode

ookk

\end{document}
EOF
```

immediately after opening it, the misspelled words should show up with underlines and no  error as depicted in #3026 appears.