### PR TITLE
do not randomize data image urls

### DIFF
--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -122,10 +122,14 @@ exports.scroll_top = () ->
 require('./jquery-plugins/katex')
 
 # Force reload all images by appending random query param to their src URL.
+# But not for base64 data images -- https://github.com/sagemathinc/cocalc/issues/3141
 $.fn.reload_images = (opts) ->
     @each ->
         for img in $(this).find('img')
-            $(img).attr('src', $(img).attr('src')+'?'+Math.random())
+            src = $(img).attr('src')
+            if misc.startswith(src, 'data:')
+                continue
+            $(img).attr('src', src + '?' + Math.random())
 
 # Highlight all code blocks that have CSS class language-r, language-python.
 # TODO: I just put in r and python for now, since this is mainly


### PR DESCRIPTION
ref: #3141

I am not sure how to test this, because when I open up normal markdown files or a chat box, and enter a  an image with a normal http-url, it still doesn't append a random number. (with or without that patch). I don't know how and where to look to check it properly.

the code itself is a no-brainer