### PR TITLE
webapp/x11: sort launcher by labels and add two more

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
+++ b/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
@@ -3,13 +3,13 @@ X11 Window frame.
 */
 
 import { React, Component, Rendered } from "../../app-framework";
-import { debounce, keys } from "underscore";
+import { debounce, keys, sortBy } from "underscore";
 const { Button } = require("react-bootstrap");
 const { Icon } = require("r_misc");
 
 import { Actions } from "./actions";
 
-const DESC = {
+const APPS = {
   /* xclock: { icon: "clock", desc:"Shows UTC time" }, */
   emacs: {
     icon: "edit",
@@ -37,7 +37,7 @@ const DESC = {
     desc: "Command line terminal"
   },
   gitk: { icon: "git", desc: "Explore Git repository in current directory" },
-  gitg: { icon: "git", desc: "gitg is a graphical user interface for git" },
+  gitg: { icon: "git", desc: "GNOME's client to work with Git repositories" },
   idle: {
     icon: "cc-icon-python",
     desc: "Minimalistic Python IDE",
@@ -57,12 +57,12 @@ const DESC = {
   lowriter: {
     desc: "LibreOffice Writer",
     icon: "file-alt",
-    label: "LO Writer"
+    label: "Writer"
   },
   localc: {
     desc: "LibreOffice Calc",
     icon: "table",
-    label: "LO Calc"
+    label: "Calc"
   },
   nteract: {
     command: "nteract",
@@ -163,11 +163,26 @@ const DESC = {
     label: "Shotwell",
     desc: "Shotwell is a personal photo manager.",
     icon: "camera"
+  },
+  evince: {
+    label: "Evince",
+    icon: "file-pdf",
+    desc: "A document viewer for PDF, PostScript, DVI, DjVu, ..."
+  },
+  calibre: {
+    label: "Calibre",
+    icon: "book",
+    desc: "A powerful and easy to use e-book manager"
   }
 };
 
-const APPS: string[] = keys(DESC);
-APPS.sort();
+function sort_apps(k): string {
+  const label = APPS[k].label;
+  const name = label ? label : k;
+  return name.toLowerCase();
+}
+
+const APP_KEYS: string[] = sortBy(keys(APPS), sort_apps);
 
 interface Props {
   actions: Actions;
@@ -186,7 +201,7 @@ export class Launcher extends Component<Props, {}> {
   }
 
   launch(app: string): void {
-    const desc = DESC[app];
+    const desc = APPS[app];
     if (desc == null) {
       return;
     }
@@ -194,7 +209,7 @@ export class Launcher extends Component<Props, {}> {
   }
 
   render_launcher(app: string): Rendered {
-    const desc = DESC[app];
+    const desc = APPS[app];
     if (desc == null) {
       return;
     }
@@ -218,7 +233,7 @@ export class Launcher extends Component<Props, {}> {
 
   render_launchers(): Rendered[] {
     const v: Rendered[] = [];
-    for (let app of APPS) {
+    for (let app of APP_KEYS) {
       v.push(this.render_launcher(app));
     }
     return v;


### PR DESCRIPTION
# Description
quick follow up of https://github.com/sagemathinc/cocalc/pull/3395

different sorting algo:

![screenshot from 2018-12-05 16-25-39](https://user-images.githubusercontent.com/207405/49523680-90119400-f8aa-11e8-91d1-107891288434.png)


# Testing Steps
1. it compiles, travis will check this
1. those two new buttons for calibre and evince open up the apps

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
