### PR TITLE
webapp: project uptime also in day resolution

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -1532,6 +1532,18 @@ exports.round2 = round2 = (num) ->
     # padding to fix floating point issue (see http://stackoverflow.com/questions/11832914/round-to-at-most-2-decimal-places-in-javascript)
     Math.round((num + 0.00001) * 100) / 100
 
+seconds2hms_days = (d, h, m, longform) ->
+    h = h % 24
+    s = h * 60 * 60 + m * 60
+    if s > 0
+        x = seconds2hms(s, longform, show_seconds=false)
+    else
+        x = ''
+    if longform
+        return "#{d} #{exports.plural(d, 'day')} #{x}".trim()
+    else
+        return "#{d}d#{x}"
+
 # like seconds2hms, but only up to minute-resultion
 exports.seconds2hm = seconds2hm = (secs, longform) ->
     return seconds2hms(secs, longform, false)
@@ -1547,6 +1559,10 @@ exports.seconds2hms = seconds2hms = (secs, longform, show_seconds=true) ->
         s = Math.round(secs % 60)
     m = Math.floor(secs / 60) % 60
     h = Math.floor(secs / 60 / 60)
+    d = Math.floor(secs / 60 / 60 / 24)
+    # for more than one day, special routine (ignoring seconds altogehter)
+    if d > 0
+        return seconds2hms_days(d, h, m, longform)
     if (h == 0 and m == 0) and show_seconds
         if longform
             return "#{s} #{exports.plural(s, 'second')}"

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -92,6 +92,9 @@ describe "sinon", ->
 describe 'seconds2hms', ->
     s2hms = misc.seconds2hms
     s2hm  = misc.seconds2hm
+    m = 60 # one minute
+    h = 60 * m # one hour
+    d = 24 * h # one day
     it 'converts to short form', ->
         expect(s2hms(0)).toEqual '0s'
         expect(s2hms(60)).toEqual '1m0s'
@@ -117,6 +120,16 @@ describe 'seconds2hms', ->
         expect(s2hm(3601, true)).toEqual '1 hour'
         expect(s2hm(7300, true)).toEqual '2 hours 1 minute'
         expect(s2hm(36000, true)).toEqual '10 hours'
+    it 'converts to short form in days resolution', ->
+        expect(s2hm(d + 2 * h + 1 * m)).toEqual '1d2h1m'
+        expect(s2hm(21 * d + 19 * h - 1)).toEqual '21d18h59m'
+        expect(s2hm(1 * d)).toEqual '1d'
+        expect(s2hm(1 * d + 3 * m)).toEqual '1d3m'
+    it 'converts to long form in hour days resolution', ->
+        expect(s2hm(1 * d + 2 * h + 1 * m, true)).toEqual '1 day 2 hours 1 minute'
+        expect(s2hm(21 * d + 19 * h - 1, true)).toEqual '21 days 18 hours 59 minutes'
+        expect(s2hm(1 * d, true)).toEqual '1 day'
+        expect(s2hm(1 * d + 3 * m, true)).toEqual '1 day 3 minutes'
 
 describe 'startswith', ->
     startswith = misc.startswith


### PR DESCRIPTION
This extends the `seconds2hms` utility function to also account for days if it is more than one day.

test: in `src/smc-util`, all tests for misc should pass: `export NODE_ENV=mocha-test && SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc-test.coffee`