### PR TITLE
support rmarkdown notebook html files

### DIFF
--- a/src/smc-webapp/frame-editors/html-editor/iframe-html.tsx
+++ b/src/smc-webapp/frame-editors/html-editor/iframe-html.tsx
@@ -8,6 +8,7 @@ import { is_safari } from "../generic/browser";
 import { is_different, list_alternatives } from "../generic/misc";
 import { throttle } from "underscore";
 import { Component, React, ReactDOM, Rendered } from "../../app-framework";
+import { change_filename_extension } from "../generic/misc";
 
 import * as CSS from "csstype";
 
@@ -29,7 +30,7 @@ interface PropTypes {
   mode: "rmd" | undefined;
   style?: any;
   derived_file_types: Set<string>;
-} // should be static; change does NOT cause update.
+} // style should be static; change does NOT cause update.
 
 export class IFrameHTML extends Component<PropTypes, {}> {
   shouldComponentUpdate(next): boolean {
@@ -101,19 +102,24 @@ export class IFrameHTML extends Component<PropTypes, {}> {
   }
 
   render_iframe() {
+    let path = this.props.path;
     if (
       this.props.mode == "rmd" &&
       this.props.derived_file_types != undefined
     ) {
-      if (!this.props.derived_file_types.contains("html")) {
+      if (this.props.derived_file_types.contains("html")) {
+        // keep path as it is; don't remove this case though because of the else
+      } else if (this.props.derived_file_types.contains("nb.html")) {
+        path = change_filename_extension(path, "nb.html");
+      } else {
         return this.render_no_html();
       }
     }
 
     // param below is just to avoid caching.
-    const src_url = `${window.app_base_url}/${this.props.project_id}/raw/${
-      this.props.path
-    }?param=${this.props.reload}`;
+    const src_url = `${window.app_base_url}/${
+      this.props.project_id
+    }/raw/${path}?param=${this.props.reload}`;
 
     return (
       <iframe

--- a/src/smc-webapp/frame-editors/rmd-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/actions.ts
@@ -61,7 +61,7 @@ export class RmdActions extends Actions {
     }
 
     let existing = Set();
-    for (let ext of ["pdf", "html"]) {
+    for (let ext of ["pdf", "html", "nb.html"]) {
       // full path
       const expected_fn = change_filename_extension(this.path, ext);
       const fn_exists = listing.some(entry => {


### PR DESCRIPTION
# Description
RMarkdown has a mode, where it generates "notebook html" files. They contain rmd itself, and some extras. This patch basically fixes the iframe viewer in rmd mode in such a way, that it picks the correct file to show. See screenshot

# Testing Steps
1. see ticket #3317, screenshot also shows a dataframe with a pager.

# Relevant Issues
#3317

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [x] Screenshots if relevant.


![screenshot from 2018-10-31 13-24-32](https://user-images.githubusercontent.com/207405/47788030-e0785d80-dd10-11e8-9280-3b4af98bfadd.png)
