### PR TITLE
Fix hash-bar bottom-margin

### DIFF
--- a/src/smc-webapp/tasks/hashtag-bar.cjsx
+++ b/src/smc-webapp/tasks/hashtag-bar.cjsx
@@ -2,7 +2,7 @@
 Hashtag bar for selecting which tasks are shown by tags
 ###
 
-{Button, ButtonGroup} = require('react-bootstrap')
+{Button, ButtonGroup, Row, Col} = require('react-bootstrap')
 
 {React, rclass, rtypes}  = require('../app-framework')
 
@@ -71,6 +71,10 @@ exports.HashtagBar = rclass
         return (x[1] for x in v)
 
     render: ->
-        <ButtonGroup style={padding:'5px', paddingBottom: '38px', overflowY: 'auto'}>
-            {@render_hashtags()}
-        </ButtonGroup>
+        <Row>
+            <Col md={12}>
+                <ButtonGroup style={padding:'5px', overflowY: 'auto'}>
+                    {@render_hashtags()}
+                </ButtonGroup>
+            </Col>
+        </Row>


### PR DESCRIPTION
# Description
On production, notice the whitespace below the hashtags:
<img width="672" alt="screen shot 2018-11-30 at 4 11 06 pm" src="https://user-images.githubusercontent.com/618575/49301014-8d362e00-f4bb-11e8-8357-9bc3dcc2f924.png">

Fixed with this PR:
<img width="605" alt="screen shot 2018-11-30 at 4 11 19 pm" src="https://user-images.githubusercontent.com/618575/49301016-8dcec480-f4bb-11e8-83a8-9b45195fd7f4.png">

Example of many hash tags:
<img width="675" alt="screen shot 2018-11-30 at 4 15 40 pm" src="https://user-images.githubusercontent.com/618575/49301017-8dcec480-f4bb-11e8-8b91-4f4f3bc41ce1.png">

# Testing Steps
1. Open a tasks file
1. Make some hashtags
1. Click on some
1. It should not produce extra whitespace below the bar
1. Add a lot of hashtags
1. They should all render

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Screenshots if relevant.
