### PR TITLE
webapp/jupyter: cache kernels by project_id and compute image name

### DIFF
--- a/src/smc-webapp/jupyter/store.ts
+++ b/src/smc-webapp/jupyter/store.ts
@@ -8,6 +8,7 @@ const misc = require("smc-util/misc");
 import { Store } from "../app-framework";
 import { Set } from "immutable";
 const { export_to_ipynb } = require("./export-to-ipynb");
+const { DEFAULT_COMPUTE_IMAGE } = require("smc-util/compute-images");
 
 // Used for copy/paste.  We make a single global clipboard, so that
 // copy/paste between different notebooks works.
@@ -321,5 +322,16 @@ export class JupyterStore extends Store<JupyterStoreState> {
   get_cell_metadata_flag = (id: any, key: any) => {
     // default is true
     return this.unsafe_getIn(["cells", id, "metadata", key], true); // TODO: type
+  };
+
+  jupyter_kernel_key = (): string => {
+    const project_id = this.get("project_id");
+    const projects_store = this.redux.getStore("projects");
+    const compute_image =
+      projects_store.getIn(["project_map", project_id, "compute_image"]) ||
+      DEFAULT_COMPUTE_IMAGE;
+    const key = [project_id, compute_image].join("::");
+    // console.log("jupyter store / jupyter_kernel_key", key);
+    return key;
   };
 }


### PR DESCRIPTION
Ref: #3099

basic (pedantic) idea: jupyter kernels depend on project id and selected compute image.