### PR TITLE
webapp file breakcrumb history: fix erroneous detection of subdirectory if dir names are similar

### DIFF
--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -1155,9 +1155,11 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     if (store == undefined) {
       return;
     }
-    let history_path =
-      store.get("history_path") != null ? store.get("history_path") : "";
-    if (!history_path.startsWith(path) || path.length > history_path.length) {
+    let history_path = store.get("history_path") || "";
+    const is_adjacent = !`${history_path}/`.startsWith(`${path}/`);
+    // given is_adjacent is false, this tests if it is a subdirectory
+    const is_nested = path.length > history_path.length;
+    if (is_adjacent || is_nested) {
       history_path = path;
     }
 


### PR DESCRIPTION
see #3046

test: 

1. setup the paths: `mkdir test; mkdir test/dirA; mkdir test/dirAB; touch test/dirA/a; touch test/dirAB/b; open test/dirA/a`
2. then first go into `dirAB`, and then up and into `dirA`.