### PR TITLE
webapp: remove bootstrap, in favor of just using react-bootstrap

### DIFF
--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -27,7 +27,6 @@
     "async-await-utils": "^2.0.4",
     "awaiting": "^3.0.0",
     "bootbox": "^4.4.0",
-    "bootstrap": "^3.3.6",
     "bootstrap-colorpicker": "^2.3.6",
     "chai": "^4.1.2",
     "codemirror": "^5.39.0",

--- a/src/webapp-smc.coffee
+++ b/src/webapp-smc.coffee
@@ -44,7 +44,7 @@ require('jquery-caret')
 require("jquery.payment")
 
 # Bootstrap
-require('bootstrap')
+require('react-bootstrap')
 
 # Bootbox: usable dialogs for bootstrap
 require("script-loader!bootbox/bootbox.min.js")  # loads from smc-webapp/node_modules


### PR DESCRIPTION

# Description

see issue #1872, the referenced upstream ticket is closed and someone reported that bootstrap removal as the solution.

basically this is a double-bootstrapping problem.

# Testing Steps
I did very little testing, just confirmed that #1872 is fixed. My fear is there could be unrelated problems. However, I'm pretty sure importing `react-bootstrap` does also introduce some code and css in such a way, that it might be fine just the way it is. 

