### PR TITLE
webapp/latex: build_logs could be undefined

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -202,6 +202,7 @@ export class Actions extends BaseActions<LatexEditorState> {
 
   check_for_fatal_error(): void {
     const build_logs: BuildLogs = this.store.get("build_logs");
+    if (!build_logs) return;
     const errors = build_logs.getIn(["latex", "parse", "errors"]);
     if (errors === undefined || errors.size < 1) return;
     const last_error = errors.get(errors.size - 1);


### PR DESCRIPTION
# Description

see issue #3262

# Testing Steps
I don't know how to reproduce this, must be some sort of race condition.

# Relevant Issues

#3262

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
