### PR TITLE
static landing page: adding William's Harvard presentation 

### DIFF
--- a/src/webapp-lib/_base.pug
+++ b/src/webapp-lib/_base.pug
@@ -221,7 +221,7 @@ html.no-js(lang="en")
         .youtube-video-container
           width            : 100%
           height           : 0
-          padding-bottom   : 56.25%
+          padding-bottom   : 45%
           overflow         : hidden
 
           iframe, object, embed

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -28,6 +28,14 @@ block content
   - var free_memory_gb = (free_quotas['memory'] / 1000).toFixed(1)
   - var free_disk_gb = (free_quotas['disk_quota'] / 1000).toFixed(1)
 
+  mixin start_free
+    div.col-sm-12.center
+      h2 Start free, upgrade later
+    div.col-sm-6.col-sm-offset-3.center
+      p.
+         A new project runs under a free plan (unlimited trial) has a quota of #{free_memory_gb} GB memory and #{free_disk_gb} GB of disk space.
+         Purchasing #[a(href="policies/pricing.html") a subscription] and upgrading your projects makes hosting more robust and increase its quotas.
+
   a.anchor#a-top
   div.container
     div.row.intro#top
@@ -44,9 +52,9 @@ block content
         +start_button
 
     div.row
-      div.col-md-12.center
+      div.col-sm-12.center
         h1 Online computing environment
-      div.col-md-6
+      div.col-sm-6
         h4  Intro to CoCalc by Mark Quinn (University of Sheffield)
         //- img(src=require('!file-loader!sagepreview/01-worksheet.png'))
         div.youtube-video-container
@@ -117,13 +125,8 @@ block content
 
   a.anchor#a-startnow
   div.container
-    div.row
-      div.col-sm-12.center
-        h2 Start free, upgrade later
-      div.col-sm-6.col-sm-offset-3.center
-        p.
-           A new project runs under a free plan (unlimited trial) has a quota of #{free_memory_gb} GB memory and #{free_disk_gb} GB of disk space.
-           Purchasing #[a(href="policies/pricing.html") a subscription] and upgrading your projects makes hosting more robust and increase its quotas.
+    div.row(style="margin-top: 6rem")
+      +start_free
       div.col-sm-12.center
         +start_button
 
@@ -339,8 +342,9 @@ block content
 
   div
     div.container
-      div.row
-        div.col-sm-12.center(style="margin-top: 6rem")
+      div.row(style="margin-top: 6rem")
+        +start_free
+        div.col-sm-12.center
           +start_button
       div.row
         div.col-sm-12.center(style="margin-top: 6rem")

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -49,7 +49,8 @@ block content
       div.col-sm-6
         //- img(src=require('!file-loader!sagepreview/01-worksheet.png'))
         div.
-          Intro to CoCalc (credits: Mark Quinn, University of Sheffield)
+          #[strong Intro to CoCalc] (credits: Mark Quinn, University of Sheffield)
+        br
         div.youtube-video-container
           iframe(src="https://www.youtube.com/embed/fHr0LFjE8Uk?rel=0" frameborder="0" allowfullscreen)
       div.col-sm-6
@@ -97,9 +98,26 @@ block content
             li Share your files #[em privately] with project collaborators &mdash; all files are synchronized in real-time.
             li #[em Time-travel] is a detailed history of all your edits and everything is backed up in #[em consistent snapshots].
             li Finally, you can select any document to #[em publish it online].
-        p.
-          A default project under a free plan has a quota of #{free_memory_gb} GB memory and #{free_disk_gb} GB of disk space.
-          #[a(href="policies/pricing.html") Subscriptions] make hosting more robust and increase quotas.
+
+      div.col-sm-6
+        div.
+          #[strong CoCalc presentation by William Stein] (Harvard, 2018)
+        br
+        div.youtube-video-container
+          iframe(src="https://www.youtube.com/embed/G5SIwRinEYk?rel=0" frameborder="0" allowfullscreen)
+      div.col-sm-6
+        p This presentation covers these topics
+        ul
+          li Background and history of CoCalc
+          li Demonstration of functionality
+          li Architectural overview, underlying tech stack, ...
+          li Synchronization of documents
+          li Collaboration and chat
+          li Culture of users, academic and commercial usage
+
+      //- p.
+      //-    A default project under a free plan has a quota of #{free_memory_gb} GB memory and #{free_disk_gb} GB of disk space.
+      //-    #[a(href="policies/pricing.html") Subscriptions] make hosting more robust and increase quotas.
 
   a.anchor#a-explore
   div.space#explore

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -46,15 +46,13 @@ block content
     div.row
       div.col-md-12.center
         h1 Online computing environment
