### PR TITLE
webapp/hub: increase default for user_search to 13 months and ignore "last active" for admins

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -982,7 +982,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     query += ', email_address'
                 query += ' FROM accounts'
                 query += " WHERE deleted IS NOT TRUE AND (#{where.join(' OR ')})"
-                if opts.active
+                if opts.active and not opts.admin
                     params.push(opts.active)
                     # name search only includes active users
                     query += " AND ((last_active >= NOW() - $#{i}::INTERVAL) OR (created >= NOW() - $#{i}::INTERVAL)) "

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -991,6 +991,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                 query += " ORDER BY last_active DESC NULLS LAST"
                 query += " LIMIT $#{i}::INTEGER"; i += 1
                 params.push(opts.limit)
+                dbg("query params=#{params}")
                 @_query
                     query  : query
                     params : params

--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -1369,7 +1369,7 @@ class exports.Connection extends EventEmitter
             query_id : -1     # So we can check that it matches the most recent query
             limit    : 20
             timeout  : DEFAULT_TIMEOUT
-            active   : '6 months'
+            active   : '13 months'
             admin    : false  # admins can do and admin version of the query, which returns email addresses and does substring searches on email
             cb       : required
 


### PR DESCRIPTION
this looks trivial, but I have to add that I haven't tested it so do not merge it without a check

* I indirectly noticed #3171 today because searching for a 2 year dormant user via email didn't give any results in the admin interface
* and well, then noticing  how the default is set, this makes it clear why #3171 is still an issue
* setting `{active:undefined or null}` for admin doesn't work, because the string as a default overwrites it ... hence I added the clause to the if  in the hub. (which requires a restart)