### PR TITLE
webapp/editor: safeguard undefined codemirror in programmatical_goto_line

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -624,6 +624,7 @@ class CodeMirrorEditor extends FileEditor
 
     programmatical_goto_line: (line) =>
         cm = @codemirror_with_last_focus
+        return if not cm?
         pos = {line:line-1, ch:0}
         info = cm.getScrollInfo()
         cm.scrollIntoView(pos, info.clientHeight/2)


### PR DESCRIPTION


# Description

# Testing Steps
1. I honestly don't know, but the stacktrace in  #3321 supports this fix

# Relevant Issues
 #3321

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
