### PR TITLE
Latex spaces in filename

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -77,9 +77,11 @@ export class Actions extends BaseActions<LatexEditorState> {
   private ext: string = "tex";
   private knitr: boolean = false; // true, if we deal with a knitr file
   private filename_knitr: string; // .rnw or .rtex
+  private bad_filename: boolean; // true, if the <filename.tex> can't be processed -- see #3230
 
   _init2(): void {
     if (!this.is_public) {
+      this._init_bad_filename();
       this._init_ext_filename(); // safe to set before syncstring init
       this._init_syncstring_value();
       this._init_ext_path(); // must come after syncstring init
@@ -88,6 +90,13 @@ export class Actions extends BaseActions<LatexEditorState> {
       this._init_config();
       this._init_first_build();
     }
+  }
+
+  _init_bad_filename(): void {
+    // #3230 two or more spaces
+    // note: if there are additional reasons why a filename is bad, add it to the
+    // alert msg in run_build.
+    this.bad_filename = /\s\s+/.test(this.path);
   }
 
   _init_ext_filename(): void {
@@ -273,6 +282,17 @@ export class Actions extends BaseActions<LatexEditorState> {
 
   async run_build(time: number, force: boolean): Promise<void> {
     this.setState({ build_logs: Map() });
+
+    console.log("this.bad_filename", this.bad_filename);
+
+    if (this.bad_filename) {
+      const err = `ERROR: It is not possible to compile this LaTeX file with the name '${
+        this.path
+      }'.
+        Please modify the filename, such that it does **not** contain two or more consecutive spaces.`;
+      this.set_error(err);
+      return;
+    }
 
     // for knitr related documents, we have to first build the derived tex file ...
     if (this.knitr) {

--- a/src/smc-webapp/frame-editors/latex-editor/gutters.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/gutters.tsx
@@ -26,6 +26,7 @@ export function update_gutters(opts: {
     // errors last so always shown if multiple issues on a single line!
     let item: Error;
     for (item of opts.log[group]) {
+      if (!item.file) continue;
       if (path_split(item.file).tail != path) {
         /* for now only show gutter marks in the master file. */
         continue;


### PR DESCRIPTION
# Description
I tried to come up with a solution mentioned in #3230 but all that doesn't work. Instead, just show an error message.

![screenshot from 2018-11-02 16-41-34](https://user-images.githubusercontent.com/207405/47925324-30e0ee00-debe-11e8-8479-5119b5d86c0d.png)



Along the way I also saw a stacktrace for gutters.

![screenshot from 2018-11-02 16-26-00](https://user-images.githubusercontent.com/207405/47925033-75b85500-debd-11e8-9daa-c9a8b4853706.png)


# Testing Steps
1. filename.tex with no spaces works
1. `file na me.tex` works as well
1. `file  name.tex` or even `file          name.tex` shows an error.

# Relevant Issues
#3230 

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
- [ ] A list of exact steps on how you tested.
- [x] Screenshots if relevant.
