### PR TITLE
webapp/x11: QGIS, DS9, Octave, Maxima, Xcas and System Monitor

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
+++ b/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
@@ -81,7 +81,7 @@ const APPS: IAPPS = {
     label: "nteract"
   },
   wxmaxima: {
-    icon: "shapes",
+    icon: "square-root-alt",
     desc: "A legendary computer algebra system",
     label: "Maxima"
   },
@@ -194,6 +194,12 @@ const APPS: IAPPS = {
     icon: "star",
     label: "SAOImage DS9",
     desc: "An astronomical imaging and data visualization application."
+  },
+  xcas: {
+    icon: "square-root-alt",
+    label: "Xcas",
+    desc:
+      "An interface to perform computer algebra, function graphs, interactive geometry (2-d and 3-d), spreadsheet and statistics, programmation."
   }
 };
 

--- a/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
+++ b/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
@@ -9,7 +9,17 @@ const { Icon } = require("r_misc");
 
 import { Actions } from "./actions";
 
-const APPS = {
+interface IAPPS {
+  [k: string]: {
+    icon: string;
+    desc: string;
+    label?: string;
+    command?: string;
+    args?: string[];
+  };
+}
+
+const APPS: IAPPS = {
   /* xclock: { icon: "clock", desc:"Shows UTC time" }, */
   emacs: {
     icon: "edit",
@@ -81,12 +91,13 @@ const APPS = {
       "An integrated development environment (IDE) for R.  RStudio, Inc. is in no way affiliated with CoCalc",
     label: "RStudio"
   },
-  // octave: {
-  //   icon: "cc-icon-octave",
-  //   desc: "Scientific programming largely compatible with Matlab",
-  //   label: "Octave",
-  //   command: "/usr/bin/octave"
-  // },
+  octave: {
+    icon: "cc-icon-octave",
+    desc: "Scientific programming largely compatible with Matlab",
+    label: "Octave",
+    command: "octave",
+    args: ["--force-gui"]
+  },
   texmacs: {
     icon: "cc-icon-tex-file",
     desc:
@@ -177,7 +188,12 @@ const APPS = {
   qgis: {
     label: "QGIS",
     icon: "globe",
-    decr: "QGIS is a user friendly Open Source Geographic Information System."
+    desc: "A user friendly Open Source Geographic Information System."
+  },
+  ds9: {
+    icon: "star",
+    label: "SAOImage DS9",
+    desc: "An astronomical imaging and data visualization application."
   }
 };
 

--- a/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
+++ b/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
@@ -173,6 +173,11 @@ const APPS = {
     label: "Calibre",
     icon: "book",
     desc: "A powerful and easy to use e-book manager"
+  },
+  qgis: {
+    label: "QGIS",
+    icon: "globe",
+    decr: "QGIS is a user friendly Open Source Geographic Information System."
   }
 };
 

--- a/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
+++ b/src/smc-webapp/frame-editors/x11-editor/launcher.tsx
@@ -200,6 +200,12 @@ const APPS: IAPPS = {
     label: "Xcas",
     desc:
       "An interface to perform computer algebra, function graphs, interactive geometry (2-d and 3-d), spreadsheet and statistics, programmation."
+  },
+  "gnome-system-monitor": {
+    icon: "heartbeat",
+    label: "System Monitor",
+    desc:
+      "Shows you what programs are running and how much processor time, memory, and disk space are being used."
   }
 };
 


### PR DESCRIPTION
# Description
Add button to X11 launchers for QGIS and DS9. Should be deployed after the next software update. Enable Octave.

Also adds some typing, because I made a typo (`descr` instead of `desc`) and there was no error...

# Testing Steps
1. ~~run "experimental"~~ recently started project
2. qgis opens up
3. ds9 opens up
4. octave opens up
5. maxima still opens up
6. xcas is also there
7. System Monitor opens up

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
