### PR TITLE
Issue/3104

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -421,4 +421,7 @@ def _jkmagic(kernel_name, **kwargs):
     # set True to record jupyter messages to sage_server log
     run_code.debug = False
 
+    # allow `anaconda.jupyter_kernel.kernel_name` etc.
+    run_code.kernel_name = kernel_name
+
     return run_code

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3882,7 +3882,7 @@ def load(*args, **kwds):
     # now handle remaining non-web arguments.
     if len(other_args) > 0:
         try:
-            exec 'salvus.namespace["%s"] = sage.structure.sage_object.load(*__args, **__kwds)' % t in salvus.namespace, {
+            exec 'salvus.namespace["%s"] = sage.misc.persist.load(*__args, **__kwds)' % t in salvus.namespace, {
                 '__args': other_args,
                 '__kwds': kwds
             }

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2019,15 +2019,41 @@ def python3(code=None, **kwargs):
     .. note::
 
         State is preserved between cells.
-        SMC %python3 mode uses the jupyter `anaconda3` kernel.
+        CoCalc %python3 mode uses the jupyter `python3` kernel.
     """
     if python3.jupyter_kernel is None:
-        python3.jupyter_kernel = jupyter("anaconda3")
+        python3.jupyter_kernel = jupyter("python3")
     return python3.jupyter_kernel(code, **kwargs)
-
-
 python3.jupyter_kernel = None
 
+def anaconda(code=None, **kwargs):
+    """
+    Block decorator to run code in a pure anaconda mode session.
+
+    To use this, put %anaconda by itself in a cell so that it applies to
+    the rest of the cell, or put it at the beginning of a line to
+    run just that line using anaconda.
+
+    You can combine %anaconda with capture, if you would like to capture
+    the output to a variable.  For example::
+
+        %capture(stdout='a')
+        %anaconda
+        x = set([1,2,3])
+        print(x)
+
+    Afterwards, a contains the output '{1, 2, 3}' and the variable x
+    in the controlling Sage session is in no way impacted.
+
+    .. note::
+
+        State is preserved between cells.
+        CoCalc %anaconda mode uses the jupyter `anaconda5` kernel.
+    """
+    if anaconda.jupyter_kernel is None:
+        anaconda.jupyter_kernel = jupyter("anaconda5")
+    return anaconda.jupyter_kernel(code, **kwargs)
+anaconda.jupyter_kernel = None
 
 def singular_kernel(code=None, **kwargs):
     """

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -2144,7 +2144,7 @@ def serve(port, host, extra_imports=False):
         namespace['_salvus_parsing'] = sage_parsing
 
         for name in [
-                'asy', 'attach', 'auto', 'capture', 'cell', 'clear',
+                'anaconda', 'asy', 'attach', 'auto', 'capture', 'cell', 'clear',
                 'coffeescript', 'cython', 'default_mode', 'delete_last_output',
                 'dynamic', 'exercise', 'fork', 'fortran', 'go', 'help', 'hide',
                 'hideall', 'input', 'java', 'javascript', 'julia', 'jupyter',

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -29,7 +29,7 @@ class TestLex:
 class TestSageVersion:
     def test_sage_vsn(self, exec2):
         code = "sage.misc.banner.banner()"
-        patn = "version 8.2"
+        patn = "version 8.3"
         exec2(code, pattern = patn)
 
 class TestDecorators:

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -61,12 +61,20 @@ class TestScala211Mode:
     def test_scala_version(self, exec2):
         exec2("%scala211\nutil.Properties.versionString", html_pattern="2.11.11")
 
+class TestAnacondaMode:
+    def test_anaconda_version(self, exec2):
+        exec2("%anaconda\nimport sys\nprint(sys.version)", pattern=r"^3\.6\.\d+ ")
+    def test_anaconda_kernel_name(self, exec2):
+        exec2("anaconda.jupyter_kernel.kernel_name", "anaconda5")
+
 class TestPython3Mode:
     def test_p3_max(self, exec2):
         exec2("%python3\nmax([],default=9)", "9", timeout=30)
+    def test_p3_kernel_name(self, exec2):
+        exec2("python3.jupyter_kernel.kernel_name", "python3")
 
     def test_p3_version(self, exec2):
-        exec2("%python3\nimport sys\nprint(sys.version)", pattern=r"^3\.5\.\d+ ")
+        exec2("%python3\nimport sys\nprint(sys.version)", pattern=r"^3\.6\.\d+ ")
 
     def test_capture_p3_01(self, exec2):
         exec2("%capture(stdout='output')\n%python3\nimport numpy as np\nnp.arange(9).reshape(3,3).trace()")


### PR DESCRIPTION
Ref: #3104.

Sagews changes:

- `%python3` mode now invokes python3 Ubuntu kernel
- `%anaconda` mode added, invokes anaconda5 kernel
- `xxx.jupyter_kernel.kernel_name` property added where 'xxx' is 'anaconda', 'python3', etc
- pytest suite updated for sage-8.3 and updated modes:
    ```
    == 177 passed, 9 skipped in 309.86 seconds ==
    ```