### PR TITLE
weabpp/lean: padding instead of margin around messages 

### DIFF
--- a/src/smc-webapp/frame-editors/lean-editor/lean-messages.tsx
+++ b/src/smc-webapp/frame-editors/lean-editor/lean-messages.tsx
@@ -253,7 +253,7 @@ class LeanMessages extends Component<Props, {}> {
       <div
         style={{
           overflowY: "auto",
-          margin: "0px 15px",
+          padding: "0px 15px",
           fontSize: this.props.font_size
         }}
       >


### PR DESCRIPTION
otherwise scrollbar looks odd

before

![screenshot from 2018-09-27 14-56-37](https://user-images.githubusercontent.com/207405/46149944-b8a65d80-c26b-11e8-9040-7e12e9c0ad2e.png)

after

![screenshot from 2018-09-27 14-57-09](https://user-images.githubusercontent.com/207405/46149952-bd6b1180-c26b-11e8-8507-31da131110c6.png)
