### PR TITLE
Fix browser forward/back navigation

### DIFF
--- a/src/smc-webapp/history.coffee
+++ b/src/smc-webapp/history.coffee
@@ -110,7 +110,7 @@ exports.set_url = (url) ->
     analytics_pageview(window.location.pathname)
 
 # Now load any specific page/project/previous state
-exports.load_target = load_target = (target, ignore_kiosk=false) ->
+exports.load_target = load_target = (target, ignore_kiosk=false, change_history=true) ->
     misc = require('smc-util/misc')
     #if DEBUG then console.log("history/load_target: #{misc.to_json(arguments)}")
     if not target
@@ -119,18 +119,18 @@ exports.load_target = load_target = (target, ignore_kiosk=false) ->
     segments = target.split('/')
     switch segments[0]
         when 'help'
-            redux.getActions('page').set_active_tab('about')
+            redux.getActions('page').set_active_tab('about', change_history)
         when 'projects'
             require.ensure [], =>
                 if segments.length > 1
                     #if DEBUG then console.log("history/load_target → load_target: #{misc.to_json([segments.slice(1).join('/'), true, ignore_kiosk])}")
                     redux.getActions('projects').load_target(segments.slice(1).join('/'), true, ignore_kiosk)
                 else
-                    redux.getActions('page').set_active_tab('projects')
+                    redux.getActions('page').set_active_tab('projects', change_history)
         when 'settings'
             if not logged_in
                 return
-            redux.getActions('page').set_active_tab('account')
+            redux.getActions('page').set_active_tab('account', change_history)
             if segments[1] == 'account'
                 redux.getActions('account').set_active_tab('account')
             if segments[1] == 'billing'
@@ -145,8 +145,8 @@ exports.load_target = load_target = (target, ignore_kiosk=false) ->
         when 'file-use', 'admin'
             if not logged_in
                 return
-            redux.getActions('page').set_active_tab(segments[0])
+            redux.getActions('page').set_active_tab(segments[0], change_history)
 
 window.onpopstate = (event) ->
     #console.log("location: " + document.location + ", state: " + JSON.stringify(event.state))
-    load_target(decodeURIComponent(document.location.pathname.slice(window.app_base_url.length + 1)))
+    load_target(decodeURIComponent(document.location.pathname.slice(window.app_base_url.length + 1)), false, false)

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -130,28 +130,34 @@ class PageActions extends Actions
         require('./project/websocket/connect').disconnect_from_project(project_id)
 
         
-    set_active_tab: (key) =>
+    set_active_tab: (key, change_history=true) =>
         @setState(active_top_tab : key)
         switch key
             when 'projects'
-                history.set_url('/projects')
+                if change_history
+                    history.set_url('/projects')
                 set_window_title('Projects')
             when 'account'
-                redux.getActions('account').push_state()
+                if change_history
+                    redux.getActions('account').push_state()
                 set_window_title('Account')
             when 'about'
-                history.set_url('/help')
+                if change_history
+                    history.set_url('/help')
                 set_window_title('Help')
             when 'file-use'
-                history.set_url('/file-use')
+                if change_history
+                    history.set_url('/file-use')
                 set_window_title('File Usage')
             when 'admin'
-                history.set_url('/admin')
+                if change_history
+                    history.set_url('/admin')
                 set_window_title('Admin')
             when undefined
                 return
             else
-                redux.getProjectActions(key)?.push_state()
+                if change_history
+                    redux.getProjectActions(key)?.push_state()
                 set_window_title("Loading Project")
                 projects_store = redux.getStore('projects')
 


### PR DESCRIPTION
# Description
Forward/back browser navigation is currently broken. You can go back one action but can't go back anymore. Additionally forward is not possible.

The issue is that every `set_active_tab` call at the page level pushes onto the browser history stack.

This change adds an option for `load_target` and page level `set_active_tab` to not push onto browser history.
Changed `window.onpopstate` to pass `change_history=false` to `load_target` so that forward and back don't alter the history stack.

# Testing Steps
1. Go to account settings
1. Go to Projects 
1. Open a project
1. Use forward and back on your browser to navigate the previous 3 actions.

# Relevant Issues
Couldn't find an issue.