### PR TITLE
webapp: hide labels of some tabs when there are many open projects

### DIFF
--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -77,14 +77,18 @@ exports.NavTab = rclass
         style           : rtypes.object
         inner_style     : rtypes.object
         add_inner_style : rtypes.object
+        show_label      : rtypes.bool
+
+    getDefaultProps: ->
+        show_label : true
 
     shouldComponentUpdate: (next) ->
         if @props.children?
             return true
-        return misc.is_different(@props, next, ['label', 'label_class', 'icon', 'close', 'active_top_tab'])
+        return misc.is_different(@props, next, ['label', 'label_class', 'icon', 'close', 'active_top_tab', 'show_label'])
 
     render_label: ->
-        if @props.label?
+        if @props.show_label and @props.label?
             <span style={marginLeft: 5} className={@props.label_class}>
                 {@props.label}
             </span>

--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -216,10 +216,11 @@ exports.ConnectionIndicator = rclass
     displayName : 'ConnectionIndicator'
 
     propTypes :
-        actions  : rtypes.object
-        ping     : rtypes.number
-        status   : rtypes.string
-        on_click : rtypes.func
+        actions       : rtypes.object
+        ping          : rtypes.number
+        status        : rtypes.string
+        on_click      : rtypes.func
+        show_pingtime : rtypes.bool
 
     reduxProps :
         page :
@@ -229,7 +230,10 @@ exports.ConnectionIndicator = rclass
             mesg_info         : rtypes.immutable.Map
 
     shouldComponentUpdate: (next) ->
-        return misc.is_different(@props, next, ['avgping', 'connection_status', 'ping', 'status', 'mesg_info'])
+        return misc.is_different(@props, next, ['avgping', 'connection_status', 'ping', 'status', 'mesg_info', 'show_pingtime'])
+
+    getDefaultProps: ->
+        show_pingtime : true
 
     render_ping: ->
         if @props.avgping?
@@ -254,7 +258,7 @@ exports.ConnectionIndicator = rclass
                 icon_style.color = 'grey'
             <div>
                 <Icon name='wifi' style={icon_style}/>
-                {@render_ping()}
+                {@render_ping() if @props.show_pingtime}
             </div>
         else if @props.connection_status == 'connecting'
             <span style={backgroundColor : '#FFA500', color : 'white', padding : '1ex', 'zIndex': 100001}>
@@ -271,8 +275,9 @@ exports.ConnectionIndicator = rclass
         document.activeElement.blur() # otherwise, it'll be highlighted even when closed again
 
     render: ->
+        width = if @props.show_pingtime then '8.5em' else '5em'
         outer_styles =
-            width      : '8.5em'
+            width      : width
             color      : '#666'
             fontSize   : '10pt'
             lineHeight : '10pt'

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -46,6 +46,8 @@ misc = require('smc-util/misc')
 
 nav_class = 'hidden-xs'
 
+HIDE_LABEL_THOLD = 6
+
 FileUsePageWrapper = (props) ->
     styles =
         zIndex       : '10'
@@ -105,8 +107,16 @@ Page = rclass
     propTypes :
         redux : rtypes.object
 
-    shouldComponentUpdate: (props) ->
-        return misc.is_different(@props, props, PAGE_REDUX_FIELDS)
+    shouldComponentUpdate: (props, state) ->
+        state_changed = misc.is_different(@state, state, ['show_label'])
+        redux_changed = misc.is_different(@props, props, PAGE_REDUX_FIELDS)
+        return redux_changed or state_changed
+
+    getInitialState: ->
+        show_label : true
+
+    componentWillReceiveProps: (next) ->
+        @setState(show_label : next.open_projects.size <= HIDE_LABEL_THOLD)
 
     componentWillUnmount: ->
         @actions('page').clear_all_handlers()
@@ -129,6 +139,7 @@ Page = rclass
             icon           = {a}
             actions        = {@actions('page')}
             active_top_tab = {@props.active_top_tab}
+            show_label     = {@state.show_label}
         />
 
     render_admin_tab: ->
@@ -140,6 +151,7 @@ Page = rclass
             inner_style    = {padding: '10px', display: 'flex'}
             actions        = {@actions('page')}
             active_top_tab = {@props.active_top_tab}
+            show_label     = {@state.show_label}
         />
 
     sign_in_tab_clicked: ->
@@ -158,6 +170,7 @@ Page = rclass
             active_top_tab  = {@props.active_top_tab}
             style           = {backgroundColor:COLORS.TOP_BAR.SIGN_IN_BG}
             add_inner_style = {color: 'black'}
+            show_label     = {@state.show_label}
         />
 
     render_support: ->
@@ -171,6 +184,7 @@ Page = rclass
             actions        = {@actions('page')}
             active_top_tab = {@props.active_top_tab}
             on_click       = {=>redux.getActions('support').show(true)}
+            show_label     = {@state.show_label}
         />
 
     render_bell: ->
@@ -193,7 +207,9 @@ Page = rclass
                 icon           = {'info-circle'}
                 inner_style    = {padding: '10px', display: 'flex'}
                 actions        = {@actions('page')}
-                active_top_tab = {@props.active_top_tab} />
+                active_top_tab = {@props.active_top_tab}
+                show_label     = {@state.show_label}
+            />
             <NavItem className='divider-vertical hidden-xs' />
             {@render_support()}
             {@render_bell()}
@@ -215,9 +231,9 @@ Page = rclass
                 active_top_tab = {@props.active_top_tab}
 
             >
-                <div style={projects_styles} className={nav_class}>
+                {<div style={projects_styles} className={nav_class}>
                     Projects
-                </div>
+                </div> if @state.show_label}
                 <AppLogo />
             </NavTab>
         </Nav>

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -279,7 +279,7 @@ Page = rclass
 
         <div ref="page" style={style} onDragOver={(e) -> e.preventDefault()} onDrop={@drop}>
             {<FileUsePageWrapper /> if @props.show_file_use}
-            {<ConnectionInfo ping={@props.ping} status={@props.connection_status} avgping={@props.avgping} actions={@actions('page')} /> if @props.show_connection}
+            {<ConnectionInfo ping={@props.ping} status={@props.connection_status} avgping={@props.avgping} actions={@actions('page')} show_pingtime = {@state.show_label}/> if @props.show_connection}
             {<Support actions={@actions('support')} /> if @props.show}
             {<VersionWarning new_version={@props.new_version} /> if @props.new_version?}
             {<CookieWarning /> if @props.cookie_warning}


### PR DESCRIPTION
This is a detail bothering me from day to day. Usually, my project nav bar looks like that:

![screenshot from 2018-08-09 12-04-40](https://user-images.githubusercontent.com/207405/43892532-7d7f4778-9bcc-11e8-9fef-5ef73d52e6ac.png)

which makes it hard to read what's there.

The goal of this here is to hide the labels of some elements when there are more than 6 projects.