### PR TITLE
add ts support to hub api mocha test

### DIFF
--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -34,9 +34,6 @@ export NODE_ENV=mocha-test && SMC_TEST=true node_modules/.bin/mocha --reporter $
 # reset node env
 export NODE_ENV="$COPY_NODE_ENV"
 
-# set PATH to find smc-sage-server, needed by testapi
-PATH=$TRAVIS_BUILD_DIR/src/smc_pyutil/smc_pyutil/bin:$PATH
-
 # some hub tests
 cd $TRAVIS_BUILD_DIR/src/smc-hub/
 npm run testpg

--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -34,6 +34,9 @@ export NODE_ENV=mocha-test && SMC_TEST=true node_modules/.bin/mocha --reporter $
 # reset node env
 export NODE_ENV="$COPY_NODE_ENV"
 
+# set PATH to find smc-sage-server, needed by testapi
+PATH=$TRAVIS_BUILD_DIR/src/smc_pyutil/smc_pyutil/bin:$PATH
+
 # some hub tests
 cd $TRAVIS_BUILD_DIR/src/smc-hub/
 npm run testpg

--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -39,7 +39,7 @@ cd $TRAVIS_BUILD_DIR/src/smc-hub/
 npm run testpg
 npm run testmisc
 npm run testkucalc
-# npm run testapi           # broken
+npm run testapi
 
 #cd $TRAVIS_BUILD_DIR/src/smc-project/; npm run test # also broken
 

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -84,7 +84,7 @@
   "scripts": {
     "test": "(npm run testpg && npm run testapi && npm run testmisc && npm run testkucalc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres/*.coffee",
-    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/ts-mocha -p ../tsconfig.json ${BAIL} --reporter ${REPORTER:-progress} test/api/*.coffee",
+    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/ts-mocha -p ../tsconfig.json ${BAIL} --reporter ${REPORTER:-progress} test/api/messages.coffee",
     "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc/*.coffee",
     "testkucalc": "echo 'TEST KUCALC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/kucalc/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -67,21 +67,24 @@
     "winston": "^2.4"
   },
   "devDependencies": {
+    "@types/expect": "^1.20.3",
+    "@types/mocha": "^5.2.5",
     "coffee-coverage": "^0.6.2",
-    "coffeescript": "^2.1.0",
     "coffeelint": "^2.0.7",
+    "coffeescript": "^2.1.0",
     "coveralls": "^2.11.2",
     "expect": "^1.12.2",
     "istanbul": "^0.4.0",
     "mocha": "*",
     "mocha-lcov-reporter": "1.0.0",
     "should": "^7.0.1",
-    "sinon": "^4.1.3"
+    "sinon": "^4.1.3",
+    "ts-mocha": "^2.0.0"
   },
   "scripts": {
     "test": "(npm run testpg && npm run testapi && npm run testmisc && npm run testkucalc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres/*.coffee",
-    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/api/*.coffee",
+    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/ts-mocha -p ../tsconfig.json ${BAIL} --reporter ${REPORTER:-progress} test/api/*.coffee",
     "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc/*.coffee",
     "testkucalc": "echo 'TEST KUCALC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/kucalc/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -84,7 +84,7 @@
   "scripts": {
     "test": "(npm run testpg && npm run testapi && npm run testmisc && npm run testkucalc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres/*.coffee",
-    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/ts-mocha -p ../tsconfig.json ${BAIL} --reporter ${REPORTER:-progress} test/api/messages.coffee",
+    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/ts-mocha -p ../tsconfig.json ${BAIL} --reporter ${REPORTER:-progress} test/api/a*.coffee",
     "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc/*.coffee",
     "testkucalc": "echo 'TEST KUCALC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/kucalc/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",

--- a/src/smc-hub/test/api/copy_between_projects.coffee
+++ b/src/smc-hub/test/api/copy_between_projects.coffee
@@ -45,7 +45,7 @@ describe 'testing copy between projects -- ', ->
 
 
     it "creates file in source project", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'write_text_file_to_project'
             body  :
@@ -58,7 +58,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "copies file to a private target", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'copy_path_between_projects'
             body  :
@@ -71,7 +71,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "reads target file 1", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'read_text_file_from_project'
             body  :
@@ -84,7 +84,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "creates folder with text file in source project", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'write_text_file_to_project'
             body  :
@@ -97,7 +97,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "copies src with directory and file", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'copy_path_between_projects'
             body  :
@@ -110,7 +110,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "reads target file 2", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'read_text_file_from_project'
             body  :
@@ -123,7 +123,7 @@ describe 'testing copy between projects -- ', ->
 
     it "copies file to directory", (done) ->
         # src:'B2/doc2.txt' tgt:'DIR3/ result:'DIR3/doc2.txt'
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'copy_path_between_projects'
             body  :
@@ -137,7 +137,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "reads target file 3", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'read_text_file_from_project'
             body  :
@@ -151,7 +151,7 @@ describe 'testing copy between projects -- ', ->
 
     it "copies directory to directory", (done) ->
         # src:'B2/' tgt:'DIR4/ result:'DIR4/doc2.txt'
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'copy_path_between_projects'
             body  :
@@ -165,7 +165,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "reads target file 4", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'read_text_file_from_project'
             body  :
@@ -188,7 +188,7 @@ describe 'testing copy between projects -- ', ->
 
     it "copies a public file to different target dir", (done) ->
         # src:'B2/doc2.txt'(public) tgt:'FOO/abc.txt'
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'copy_public_path_between_projects'
             body  :
@@ -201,7 +201,7 @@ describe 'testing copy between projects -- ', ->
                 done(err)
 
     it "reads copied public file", (done) ->
-        @timeout(15000)
+        @timeout(25000)
         api.call
             event : 'read_text_file_from_project'
             body  :


### PR DESCRIPTION
# Description
Fixes error reported by @haraldschilly, `Error: Cannot find module './failing-to-save'`, for the case of `smc-hub$ npm run testapi`

Should not affect production. The only changes are to devDependencies and scripts in package.json and test timeouts in the hub api mocha suite.

# Testing Steps
1. Install this PR patch.
1. Restart project.
1. In one .term:
    ```     
    cd ~/cocalc/src
    . smc-env 
    npm run clean
    time npm run make
    # real    5m26.959s
    dev/project/start_postgres.py
    # leave server running in foreground
    ```
1. In another .term:
    ```
    cd ~/cocalc/src
    . smc-env
    . dev/project/postgres-env
    cd smc-hub
    time BAIL=-b npm run testapi 2>&1 | grep -v debug
    # 101 passing (55s)
    ../scripts/mocha_clean.sh
    ```

# Relevant Issues #2627

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end: N/A
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
