### PR TITLE
webapp/jupyter: add button to restart and run all cells

### DIFF
--- a/src/smc-webapp/jupyter/commands.ts
+++ b/src/smc-webapp/jupyter/commands.ts
@@ -165,6 +165,7 @@ export function commands(actions: any) {
 
     "confirm restart kernel and run all cells": {
       m: "Restart and run all...",
+      i: 'forward',
       f() {
         // TODO: async/await?
         actions.confirm_dialog({

--- a/src/smc-webapp/jupyter/top-buttonbar.tsx
+++ b/src/smc-webapp/jupyter/top-buttonbar.tsx
@@ -182,6 +182,7 @@ export class TopButtonbar0 extends Component<TopButtonbarProps> {
       { name: "run cell and select next", label: "Run" },
       { name: "interrupt kernel", style: stop_style },
       "confirm restart kernel",
+      "confirm restart kernel and run all cells",
       { name: "tab key", label: "Tab" }
     ]);
   }


### PR DESCRIPTION
# Description
Button to restart kernel and run all cells. 

# Testing Steps
1. clicking the button does the same as calling it from the menu

# Relevant Issues
#3095 and https://github.com/jupyter/notebook/pull/2965

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
