### PR TITLE
remove host info from project settings

### DIFF
--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -627,26 +627,6 @@ ProjectControlPanel = rclass
                 cb()
         ])
 
-    ssh_notice: ->
-        project_id = @props.project.get('project_id')
-        host = @props.project.get('host')?.get('host')
-        if host?
-            if @state.show_ssh
-                <div>
-                    SSH into your project: <span style={color:'#666'}>First add your public key to <a onClick={@open_authorized_keys} href=''>~/.ssh/authorized_keys</a>, then use the following username@host:</span>
-                    {### WARNING: previous use of <FormControl> here completely breaks copy on Firefox. ###}
-                    <pre>{"#{misc.replace_all(project_id, '-', '')}@#{host}.cocalc.com"} </pre>
-                    <a href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key" target="_blank">
-                    <Icon name='life-ring'/> How to create SSH keys</a>
-                </div>
-            else
-                <Row>
-                    <Col sm={12}>
-                        <Button bsStyle='info' onClick={=>@setState(show_ssh : true)} style={float:'right'}>
-                            <Icon name='terminal' /> SSH Into Your Project...
-                        </Button>
-                    </Col>
-                </Row>
 
     render_state: ->
         <span style={fontSize : '12pt', color: '#666'}>
@@ -718,13 +698,6 @@ ProjectControlPanel = rclass
                 <Icon name='stop' /> Stop Project...
             </Button>
         </ButtonToolbar>
-
-    show_host: ->
-        host = @props.project.get('host')?.get('host')
-        if host
-            <LabeledRow key='host' label='Host'>
-                <pre>{host}.sagemath.com</pre>
-            </LabeledRow>
 
     render_idle_timeout_row: ->
         if @props.project.getIn(['state', 'state']) != 'running'
@@ -888,10 +861,8 @@ ProjectControlPanel = rclass
             <LabeledRow key='project_id' label='Project id'>
                 <pre>{@props.project.get('project_id')}</pre>
             </LabeledRow>
-            {@show_host() if @props.allow_ssh}
+            {<hr /> if @props.kucalc != 'yes'}
             {@render_select_compute_image_row()}
-            {<hr /> if @props.allow_ssh}
-            {@ssh_notice() if @props.allow_ssh}
         </ProjectSettingsPanel>
 
 exports.CollaboratorsList = CollaboratorsList = rclass


### PR DESCRIPTION
when I looked at the changes to the project image selector, I noticed a funny line below:

![screenshot from 2018-08-16 12-14-24](https://user-images.githubusercontent.com/207405/44203257-aaceca00-a14e-11e8-8cac-b907e3230a1b.png)

This PR removes this, there is already a box for the ssh info and there is also no host information (it was still hard coding `...sagemath.com`)

... or is this being used somewhere, e.g. in docker? even there, it wouldn't make much sense as it is, due to hardcoding the DNS.