### PR TITLE
formatting *.r code and better display of error messages about syntax problems for python and R

### DIFF
--- a/src/smc-project/browser-websocket/api.ts
+++ b/src/smc-project/browser-websocket/api.ts
@@ -42,12 +42,17 @@ export function init_websocket_api(
   });
 }
 
-async function handle_api_call(client: any, data: any, primus:any, logger:any): Promise<any> {
+async function handle_api_call(
+  client: any,
+  data: any,
+  primus: any,
+  logger: any
+): Promise<any> {
   switch (data.cmd) {
     case "listing":
       return await listing(data.path, data.hidden);
     case "prettier":
-      return await prettier(client, data.path, data.options);
+      return await prettier(client, data.path, data.options, logger);
     case "jupyter":
       return await jupyter(data.path, data.endpoint, data.query);
     case "exec":
@@ -67,8 +72,13 @@ async function listing(path: string, hidden?: boolean): Promise<object[]> {
 }
 
 import { run_prettier } from "../prettier";
-async function prettier(client: any, path: string, options: any): Promise<any> {
-  return await run_prettier(client, path, options);
+async function prettier(
+  client: any,
+  path: string,
+  options: any,
+  logger: any
+): Promise<any> {
+  return await run_prettier(client, path, options, logger);
 }
 
 import { handle_request as jupyter } from "../jupyter/websocket-api";

--- a/src/smc-project/prettier.ts
+++ b/src/smc-project/prettier.ts
@@ -18,6 +18,7 @@ const { math_escape, math_unescape } = require("smc-util/markdown-utils");
 const prettier = require("prettier");
 const { latex_format } = require("./latex-format");
 const { python_format } = require("./python-format");
+const { r_format } = require("./r-format");
 const body_parser = require("body-parser");
 const express = require("express");
 const { remove_math, replace_math } = require("smc-util/mathjax-utils"); // from project Jupyter
@@ -27,7 +28,8 @@ import { callback } from "awaiting";
 export async function run_prettier(
   client: any,
   path: string,
-  options: any
+  options: any,
+  logger: any
 ): Promise<object> {
   // What we do is edit the syncstring with the given path to be "prettier" if possible...
   let syncstring = client.sync_string({ path, reference_only: true });
@@ -49,11 +51,15 @@ export async function run_prettier(
       case "python":
         pretty = await python_format(input, options);
         break;
+      case "r":
+        pretty = await r_format(input, options, logger);
+        break;
       default:
         pretty = prettier.format(input, options);
     }
   } catch (err) {
-    return { status: "error", phase: "format", error: err };
+    logger.debug(`run_prettier error: ${err.message}`);
+    return { status: "error", phase: "format", error: err.message };
   }
   if (options.parser === "markdown") {
     pretty = math_unescape(replace_math(pretty, math));

--- a/src/smc-project/prettier.ts
+++ b/src/smc-project/prettier.ts
@@ -49,7 +49,7 @@ export async function run_prettier(
         pretty = await latex_format(input, options);
         break;
       case "python":
-        pretty = await python_format(input, options);
+        pretty = await python_format(input, options, logger);
         break;
       case "r":
         pretty = await r_format(input, options, logger);

--- a/src/smc-project/python-format.ts
+++ b/src/smc-project/python-format.ts
@@ -21,6 +21,17 @@ function yapf(input_path) {
   return spawn("yapf", ["-i", input_path]);
 }
 
+// TODO this doesn't do what it should …
+function last_line(str: string): string {
+  return (
+    str
+      .trim()
+      .split(/\r?\n/)
+      .slice(-1)
+      .pop() || ""
+  );
+}
+
 export async function python_format(
   input: string,
   options: ParserOptions
@@ -39,17 +50,20 @@ export async function python_format(
   // read data as it is produced.
   py_formatter.stdout.on("data", data => (stdout += data.toString()));
   py_formatter.stderr.on("data", data => (stderr += data.toString()));
+  // only last line
+  // stdout = last_line(stdout);
+  stderr = last_line(stderr);
   // wait for subprocess to close.
   let code = await callback(close, py_formatter);
   if (code) {
-    throw Error(
-      `Python formatter "${util}" exited with code ${code}\nOutput:\n${stdout}\n${stderr}`
+    throw new Error(
+      `Python formatter "${util}" exited with code ${code}:\n${stdout}\n${stderr}`
     );
   }
 
   // all fine, we read from the temp file
-  let output : Buffer = await callback(readFile, input_path);
-  let s : string = output.toString('utf-8');
+  let output: Buffer = await callback(readFile, input_path);
+  let s: string = output.toString("utf-8");
 
   return s;
 }

--- a/src/smc-project/r-format.ts
+++ b/src/smc-project/r-format.ts
@@ -1,0 +1,54 @@
+const { writeFile, readFile } = require("fs");
+const tmp = require("tmp");
+const { callback } = require("awaiting");
+const { spawn } = require("child_process");
+// const { replace_all } = require("smc-util/misc");
+
+interface ParserOptions {
+  parser?: string;
+  tabWidth?: number;
+  lineWidth?: number;
+}
+
+function close(proc, cb): void {
+  proc.on("close", code => cb(undefined, code));
+}
+
+function formatR(input_path: string, logger: any) {
+  // in-place is fine, according to my tests
+  const expr = `suppressMessages(require(formatR)); tidy_source(source="${input_path}", file="${input_path}", indent=2, width.cutoff=80)`;
+  return spawn("R", ["--quiet", "--vanilla", "--no-save", "-e", expr]);
+}
+
+export async function r_format(
+  input: string,
+  options: ParserOptions,
+  logger: any
+): Promise<string> {
+  // create input temp file
+  const input_path: string = await callback(tmp.file);
+  await callback(writeFile, input_path, input);
+
+  // spawn the R formatter
+  const r_formatter = formatR(input_path, logger);
+
+  // stdout/err capture
+  let stdout: string = "";
+  let stderr: string = "";
+  // read data as it is produced.
+  r_formatter.stdout.on("data", data => (stdout += data.toString()));
+  r_formatter.stderr.on("data", data => (stderr += data.toString()));
+  // wait for subprocess to close.
+  let code = await callback(close, r_formatter);
+  if (code) {
+    const err_msg = `${stderr}`;
+    logger.debug(`R_FORMAT ${err_msg}`);
+    throw new Error(err_msg);
+  }
+
+  // all fine, we read from the temp file
+  let output: Buffer = await callback(readFile, input_path);
+  let s: string = output.toString("utf-8");
+
+  return s;
+}

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1468,6 +1468,9 @@ export class Actions<T = CodeEditorState> extends BaseActions<
       case "py":
         parser = "python";
         break;
+      case "r":
+        parser = "r";
+        break;
       default:
         return;
     }

--- a/src/smc-webapp/frame-editors/code-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/code-editor/editor.ts
@@ -6,7 +6,7 @@ import { CodemirrorEditor } from "./codemirror-editor";
 import { filename_extension, set } from "../generic/misc";
 import { createEditor } from "../frame-tree/editor";
 
-const FORMAT = set(["js", "jsx", "ts", "tsx", "json", "md", "css", "py"]);
+const FORMAT = set(["js", "jsx", "ts", "tsx", "json", "md", "css", "py", "r"]);
 
 const EDITOR_SPEC = {
   cm: {

--- a/src/smc-webapp/frame-editors/codemirror/cm-options.ts
+++ b/src/smc-webapp/frame-editors/codemirror/cm-options.ts
@@ -221,7 +221,7 @@ export function cm_options(
   const ext = filename_extension_notilde(filename);
 
   // Ugly until https://github.com/sagemathinc/cocalc/issues/2847 is implemented:
-  if (["js", "jsx", "ts", "tsx", "json", "md"].includes(ext)) {
+  if (["js", "jsx", "ts", "tsx", "json", "md", "r"].includes(ext)) {
     opts.tab_size = opts.indent_unit = 2;
   }
 

--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -1,4 +1,10 @@
-import { React, rclass, rtypes, Component, Rendered } from "../../app-framework";
+import {
+  React,
+  rclass,
+  rtypes,
+  Component,
+  Rendered
+} from "../../app-framework";
 
 const { ErrorDisplay, Loading } = require("smc-webapp/r_misc");
 
@@ -23,7 +29,6 @@ interface FrameTreeEditorReactProps {
 
 interface FrameTreeEditorReduxProps {
   editor_settings?: Map<string, any>;
-
   is_public: boolean;
   has_unsaved_changes: boolean;
   has_uncommitted_changes: boolean;
@@ -33,20 +38,18 @@ interface FrameTreeEditorReduxProps {
   error: string;
   cursors: Map<string, any>;
   status: string;
-
   load_time_estimate?: Map<string, any>;
   value?: string;
-
   reload: Map<string, number>;
   resize: number; // if changes, means that frames have been resized, so may need refreshing; passed to leaf.
   misspelled_words: Set<string>;
   is_saving: boolean;
   gutter_markers: Map<string, any>;
-
   settings: Map<string, any>;
 }
 
-type FrameTreeEditorProps = FrameTreeEditorReactProps & FrameTreeEditorReduxProps;
+type FrameTreeEditorProps = FrameTreeEditorReactProps &
+  FrameTreeEditorReduxProps;
 
 const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
   private editor_spec: any = {};
@@ -120,7 +123,6 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
           "status",
           "load_time_estimate",
           "value",
-
           "reload",
           "resize",
           "misspelled_words",
@@ -128,9 +130,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
           "has_uncommitted_changes",
           "is_saving",
           "gutter_markers",
-
           "editor_settings",
-
           "settings"
         ]
       ) ||
@@ -205,7 +205,9 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
           maxWidth: "100%",
           margin: "1ex",
           maxHeight: "30%",
-          overflowY: "scroll"
+          overflowY: "scroll",
+          fontFamily: "monospace",
+          fontSize: "85%"
         }}
       />
     );
@@ -249,7 +251,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
       </div>
     );
   }
-} as React.ComponentType<FrameTreeEditorReactProps>
+} as React.ComponentType<FrameTreeEditorReactProps>;
 
 const FrameTreeEditor = rclass(FrameTreeEditor0);
 

--- a/src/smc-webapp/frame-editors/frame-tree/util.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/util.ts
@@ -43,5 +43,6 @@ export const PRETTIER_SUPPORT = {
   tsx: true,
   json: true,
   py: true, // use external tool
-  tex: true  // actually use latexformat
+  tex: true, // actually use latexformat
+  r: true // formatR
 };

--- a/src/smc-webapp/frame-editors/generic/client.ts
+++ b/src/smc-webapp/frame-editors/generic/client.ts
@@ -86,6 +86,8 @@ export async function prettier(
           loc.start.line
         } column ${loc.start.column}) -- fix and run again.`
       );
+    } else if (resp.error) {
+      throw Error(resp.error);
     } else {
       throw Error("Syntax error prevented formatting code.");
     }
@@ -184,9 +186,8 @@ export async function user_search(opts: {
   query_id?: number;
   limit?: number;
   timeout?: number;
-  admin? : boolean;
-  active? : string;
+  admin?: boolean;
+  active?: string;
 }): Promise<User[]> {
   return callback_opts(webapp_client.user_search)(opts);
 }
-


### PR DESCRIPTION
"formatR" with useful defaults and reporting python formatting errors (last line) if possible. also a bit of tweaking for the error message.

obligatory screenshots: messy R code, syntax error, formatted

![screenshot from 2018-08-23 19-14-49](https://user-images.githubusercontent.com/207405/44550576-f708a400-a724-11e8-9d22-c051911b0e10.png)


![screenshot from 2018-08-23 20-44-15](https://user-images.githubusercontent.com/207405/44550584-fa039480-a724-11e8-9bb6-0892f6f0d2f6.png)


![screenshot from 2018-08-23 20-44-28](https://user-images.githubusercontent.com/207405/44550593-fcfe8500-a724-11e8-977e-b1115b77de79.png)
