### PR TITLE
webapp/jupyter2: do not call api when path is not known -- issue #3216

### DIFF
--- a/src/smc-webapp/jupyter/actions.ts
+++ b/src/smc-webapp/jupyter/actions.ts
@@ -265,8 +265,10 @@ export class JupyterActions extends Actions<JupyterStoreState> {
     if (this._state === "closed") {
       throw Error("closed");
     }
+    const path = this.store.get("path");
+    if (!path) throw Error("path unknown");
     return await (await this.init_project_conn()).api.jupyter(
-      this.store.get("path"),
+      path,
       endpoint,
       query,
       timeout_ms


### PR DESCRIPTION
# Description
Fixing an uncaught exception

# Testing Steps
I don't know how to reproduce. Maybe by opening a jupyter file and closing it quickly?

# Relevant Issues
That whole fix is based on some thoughts outlined in #3216 

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
