### PR TITLE
webapp/frame editor: more than one type of error styling

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -33,7 +33,8 @@ import {
   FrameDirection,
   FrameTree,
   ImmutableFrameTree,
-  SetMap
+  SetMap,
+  ErrorStyles
 } from "../frame-tree/types";
 import { SettingsObject } from "../settings/types";
 import { misspelled_words } from "./spell-check";
@@ -75,6 +76,7 @@ export interface CodeEditorState {
   value?: string;
   load_time_estimate: number;
   error: any;
+  errorstyle?: ErrorStyles;
   status: any;
   read_only: boolean;
   settings: Map<string, any>; // settings specific to this file (but **not** this user or browser), e.g., spell check language.
@@ -1272,7 +1274,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
   }
 
   // big scary error shown at top
-  set_error(error?: object | string): void {
+  set_error(error?: object | string, style?: ErrorStyles): void {
     if (error === undefined) {
       this.setState({ error });
     } else {
@@ -1287,6 +1289,14 @@ export class Actions<T = CodeEditorState> extends BaseActions<
         error = e;
       }
       this.setState({ error });
+    }
+
+    switch (style) {
+      case "monospace":
+        this.setState({ errorstyle: style });
+        break;
+      default:
+        this.setState({ errorstyle: undefined });
     }
   }
 
@@ -1501,7 +1511,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
       await prettier(this.project_id, this.path, options);
       this.set_error("");
     } catch (err) {
-      this.set_error(`Error formatting code: \n${err}`);
+      this.set_error(`Error formatting code: \n${err}`, "monospace");
     } finally {
       this.set_status("");
     }

--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -9,9 +9,9 @@ import {
 const { ErrorDisplay, Loading } = require("smc-webapp/r_misc");
 
 import { FormatBar } from "./format-bar";
-
 import { StatusBar } from "./status-bar";
 const { FrameTree } = require("./frame-tree");
+import { ErrorStyles } from "../frame-tree/types";
 
 import { copy, is_different } from "../generic/misc";
 
@@ -36,6 +36,7 @@ interface FrameTreeEditorReduxProps {
   is_loaded: boolean;
   local_view_state: Map<string, any>;
   error: string;
+  errorstyle: ErrorStyles;
   cursors: Map<string, any>;
   status: string;
   load_time_estimate?: Map<string, any>;
@@ -82,6 +83,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
         is_loaded: rtypes.bool.isRequired,
         local_view_state: rtypes.immutable.Map.isRequired,
         error: rtypes.string.isRequired,
+        errorstyle: rtypes.string,
         cursors: rtypes.immutable.Map.isRequired,
         status: rtypes.string.isRequired,
 
@@ -119,6 +121,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
           "is_loaded",
           "local_view_state",
           "error",
+          "errorstyle",
           "cursors",
           "status",
           "load_time_estimate",
@@ -197,18 +200,21 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
     if (!this.props.error) {
       return;
     }
+    let style: any = {
+      maxWidth: "100%",
+      margin: "1ex",
+      maxHeight: "30%",
+      overflowY: "scroll"
+    };
+    if (this.props.errorstyle === "monospace") {
+      style.fontFamily = "monospace";
+      style.fontSize = "85%";
+    }
     return (
       <ErrorDisplay
         error={this.props.error}
         onClose={() => this.props.actions.set_error("")}
-        style={{
-          maxWidth: "100%",
-          margin: "1ex",
-          maxHeight: "30%",
-          overflowY: "scroll",
-          fontFamily: "monospace",
-          fontSize: "85%"
-        }}
+        style={style}
       />
     );
   }

--- a/src/smc-webapp/frame-editors/frame-tree/types.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/types.ts
@@ -1,6 +1,6 @@
 import { Map } from "immutable";
 
-export type FrameDirection = 'row' | 'col';
+export type FrameDirection = "row" | "col";
 
 /* Interface for object that describes a binary tree. */
 export interface FrameTree {
@@ -19,3 +19,5 @@ export type ImmutableFrameTree = Map<string, any>;
 export interface SetMap {
   [key: string]: boolean;
 }
+
+export type ErrorStyles = undefined | "monospace";


### PR DESCRIPTION
this makes it so that normal error messages have proportional width and all format errors are monospaced. to refine this for each formatter, it would just require to set a flag-variable  in the switch/case block in `code-editor/actions → format()` when running the formatter.

I triggered that one below by stopping the hub

![screenshot from 2018-08-26 18-37-44](https://user-images.githubusercontent.com/207405/44630547-acbf3700-a95f-11e8-8c08-a1df7c477dd2.png)

yaml syntax error

![screenshot from 2018-08-26 18-38-28](https://user-images.githubusercontent.com/207405/44630556-bb0d5300-a95f-11e8-84c5-eb4d68d98b40.png)