-      div.col-sm-6
+      div.col-md-6
+        h4  Intro to CoCalc by Mark Quinn (University of Sheffield)
         //- img(src=require('!file-loader!sagepreview/01-worksheet.png'))
-        div.
-          #[strong Intro to CoCalc] (credits: Mark Quinn, University of Sheffield)
-        br
         div.youtube-video-container
           iframe(src="https://www.youtube.com/embed/fHr0LFjE8Uk?rel=0" frameborder="0" allowfullscreen)
       div.col-sm-6
-        p #{NAME} is a #[strong sophisticated online environment] for
+        h4 #{NAME} is a sophisticated online workspace
         ul
           li.
             #[strong Mathematical calculation]:
@@ -84,6 +82,12 @@ block content
             #[a(href="https://julialang.org/") Julia],
             #[a(href="https://www.scala-lang.org/") Scala],
             …
+        p #[strong Collaborative Environment]
+        p
+          ul
+            li Share your files #[strong privately] with project collaborators &mdash; all files are synchronized in real-time.
+            li #[strong Time-travel] is a detailed history of all your edits and everything is backed up in #[strong consistent snapshots].
+            li Finally, you can select any document to #[strong publish it online].
         p #[strong Zero Setup:] getting started does not require any software setup.
           ol
             li First, create your personal #[strong account].
@@ -92,28 +96,23 @@ block content
               Finally, create a #[strong worksheet] or upload your own files:
               #{NAME} supports online editing of #[a(href="http://jupyter.org/") Jupyter Notebooks], Sage Worksheets,
               #[a(href="./doc/latex-editor.html") LaTeX files], etc.
-        p #[strong Collaborative Environment]
-        p
-          ul
-            li Share your files #[em privately] with project collaborators &mdash; all files are synchronized in real-time.
-            li #[em Time-travel] is a detailed history of all your edits and everything is backed up in #[em consistent snapshots].
-            li Finally, you can select any document to #[em publish it online].
 
+  a.anchor#a-presentation
+  div.container
+    div.row
       div.col-sm-6
-        div.
-          #[strong CoCalc presentation by William Stein] (Harvard, 2018)
-        br
+        h4  CoCalc talk by William Stein (Harvard, 2018)
         div.youtube-video-container
           iframe(src="https://www.youtube.com/embed/G5SIwRinEYk?rel=0" frameborder="0" allowfullscreen)
       div.col-sm-6
-        p This presentation covers these topics
+        h4 Presentation outline
         ul
           li Background and history of CoCalc
           li Demonstration of functionality
           li Architectural overview, underlying tech stack, ...
-          li Synchronization of documents
+          li Synchronization of documents, the backbone of collaboration
           li Collaboration and chat
-          li Culture of users, academic and commercial usage
+          li Culture, open-source, academic and commercial usage
 
       //- p.
       //-    A default project under a free plan has a quota of #{free_memory_gb} GB memory and #{free_disk_gb} GB of disk space.

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -114,9 +114,18 @@ block content
           li Collaboration and chat
           li Culture, open-source, academic and commercial usage
 
-      //- p.
-      //-    A default project under a free plan has a quota of #{free_memory_gb} GB memory and #{free_disk_gb} GB of disk space.
-      //-    #[a(href="policies/pricing.html") Subscriptions] make hosting more robust and increase quotas.
+
+  a.anchor#a-startnow
+  div.container
+    div.row
+      div.col-sm-12.center
+        h2 Start free, upgrade later
+      div.col-sm-6.col-sm-offset-3.center
+        p.
+           A new project runs under a free plan (unlimited trial) has a quota of #{free_memory_gb} GB memory and #{free_disk_gb} GB of disk space.
+           Purchasing #[a(href="policies/pricing.html") a subscription] and upgrading your projects makes hosting more robust and increase its quotas.
+      div.col-sm-12.center
+        +start_button
 
   a.anchor#a-explore
   div.space#explore


### PR DESCRIPTION
#3170 

changes: 
* presentation 2nd after intro presentation video. it fits to have both of them there
* moved the text about starting free vs. upgrading to be above two places where the create account button is. added the clarification that this is a unlimited trial. this should make it much more explicit about what to expect with creating an account

![screenshot from 2018-09-14 11-45-45](https://user-images.githubusercontent.com/207405/45542996-c099e280-b813-11e8-8f3a-a17ffc9be39d.png)

![screenshot from 2018-09-14 11-45-27](https://user-images.githubusercontent.com/207405/45542998-c099e280-b813-11e8-9035-54bff0991cf0.png)
