### PR TITLE
Fix setting continue_first_subscription incorrectly

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1016,7 +1016,7 @@ ConfirmPaymentMethod = rclass
 
     render: ->
         if not @props.customer
-            return <AddPaymentMethod redux={redux} on_close={@props.on_close} />
+            return <AddPaymentMethod redux={redux} />
         for card_data in @props.customer.sources.data
             if card_data.id == @props.customer.default_source
                 default_card = card_data


### PR DESCRIPTION
# Description
Remove incorrect callback which set `continue_first_subscription` to false.

# Testing Steps
1. Open an account that has no prior credit card entered.
1. Click `Account` > `Subscriptions/Course Packages`.
1. Select $14/mo Standard Plan.
1. Enter valid credit card and click "Add Credit Card".
<img width="963" alt="screen shot 2018-11-26 at 3 12 50 pm" src="https://user-images.githubusercontent.com/618575/49022870-d4f04900-f18d-11e8-9a3a-c5f2463a0aef.png">
1. After a wait, no weirdness should happen.
<img width="963" alt="screen shot 2018-11-26 at 3 13 02 pm" src="https://user-images.githubusercontent.com/618575/49022868-d4f04900-f18d-11e8-9a3c-f5484332e4a6.png">

# Relevant Issues
#3363

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Screenshots if relevant.
