### PR TITLE
syncdoc: safeguarding a debug statement 

### DIFF
--- a/src/smc-webapp/syncdoc.coffee
+++ b/src/smc-webapp/syncdoc.coffee
@@ -314,9 +314,9 @@ class SynchronizedDocument2 extends SynchronizedDocument
 
     _debug_sync_state: (info) =>
         console.log "--- #{info}"
-        console.log "codemirror='#{@codemirror.getValue()}'"
-        console.log "syncstring='#{@_syncstring.to_str()}'"
-        if info == 'after' and @codemirror.getValue() != @_syncstring.to_str()
+        console.log "codemirror='#{@codemirror?.getValue()}'"
+        console.log "syncstring='#{@_syncstring?.to_str()}'"
+        if info == 'after' and @codemirror?.getValue() != @_syncstring?.to_str()
             console.warn("BUG -- values are different!")
 
     # Set value of the syncstring to equal current value of the codemirror editor


### PR DESCRIPTION
# Description
Well, this is obviously only used during testing. I've safeguarded it.


# Relevant Issues
see #3322

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [ ] Screenshots if relevant.
