### PR TITLE
preflight check: test explicitly for FF 60.2 ESR

### DIFF
--- a/src/smc-webapp/client_browser.coffee
+++ b/src/smc-webapp/client_browser.coffee
@@ -101,14 +101,6 @@ class Connection extends client.Connection
         if prom_client.enabled
             @on('start_metrics', prom_client.start_metrics)
 
-        # Wait until load totally done.
-        setTimeout(@_firefox60_bug, 5000)
-
-    _firefox60_bug: =>
-        {name, version} = require('misc/browser').get_browser()
-        if name == 'Firefox' and (version == '59' or version == '60' or version == '61')
-            @alert_message(type:'error', block:'true', timeout:10000, message:"Firefox versions 59, 60 and 61 have a MAJOR bug. You *must* use a different web browser or change your TLS settings. See https://tinyurl.com/y9hphj39 and https://tinyurl.com/yboeepsf")
-
     _setup_window_smc: () =>
         # if we are in DEBUG mode, inject the client into the global window object
         window.enable_post = =>

--- a/src/smc-webapp/jupyter/complete.tsx
+++ b/src/smc-webapp/jupyter/complete.tsx
@@ -1,3 +1,5 @@
+declare const $: any;
+
 import { React, Component } from "../app-framework"; // TODO: this will move
 import { Map as ImmutableMap } from "immutable";
 
@@ -46,7 +48,7 @@ export class Complete extends Component<CompleteProps> {
   }
 
   key = (e: any) => {
-    if (e.keyCode === 27  && this.props.actions.close_complete != null) {
+    if (e.keyCode === 27 && this.props.actions.close_complete != null) {
       this.props.actions.close_complete(this.props.id);
     }
     if (e.keyCode !== 13) {

--- a/src/webapp-lib/preflight-checks.ts
+++ b/src/webapp-lib/preflight-checks.ts
@@ -10,6 +10,7 @@ Chrome is wrong on that page, I assume we should check for 61 or 62.
 interface ISpecs {
   name: string;
   version: number;
+  buildID: string /* only FF, first 8 digits are a date-timestamp */;
 }
 
 /* credits: https://stackoverflow.com/a/38080051/54236 */
@@ -20,21 +21,22 @@ const get_spec = function(): ISpecs {
   let M = ua.match(mstr) || [];
   if (/trident/i.test(M[1])) {
     tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
-    return { name: "IE", version: parseInt(tem[1]) || NaN };
+    return { name: "IE", version: parseInt(tem[1]) || NaN, buildID: "" };
   }
   if (M[1] === "Chrome") {
     tem = ua.match(/\b(OPR|Edge)\/(\d+)/);
     if (tem != null)
       return {
         name: tem[1].replace("OPR", "Opera"),
-        version: parseInt(tem[2])
+        version: parseInt(tem[2]),
+        buildID: ""
       };
   }
   M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, "-?"];
   if ((tem = ua.match(/version\/(\d+)/i)) != null) {
     M.splice(1, 1, tem[1]);
   }
-  return { name: M[0], version: parseInt(M[1]) };
+  return { name: M[0], version: parseInt(M[1]), buildID: navigator.buildID };
 };
 
 function halt_and_catch_fire(msg: string): void {
@@ -68,9 +70,20 @@ function preflight_check(): void {
   const oldOpera = spec.name === "Opera" && spec.version < 55;
   const oldChrome = spec.name === "Chrome" && spec.version < 62;
 
-  // known browser bug
+  // known FF browser bug -- unless https://github.com/sagemathinc/cocalc/issues/2875#issuecomment-420686094
+  // we check if the buildID (date ISO string plus some version number) is at least indicating version 60.2esr or later
+  const ff60esr =
+    spec.name === "Firefox" &&
+    spec.version == 60 &&
+    (spec.buildID !== undefined &&
+      spec.buildID.length >= 8 &&
+      spec.buildID.slice(0, 8) >= "20180903");
+
   const buggyFF =
-    spec.name === "Firefox" && 59 <= spec.version && spec.version <= 61;
+    spec.name === "Firefox" &&
+    59 <= spec.version &&
+    spec.version <= 61 &&
+    !ff60esr;
 
   if (oldFF || oldIE || oldEdge || oldSafari || oldOpera || oldChrome) {
     const msg = `<div style='text-align:center'>
@@ -97,8 +110,11 @@ function preflight_check(): void {
              <a href="https://github.com/sagemathinc/cocalc/issues/2875">issue #2875</a> caused by
              <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1453204">firefox issue #1453204</a>!
           </p>
-          <p>Either update to at least Firefox version 62 beta 11
-             or switch to a recent version of <a target="_blank" href='https://google.com/chrome'>Google Chrome</a>.
+          <p>Either update to at least Firefox version 62,
+             switch to a recent version of <a target="_blank" href='https://google.com/chrome'>Google Chrome</a>,
+             or tweak your TSL settings (we wouldn't recommend that, though):
+             <a href="https://tinyurl.com/y9hphj39">https://tinyurl.com/y9hphj39</a> and
+             <a href="https://tinyurl.com/yboeepsf">https://tinyurl.com/yboeepsf</a>.
           </p>
           <p>Learn more about our
             <a href="https://github.com/sagemathinc/cocalc/wiki/BrowserRequirements" target="_blank" >browser requirements</a>.

--- a/src/webapp-lib/preflight-checks.ts
+++ b/src/webapp-lib/preflight-checks.ts
@@ -10,7 +10,8 @@ Chrome is wrong on that page, I assume we should check for 61 or 62.
 interface ISpecs {
   name: string;
   version: number;
-  buildID: string /* only FF, first 8 digits are a date-timestamp */;
+  /* buildID only for FF, first 8 digits are a date-timestamp */
+  buildID: string | undefined;
 }
 
 /* credits: https://stackoverflow.com/a/38080051/54236 */
@@ -36,7 +37,11 @@ const get_spec = function(): ISpecs {
   if ((tem = ua.match(/version\/(\d+)/i)) != null) {
     M.splice(1, 1, tem[1]);
   }
-  return { name: M[0], version: parseInt(M[1]), buildID: navigator.buildID };
+  return {
+    name: M[0],
+    version: parseInt(M[1]),
+    buildID: (navigator as any).buildID
+  };
 };
 
 function halt_and_catch_fire(msg: string): void {


### PR DESCRIPTION
because that's the only one in version 60 that works, and remove that little alert box from the browser client

rationale behind this is explained here https://github.com/sagemathinc/cocalc/issues/2875#issuecomment-420682930

testing: so far I haven't …  and compiling it suddenly causes

```
2018-09-12T15:39:55.992Z - debug: Uncaught exception: TSError: ⨯ Unable to compile TypeScript:
../smc-webapp/jupyter/complete.tsx(32,5): error TS2304: Cannot find name '$'.
```

well, added another commit, now it compiles, and works locally for me. we should check if existing warnings for FF 60 and 61 still show up.

plan to finish: check if my dev project loads find in my chrome and ff 60.2 esr, while the warning appears for an older firefox.