### PR TITLE
adding custom global type defs for cocalc

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,3 +1,6 @@
-declare const $: any;
+import * as $ from "jquery"; // picks jQuery from @types
+declare const $ = $;
+// declare const $: any; // old more general approach
 declare const window: any;
 declare const localStorage: any;
+// export { $, window, localStorage }; // didn't work, but maybe it should?

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,3 @@
+declare const $: any;
+declare const window: any;
+declare const localStorage: any;

--- a/src/smc-project/globals.d.ts
+++ b/src/smc-project/globals.d.ts
@@ -1,3 +1,6 @@
-declare const $: any;
+import * as $ from "jquery"; // picks jQuery from @types
+declare const $ = $;
+// declare const $: any; // old more general approach
 declare const window: any;
 declare const localStorage: any;
+// export { $, window, localStorage }; // didn't work, but maybe it should?

--- a/src/smc-project/globals.d.ts
+++ b/src/smc-project/globals.d.ts
@@ -1,0 +1,3 @@
+declare const $: any;
+declare const window: any;
+declare const localStorage: any;

--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@types/expect": "^1.20.3",
+    "@types/jquery": "^3.3.6",
     "@types/mocha": "^5.2.5",
     "async": "^1.5.0",
     "async-await-utils": "^2.0.4",

--- a/src/smc-webapp/jupyter/actions.ts
+++ b/src/smc-webapp/jupyter/actions.ts
@@ -37,11 +37,6 @@ const commands = require("./commands");
 const cell_utils = require("./cell-utils");
 const { cm_options } = require("./cm_options");
 
-// TODO: seperate front specific code that uses this stuff
-declare const $: any;
-declare const window: any;
-declare const localStorage: any;
-
 let jupyter_kernels = immutable.Map(); // map project_id (string) -> kernels (immutable)
 
 const { IPynbImporter } = require("./import-from-ipynb");

--- a/src/smc-webapp/jupyter/cell-input.tsx
+++ b/src/smc-webapp/jupyter/cell-input.tsx
@@ -6,8 +6,6 @@ import { Map as ImmutableMap, fromJS } from "immutable";
 import { Button } from "react-bootstrap";
 
 // TODO: import jquery
-// to make compiling TS in the hub work
-declare const $: any;
 
 // TODO: use imports
 const misc = require("smc-util/misc");
@@ -87,7 +85,8 @@ export class CellInput extends Component<CellInputProps> {
       nextProps.cell.get("end") !== this.props.cell.get("end") ||
       nextProps.cell.get("tags") !== this.props.cell.get("tags") ||
       nextProps.cell.get("cursors") !== this.props.cell.get("cursors") ||
-      nextProps.cell.get("line_numbers") !== this.props.cell.get("line_numbers") ||
+      nextProps.cell.get("line_numbers") !==
+        this.props.cell.get("line_numbers") ||
       nextProps.cm_options !== this.props.cm_options ||
       nextProps.trust !== this.props.trust ||
       (nextProps.is_markdown_edit !== this.props.is_markdown_edit &&
@@ -189,7 +188,10 @@ export class CellInput extends Component<CellInputProps> {
           value={value}
           project_id={this.props.project_id}
           file_path={this.props.directory}
-          href_transform={href_transform(this.props.project_id, this.props.cell)}
+          href_transform={href_transform(
+            this.props.project_id,
+            this.props.cell
+          )}
           post_hook={markdown_post_hook}
           safeHTML={!this.props.trust}
         />
@@ -213,9 +215,16 @@ export class CellInput extends Component<CellInputProps> {
     }
   }
   render_complete() {
-    if (this.props.complete && this.props.complete.get("matches", fromJS([])).size > 0) {
+    if (
+      this.props.complete &&
+      this.props.complete.get("matches", fromJS([])).size > 0
+    ) {
       return (
-        <Complete complete={this.props.complete} actions={this.props.actions} id={this.props.id} />
+        <Complete
+          complete={this.props.complete}
+          actions={this.props.actions}
+          id={this.props.id}
+        />
       );
     }
   }

--- a/src/smc-webapp/jupyter/cell-list.tsx
+++ b/src/smc-webapp/jupyter/cell-list.tsx
@@ -2,9 +2,6 @@
 React component that renders the ordered list of cells
 */
 
-// to make compiling TS in the hub work
-declare const $: any;
-
 import * as immutable from "immutable";
 import { React, Component } from "../app-framework"; // TODO: this will move
 const { Loading } = require("../r_misc");

--- a/src/smc-webapp/jupyter/cell-output-message.tsx
+++ b/src/smc-webapp/jupyter/cell-output-message.tsx
@@ -14,9 +14,6 @@ Handling of output messages.
 TODO: most components should instead be in separate files.
 */
 
-// to make compiling TS in the hub work
-declare const $: any;
-
 import { React, Component } from "../app-framework"; // TODO: this will move
 import { Button } from "react-bootstrap";
 import * as immutable from "immutable";

--- a/src/smc-webapp/jupyter/server-urls.ts
+++ b/src/smc-webapp/jupyter/server-urls.ts
@@ -3,6 +3,7 @@ Functions for getting or formatting url's for various backend endpoints
 */
 
 // TODO: seperate front specific code that uses this stuff
+// interestingly, removing "window" here triggers a problem with the non-standard window.app_base_url attribute
 declare const window: any;
 
 export function get_server_url(project_id: string) {

--- a/src/smc-webapp/jupyter/store.ts
+++ b/src/smc-webapp/jupyter/store.ts
@@ -7,9 +7,6 @@ import { Store } from "../app-framework";
 import { Set } from "immutable";
 const { export_to_ipynb } = require("./export-to-ipynb");
 
-// TODO: seperate front specific code that uses this stuff
-declare const localStorage: any;
-
 // Used for copy/paste.  We make a single global clipboard, so that
 // copy/paste between different notebooks works.
 let global_clipboard: any = undefined;
@@ -47,7 +44,7 @@ export interface JupyterStoreState {
   view_mode: string;
   mode: string;
   nbconvert: any;
-  about: boolean;  
+  about: boolean;
   start_time: any;
   complete: any;
   introspect: any;
@@ -321,6 +318,6 @@ export class JupyterStore extends Store<JupyterStoreState> {
 
   get_cell_metadata_flag = (id: any, key: any) => {
     // default is true
-    return this.unsafe_getIn(["cells", id, "metadata", key],true); // TODO: type
+    return this.unsafe_getIn(["cells", id, "metadata", key], true); // TODO: type
   };
 }


### PR DESCRIPTION
quick attempt to add declarations for `$`, `window` and so on.

ideas from here: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html

interestingly, this doesn't work for `window.app_base_url` in `jupyter/server-urls.ts`. So, despite that I can start the hub in my dev project, maybe all this isn't working at all. 