### PR TITLE
support pythontex 

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -463,7 +463,7 @@ export class Actions extends BaseActions<LatexEditorState> {
 
     try {
       // Run PythonTeX
-      output = await pythontex(this.project_id, this.path, time, status);
+      output = await pythontex(this.project_id, this.path, time, force, status);
       // Now run latex again, since we had to run pythontex, which changes
       // the inserted snippets. This +1 forces re-running latex... but still dedups
       // it in case of multiple users.

--- a/src/smc-webapp/frame-editors/latex-editor/build.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/build.tsx
@@ -32,6 +32,7 @@ export interface IBuildSpecs {
   latex: IBuildSpec;
   bibtex: IBuildSpec;
   sagetex: IBuildSpec;
+  pythontex: IBuildSpec;
   knitr: IBuildSpec;
   clean: IBuildSpec;
 }
@@ -63,6 +64,13 @@ const BUILD_SPECS: IBuildSpecs = {
     label: "SageTex",
     icon: "cc-icon-sagemath-bold",
     tip: "Run SageTex, if necessary"
+  },
+
+  pythontex: {
+    button: false,
+    label: "PythonTeX",
+    icon: "cc-icon-python",
+    tip: "Run PythonTeX3, if necessary"
   },
 
   knitr: {
@@ -252,6 +260,7 @@ class Build extends Component<Props, {}> {
         {this.render_status()}
         {this.render_log("latex")}
         {this.render_log("sagetex")}
+        {this.render_log("pythontex")}
         {this.render_log("knitr")}
         {this.render_log("bibtex")}
         {this.render_clean()}

--- a/src/smc-webapp/frame-editors/latex-editor/clean.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/clean.ts
@@ -17,7 +17,8 @@ const EXTENSIONS: string[] = [
   ".sagetex.scmd",
   ".sagetex.sout",
   ".pdfsync",
-  "-concordance.tex"
+  "-concordance.tex",
+  ".pytxcode"
 ];
 
 export async function clean(

--- a/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -183,7 +183,9 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
       this.props.build_logs.getIn(["latex", "parse"]) !=
         props.build_logs.getIn(["latex", "parse"]) ||
       this.props.build_logs.getIn(["knitr", "parse"]) !=
-        props.build_logs.getIn(["knitr", "parse"])
+        props.build_logs.getIn(["knitr", "parse"]) ||
+      this.props.build_logs.getIn(["pythontex", "parse"]) !=
+        props.build_logs.getIn(["pythontex", "parse"])
     );
   }
 
@@ -274,6 +276,7 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
           this.render_group("latex", group)
         )}
         {["errors", "warnings"].map(group => this.render_group("knitr", group))}
+        {this.render_group("pythontex", "errors")}
       </div>
     );
   }

--- a/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
@@ -1,0 +1,55 @@
+/*
+Run PythonTeX
+*/
+
+import { exec, ExecOutput } from "../generic/client";
+import { parse_path } from "../frame-tree/util";
+
+// export async function sagetex_hash(
+//   project_id: string,
+//   path: string,
+//   time: number,
+//   status: Function
+// ): Promise<string> {
+//   const { base, directory } = parse_path(path); // base, directory, filename
+//   const s = sagetex_file(base);
+//   status(`sha1sum ${s}`);
+//   const output = await exec({
+//     allow_post: true, // very quick computation of sha1 hash
+//     timeout: 10,
+//     command: "sha1sum",
+//     args: [s],
+//     project_id: project_id,
+//     path: directory,base
+//     err_on_exit: true,
+//     aggregate: time
+//   });
+//   return output.stdout.split(" ")[0];
+// }
+
+// command documentation
+//
+// we limit the number of jobs, could be bad for memory usage causing OOM or whatnot
+// -j N, --jobs N        Allow N jobs at once; defaults to cpu_count().
+
+export async function pythontex(
+  project_id: string,
+  path: string,
+  hash: string,
+  status: Function
+): Promise<ExecOutput> {
+  const { base, directory } = parse_path(path);
+  const args = ["--jobs", "2", base];
+  status(`pythontex ${args.join(" ")}`);
+  return exec({
+    allow_post: false, // definitely could take a long time to fully run this
+    timeout: 360,
+    bash: true, // timeout is enforced by ulimit
+    command: "pythontex3",
+    args: args,
+    project_id: project_id,
+    path: directory,
+    err_on_exit: false,
+    aggregate: hash ? { value: hash } : undefined
+  });
+}

--- a/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
@@ -28,7 +28,7 @@ export async function pythontex(
   const args = ["--jobs", "2"];
   if (force) {
     // forced build implies to run all snippets
-    args.concat("--rerun=always");
+    args.push("--rerun=always");
   }
   status(`pythontex ${args.join(" ")}`);
   const aggregate = time && !force ? { value: time } : undefined;

--- a/src/smc-webapp/project_store.ts
+++ b/src/smc-webapp/project_store.ts
@@ -55,7 +55,7 @@ const MASKED_FILE_EXTENSIONS = {
   py: ["pyc"],
   java: ["class"],
   cs: ["exe"],
-  tex: "aux bbl blg fdb_latexmk fls glo idx ilg ind lof log nav out snm synctex.gz toc xyc synctex.gz(busy) sagetex.sage sagetex.sout sagetex.scmd sagetex.sage.py sage-plots-for-FILENAME".split(
+  tex: "aux bbl blg fdb_latexmk fls glo idx ilg ind lof log nav out snm synctex.gz toc xyc synctex.gz(busy) sagetex.sage sagetex.sout sagetex.scmd sagetex.sage.py sage-plots-for-FILENAME pytxcode pythontex-files-BASENAME".split(
     " "
   ),
   rnw: ["tex", "NODOT-concordance.tex"],
@@ -509,6 +509,9 @@ function _compute_file_masks(listing) {
               mask_ext = mask_ext.slice("NODOT".length);
             } else if (mask_ext.indexOf("FILENAME") >= 0) {
               bn = mask_ext.replace("FILENAME", filename);
+              mask_ext = "";
+            } else if (mask_ext.indexOf("BASENAME") >= 0) {
+              bn = mask_ext.replace("BASENAME", basename.slice(0, -1));
               mask_ext = "";
             } else {
               bn = basename;


### PR DESCRIPTION
ref: #3160

* main goal: editing a pythontex latex document works
* in case of errors, pythontex stdout is parsed and an error indicator added to the gutter
* example document added to https://github.com/sagemathinc/cocalc-example-files/tree/master/latex/pythontex
* pdf preview isn't updated during a build run with an intermediate sagetex or pythontex step

testing: the example document in the cocalc examples mentioned above showcases code, formulas, sympy blocks and error handling

![screenshot from 2018-09-12 18-52-54](https://user-images.githubusercontent.com/207405/45440732-5c650a80-b6bd-11e8-8ea8-65ce071f5efb.png)
