### PR TITLE
pdf viewer: initialize loading the viewer with a "reload"  value right from the start

### DIFF
--- a/src/smc-webapp/frame-editors/pdf-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/pdf-editor/actions.ts
@@ -25,6 +25,12 @@ export class PDFActions extends Actions<PDFEditorState> {
     return { type: "pdfjs_canvas" };
   }
 
+  _init2(): void {
+    if (!this.is_public) {
+      this.reload("");
+    }
+  }
+
   reload(_: string /* id not used here */): void {
     const now: number = new Date().valueOf();
     let type: string;


### PR DESCRIPTION
ref #3182

I'm not sure if this makes really sense, but just from testing it (see referenced ticket) it works.

Below you can see the `reload={...}` property with a value, which appears in the PDFJS (unnamed, though) component after opening it. Without that patch, there is no such property because `props.reload` is `undefined`.

![screenshot from 2018-09-14 16-05-02](https://user-images.githubusercontent.com/207405/45555268-9c9cc800-b838-11e8-9f52-3afd88da6cd9.png)
