### PR TITLE
Terminal scrollbar padding

### DIFF
--- a/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
@@ -109,7 +109,7 @@ export class TerminalFrame extends Component<Props, {}> {
     return (
       <div
         className={"smc-vfill"}
-        style={{ backgroundColor: color, padding: "4px" }}
+        style={{ backgroundColor: color, padding: "0 0 0 4px" }}
         onClick={() => {
           /* otherwise, clicking right outside term defocuses,
              which is confusing */


### PR DESCRIPTION
# Description

This adjust the padding of the terminal panel, such that the scrollbar doesn't look like it is floating free. In the screenshots, I switched to a dark background to make the difference clearly visible.

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [x] Screenshots if relevant.

## before

![screenshot from 2018-10-16 10-49-36](https://user-images.githubusercontent.com/207405/47004349-a82e2800-d131-11e8-8520-e2a4c79603e3.png)

## after

![screenshot from 2018-10-16 10-51-02](https://user-images.githubusercontent.com/207405/47004347-a82e2800-d131-11e8-8b9c-b7779173a15e.png)

