### PR TITLE
prettier yaml formatting

### DIFF
--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -30,7 +30,7 @@
     "node-cleanup": "^2.1.2",
     "pidusage": "^1.2.0",
     "posix": "^4.0.0",
-    "prettier": "^1.12.0",
+    "prettier": "^1.14.2",
     "primus": "^7.2.2",
     "primus-multiplex": "^3.2.1",
     "primus-responder": "^1.0.4",

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1439,6 +1439,8 @@ export class Actions<T = CodeEditorState> extends BaseActions<
     });
   }
 
+  // ATTN to enable a formatter, you also have to let it show up in the format bar
+  // e.g. look into frame-editors/code-editor/editor.ts
   async format(id?: string): Promise<void> {
     const cm = this._get_cm(id);
     if (!cm) return;
@@ -1467,6 +1469,10 @@ export class Actions<T = CodeEditorState> extends BaseActions<
         break;
       case "py":
         parser = "python";
+        break;
+      case "yml":
+      case "yaml":
+        parser = "yaml";
         break;
       default:
         return;

--- a/src/smc-webapp/frame-editors/code-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/code-editor/editor.ts
@@ -6,7 +6,17 @@ import { CodemirrorEditor } from "./codemirror-editor";
 import { filename_extension, set } from "../generic/misc";
 import { createEditor } from "../frame-tree/editor";
 
-const FORMAT = set(["js", "jsx", "ts", "tsx", "json", "md", "css", "py"]);
+const FORMAT = set([
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "json",
+  "md",
+  "css",
+  "py",
+  "yaml"
+]);
 
 const EDITOR_SPEC = {
   cm: {

--- a/src/smc-webapp/frame-editors/code-editor/spell-check.ts
+++ b/src/smc-webapp/frame-editors/code-editor/spell-check.ts
@@ -23,7 +23,7 @@ export async function misspelled_words(opts: Options): Promise<string[]> {
   }
 
   let mode: string;
-  const ext = filename_extension(opts.path).toLowerCase();
+  const ext = filename_extension(opts.path);
   if (ext == "html") {
     mode = "--mode=html";
   } else if (ext == "tex" || KNITR_EXTS.includes(ext)) {

--- a/src/smc-webapp/frame-editors/frame-tree/util.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/util.ts
@@ -42,6 +42,8 @@ export const PRETTIER_SUPPORT = {
   ts: true,
   tsx: true,
   json: true,
+  yaml: true,
+  yml: true,
   py: true, // use external tool
-  tex: true  // actually use latexformat
+  tex: true // actually use latexformat
 };

--- a/src/smc-webapp/frame-editors/generic/misc.ts
+++ b/src/smc-webapp/frame-editors/generic/misc.ts
@@ -5,7 +5,7 @@ THIS SHOULD BE MOVED OUT OF frame-editors/
 This is a rewrite of what we're using from smc-util/misc...
 */
 
-const underscore = require('underscore');
+const underscore = require("underscore");
 
 interface SplittedPath {
   head: string;
@@ -28,7 +28,7 @@ export function filename_extension(filename: string): string {
     return "";
   }
   const ext = match[1];
-  return ext ? ext : "";
+  return (ext ? ext : "").toLowerCase();
 }
 
 // If input name foo.bar, returns object {name:'foo', ext:'bar'}.
@@ -203,7 +203,7 @@ export function uuid(): string {
 const uuid_regexp = new RegExp(
   /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/i
 );
-export function is_valid_uuid_string(uuid:string) : boolean {
+export function is_valid_uuid_string(uuid: string): boolean {
   return (
     typeof uuid === "string" && uuid.length === 36 && uuid_regexp.test(uuid)
   );


### PR DESCRIPTION
this looks small and easy to merge, but it's not. take your time to review!

- [ ]  prettier updated. implies updating projects … (yaml isn't installed in the version we have, that's why)
- [ ] the filename extension function got a `toLowerCase()`. this was already an issue before regarding spellchecking. I can't think of a reason why not to do this.
- [ ] I have tested the formatting itself, I think it's ok and it even properly complains about syntax errors. below are three screenshots: ugly → syntax error (which I fixed) → result

![screenshot from 2018-08-22 17-46-34](https://user-images.githubusercontent.com/207405/44475090-736f8a00-a634-11e8-8df4-00f6a5fa2611.png)

![screenshot from 2018-08-22 17-46-57](https://user-images.githubusercontent.com/207405/44475098-779ba780-a634-11e8-928e-3fefde82b30a.png)

![screenshot from 2018-08-22 17-47-29](https://user-images.githubusercontent.com/207405/44475101-7b2f2e80-a634-11e8-876d-a47ce3352e8e.png)
