### PR TITLE
static/landingpage: we no longer need that FF extra warning

### DIFF
--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -40,10 +40,6 @@ block content
           img(src=require('!url-loader?mimetype=image/svg+xml!cocalc-logo.svg'))
       div.col-sm-12.center.descr.
         #{htmlWebpackPlugin.options.description}
-      div.col-sm-12.center.ff-only
-        div.alert.alert-danger.
-          WARNING: There is #[a.alert-link(href="https://github.com/sagemathinc/cocalc/issues/2875") a serious bug in recent versions of Firefox].
-          Working on #{NAME} using Firefox may be severely impaired, because Firefox disconnects you due to this bug.  Use any other web browser.
       div.col-sm-12.center
         +start_button
 


### PR DESCRIPTION
there is already a version-specific warning when the webapp starts and since FF 62 was released, there is IMHO no longer a reason any more to show this unconditional warning.

test: to build the static pages run `env CC_STATICPAGES=true NODE_ENV=development webpack --debug --output-pathinfo --progress --colors` in the `src` directory.