### PR TITLE
hotfix course payment

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -140,7 +140,6 @@ class BillingActions extends Actions
         @_action('cancel_subscription', 'Cancel a subscription', {subscription_id : id, cb : cb})
 
     create_subscription: (plan='standard') =>
-        {webapp_client} = require('./webapp_client')   # do not put at top level, since some code runs on server
         lsa = last_subscription_attempt
         if lsa? and lsa.plan == plan and lsa.timestamp > misc.server_minutes_ago(2)
             @setState(action:'', error: 'Too many subscription attempts in the last minute.  Please **REFRESH YOUR BROWSER** THEN  DOUBLE CHECK YOUR SUBSCRIPTION LIST!')
@@ -1866,7 +1865,7 @@ exports.PayCourseFee = PayCourseFee = rclass
                 members-only server and enable full internet access.
                 <br/><br/>
                 <ButtonToolbar>
-                    <Button onClick={@buy_subscription} bsStyle='primary'>
+                    <Button onClick={=>@buy_subscription()} bsStyle='primary'>
                         Pay ${STUDENT_COURSE_PRICE} Fee
                     </Button>
                     <Button onClick={=>@setState(confirm:false)}>Cancel</Button>

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -2100,19 +2100,19 @@ BillingPage = rclass
         </div>
 
 exports.BillingPageRedux = rclass
-    displayName : 'BillingPage-redux'
+    displayName : 'BillingPageRedux-redux'
 
     render: ->
         <BillingPage is_simplified={false} redux={redux} />
 
 exports.BillingPageSimplifiedRedux = rclass
-    displayName : 'BillingPage-redux'
+    displayName : 'BillingPageSimplifiedRedux-redux'
 
     render: ->
         <BillingPage is_simplified={true} redux={redux} />
 
 exports.BillingPageForCourseRedux = rclass
-    displayName : 'BillingPage-redux'
+    displayName : 'BillingPageForCourseRedux-redux'
 
     render: ->
         <BillingPage is_simplified={true} for_course={true} redux={redux} />

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -2267,7 +2267,7 @@ exports.ProjectFiles = rclass ({name}) ->
                 <Icon name='exclamation-triangle'/> Error: Your instructor requires you to pay the course fee for this project.
                 {<CourseProjectExtraHelp/> if cards}
             </h4>
-            {@render_upgrade_in_place()}
+            {@render_pay()}
         </Alert>
 
     render_course_payment_warning: (pay) ->

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -2267,7 +2267,7 @@ exports.ProjectFiles = rclass ({name}) ->
                 <Icon name='exclamation-triangle'/> Error: Your instructor requires you to pay the course fee for this project.
                 {<CourseProjectExtraHelp/> if cards}
             </h4>
-            {@render_pay()}
+            {@render_upgrade_in_place()}
         </Alert>
 
     render_course_payment_warning: (pay) ->


### PR DESCRIPTION
webapp: if course payment required, show the payment dialog (not the more general upgrade in place)

I haven't tested it, but at least the "other" dialog shows up on the files page.