### PR TITLE
syntax highlight R code in rnw and rtex files 

### DIFF
--- a/src/smc-webapp/codemirror/custom-modes.coffee
+++ b/src/smc-webapp/codemirror/custom-modes.coffee
@@ -73,7 +73,11 @@ CodeMirror.defineMode "rnw", (config) ->
         open       : /^<<.+?>>=/
         close      : /^@/
         mode       : CodeMirror.getMode(config, 'r')
-    return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "stex2"), block)
+    inline =
+        open  : "\\Sexpr{"
+        close : "}"
+        mode  : CodeMirror.getMode(config, 'r')
+    return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "stex2"), block, inline)
 
 CodeMirror.defineMode "rtex", (config) ->
     block =
@@ -81,7 +85,11 @@ CodeMirror.defineMode "rtex", (config) ->
         close      : /^%%\s+end\.rcode/
         indent     : '% '
         mode       : CodeMirror.getMode(config, 'r')
-    return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "stex2"), block)
+    inline =
+        open  : "\\rinline{"
+        close : "}"
+        mode  : CodeMirror.getMode(config, 'r')
+    return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "stex2"), block, inline)
 
 CodeMirror.defineMode "cython", (config) ->
     # FUTURE: need to figure out how to do this so that the name

--- a/src/smc-webapp/codemirror/custom-modes.coffee
+++ b/src/smc-webapp/codemirror/custom-modes.coffee
@@ -68,6 +68,21 @@ CodeMirror.defineMode "stex2", (config) ->
         mode  : CodeMirror.getMode(config, 'sagews')
     return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "stex"), options...)
 
+CodeMirror.defineMode "rnw", (config) ->
+    block =
+        open       : /^<<.+?>>=/
+        close      : /^@/
+        mode       : CodeMirror.getMode(config, 'r')
+    return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "stex2"), block)
+
+CodeMirror.defineMode "rtex", (config) ->
+    block =
+        open       : /^%%\s+begin\.rcode/
+        close      : /^%%\s+end\.rcode/
+        indent     : '% '
+        mode       : CodeMirror.getMode(config, 'r')
+    return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "stex2"), block)
+
 CodeMirror.defineMode "cython", (config) ->
     # FUTURE: need to figure out how to do this so that the name
     # of the mode is cython

--- a/src/smc-webapp/file-associations.coffee
+++ b/src/smc-webapp/file-associations.coffee
@@ -60,8 +60,8 @@ codemirror_associations =
     pyx    : 'python'
     r      : 'r'
     rmd    : 'rmd'
-    rnw    : 'stex2'
-    rtex   : 'stex2'
+    rnw    : 'rnw'
+    rtex   : 'rtex'
     rst    : 'rst'
     rb     : 'text/x-ruby'
     ru     : 'text/x-ruby'
@@ -132,13 +132,13 @@ file_associations['tex'] =
 file_associations['rnw'] =
     editor : 'latex'
     icon   : 'cc-icon-tex-file'
-    opts   : {mode:'stex2', indent_unit:4, tab_size:4}
+    opts   : {mode:'stex2', indent_unit:4, tab_size:4, mode:codemirror_associations['rnw']}
     name   : "R Knitr Rnw"
 
 file_associations['rtex'] =
     editor : 'latex'
     icon   : 'cc-icon-tex-file'
-    opts   : {mode:'stex2', indent_unit:4, tab_size:4}
+    opts   : {mode:'stex2', indent_unit:4, tab_size:4, mode:codemirror_associations['rtex']}
     name   : "R Knitr Rtex"
 
 file_associations['html'] =


### PR DESCRIPTION
ref #3047

test: rnw and rtex default files look ok (latex still highlighted). nothing else is touched.

what's actually a bit sad is the overall R syntax highlighting (i.e. no constants,etc.) → [made this pr](https://github.com/codemirror/CodeMirror/pull/5586) upstream.

obligatory screenshots

### rtex

![screenshot from 2018-09-20 17-16-25](https://user-images.githubusercontent.com/207405/45828603-3eb92600-bcf9-11e8-8c81-c2135b75bff9.png)

## rnw

![screenshot from 2018-09-20 17-16-42](https://user-images.githubusercontent.com/207405/45828624-48db2480-bcf9-11e8-94f7-0a71859196ec.png)

## .. and inline

![screenshot from 2018-09-20 17-48-24](https://user-images.githubusercontent.com/207405/45830455-71651d80-bcfd-11e8-9360-655e62e02135.png)


![screenshot from 2018-09-20 17-47-42](https://user-images.githubusercontent.com/207405/45830447-6ca06980-bcfd-11e8-9fa4-a88bfee8abd5.png)
