### PR TITLE
webapp/project files tab: add slight border around tabs

### DIFF
--- a/src/smc-webapp/project/file-tab.cjsx
+++ b/src/smc-webapp/project/file-tab.cjsx
@@ -18,6 +18,15 @@ exports.DEFAULT_FILE_TAB_STYLES =
     flexShrink   : '1'
     overflow     : 'hidden'
 
+setBorder = (style, is_active) ->
+    col = if is_active then COLORS.BLUE_BG else COLORS.GRAY_LL
+    borderStyle = "1px solid #{col}"
+    return misc.merge(style,
+        borderLeft   : borderStyle
+        borderRight  : borderStyle
+        borderTop    : borderStyle
+    )
+
 
 exports.FileTab = rclass
     displayName : 'FileTab'
@@ -74,6 +83,7 @@ exports.FileTab = rclass
             styles = misc.copy(exports.DEFAULT_FILE_TAB_STYLES)
             if @props.is_active
                 styles.backgroundColor = COLORS.BLUE_BG
+            styles = setBorder(styles, @props.is_active)
         else
             styles.flex = 'none'
 

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -46,7 +46,7 @@ project_file = require('./project_file')
 {file_associations} = require('./file-associations')
 
 {React, ReactDOM, rclass, redux, rtypes, Redux} = require('./app-framework')
-{DeletedProjectWarning, ErrorBoundary, Icon, Loading, Space} = require('./r_misc')
+{DeletedProjectWarning, ErrorBoundary, Icon, Loading, Space, COLORS} = require('./r_misc')
 
 {ChatIndicator} = require('./chat-indicator')
 
@@ -464,7 +464,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
     render_file_tabs: (is_public) ->
         shrink_fixed_tabs = $(window).width() < (376 + (@props.open_files_order.size + @props.num_ghost_file_tabs) * 250)
 
-        <div className="smc-file-tabs" ref="projectNav" style={width:'100%', height:'32px', borderBottom: "1px solid #e1e1e1"}>
+        <div className="smc-file-tabs" ref="projectNav" style={width:'100%', height:'33px', borderBottom: "1px solid #{COLORS.GRAY_LL}"}>
             <div style={display:'flex'}>
                 {<Nav
                     bsStyle   = "pills"


### PR DESCRIPTION
a little experiment how a slight border around file tabs looks like

![screenshot from 2018-08-10 13-39-56](https://user-images.githubusercontent.com/207405/43956055-ee658ef8-9ca2-11e8-96bc-4a738229bc8c.png)
