### PR TITLE
jupyter: format code cells using existing prettier infrastructure

### DIFF
--- a/src/smc-project/browser-websocket/api.ts
+++ b/src/smc-project/browser-websocket/api.ts
@@ -42,12 +42,19 @@ export function init_websocket_api(
   });
 }
 
-async function handle_api_call(client: any, data: any, primus:any, logger:any): Promise<any> {
+async function handle_api_call(
+  client: any,
+  data: any,
+  primus: any,
+  logger: any
+): Promise<any> {
   switch (data.cmd) {
     case "listing":
       return await listing(data.path, data.hidden);
     case "prettier":
       return await prettier(client, data.path, data.options);
+    case "prettier_string":
+      return await prettier_string(data.str, data.options);
     case "jupyter":
       return await jupyter(data.path, data.endpoint, data.query);
     case "exec":
@@ -66,9 +73,12 @@ async function listing(path: string, hidden?: boolean): Promise<object[]> {
   return await callback(get_listing, path, hidden);
 }
 
-import { run_prettier } from "../prettier";
+import { run_prettier, run_prettier_string } from "../prettier";
 async function prettier(client: any, path: string, options: any): Promise<any> {
   return await run_prettier(client, path, options);
+}
+async function prettier_string(str: string, options: any): Promise<string> {
+  return await run_prettier_string(str, options);
 }
 
 import { handle_request as jupyter } from "../jupyter/websocket-api";

--- a/src/smc-project/prettier.ts
+++ b/src/smc-project/prettier.ts
@@ -42,16 +42,7 @@ export async function run_prettier(
     [input, math] = remove_math(math_escape(input));
   }
   try {
-    switch (options.parser) {
-      case "latex":
-        pretty = await latex_format(input, options);
-        break;
-      case "python":
-        pretty = await python_format(input, options);
-        break;
-      default:
-        pretty = prettier.format(input, options);
-    }
+    pretty = await run_prettier_string(input, options);
   } catch (err) {
     return { status: "error", phase: "format", error: err };
   }
@@ -61,4 +52,22 @@ export async function run_prettier(
   syncstring.from_str(pretty);
   await callback(syncstring._save);
   return { status: "ok" };
+}
+
+export async function run_prettier_string(
+  str: string,
+  options: any
+): Promise<string> {
+  let pretty;
+  switch (options.parser) {
+    case "latex":
+      pretty = await latex_format(str, options);
+      break;
+    case "python":
+      pretty = await python_format(str, options);
+      break;
+    default:
+      pretty = prettier.format(str, options);
+  }
+  return pretty;
 }

--- a/src/smc-project/python-format.ts
+++ b/src/smc-project/python-format.ts
@@ -48,8 +48,8 @@ export async function python_format(
   }
 
   // all fine, we read from the temp file
-  let output : Buffer = await callback(readFile, input_path);
-  let s : string = output.toString('utf-8');
+  let output: Buffer = await callback(readFile, input_path);
+  let s: string = output.toString("utf-8");
 
   return s;
 }

--- a/src/smc-webapp/frame-editors/generic/client.ts
+++ b/src/smc-webapp/frame-editors/generic/client.ts
@@ -184,9 +184,8 @@ export async function user_search(opts: {
   query_id?: number;
   limit?: number;
   timeout?: number;
-  admin? : boolean;
-  active? : string;
+  admin?: boolean;
+  active?: string;
 }): Promise<User[]> {
   return callback_opts(webapp_client.user_search)(opts);
 }
-

--- a/src/smc-webapp/jupyter/commands.ts
+++ b/src/smc-webapp/jupyter/commands.ts
@@ -109,7 +109,8 @@ export function commands(actions: any) {
     "close pager": {
       m: "Close pager",
       k: [{ which: 27, mode: "escape" }],
-      f: () => (store.get("introspect") != null ? actions.clear_introspect() : undefined)
+      f: () =>
+        store.get("introspect") != null ? actions.clear_introspect() : undefined
     },
 
     "confirm restart kernel": {
@@ -119,7 +120,8 @@ export function commands(actions: any) {
       f() {
         return actions.confirm_dialog({
           title: "Restart kernel?",
-          body: "Do you want to restart the current kernel?  All variables will be lost.",
+          body:
+            "Do you want to restart the current kernel?  All variables will be lost.",
           choices: [
             { title: "Continue running" },
             { title: "Restart", style: "danger", default: true }
@@ -142,7 +144,11 @@ export function commands(actions: any) {
             "Do you want to restart the current kernel and clear all output?  All variables and outputs will be lost, though most past output is always available in TimeTravel.",
           choices: [
             { title: "Continue running" },
-            { title: "Restart and clear all outputs", style: "danger", default: true }
+            {
+              title: "Restart and clear all outputs",
+              style: "danger",
+              default: true
+            }
           ],
           cb(choice) {
             if (choice === "Restart and clear all outputs") {
@@ -164,7 +170,11 @@ export function commands(actions: any) {
             "Are you sure you want to restart the current kernel and re-execute the whole notebook?  All variables and output will be lost, though most past output is always available in TimeTravel.",
           choices: [
             { title: "Continue running" },
-            { title: "Restart and run all cells", style: "danger", default: true }
+            {
+              title: "Restart and run all cells",
+              style: "danger",
+              default: true
+            }
           ],
           cb(choice) {
             if (choice === "Restart and run all cells") {
@@ -190,7 +200,8 @@ export function commands(actions: any) {
       f() {
         actions.confirm_dialog({
           title: "Shutdown kernel?",
-          body: "Do you want to shutdown the current kernel?  All variables will be lost.",
+          body:
+            "Do you want to shutdown the current kernel?  All variables will be lost.",
           choices: [
             { title: "Continue running" },
             { title: "Shutdown", style: "danger", default: true }
@@ -266,33 +277,47 @@ export function commands(actions: any) {
     },
 
     "extend selection above": {
-      k: [{ mode: "escape", shift: true, which: 75 }, { mode: "escape", shift: true, which: 38 }],
+      k: [
+        { mode: "escape", shift: true, which: 75 },
+        { mode: "escape", shift: true, which: 38 }
+      ],
       f: () => actions.extend_selection(-1)
     },
 
     "extend selection below": {
-      k: [{ mode: "escape", shift: true, which: 74 }, { mode: "escape", shift: true, which: 40 }],
+      k: [
+        { mode: "escape", shift: true, which: 74 },
+        { mode: "escape", shift: true, which: 40 }
+      ],
       f: () => actions.extend_selection(1)
     },
 
     "find and replace": {
       m: "Find and replace",
-      k: [{ mode: "escape", which: 70 }, { alt: true, mode: "escape", which: 70 }],
+      k: [
+        { mode: "escape", which: 70 },
+        { alt: true, mode: "escape", which: 70 }
+      ],
       f: () => actions.show_find_and_replace()
     },
 
     "global undo": {
       m: "Undo",
       i: "undo",
-      d: "Global user-aware undo.  Undo the last change *you* made to the notebook.",
-      k: [{ alt: true, mode: "escape", which: 90 }, { ctrl: true, mode: "escape", which: 90 }],
+      d:
+        "Global user-aware undo.  Undo the last change *you* made to the notebook.",
+      k: [
+        { alt: true, mode: "escape", which: 90 },
+        { ctrl: true, mode: "escape", which: 90 }
+      ],
       f: () => actions.undo()
     },
 
     "global redo": {
       m: "Redo",
       i: "repeat",
-      d: "Global user-aware redo.  Redo the last change *you* made to the notebook.",
+      d:
+        "Global user-aware redo.  Redo the last change *you* made to the notebook.",
       k: [
         { alt: true, mode: "escape", which: 90, shift: true },
         { ctrl: true, mode: "escape", which: 90, shift: true },
@@ -603,7 +628,10 @@ export function commands(actions: any) {
 
     "select all cells": {
       m: "Select all cells",
-      k: [{ alt: true, mode: "escape", which: 65 }, { ctrl: true, mode: "escape", which: 65 }],
+      k: [
+        { alt: true, mode: "escape", which: 65 },
+        { ctrl: true, mode: "escape", which: 65 }
+      ],
       f: () => actions.select_all_cells()
     },
 
@@ -788,6 +816,11 @@ export function commands(actions: any) {
     "delete protect": {
       m: "Toggle delete protection",
       f: () => actions.toggle_delete_protection()
+    },
+
+    "format cells": {
+      m: "Format cells",
+      f: () => actions.format_selected_cells()
     }
   };
 }

--- a/src/smc-webapp/jupyter/top-buttonbar.tsx
+++ b/src/smc-webapp/jupyter/top-buttonbar.tsx
@@ -167,10 +167,9 @@ export class TopButtonbar0 extends Component<TopButtonbarProps> {
 
   render_group_run() {
     let stop_style: React.CSSProperties | undefined;
-    if (
-      ((this.props.kernel_usage && this.props.kernel_usage.get("cpu")) || 0) >
-      50
-    ) {
+    const cpu_usage =
+      (this.props.kernel_usage && this.props.kernel_usage.get("cpu")) || 0;
+    if (cpu_usage > 50) {
       stop_style = { backgroundColor: "rgb(92,184,92)", color: "white" };
     }
 
@@ -178,7 +177,8 @@ export class TopButtonbar0 extends Component<TopButtonbarProps> {
       { name: "run cell and select next", label: "Run" },
       { name: "interrupt kernel", style: stop_style },
       "confirm restart kernel",
-      { name: "tab key", label: "Tab" }
+      { name: "tab key", label: "Tab" },
+      { name: "format cells", label: "FMT" }
     ]);
   }
 

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -73,6 +73,7 @@
     "pegjs": "^0.10.0",
     "pnotify": "^3.0.0",
     "prom-client": "^10.1.1",
+    "promise-limit": "^2.7.0",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-bootstrap": "^0.31.5",

--- a/src/smc-webapp/project/websocket/api.ts
+++ b/src/smc-webapp/project/websocket/api.ts
@@ -22,6 +22,14 @@ export class API {
     return await this.call({ cmd: "prettier", path: path, options: options });
   }
 
+  async prettier_string(str: string, options: any): Promise<any> {
+    return await this.call({
+      cmd: "prettier_string",
+      str: str,
+      options: options
+    });
+  }
+
   async jupyter(
     path: string,
     endpoint: string,


### PR DESCRIPTION
this is a proof of concept how this could work. I was also curious how the API is implemented. To explain what's going on look at the before & after screenshots below. I did add the "needs review" label, which is actually "Please give me some early feedback about what I'm doing here". Should we add such a label in orange? I'll add it.

What's missing:

- [ ] am I using the API correctly?
- [ ] yes, `_format_cell` returns something, I'm aware of that ... but the limit function doesn't want a void promise.
- [ ] button is a stub, obviously
- [ ] add a menu entry to format all cells
- [ ] deal with non-python code (e.g. show a warning message to the user)

before: all 4 cells are selected

![screenshot from 2018-08-22 13-50-36](https://user-images.githubusercontent.com/207405/44462230-3d221280-a614-11e8-89fb-5ba79955d956.png)


after: 

![screenshot from 2018-08-22 13-50-50](https://user-images.githubusercontent.com/207405/44462234-427f5d00-a614-11e8-9649-6bf29905b233.png)
