### PR TITLE
terminal: use browser's generic monospace font

### DIFF
--- a/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
@@ -194,10 +194,13 @@ export class Terminal {
     }
 
     /* Disabled, due to https://github.com/sagemathinc/cocalc/issues/3304
-    if (settings.get("font") !== this.terminal_settings.get("font")) {
-      this.terminal.setOption("fontFamily", settings.get("font"));
-    }
+    * if (settings.get("font") !== this.terminal_settings.get("font")) {
+    *   this.terminal.setOption("fontFamily", settings.get("font"));
+    * }
     */
+    // instead, tell the terminal to use the browser's setting for the generic "monospace" font family
+    // this can be tuned in the browser settings
+    this.terminal.setOption("fontFamily", "monospace");
 
     this.terminal_settings = settings;
   }


### PR DESCRIPTION
# Description
use browser settings for "monospace" generic font family[1] in terminal (just like it is used in the text editor, too)

[1] https://developer.mozilla.org/de/docs/Web/CSS/font-family

# Testing Steps
1. change font settings in your browser, terminal font changes accordingly -- i.e. not using any web-fonts, but your actual settings

# Relevant Issues
* follow up to #3304

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Screenshots if relevant.
