### PR TITLE
webapp/sagews: hotfix to bypass #2757

### DIFF
--- a/src/smc-webapp/sagews/sagews.coffee
+++ b/src/smc-webapp/sagews/sagews.coffee
@@ -1669,15 +1669,27 @@ class SynchronizedWorksheet extends SynchronizedDocument2
                 obj = undefined
             if mesg.javascript.coffeescript
                 if not CoffeeScript?
-                    # DANGER: this is the only async code in process_output_mesg
-                    misc_page.load_coffeescript_compiler () =>
-                        sagews_eval(CoffeeScript?.compile(code), @, opts.element, undefined, obj, redux)
+                     # hotfix to catch problem #2752
+                    if false
+                        # DANGER: this is the only async code in process_output_mesg
+                        misc_page.load_coffeescript_compiler () =>
+                            sagews_eval(CoffeeScript?.compile(code), @, opts.element, undefined, obj, redux)
+                    else
+                        t = $('<div class="sagews-output-stderr">')
+                        t.html('''
+                               <div>
+                               <h4>Error: <code>%coffeescript</code> is currently broken.</h4>
+                               Please convert the block of code above to <code>%javascript</code>.
+                               See <a href="https://github.com/sagemathinc/cocalc/issues/2752">issue #2752</a> for more information.
+                               </div>
+                               ''')
+                        output.append(t)
                 else
                     # DANGER: this is the only async code in process_output_mesg
                     sagews_eval(CoffeeScript?.compile(code), @, opts.element, undefined, obj, redux)
             else
                 # The eval below is an intentional cross-site scripting vulnerability
-                # in the fundamental design of SMC.
+                # in the fundamental design of CoCalc.
                 # Note that there is an allow_javascript document option, which (at some point) users
                 # will be able to set.  There is one more instance of eval below in _receive_broadcast.
                 sagews_eval(code, @, opts.element, undefined, obj, redux)


### PR DESCRIPTION
Ref: #2757

not the prettiest thing, and it's also not a "fix", but existing worksheets do at least load up without showing control characters and a user learns about the problem

![screenshot from 2018-09-14 21-33-04](https://user-images.githubusercontent.com/207405/45573335-93c5e980-b86c-11e8-8775-1ef13f910681.png)
