### PR TITLE
webapp: handle objects occurring as unhandledrejection reasons

### DIFF
--- a/src/webapp-lib/webapp-error-reporter.coffee
+++ b/src/webapp-lib/webapp-error-reporter.coffee
@@ -299,7 +299,7 @@ if ENABLED
         # just to make sure there is a message
         reason = e.reason ? '<no reason>'
         if typeof(reason) == 'object'
-            reason = misc.trunc_middle(misc.to_json(reason), 1000)
+            reason = "${reason.stack ? reason.message ? ''}"
         e.message = "unhandledrejection: #{reason}"
         reportException(e, "unhandledrejection")
 

--- a/src/webapp-lib/webapp-error-reporter.coffee
+++ b/src/webapp-lib/webapp-error-reporter.coffee
@@ -297,7 +297,10 @@ if ENABLED and window.console?
 if ENABLED
     window.addEventListener "unhandledrejection",(e) ->
         # just to make sure there is a message
-        e.message = "unhandledrejection: #{e.reason ? '<no reason>'}"
+        reason = e.reason ? '<no reason>'
+        if typeof(reason) == 'object'
+            reason = misc.trunc_middle(misc.to_json(reason), 1000)
+        e.message = "unhandledrejection: #{reason}"
         reportException(e, "unhandledrejection")
 
 # public API


### PR DESCRIPTION
Since d1100d5931c2080039388778115ab8ae062aaa1e, which includes an earlier fix about handling these type of intercepted problems, "reason" messages of unhandledrejection errors are reported as `unhandledrejection: [object Object]`. The goal of this patch is to get more info about that object.