### PR TITLE
Pytest update for 2018-10-29

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -4298,7 +4298,7 @@ def julia(code=None, **kwargs):
 
     """
     if julia.jupyter_kernel is None:
-        julia.jupyter_kernel = jupyter("julia")
+        julia.jupyter_kernel = jupyter("julia-0.7")
     return julia.jupyter_kernel(code, **kwargs)
 
 

--- a/src/smc_sagews/smc_sagews/tests/test_00_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_00_timing.py
@@ -142,6 +142,6 @@ class TestStartSageServer:
 
         # check timing
         print("elapsed 2+2 %s"%elapsed)
-        assert elapsed < 15.0
+        assert elapsed < 25.0
 
         return

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -29,7 +29,7 @@ class TestLex:
 class TestSageVersion:
     def test_sage_vsn(self, exec2):
         code = "sage.misc.banner.banner()"
-        patn = "version 8.3"
+        patn = "version 8.[34]"
         exec2(code, pattern = patn)
 
 class TestDecorators:

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -29,7 +29,7 @@ class TestLex:
 class TestSageVersion:
     def test_sage_vsn(self, exec2):
         code = "sage.misc.banner.banner()"
-        patn = "version 8.[34]"
+        patn = "version 8.4"
         exec2(code, pattern = patn)
 
 class TestDecorators:

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -6,6 +6,10 @@ import re
 import os
 from textwrap import dedent
 
+class TestLatexMode:
+    def test_latex(self, execblob):
+        execblob("%latex\nhello", want_html = False, file_type='png', ignore_stdout = True)
+
 class TestP3Mode:
     """
     not the same as python3 mode, which is an alias for anaconda3
@@ -17,7 +21,7 @@ class TestP3Mode:
 
 class TestSingularMode:
     def test_singular_version(self, exec2):
-        exec2('%singular_kernel\nsystem("version");','4103\n')
+        exec2('%singular_kernel\nsystem("version");',pattern=r"^41\d\d\b")
     def test_singular_factor_polynomial(self, exec2):
         code = dedent('''
         %singular_kernel
@@ -119,6 +123,7 @@ class TestPython3DefaultMode:
     def test_capture_p3d_02(self, exec2):
         exec2("%sage\nprint(output)", "99\n")
 
+#@pytest.mark.skip(reason="bash mode ng for sage-8.4")
 class TestShMode:
     def test_start_sh(self, exec2):
         code = "%sh\ndate +%Y-%m-%d"
@@ -157,6 +162,7 @@ class TestShMode:
     def test_bad_command(self, exec2):
         exec2("%sh xyz", pattern="command not found")
 
+#@pytest.mark.skip(reason="bash mode ng for sage-8.4")
 class TestShDefaultMode:
     def test_start_sh_dflt(self, exec2):
         exec2("%default_mode sh")

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -278,5 +278,5 @@ class TestJuliaMode:
         exec2('%julia\nquadratic(a, sqr_term, b) = (-b + sqr_term) / 2a\nquadratic(2.0, -2.0, -12.0)', '2.5', timeout=40)
 
     def test_julia_version(self, exec2):
-        exec2("%julia\nVERSION", pattern='"0.6.3"', timeout=40)
+        exec2("%julia\nVERSION", pattern='v"0.7.0"', timeout=40)
 

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -123,7 +123,6 @@ class TestPython3DefaultMode:
     def test_capture_p3d_02(self, exec2):
         exec2("%sage\nprint(output)", "99\n")
 
-#@pytest.mark.skip(reason="bash mode ng for sage-8.4")
 class TestShMode:
     def test_start_sh(self, exec2):
         code = "%sh\ndate +%Y-%m-%d"
@@ -162,7 +161,6 @@ class TestShMode:
     def test_bad_command(self, exec2):
         exec2("%sh xyz", pattern="command not found")
 
-#@pytest.mark.skip(reason="bash mode ng for sage-8.4")
 class TestShDefaultMode:
     def test_start_sh_dflt(self, exec2):
         exec2("%default_mode sh")


### PR DESCRIPTION
Ready for review
~~Marked "work in progress" until new compute image is deployed (see below).~~

# Description

update sagews pytest suite for compute image updates
- julia 1.x
- sage 8.3 or 8.4
- singular 41xx
- add simple test for %latex mode

# Testing Steps
1. select *experimental* compute image if before Monday, Oct 29
1. cd ~/cocalc/src/smc_sagews/smc_sagews/tests
1. python -m pytest

# Relevant Issues

#3302 for %latex

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.
- [x] A list of exact steps on how you tested.
- [NA] Screenshots if relevant.
