### PR TITLE
latex: fix customizing build command 

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -146,8 +146,14 @@ export class Actions extends BaseActions<LatexEditorState> {
     const set_cmd = (): void => {
       const x = this._syncdb.get_one({ key: "build_command" });
       if (x !== undefined && x.get("value") !== undefined) {
-        const cmd: List<string> = x.get("value");
-        if (cmd.size > 0) {
+        const cmd: List<string> | string = x.get("value");
+        if (typeof cmd === "string") {
+          // #3159
+          if (cmd.length > 0) {
+            this.setState({ build_command: cmd });
+            return;
+          }
+        } else if (cmd.size > 0) {
           this.setState({ build_command: fromJS(cmd) });
           return;
         }


### PR DESCRIPTION
ref: #3159

well, pretty clear fix, type info was misleading

obligatory bonus screenshot featuring build command `latexmk -pdf -f -g -bibtex -synctex=1 -interaction=nonstopmode issue-3159.tex; pythontex3 issue-3159.tex; latexmk -pdf -f -g -bibtex -synctex=1 -interaction=nonstopmode issue-3159.tex`

![screenshot-cocalc com-2018 09 09-22-41-50](https://user-images.githubusercontent.com/207405/45268748-a5c91600-b481-11e8-9ae1-1f7f5e7275c4.png)
