### PR TITLE
webapp/project: enable XML editor for kml and cml and also formatting

### DIFF
--- a/src/smc-webapp/file-associations.coffee
+++ b/src/smc-webapp/file-associations.coffee
@@ -82,6 +82,8 @@ codemirror_associations =
     bib    : 'stex'
     bbl    : 'stex'
     xml    : 'xml'
+    cml    : 'xml'  # http://www.xml-cml.org/, e.g. used by avogadro
+    kml    : 'xml'  # https://de.wikipedia.org/wiki/Keyhole_Markup_Language
     xsl    : 'xsl'
     ''     : 'text'
 

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1655,6 +1655,8 @@ export class Actions<T = CodeEditorState> extends BaseActions<
         parser = "html-tidy";
         break;
       case "xml":
+      case "cml":
+      case "kml":
         parser = "xml-tidy";
         break;
       case "c":

--- a/src/smc-webapp/frame-editors/code-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/code-editor/editor.ts
@@ -21,6 +21,8 @@ const FORMAT = set([
   "yml",
   "yaml",
   "xml",
+  "cml" /* that's xml */,
+  "kml" /* geodata keyhole markup, also xml */,
   "c",
   "c++",
   "cc",

--- a/src/smc-webapp/frame-editors/codemirror/cm-options.ts
+++ b/src/smc-webapp/frame-editors/codemirror/cm-options.ts
@@ -266,7 +266,10 @@ export function cm_options(
     matchBrackets: opts.match_brackets,
     autoCloseBrackets: opts.auto_close_brackets && !["hs", "lhs"].includes(ext), //972
     autoCloseTags:
-      opts.mode.indexOf("xml") !== -1 || opts.mode.indexOf("html") !== -1
+      opts.mode.indexOf("xml") !== -1 ||
+      opts.mode.indexOf("html") !== -1 ||
+      opts.mode.indexOf("cml") !== -1 ||
+      opts.mode.indexOf("kml") !== -1
         ? opts.auto_close_xml_tags
         : undefined,
     autoCloseLatex:
@@ -310,7 +313,7 @@ export function cm_options(
   } else {
     // options.theme MUST be set to something because this code is in CodeMirror
     //    cm.options.theme.replace...
-    options.theme = 'default';
+    options.theme = "default";
   }
 
   return options;

--- a/src/smc-webapp/frame-editors/frame-tree/util.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/util.ts
@@ -56,5 +56,7 @@ export const PRETTIER_SUPPORT = {
   "c++": true, // --*--
   cpp: true, // --*--
   h: true, // --*--
-  xml: true // tidy
+  xml: true, // tidy
+  cml: true, // tidy for xml
+  kml: true // tidy for xml
 };


### PR DESCRIPTION
# Description
This patch tells cocalc to use the XML editor for kml and cml files.
* https://en.wikipedia.org/wiki/Keyhole_Markup_Language … for GIS
* http://www.xml-cml.org/ ... chemistry, e.g. used by https://avogadro.cc/

# Testing Steps
There isn't much to test.
1. files ending in cml or kml open with the xml editor (syntax highlighting)
2. clicking the format button formats using xml

Example content: see the wikipedia page for kml and the other one for files like

```
<molecule xmlns='http://www.xml-cml.org/schema'>
  <atom>
    <bond>
      <molecule />
    </bond>
  </atom>
</molecule>
```

it's just xml though. 

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
