### PR TITLE
webapp: middle mouse click to close editor and project tabs

### DIFF
--- a/src/smc-webapp/project/file-tab.cjsx
+++ b/src/smc-webapp/project/file-tab.cjsx
@@ -67,6 +67,11 @@ exports.FileTab = rclass
         else
             actions.set_active_tab(@props.name)
 
+    # middle mouse click closes
+    onMouseDown: (e) ->
+        if e.button == 1
+            @close_file(e, misc.tab_to_path(@props.name))
+
     render : ->
         styles = {}
 
@@ -112,10 +117,11 @@ exports.FileTab = rclass
             content = <Tip title={@props.tooltip} stable={true} placement={'bottom'} size={'small'}> {content} </Tip>
 
         <NavItem
-            ref     = 'tab'
-            style   = {styles}
-            active  = {@props.is_active}
-            onClick = {@click}
+            ref         = 'tab'
+            style       = {styles}
+            active      = {@props.is_active}
+            onClick     = {@click}
+            onMouseDown = {@onMouseDown}
         >
             <div style={width:'100%', color:text_color, cursor : 'pointer'}>
                 <div style={x_button_styles}>

--- a/src/smc-webapp/projects_nav.cjsx
+++ b/src/smc-webapp/projects_nav.cjsx
@@ -72,14 +72,21 @@ ProjectTab = rclass
         @refs.tab?.node.children[0].removeAttribute('href')
     componentDidMount: ->
         @strip_href()
+        document.addEventListener('mousedown', @onMouseDown)
     componentDidUpdate: () ->
         @strip_href()
-
+    componentWillUnmount: () ->
+       document.removeEventListener('mousedown', @onMouseDown)
 
     close_tab: (e) ->
         e.stopPropagation()
         e.preventDefault()
         @actions('page').close_project_tab(@props.project_id)
+
+    # middle mouse click closes
+    onMouseDown: (e) ->
+        if e.button == 1
+            @close_tab(e)
 
     render: ->
         title  = @props.project?.get('title') ? @props.public_project_titles?.get(@props.project_id)


### PR DESCRIPTION
# Description
middle mouse click to close editor and project tabs. this is then consistent with many other tab-based applications.

# Testing Steps
1. middle mouse click on an editor tab → closes it
1. middle mouse click on a project tab → closes it

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
