### PR TITLE
format bib files via biber

### DIFF
--- a/src/smc-project/formatters/bib-format.ts
+++ b/src/smc-project/formatters/bib-format.ts
@@ -1,0 +1,86 @@
+const { writeFile, readFile, unlink } = require("fs");
+const tmp = require("tmp");
+const { callback } = require("awaiting");
+const { spawn } = require("child_process");
+const { execute_code } = require("smc-util-node/execute-code");
+const {
+  callback_opts
+} = require("smc-webapp/frame-editors/generic/async-utils");
+
+interface ParserOptions {
+  parser: string;
+}
+
+// ref: man biber
+
+async function biber(input_path, output_path) {
+  const args = [
+    "--tool",
+    "--output-align",
+    "--output-indent=2",
+    "--output-fieldcase=lower",
+    "--output-file",
+    output_path,
+    input_path
+  ];
+
+  return await callback_opts(execute_code)({
+    command: "biber",
+    args: args,
+    err_on_exit: false,
+    bash: false,
+    timeout: 20
+  });
+}
+
+export async function bib_format(
+  input: string,
+  options: ParserOptions,
+  logger: any
+): Promise<string> {
+  // create input temp file
+  const input_path: string = await callback(tmp.file);
+  const output_path: string = await callback(tmp.file);
+  try {
+    await callback(writeFile, input_path, input);
+
+    // spawn the bibtex formatter
+    let bib_formatter;
+    try {
+      switch (options.parser) {
+        case "bib-biber":
+          bib_formatter = await biber(input_path, output_path);
+          break;
+        default:
+          throw Error(`Unknown XML formatter utility '${options.parser}'`);
+      }
+    } catch (e) {
+      logger.debug(`Calling Bibtex formatter raised ${e}`);
+      throw new Error(
+        `Bibtex formatter broken or not available. Is '${
+          options.parser
+        }' installed?`
+      );
+    }
+
+    const { exit_code, stdout, stderr } = bib_formatter;
+    const code = exit_code;
+
+    const problem = code >= 1;
+    if (problem) {
+      const msg = `Bibtex formatter "${
+        options.parser
+      }" exited with code ${code}\nOutput:\n${stdout}\n${stderr}`;
+      throw Error(msg);
+    }
+
+    // all fine, we read from the temp file
+    let output: Buffer = await callback(readFile, output_path);
+    let s: string = output.toString("utf-8");
+    return s;
+  } finally {
+    // logger.debug(`bibtex formatter done, unlinking ${input_path}`);
+    unlink(input_path);
+    unlink(output_path);
+  }
+}

--- a/src/smc-project/formatters/prettier.ts
+++ b/src/smc-project/formatters/prettier.ts
@@ -20,6 +20,7 @@ const { latex_format } = require("./latex-format");
 const { python_format } = require("./python-format");
 const { html_format } = require("./html-format");
 const { xml_format } = require("./xml-format");
+const { bib_format } = require("./bib-format");
 const { r_format } = require("./r-format");
 const { clang_format } = require("./clang-format");
 const { gofmt } = require("./gofmt");
@@ -87,6 +88,9 @@ export async function run_prettier_string(
       break;
     case "xml-tidy":
       pretty = await xml_format(str, options, logger);
+      break;
+    case "bib-biber":
+      pretty = await bib_format(str, options, logger);
       break;
     case "clang-format":
       const ext = misc.filename_extension(path !== undefined ? path : "");

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1659,6 +1659,9 @@ export class Actions<T = CodeEditorState> extends BaseActions<
       case "kml":
         parser = "xml-tidy";
         break;
+      case "bib":
+        parser = "bib-biber";
+        break;
       case "c":
       case "c++":
       case "cc":

--- a/src/smc-webapp/frame-editors/code-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/code-editor/editor.ts
@@ -27,7 +27,8 @@ const FORMAT = set([
   "c++",
   "cc",
   "cpp",
-  "h"
+  "h",
+  "bib"
 ]);
 
 export const cm = {

--- a/src/smc-webapp/frame-editors/codemirror/cm-options.ts
+++ b/src/smc-webapp/frame-editors/codemirror/cm-options.ts
@@ -239,7 +239,8 @@ export function cm_options(
     "c++",
     "cc",
     "cpp",
-    "h"
+    "h",
+    "bib"
   ];
   if (tab2exts.includes(ext)) {
     opts.tab_size = opts.indent_unit = 2;

--- a/src/smc-webapp/frame-editors/frame-tree/util.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/util.ts
@@ -58,5 +58,6 @@ export const PRETTIER_SUPPORT = {
   h: true, // --*--
   xml: true, // tidy
   cml: true, // tidy for xml
-  kml: true // tidy for xml
+  kml: true, // tidy for xml
+  bib: true // via biber --tool
 };


### PR DESCRIPTION
# Description
this is modeled after the xml formatter, which we streamlined to use cocalc's execute function.

# Testing Steps
1. this only concerns a `.bib` file, which should have a format button.

# Relevant Issues
issue #3315

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
