### PR TITLE
webapp/latex: improve masking of pythontex cache dir 

### DIFF
--- a/src/smc-webapp/project_store.ts
+++ b/src/smc-webapp/project_store.ts
@@ -55,7 +55,7 @@ const MASKED_FILE_EXTENSIONS = {
   py: ["pyc"],
   java: ["class"],
   cs: ["exe"],
-  tex: "aux bbl blg fdb_latexmk fls glo idx ilg ind lof log nav out snm synctex.gz toc xyc synctex.gz(busy) sagetex.sage sagetex.sout sagetex.scmd sagetex.sage.py sage-plots-for-FILENAME pytxcode pythontex-files-BASENAME".split(
+  tex: "aux bbl blg fdb_latexmk fls glo idx ilg ind lof log nav out snm synctex.gz toc xyc synctex.gz(busy) sagetex.sage sagetex.sout sagetex.scmd sagetex.sage.py sage-plots-for-FILENAME pytxcode pythontex-files-BASEDASHNAME".split(
     " "
   ),
   rnw: ["tex", "NODOT-concordance.tex"],
@@ -513,6 +513,12 @@ function _compute_file_masks(listing) {
               mask_ext = "";
             } else if (mask_ext.indexOf("BASENAME") >= 0) {
               bn = mask_ext.replace("BASENAME", basename.slice(0, -1));
+              mask_ext = "";
+            } else if (mask_ext.indexOf("BASEDASHNAME") >= 0) {
+              // BASEDASHNAME is like BASENAME, but replaces spaces by dashes
+              // https://github.com/sagemathinc/cocalc/issues/3229
+              const fragment = basename.slice(0, -1).replace(/ /g, "-");
+              bn = mask_ext.replace("BASEDASHNAME", fragment);
               mask_ext = "";
             } else {
               bn = basename;


### PR DESCRIPTION
ref #3229

the overall goal is to have `pythontex-files-pytex-1` grayed out in the files listing:

![screenshot from 2018-10-01 12-17-00](https://user-images.githubusercontent.com/207405/46283233-1d1b3280-c574-11e8-8cfd-c5f4a9094652.png)
