### PR TITLE
hub: fix startup which requires $ to be declared, but is not

### DIFF
--- a/src/smc-webapp/jupyter/cell-output-message.tsx
+++ b/src/smc-webapp/jupyter/cell-output-message.tsx
@@ -14,6 +14,8 @@ Handling of output messages.
 TODO: most components should instead be in separate files.
 */
 
+declare const $: any;
+
 import { React, Component } from "../app-framework"; // TODO: this will move
 import { Button } from "react-bootstrap";
 import * as immutable from "immutable";


### PR DESCRIPTION
because of

```
2018-09-08T17:09:46.145Z - debug: init_share_server: initializing share server at  /14eed217-2d3c-4975-a381-b69edcb40e0e/port/56754/share
loading jsdom...
loading jQuery...
ensure the global variable window.CodeMirror is defined....
jsdom support loaded
2018-09-08T17:10:02.811Z - debug: BUG ****************************************************************************
2018-09-08T17:10:02.812Z - debug: Uncaught exception: TSError: ⨯ Unable to compile TypeScript:
../smc-webapp/jupyter/cell-output-message.tsx(225,21): error TS2304: Cannot find name '$'.
 
2018-09-08T17:10:02.814Z - debug: TSError: ⨯ Unable to compile TypeScript:
../smc-webapp/jupyter/cell-output-message.tsx(225,21): error TS2304: Cannot find name '$'.
 
    at createTSError (/home/user/smc/src/node_modules/ts-node/dist/index.js:272:13)
    at getOutput (/home/user/smc/src/node_modules/ts-node/dist/index.js:342:17)
    at Object.compile (/home/user/smc/src/node_modules/ts-node/dist/index.js:443:17)
    at Module.m._compile (/home/user/smc/src/node_modules/ts-node/dist/index.js:340:9)
    at Module._extensions..js (module.js:656:9)
    at Object.require.extensions.(anonymous function) [as .tsx] (/home/user/smc/src/node_modules/ts-node/dist/index.js:382:17)
    at Module.load (/home/user/smc/src/smc-hub/node_modules/coffeescript/lib/coffeescript/register.js:49:9)
    at tryModuleLoad (module.js:526:17)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:590:9)
    at require (internal/module.js:22:1)
    at Object.<anonymous> (/home/user/smc/src/smc-webapp/jupyter/cell-output.tsx:22:1)
    at Module._compile (module.js:531:9)
    at Module.m._compile (/home/user/smc/src/node_modules/ts-node/dist/index.js:340:9)
    at Module._extensions..js (module.js:656:9)
    at Object.require.extensions.(anonymous function) [as .tsx] (/home/user/smc/src/node_modules/ts-node/dist/index.js:382:17)
    at Module.load (/home/user/smc/src/smc-hub/node_modules/coffeescript/lib/coffeescript/register.js:49:9)
    at tryModuleLoad (module.js:526:17)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:590:9)
    at require (internal/module.js:22:1)
    at Object.<anonymous> (/home/user/smc/src/smc-webapp/jupyter/cell.tsx:22:1)
    at Module._compile (module.js:531:9)
    at Module.m._compile (/home/user/smc/src/node_modules/ts-node/dist/index.js:340:9)
    at Module._extensions..js (module.js:656:9)
[...]