### PR TITLE
lean editor: block comment syntax

### DIFF
--- a/src/smc-webapp/codemirror/mode/lean.ts
+++ b/src/smc-webapp/codemirror/mode/lean.ts
@@ -6,53 +6,52 @@ This is just a first tiny quick step.  To finish this:
 - Look at https://codemirror.net/demo/simplemode.html for how this works.
 - Put everything from https://github.com/leanprover/vscode-lean/blob/master/syntaxes/lean.json in here.
 
-NOTE(hsy): I think the alternative that works with safari is this negative look ahead
-
-/((?!\.).{1}|^)\b(import|prelude|theory|definition|def|abbreviation|instance|renaming|hiding|exposing|parameter|parameters|begin|constant|constants|lemma|variable|variables|theorem|example|open|axiom|inductive|coinductive|with|structure|universe|universes|alias|precedence|reserve|postfix|prefix|infix|infixl|infixr|notation|end|using|namespace|section|local|set_option|extends|include|omit|class|classes|instances|raw|run_cmd)\b/gm
-
-playgroud: https://regex101.com/r/lop9Se/1
+playgroud to see the alternative of negative look ahead in action: https://regex101.com/r/lop9Se/1
 
 */
 
 (CodeMirror as any).defineSimpleMode("lean", {
   start: [
     { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: "string" },
+    { regex: /\/-/, token: "comment", next: "blockcomment" },
     {
       regex: /#(print|eval|reduce|check|help|exit)\b/,
+      token: "variable-3"
+    },
+    { regex: /--.*/, token: "comment" },
+    { regex: /[-+\/*=<>!]+/, token: "operator" },
+    {
+      regex: /((?!\.).{1}|^)\b(import|prelude|theory|definition|def|abbreviation|instance|renaming|hiding|exposing|parameter|parameters|begin|constant|constants|lemma|variable|variables|theorem|example|open|axiom|inductive|coinductive|with|structure|universe|universes|alias|precedence|reserve|postfix|prefix|infix|infixl|infixr|notation|end|using|namespace|section|local|set_option|extends|include|omit|class|classes|instances|raw|run_cmd)\b/,
       token: "keyword"
     },
     {
-      regex: /\b(?!\.)(import|prelude|theory|definition|def|abbreviation|instance|renaming|hiding|exposing|parameter|parameters|begin|constant|constants|lemma|variable|variables|theorem|example|open|axiom|inductive|coinductive|with|structure|universe|universes|alias|precedence|reserve|postfix|prefix|infix|infixl|infixr|notation|end|using|namespace|section|local|set_option|extends|include|omit|class|classes|instances|raw|run_cmd)\b/,
-      token: "keyword"
-    },
-    {
-      regex: /\b(?!\.)(calc|have|this|match|do|suffices|show|by|in|at|let|forall|fun|exists|assume|from)\b/,
-      token: "keyword"
+      regex: /((?!\.).{1}|^)\b(calc|have|this|match|do|suffices|show|by|in|at|let|forall|fun|exists|assume|from)\b/,
+      token: "variable-2"
     },
     {
       regex: /\b(Prop|Type|Sort)\b/,
-      token: "keyword"
+      token: "atom"
     },
     {
       regex: /0x[a-f\d]+|[-+]?(?:\.\d+|\d+\.?\d*)(?:e[-+]?\d+)?/i,
       token: "number"
     },
-    { regex: /--.*/, token: "comment" },
-    { regex: /[-+\/*=<>!]+/, token: "operator" },
+    { regex: /\/-.*?-\//, token: "comment" },
     { regex: /begin/, indent: true },
     { regex: /end/, dedent: true },
-    { regex: /[a-z$][\w$]*/, token: "variable" }
+    { regex: /[a-z$][\w$]*/, token: "variable" },
+    { regex: /b?"/, token: "string", next: "string" }
   ],
   string: [
     { regex: /"/, token: "string", next: "start" },
     { regex: /(?:[^\\"]|\\(?:.|$))*/, token: "string" }
   ],
-  comment: [{ regex: /\(-.*-\)/, token: "comment", next: "start" }],
+  blockcomment: [
+    { regex: /.*?-\//, token: "comment", next: "start" },
+    { regex: /.*/, token: "comment" }
+  ],
   meta: {
     dontIndentStates: ["comment"],
-    /* electricInput: /^\s*\}$/, */
-    blockCommentStart: "(-",
-    blockCommentEnd: "-)",
     lineComment: "--"
   }
 });


### PR DESCRIPTION
this changes a few details and introduces support for block comments. the order matters a lot, that's where I struggled most. I also need to find a good lean code example for testing … here is the screenshot how block comments look like with that patch

![screenshot from 2018-09-06 17-27-00](https://user-images.githubusercontent.com/207405/45168031-abf99100-b1fa-11e8-9a76-a64dc9a2b2a6.png)
