### PR TITLE
x11: more apps and space around buttons

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
+++ b/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
@@ -3,9 +3,7 @@ X11 Window frame.
 */
 
 import { React, Component, Rendered } from "../../app-framework";
-
 import { debounce, keys } from "underscore";
-
 const { Button } = require("react-bootstrap");
 const { Icon } = require("r_misc");
 
@@ -39,6 +37,7 @@ const DESC = {
     desc: "Command line terminal"
   },
   gitk: { icon: "git", desc: "Explore Git repository in current directory" },
+  gitg: { icon: "git", desc: "gitg is a graphical user interface for git" },
   idle: {
     icon: "cc-icon-python",
     desc: "Minimalistic Python IDE",
@@ -54,6 +53,16 @@ const DESC = {
     desc:
       "A powerful office suite (spreadsheet, word processor, presentations, etc. -- open Word, Excel, Powerpoint, etc.)",
     label: "LibreOffice"
+  },
+  lowriter: {
+    desc: "LibreOffice Writer",
+    icon: "file-alt",
+    label: "LO Writer"
+  },
+  localc: {
+    desc: "LibreOffice Calc",
+    icon: "table",
+    label: "LO Calc"
   },
   nteract: {
     command: "nteract",
@@ -72,11 +81,12 @@ const DESC = {
       "An integrated development environment (IDE) for R.  RStudio, Inc. is in no way affiliated with CoCalc",
     label: "RStudio"
   },
-  /* octave: {
-    icon: "cubes",
-    desc: "Scientific programming largely compatible with Matlab",
-    label: "Octave"
-  },*/
+  // octave: {
+  //   icon: "cc-icon-octave",
+  //   desc: "Scientific programming largely compatible with Matlab",
+  //   label: "Octave",
+  //   command: "/usr/bin/octave"
+  // },
   texmacs: {
     icon: "cc-icon-tex-file",
     desc:
@@ -87,6 +97,72 @@ const DESC = {
     icon: "cc-icon-tex-file",
     desc: "An integrated writing environment for creating LaTeX documents",
     label: "TeXstudio"
+  },
+  openmodelica: {
+    icon: "cogs",
+    desc:
+      "an open-source Modelica-based modeling and simulation environment intended for industrial and academic usage",
+    label: "OpenModelica",
+    command: "OMEdit"
+  },
+  pspp: {
+    icon: "table",
+    desc: "Statistical analysis of sampled data, similar to SPSS",
+    label: "PSPP",
+    command: "psppire"
+  },
+  gnumeric: {
+    icon: "table",
+    desc:
+      "Gnumeric is a spreadsheet, a computer program used to manipulate and analyze numeric data",
+    label: "Gnumeric",
+    command: "gnumeric"
+  },
+  scribus: {
+    icon: "address-card",
+    desc: "a page layout program",
+    command: "scribus",
+    label: "Scribus"
+  },
+  spyder: {
+    command: "spyder3",
+    desc:
+      "Spyder is a powerful scientific environment written in Python, for Python, and designed by and for scientists, engineers and data analysts.",
+    icon: "calculator",
+    label: "Spyder"
+  },
+  gchempaint: {
+    desc: "GChemPaint is a 2D chemical structures editor.",
+    icon: "atom",
+    label: "GChemPaint"
+  },
+  dia: {
+    desc: "Dia is a program to draw structured diagrams.",
+    icon: "connectdevelop",
+    label: "Dia"
+  },
+  pycharm: {
+    command: "pycharm.sh",
+    desc: "A powerful and smart IDE for productive Python development.",
+    icon: "cc-icon-python",
+    label: "PyCharm"
+  },
+  intellij: {
+    label: "IntelliJ IDEA",
+    desc: "A powerful and smart IDE for productive JAVA development.",
+    command: "idea.sh",
+    icon: "lightbulb"
+  },
+  avogadro: {
+    label: "Avogadro",
+    desc:
+      "An advanced molecule editor and visualizer designed for cross-platform use in computational chemistry, molecular modeling, bioinformatics, materials science, and related areas",
+    icon: "atom"
+  },
+  shotwell: {
+    label: "Shotwell",
+    desc: "Shotwell is a personal photo manager.",
+    icon: "camera"
   }
 };
 
@@ -128,7 +204,12 @@ export class Launcher extends Component<Props, {}> {
     }
 
     return (
-      <Button key={app} onClick={() => this.launch(app)} title={desc.desc}>
+      <Button
+        key={app}
+        onClick={() => this.launch(app)}
+        title={desc.desc}
+        style={{ margin: "5px" }}
+      >
         {icon}
         {desc.label ? desc.label : app}
       </Button>
@@ -145,7 +226,7 @@ export class Launcher extends Component<Props, {}> {
 
   render(): Rendered {
     return (
-      <div style={{ overflowY: "auto", margin: "5px" }}>
+      <div style={{ overflowY: "auto", padding: "5px" }}>
         {this.render_launchers()}
       </div>
     );


### PR DESCRIPTION
# Description
more x11 buttons

![screenshot from 2018-12-05 11-33-10](https://user-images.githubusercontent.com/207405/49507833-950e1d80-f881-11e8-97f0-00a6dde6f51c.png)


# Testing Steps
1. this is easy to test. click through the new buttons ...

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
