### PR TITLE
webapp: make "RMarkdown" support more visible in new/create files

### DIFF
--- a/src/smc-webapp/file-associations.coffee
+++ b/src/smc-webapp/file-associations.coffee
@@ -157,7 +157,7 @@ file_associations['md'] =
 file_associations['rmd'] =
     icon   : 'cc-icon-r'
     opts   : {indent_unit:4, tab_size:4, mode:codemirror_associations['rmd']}
-    name   : "Rmd"
+    name   : "RMarkdown"
 
 file_associations['rst'] =
     icon   : 'fa-file-code-o'

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -2043,7 +2043,7 @@ ProjectFilesNew = rclass
     getDefaultProps: ->
         file_search : ''
 
-    new_file_button_types : ['ipynb', 'sagews', 'tex', 'term',  'x11', 'rnw', 'rtex', 'md', 'tasks', 'course', 'sage', 'py', 'sage-chat']
+    new_file_button_types : ['ipynb', 'sagews', 'tex', 'term',  'x11', 'rnw', 'rtex', 'rmd', 'md', 'tasks', 'course', 'sage', 'py', 'sage-chat']
 
     file_dropdown_icon: ->
         <span style={whiteSpace: 'nowrap'}>

--- a/src/smc-webapp/project_new.cjsx
+++ b/src/smc-webapp/project_new.cjsx
@@ -158,6 +158,10 @@ exports.FileTypeSelector = FileTypeSelector = rclass
                     <Tip icon='cc-icon-jupyter' title='Jupyter notebook' tip='Create an interactive notebook for using Python, Julia, R and more.'>
                         <NewFileButton icon='cc-icon-jupyter' name='Jupyter notebook' on_click={@props.create_file} ext={'ipynb'} />
                     </Tip>
+                    <Tip title='RMarkdown File'  icon='cc-icon-r'
+                        tip='RMarkdown document with real-time preview.'>
+                        <NewFileButton icon='cc-icon-r' name='RMarkdown' on_click={@props.create_file} ext='rmd' />
+                    </Tip>
                 </Col>
                 <Col sm={6}>
                     <Tip icon='file' title='Any Type of File' tip='Create a wide range of files, including HTML, Markdown, C/C++ and Java programs, etc.'>


### PR DESCRIPTION
# Description
This just adds RMarkdown to the create/new dialogs. 

# Testing Steps
1. files → create → dropdown → click RMarkdown
2. +new → RMardown button

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [x] Screenshots if relevant.


![screenshot from 2018-11-12 11-20-15](https://user-images.githubusercontent.com/207405/48341288-f53be600-e66c-11e8-9068-755bac0646e9.png)
![screenshot from 2018-11-12 11-20-03](https://user-images.githubusercontent.com/207405/48341290-f53be600-e66c-11e8-9272-a5755b545be6.png)
