### PR TITLE
time travel: show rtex/rmd history, not tex

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1007,9 +1007,9 @@ export class Actions<T = CodeEditorState> extends BaseActions<
     return this.redux.getProjectActions(this.project_id);
   }
 
-  time_travel(): void {
+  time_travel(path?:string): void {
     this._get_project_actions().open_file({
-      path: history_path(this.path),
+      path: history_path(path || this.path),
       foreground: true
     });
   }

--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -757,6 +757,16 @@ export class Actions extends BaseActions<LatexEditorState> {
     this.synctex_tex_to_pdf(line, ch, this.path);
   }
 
+  time_travel(): void {
+    // knitr case: point to editor file, not the generated tex
+    // https://github.com/sagemathinc/cocalc/issues/3336
+    if (this.knitr) {
+      super.time_travel(this.filename_knitr);
+    } else {
+      super.time_travel();
+    }
+  }
+
   download(id: string): void {
     const node = this._get_frame_node(id);
     if (!node) {


### PR DESCRIPTION
# Description
this is a small fix for time travel, to show up rmd and rtex files and not the autogenerated tex file.

# Testing Steps
* I tested if time travel properly shows up for an ".md", ".rmd", ".tex", and ".rnw" and ".rtex" file.

# Relevant Issues
#3336

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Screenshots if relevant.
