### PR TITLE
webapp/terminal: fixing hidden scrollbar

### DIFF
--- a/src/smc-webapp/frame-editors/terminal-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/actions.ts
@@ -13,7 +13,4 @@ export class Actions extends CodeEditorActions {
   _raw_default_frame_tree(): FrameTree {
     return { type: "terminal" };
   }
-
-
-
 }

--- a/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
@@ -118,8 +118,12 @@ export class Terminal {
     this.set_connection_status("disconnected");
   }
 
+  static get rendererType() {
+    return "dom";
+  }
+
   private get_xtermjs_options(): any {
-    const rendererType = "dom";
+    const rendererType = Terminal.rendererType;
     const settings = this.account.get("terminal");
     if (settings == null) {
       // not fully loaded yet.

--- a/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
@@ -55,6 +55,7 @@ export class Terminal {
   private term_path: string;
   private number: number;
   private id: string;
+  readonly rendererType: "dom" | "canvas";
   private terminal: XTerminal;
   private is_paused: boolean = false;
   private keyhandler_initialized: boolean = false;
@@ -103,6 +104,7 @@ export class Terminal {
     this.terminal_settings = Map(); // what was last set.
     this.project_id = actions.project_id;
     this.path = actions.path;
+    this.rendererType = "dom";
     this.term_path = aux_file(`${this.path}-${number}`, "term");
     this.number = number;
     this.id = id;
@@ -118,12 +120,8 @@ export class Terminal {
     this.set_connection_status("disconnected");
   }
 
-  static get rendererType() {
-    return "dom";
-  }
-
   private get_xtermjs_options(): any {
-    const rendererType = Terminal.rendererType;
+    const rendererType = this.rendererType;
     const settings = this.account.get("terminal");
     if (settings == null) {
       // not fully loaded yet.

--- a/src/smc-webapp/frame-editors/terminal-editor/terminal-manager.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/terminal-manager.ts
@@ -61,7 +61,7 @@ export class TerminalManager {
   }
 
   get_terminal(id: string, parent: HTMLElement): Terminal {
-    if (this.terminals[id] != null)  {
+    if (this.terminals[id] != null) {
       parent.appendChild(this.terminals[id].element);
     } else {
       this.terminals[id] = new Terminal(
@@ -110,5 +110,4 @@ export class TerminalManager {
   get(id: string): Terminal | undefined {
     return this.terminals[id];
   }
-
 }

--- a/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
@@ -86,9 +86,12 @@ export class TerminalFrame extends Component<Props, {}> {
     // See https://stackoverflow.com/questions/10864249/disabling-right-click-context-menu-on-a-html-canvas
     // NOTE: this would probably make sense in DOM mode instead of canvas mode;
     // if we switch, disable this...
+    // Well, this context menu is still silly. Always disable it.
+    //if (Terminal.rendererType != "dom") {
     $(node).bind("contextmenu", function() {
       return false;
     });
+    //}
 
     // TODO: Obviously restoring the exact scroll position would be better...
     this.terminal.scroll_to_bottom();
@@ -124,7 +127,7 @@ export class TerminalFrame extends Component<Props, {}> {
           this.terminal.focus();
         }}
       >
-        <div className={"smc-vfill"} ref={"terminal"} />
+        <div className={"smc-vfill cocalc-xtermjs"} ref={"terminal"} />
       </div>
     );
   }

--- a/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
@@ -87,11 +87,11 @@ export class TerminalFrame extends Component<Props, {}> {
     // NOTE: this would probably make sense in DOM mode instead of canvas mode;
     // if we switch, disable this...
     // Well, this context menu is still silly. Always disable it.
-    //if (Terminal.rendererType != "dom") {
-    $(node).bind("contextmenu", function() {
-      return false;
-    });
-    //}
+    if (true || this.terminal.rendererType != "dom") {
+      $(node).bind("contextmenu", function() {
+        return false;
+      });
+    }
 
     // TODO: Obviously restoring the exact scroll position would be better...
     this.terminal.scroll_to_bottom();

--- a/src/smc-webapp/index.sass
+++ b/src/smc-webapp/index.sass
@@ -368,3 +368,11 @@ span.katex
 //  position: absolute
 //  font-size: 28px
 //  margin-top: -14px
+
+
+// issue https://github.com/sagemathinc/cocalc/issues/3389
+// fixing terminal scroll bar
+div.cocalc-xtermjs > div.terminal.xterm > div.xterm-viewport
+  background: transparent !important
+  z-index: 1
+


### PR DESCRIPTION
# Description
This brings the div with the scrollbar in front of the other one: #3389

There is also some artifact left from exposing the render type … but it's no good to have that context menu even in dom mode.

# Testing Steps
I tested this with a bright (black on white) and a dark theme, in chrome and firefox, and also when I've both opened at the same time. Didn't notice any Problems.

# Relevant Issues
 #3389

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Screenshots if relevant.
