### PR TITLE
webapp/latex: build cmd could be uninitialized

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/build-command.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/build-command.tsx
@@ -1,4 +1,3 @@
-
 /*
 Customization and selection of the build command.
 
@@ -57,9 +56,13 @@ export class BuildCommand extends Component<Props, State> {
     }
   }
 
-  build_command_string(cmd: string | List<string>): string {
+  // cmd could be undefined -- https://github.com/sagemathinc/cocalc/issues/3290
+  build_command_string(cmd: string | List<string> | undefined): string {
     let s: string;
-    if (typeof cmd === "string") {
+    if (cmd == null) {
+      // cmd is not initialized, see actions._init_config
+      return "";
+    } else if (typeof cmd === "string") {
       s = cmd;
     } else {
       let v: string[] = [];


### PR DESCRIPTION
# Description
See #3290 

# Testing Steps
I don't know how to trigger it, but my interpretation of the stacktrace  suggests that (very early) the build command isn't initialized. I added that as a case.

I guess these two cases should be tested:
* new document shows default build command
* reloading document with modified build command shows the modified one

# Relevant Issues
 #3290

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
