### PR TITLE
webapp/project: format c, c++ files

### DIFF
--- a/src/smc-project/browser-websocket/api.ts
+++ b/src/smc-project/browser-websocket/api.ts
@@ -58,7 +58,7 @@ async function handle_api_call(
     case "prettier":
       return await run_prettier(client, data.path, data.options, logger);
     case "prettier_string":
-      return await run_prettier_string(data.str, data.options, logger);
+      return await run_prettier_string(data.path, data.str, data.options, logger);
     case "jupyter":
       return await jupyter(data.path, data.endpoint, data.query);
     case "exec":

--- a/src/smc-project/clang-format.ts
+++ b/src/smc-project/clang-format.ts
@@ -1,0 +1,73 @@
+const { writeFile, readFile } = require("fs");
+const tmp = require("tmp");
+const { callback } = require("awaiting");
+const { spawn } = require("child_process");
+// const { replace_all } = require("smc-util/misc");
+
+interface ParserOptions {
+  parser: string;
+  tabWidth: number;
+}
+
+function close(proc, cb): void {
+  proc.on("close", code => cb(undefined, code));
+}
+
+// ref: https://clang.llvm.org/docs/ClangFormat.html
+
+function run_clang_format(
+  input_path: string,
+  indent: number /*, logger: any*/
+) {
+  const style = `-style={BasedOnStyle: google, IndentWidth: ${indent}}`;
+  const args = ["-i", style, input_path];
+  // logger.debug(`run_clang_format args: [${args}]`);
+  return spawn("clang-format", args);
+}
+
+export async function clang_format(
+  input: string,
+  options: ParserOptions,
+  ext: string,
+  logger: any
+): Promise<string> {
+  // create input temp file
+  // we have to set the correct filename extension, because clang format uses it
+  const input_path: string = await callback(tmp.file, { postfix: `.${ext}` });
+  // logger.debug(`clang_format tmp file: ${input_path}`);
+  await callback(writeFile, input_path, input);
+
+  // spawn the html formatter
+  let formatter;
+  let indent = options.tabWidth || 2;
+
+  switch (options.parser) {
+    case "clang-format":
+      formatter = run_clang_format(input_path, indent /*, logger*/);
+      break;
+    default:
+      throw Error(`Unknown C/C++ code formatting utility '${options.parser}'`);
+  }
+  // stdout/err capture
+  let stdout: string = "";
+  let stderr: string = "";
+  // read data as it is produced.
+  formatter.stdout.on("data", data => (stdout += data.toString()));
+  formatter.stderr.on("data", data => (stderr += data.toString()));
+  // wait for subprocess to close.
+  let code = await callback(close, formatter);
+  if (code >= 1) {
+    const err_msg = `C/C++ code formatting utility "${
+      options.parser
+    }" exited with code ${code}\nOutput:\n${stdout}\n${stderr}`;
+    logger.debug(`clang-format error: ${err_msg}`);
+    throw Error(err_msg);
+  }
+
+  // all fine, we read from the temp file
+  let output: Buffer = await callback(readFile, input_path);
+  let s: string = output.toString("utf-8");
+  // logger.debug(`clang_format output s ${s}`);
+
+  return s;
+}

--- a/src/smc-project/prettier.ts
+++ b/src/smc-project/prettier.ts
@@ -62,7 +62,7 @@ export async function run_prettier(
 }
 
 export async function run_prettier_string(
-  path: string,
+  path: string | undefined,
   str: string,
   options: any,
   logger: any
@@ -83,7 +83,7 @@ export async function run_prettier_string(
       pretty = await html_format(str, options);
       break;
     case "clang-format":
-      const ext = misc.filename_extension(path);
+      const ext = misc.filename_extension(path !== undefined ? path : '');
       pretty = await clang_format(str, options, ext, logger);
       break;
     default:

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -667,7 +667,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
     }
   }
 
-  close_frame_hook(_:string) : void {
+  close_frame_hook(_: string): void {
     // overload in derived class...
   }
 
@@ -1496,6 +1496,13 @@ export class Actions<T = CodeEditorState> extends BaseActions<
         break;
       case "html":
         parser = "html-tidy";
+        break;
+      case "c":
+      case "c++":
+      case "cc":
+      case "cpp":
+      case "h":
+        parser = "clang-format";
         break;
       default:
         return;

--- a/src/smc-webapp/frame-editors/code-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/code-editor/editor.ts
@@ -16,7 +16,12 @@ const FORMAT = set([
   "css",
   "py",
   "r",
-  "yaml"
+  "yaml",
+  "c",
+  "c++",
+  "cc",
+  "cpp",
+  "h"
 ]);
 
 const EDITOR_SPEC = {

--- a/src/smc-webapp/frame-editors/codemirror/cm-options.ts
+++ b/src/smc-webapp/frame-editors/codemirror/cm-options.ts
@@ -36,7 +36,7 @@ export function cm_options(
 
   let opts = defaults(default_opts, {
     undoDepth: 0, // we use our own sync-aware undo.
-    mode: 'txt',
+    mode: "txt",
     show_trailing_whitespace: editor_settings.get(
       "show_trailing_whitespace",
       true
@@ -225,7 +225,23 @@ export function cm_options(
   const ext = filename_extension_notilde(filename);
 
   // Ugly until https://github.com/sagemathinc/cocalc/issues/2847 is implemented:
-  if (["js", "jsx", "ts", "tsx", "json", "md", "r", "html"].includes(ext)) {
+  if (
+    [
+      "js",
+      "jsx",
+      "ts",
+      "tsx",
+      "json",
+      "md",
+      "r",
+      "html",
+      "c",
+      "c++",
+      "cc",
+      "cpp",
+      "h"
+    ].includes(ext)
+  ) {
     opts.tab_size = opts.indent_unit = 2;
   }
 

--- a/src/smc-webapp/frame-editors/frame-tree/util.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/util.ts
@@ -48,5 +48,10 @@ export const PRETTIER_SUPPORT = {
   py: true, // use external tool
   tex: true, // actually use latexformat
   html: true, // uses old-school "tidy" with some specific parameters
-  r: true // formatR
+  r: true, // formatR
+  c: true, // clang-format
+  cc: true, // --*--
+  "c++": true, // --*--
+  cpp: true, // --*--
+  h: true // --*--
 };


### PR DESCRIPTION
This should be straight forward to review. For testing, paste a c, cc, h or c++ file and use the format button. 

before

![screenshot from 2018-09-10 13-53-11](https://user-images.githubusercontent.com/207405/45296041-0a778580-b501-11e8-93b6-7e673d738b37.png)

after

![screenshot from 2018-09-10 13-53-24](https://user-images.githubusercontent.com/207405/45296048-0ea3a300-b501-11e8-80d1-dbaf7b11caad.png)
