### PR TITLE
webapp errors: fix unhandledrejection error reporting

### DIFF
--- a/src/webapp-lib/webapp-error-reporter.coffee
+++ b/src/webapp-lib/webapp-error-reporter.coffee
@@ -295,7 +295,10 @@ if ENABLED and window.console?
     wrapFunction(console, "error", (-> sendLogLine("error", arguments)))
 
 if ENABLED
-    window.addEventListener("unhandledrejection",(e) -> reportException(e.reason,"unhandledrejection"))
+    window.addEventListener "unhandledrejection",(e) ->
+        # just to make sure there is a message
+        e.message ?= '<no message>'
+        reportException(e, "unhandledrejection")
 
 # public API
 


### PR DESCRIPTION
this fix is based on that below. the whole point is to report an exception `e` as `e`, and not `e.reason`.

---

chrome: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36`

smc_git_rev: 9dde507f765bbe78bafc6d00b22375271ebd1c16

Date: 2018-09-28 13:34:51.692758

`{"0":"misc.defaults -- TypeError: property 'message' must be specified: "}`

```
<generated>
Error
    at s (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:854984)
    at h (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:857629)
    at console.<anonymous> (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:857843)
    at console.e.(anonymous function) [as warn] (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:857706)
    at Object.t.defaults (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:1163709)
    at m (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:854311)
    at u (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:854032)
    at https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:857992
    at function.e._wrapper.e._wrapper (https://cocalc.com/static/smc-2bee88b0c9d7755adaa4.cacheme.js?2bee88b0c9d7755adaa4:5:855526)
```