### PR TITLE
Issue/369

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1038,6 +1038,8 @@ class Salvus(object):
                             # BUGFIX: be careful to *NOT* assign to _!!  see https://github.com/sagemathinc/cocalc/issues/1107
                             block2 = "sage.misc.session.state_at_init = dict(globals());sage.misc.session._dummy=sage.misc.session.show_identifiers();\n"
                             exec compile(block2, '', 'single') in namespace, locals
+                            b2a = "try: load(os.environ['SAGE_STARTUP_FILE'])\nexcept: pass\n"
+                            exec compile(b2a, '', 'single') in namespace, locals
                     features = sage_parsing.get_future_features(block, 'single')
                     if features:
                         compile_flags = reduce(operator.or_, (feature.compiler_flag for feature in features.itervalues()), compile_flags)

--- a/src/smc_sagews/smc_sagews/tests/a-init.sage
+++ b/src/smc_sagews/smc_sagews/tests/a-init.sage
@@ -1,0 +1,2 @@
+# testing init.sage load from custom location
+sys.path.append("xyzzy")

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -115,7 +115,7 @@ class ConnectionJSON(object):
                 raise EOFError
             s += t
 
-        mtyp = chr(s[0])
+        mtyp = s[0]
         if mtyp == 'j':
             try:
                 return 'json', json.loads(s[1:].decode())
@@ -683,7 +683,6 @@ import time
 @pytest.fixture(scope = "class")
 def own_sage_server(request):
     assert os.geteuid() != 0, "Do not run as root, will kill all sage_servers."
-    #os.system("pkill -f sage_server_command_line")
     print("starting new sage_server")
     os.system("smc-sage-server start")
     time.sleep(0.5)

--- a/src/smc_sagews/smc_sagews/tests/test_00_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_00_timing.py
@@ -66,7 +66,7 @@ class TestStartSageServer:
         start = time.time()
 
         # start a new sage_server process
-        os.system("smc-sage-server start")
+        os.system(conftest.start_cmd())
         print("sage_server start time %s sec"%(time.time() - start))
         # add pause here because sometimes the log file isn't ready immediately
         time.sleep(0.5)

--- a/src/smc_sagews/smc_sagews/tests/test_env.py
+++ b/src/smc_sagews/smc_sagews/tests/test_env.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# test_env.py
+# tests of sage worksheet environment options
+import conftest
+import os
+import sys
+
+class TestSetEnv:
+    def test_set_startup(self, exec2, test_ro_data_dir):
+        """
+        verify that SAGE_STARTUP_FILE is set by pytest to a-init.sage
+        """
+        pssf = os.path.join(test_ro_data_dir, conftest.my_sage_startup())
+        exec2("print(os.environ['SAGE_STARTUP_FILE'])",pssf)
+
+    def test_init_sage(self, exec2):
+        exec2("sys.path[-1]", "xyzzy")

--- a/src/smc_sagews/smc_sagews/tests/test_graphics.py
+++ b/src/smc_sagews/smc_sagews/tests/test_graphics.py
@@ -50,7 +50,7 @@ class TestOctavePlot:
 
 class TestRPlot:
     def test_r_smallplot(self,execblob):
-        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type = 'png')
+        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type = 'svg')
     def test_r_bigplot(self,execblob):
         "lots of points, do not overrun blob size limit"
         code = """%r
@@ -58,7 +58,7 @@ N <- 100000
 xx <- rnorm(N, 5) + 3
 yy <- rnorm(N, 3) - 1
 plot(xx, yy, cex=.1)"""
-        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type = 'png')
+        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type = 'svg')
 
 class TestShowGraphs:
     def test_issue594(self, test_id, sagews):

--- a/src/smc_sagews/smc_sagews/tests/test_unicode.py
+++ b/src/smc_sagews/smc_sagews/tests/test_unicode.py
@@ -83,7 +83,6 @@ class TestErr:
         assert 'stderr' in mesg
         assert 'Error in lines 1-1' in mesg['stderr']
         assert 'should be replaced by < " >' not in mesg['stderr']
-        # 2 done
         conftest.recv_til_done(sagews, test_id)
     def test_bad_quote(self, test_id, sagews):
         # assign x to U+201C (could use U+201D) to trigger bad quote warning
@@ -96,9 +95,12 @@ class TestErr:
         assert typ == 'json'
         assert mesg['id'] == test_id
         assert 'stderr' in mesg
-        assert 'Error in lines 1-1' in mesg['stderr']
+        assert 'non-ascii' in mesg['stderr']
+        typ, mesg = sagews.recv()
+        assert typ == 'json'
+        assert mesg['id'] == test_id
+        assert 'stderr' in mesg
         assert 'should be replaced by < " >' in mesg['stderr']
-        # 2 done
         conftest.recv_til_done(sagews, test_id)
     def test_bad_mult(self, test_id, sagews):
         # warn about possible missing '*' with patterns like 3x^2 and 5(1+x)

--- a/src/smc_sagews/smc_sagews/tests/test_unicode.py
+++ b/src/smc_sagews/smc_sagews/tests/test_unicode.py
@@ -96,11 +96,12 @@ class TestErr:
         assert mesg['id'] == test_id
         assert 'stderr' in mesg
         assert 'non-ascii' in mesg['stderr']
-        typ, mesg = sagews.recv()
-        assert typ == 'json'
-        assert mesg['id'] == test_id
-        assert 'stderr' in mesg
-        assert 'should be replaced by < " >' in mesg['stderr']
+        if 'should be replaced by < " >' not in mesg['stderr']:
+            typ, mesg = sagews.recv()
+            assert typ == 'json'
+            assert mesg['id'] == test_id
+            assert 'stderr' in mesg
+            assert 'should be replaced by < " >' in mesg['stderr']
         conftest.recv_til_done(sagews, test_id)
     def test_bad_mult(self, test_id, sagews):
         # warn about possible missing '*' with patterns like 3x^2 and 5(1+x)


### PR DESCRIPTION
Ref: #369 

Add `SAGE_STARTUP_FILE` (defaults to `~/.sage/init.sage`) processing to sage_server.

Commits with "baseline" in comment were to get pytest suite working with current CoCalc before `sage_server` changes in this PR.

Pytest cases added in `tests/test_env.py`. To test, apply patch for this PR, then:
```
cd ~/cocalc/src/smc_sagews/smc_sagews/tests
python -m pytest
==>
= 172 passed, 5 skipped in 431.19 seconds =
```
