### PR TITLE
Static landing pages improvements

### DIFF
--- a/src/webapp-lib/_base.pug
+++ b/src/webapp-lib/_base.pug
@@ -117,8 +117,8 @@ html.no-js(lang="en")
             //- li
             //-   a(href=PREFIX + "#a-explore") Explore
 
-            li(class=navbar_highlight("policies"))
-              a(href=PREFIX + "policies/index.html") Policies
+            li(class=navbar_highlight('features'))
+              a(href=PREFIX + "doc/features.html") Features
 
             if htmlWebpackPlugin.options.COMP_ENV
               li(class=navbar_highlight('software'))
@@ -129,6 +129,10 @@ html.no-js(lang="en")
 
             li(class=navbar_highlight('api'))
               a(href=PREFIX + "doc/api.html") API
+
+            li(class=navbar_highlight("policies"))
+              a(href=PREFIX + "policies/index.html") Policies
+
             li
               a.get-started(href=PREFIX + "app") Sign In
 

--- a/src/webapp-lib/doc/features.pug
+++ b/src/webapp-lib/doc/features.pug
@@ -1,23 +1,49 @@
-//- feature page
+//- for development, run $ env CC_COMP_ENV=true CC_STATICPAGES=true npm run webpack-debug
 
 extends ../_base.pug
 
 block vars
-  - subtitle = "Features"
+  -
+    navbar_active = 'features';
+    subtitle = NAME + " Special Features";
 
 block header
   meta(name="description" content=NAME + " Features")
 
 block content
-  a.anchor#a-top
-  div.container
-    div.row#top
-      h1 Features
 
-
-  //- CSS comes at the bottom: overwrites styles defined in the header
   style
     :sass
       @import "smc-webapp/_colors.sass"
-      div#top
-        margin           : 5rem 0
+      div.row#top
+        min-height: 50vh
+        ul
+          li
+            margin-top    : 10px
+            margin-bottom : 10px
+            a
+              font-weight   : bold
+              padding-right : 10px
+
+  a.anchor#a-top
+  div.container
+    div.row#top
+      h1 #{NAME} Features
+      div= "These pages feature in-depth explanations about what " + NAME + " is able to do."
+      ul
+        li
+          a(href='jupyter-notebook.html') Jupyter Notebooks:
+          span #{NAME} offers a platform-specific edition of notebooks with real-time collaboration, chat, and precise edit-history
+
+        li
+          a(href='r-statistical-software.html') R statistical software:
+          span notebook, command-line, LaTeX with Knitr and RMarkdown, and much more
+
+        li
+          a(href='latex-editor.html') LaTeX Editor:
+          span learn how #{NAME}'s LaTeX editor can help you being a productive author online
+
+        li
+          span There is much more to explore. Just to name a few, there are Sage Worksheets, Course management, Task management, Chat, etc.
+
+

--- a/src/webapp-lib/doc/latex-editor.pug
+++ b/src/webapp-lib/doc/latex-editor.pug
@@ -280,9 +280,9 @@ block content
           div.
             You can configure if your published files should be listed publicly, or rather only be available via a confidential URL.
 
-  div
-    div.container
-      div.row
-        div.col-sm-12.center(style="margin-top: 6rem")
-          +start_button
 
+  div.container
+    div.row(style="margin-top: 6rem")
+      +start_free
+      div.col-sm-12.center
+        +start_button

--- a/src/webapp-lib/doc/software.pug
+++ b/src/webapp-lib/doc/software.pug
@@ -8,24 +8,9 @@ block vars
     subtitle = NAME + " Software Environments";
 
 block header
-  meta(name="description" content=NAME + " Features")
+  meta(name="description" content=NAME + " Software Environments")
 
 block content
-  a.anchor#a-top
-  div.container
-    div.row#top
-      h1 Available Software
-      div= "These pages contain information about available software on " + NAME + "."
-      ul
-        li
-          a(href='software-executables.html') Executables
-        li
-          a(href='software-python.html') Python Libraries
-        li
-          a(href='software-r.html') R Statistical Software Libraries
-        li
-          a(href='software-julia.html') Julia Libraries
-
 
   style
     :sass
@@ -36,3 +21,26 @@ block content
           li
             margin-top    : 10px
             margin-bottom : 10px
+            a
+              font-weight: bold
+          span
+            padding-left  : 10px
+
+  a.anchor#a-top
+  div.container
+    div.row#top
+      h1 Available Software
+      div= "These pages contain information about available software on " + NAME + "."
+      ul
+        li
+          a(href='software-executables.html') Executables:
+          span (subset) of all available software on #{NAME}
+        li
+          a(href='software-python.html') Python Libraries:
+          span see what libraries in which environments #{NAME} offers and their versions
+        li
+          a(href='software-r.html') R Statistical Software Packages
+          span #{NAME} maintains an extensive set of R packages
+        li
+          a(href='software-julia.html') Julia Libraries
+          span installed libraries for Julia


### PR DESCRIPTION
# Description
The main aspect of this patch is to introduce a "Features" page pointing to the special latex, R and jupyter notebook pages. I think the wording needs to be fixed a little bit.

# Testing Steps
The pages should still compile. It did work fine for me...


### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [x] Screenshots if relevant.

![screenshot from 2018-10-25 21-25-17](https://user-images.githubusercontent.com/207405/47525225-fdd6a300-d89c-11e8-952d-b4c9ebe41537.png)

