### PR TITLE
jupyter2/project:

### DIFF
--- a/src/smc-project/jupyter/execute-code.ts
+++ b/src/smc-project/jupyter/execute-code.ts
@@ -201,14 +201,16 @@ export class CodeExecutionEmitter extends EventEmitter
     // it's **silently** immutable, which
     // is pretty annoying for our use. For now, we
     // just copy it, which is a waste.
+    // const dbg = this.kernel.dbg(`_execute_code('${trunc(this.code, 15)}')`);
     // dbg("push_mesg", mesg);
+    const header = mesg.header;
     mesg = copy_with(mesg, ["metadata", "content", "buffers", "done"]);
     // dbg("push_mesg after copy_with", mesg);
     mesg = deep_copy(mesg);
-    // dbg("push_mesg after deep copy", mesg);
-    if (mesg.header !== undefined) {
-      mesg.msg_type = mesg.header.msg_type;
+    if (header !== undefined) {
+      mesg.msg_type = header.msg_type;
     }
+    // dbg("push_mesg after copying msg_type", mesg);
     this.emit_output(mesg);
   }
 

--- a/src/smc-webapp/jupyter/output-handler.ts
+++ b/src/smc-webapp/jupyter/output-handler.ts
@@ -31,9 +31,9 @@ const now = () => misc.server_time() - 0;
 
 export class OutputHandler extends EventEmitter {
   private _opts: any;
-  private _n: any;
-  private _clear_before_next_output: any;
-  private _output_length: any;
+  private _n: number;
+  private _clear_before_next_output: boolean;
+  private _output_length: number;
   private _in_more_output_mode: any;
   private _state: any;
   private _stdin_cb: any;

--- a/src/smc-webapp/jupyter/project-actions.ts
+++ b/src/smc-webapp/jupyter/project-actions.ts
@@ -444,9 +444,10 @@ export class JupyterActions extends JupyterActions0 {
     const dbg = this.dbg(`manager_run_cell(id='${id}')`);
     dbg();
 
+    // if @_run_again[id] is set on completion of eval, then cell is run again; this is used only when re-running a cell currently running.
     if (this._run_again != null) {
       delete this._run_again[id];
-    } // if @_run_again[id] is set on completion of eval, then cell is run again; this is used only when re-running a cell currently running.
+    }
 
     this.ensure_backend_kernel_setup();
 


### PR DESCRIPTION
ref:  #3092

root cause: look closely at the changed lines in execute-code: `msg_type` was always undefined, because earlier the `mesg` object was already stripped of the `header` dict.

I also added types in another file I sifted through via debugging, I hope that's fine.

test:

```
from IPython.display import clear_output
from time import sleep

for i in range(10):
    clear_output(wait=True)
    print('.' * i)
    sleep(.1)
```

which should just show 10 dots in the end.