### PR TITLE
webapp: fix terminal help url

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -53,6 +53,7 @@ import { Terminal } from "../terminal-editor/connected-terminal";
 import { TerminalManager } from "../terminal-editor/terminal-manager";
 
 const copypaste = require("smc-webapp/copy-paste-buffer");
+const { open_new_tab } = require("smc-webapp/misc_page");
 
 interface gutterMarkerParams {
   line: number;
@@ -1007,7 +1008,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
     return this.redux.getProjectActions(this.project_id);
   }
 
-  time_travel(path?:string): void {
+  time_travel(path?: string): void {
     this._get_project_actions().open_file({
       path: history_path(path || this.path),
       foreground: true
@@ -1016,10 +1017,7 @@ export class Actions<T = CodeEditorState> extends BaseActions<
 
   help(type: string): void {
     const url = WIKI_HELP_URL + type + "-help";
-    const w = window.open(url, "_blank");
-    if (w) {
-      w.focus();
-    }
+    open_new_tab(url);
   }
 
   change_font_size(delta: number, id?: string): void {

--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -40,6 +40,7 @@ import {
   change_filename_extension
 } from "../generic/misc";
 import { IBuildSpecs } from "./build";
+const { open_new_tab } = require("smc-webapp/misc_page");
 
 export interface BuildLog extends ExecOutput {
   parse?: IProcessedLatexLog;
@@ -725,11 +726,7 @@ export class Actions extends BaseActions<LatexEditorState> {
   }
 
   help(): void {
-    // TODO: call version that deals with popup blockers...
-    const w = window.open(HELP_URL, "_blank");
-    if (w) {
-      w.focus();
-    }
+    open_new_tab(HELP_URL);
   }
 
   zoom_page_width(id: string): void {

--- a/src/smc-webapp/frame-editors/terminal-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/actions.ts
@@ -3,6 +3,9 @@ Terminal Editor Actions
 */
 import { Actions as CodeEditorActions } from "../code-editor/actions";
 import { FrameTree } from "../frame-tree/types";
+const { open_new_tab } = require("smc-webapp/misc_page");
+
+const HELP_URL = "https://doc.cocalc.com/terminal.html";
 
 export class Actions extends CodeEditorActions {
   // no need to open any syncstring for terminals -- they don't use database sync.
@@ -12,5 +15,9 @@ export class Actions extends CodeEditorActions {
 
   _raw_default_frame_tree(): FrameTree {
     return { type: "terminal" };
+  }
+
+  help(): void {
+    open_new_tab(HELP_URL);
   }
 }


### PR DESCRIPTION
# Description
This is rather trivial, and changes to use the popup-blocker aware tab opener

# Testing Steps
1. x11 help → as usual
2. latex help → opens new page, as usual
3. terminal help → new page

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
