### PR TITLE
webapp: support adb ada files

### DIFF
--- a/src/smc-webapp/codemirror/mode/ada.ts
+++ b/src/smc-webapp/codemirror/mode/ada.ts
@@ -1,0 +1,41 @@
+import * as CodeMirror from "codemirror";
+
+// Little first step for Ada
+
+// This is redundant with the regexp's below, but we need this to do completions
+// before the terms are ever used.
+export const completions: string[] = "abort|else|new|return|abs|elsif|not|reverse|abstract|end|null|accept|entry|select|access|exception|of|separate|aliased|exit|or|some|all|others|subtype|and|for|out|synchronized|array|function|overriding|at|tagged|generic|package|task|begin|goto|pragma|terminate|body|private|then|if|procedure|type|case|in|protected|constant|interface|until|is|raise|use|declare|range|delay|limited|record|when|delta|loop|rem|while|digits|renames|with|do|mod|requeue|xor".split(
+  "|"
+);
+completions.sort();
+
+(CodeMirror as any).defineSimpleMode("ada", {
+  start: [
+    { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: "string" },
+    { regex: /--.*/, token: "comment" },
+    { regex: /[-+\/*=<>!:]+/, token: "operator" },
+    {
+      regex: /\b(abort|else|new|return|abs|elsif|not|reverse|abstract|end|null|accept|entry|select|access|exception|of|separate|aliased|exit|or|some|all|others|subtype|and|for|out|synchronized|array|function|overriding|at|tagged|generic|package|task|begin|goto|pragma|terminate|body|private|then|if|procedure|type|case|in|protected|constant|interface|until|is|raise|use|declare|range|delay|limited|record|when|delta|loop|rem|while|digits|renames|with|do|mod|requeue|xor)\b/,
+      token: "atom"
+    },
+    {
+      regex: /0x[a-f\d]+|[-+]?(?:\.\d+|\d+\.?\d*)(?:e[-+]?\d+)?/i,
+      token: "number"
+    },
+    { regex: /(if|elseif|case|when|begin|while|loop)/, indent: true },
+    { regex: /(end)/, dedent: true },
+    {
+      regex: /\b([A-Za-z_0-9]+)\b/,
+      token: "variable-3"
+    },
+    { regex: /b?"/, token: "string", next: "string" }
+  ],
+  string: [
+    { regex: /"/, token: "string", next: "start" },
+    { regex: /(?:[^\\"]|\\(?:.|$))*/, token: "string" }
+  ],
+  meta: {
+    dontIndentStates: ["comment"],
+    lineComment: "--"
+  }
+});

--- a/src/smc-webapp/codemirror/modes.coffee
+++ b/src/smc-webapp/codemirror/modes.coffee
@@ -101,3 +101,5 @@ require('./mode/pari.js')
 require('./mode/mediawiki/mediawiki.js')
 
 require('./mode/lean')
+
+require('./mode/ada.ts')

--- a/src/smc-webapp/file-associations.coffee
+++ b/src/smc-webapp/file-associations.coffee
@@ -8,6 +8,7 @@ via the newer registration system.
 ###
 
 codemirror_associations =
+    adb    : 'ada'
     c      : 'text/x-c'
     'c++'  : 'text/x-c++src'
     cql    : 'text/x-sql'


### PR DESCRIPTION
well, when we install the compiler, we should also support file formatting. this is closely modeled after the lean file. good enough for the very basics.

![screenshot from 2018-10-05 16-45-06](https://user-images.githubusercontent.com/207405/46542198-254dd780-c8be-11e8-8f09-cb870d46f8d1.png)
