### PR TITLE
Update Stripe

### DIFF
--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -2187,7 +2187,7 @@ class exports.Client extends EventEmitter
                 (cb) =>
                     if schema.cancel_at_period_end
                         dbg("Setting subscription to cancel at period end")
-                        @_stripe.customers.cancelSubscription(customer_id, subscription.id, {at_period_end:true}, cb)
+                        @_stripe.subscriptions.update(subscription.id, {cancel_at_period_end:true}, cb)
                     else
                         cb()
                 (cb) =>
@@ -2231,7 +2231,7 @@ class exports.Client extends EventEmitter
                     dbg("cancel the subscription at stripe")
                     # This also returns the subscription, which lets
                     # us easily get the metadata of all projects associated to this subscription.
-                    @_stripe.customers.cancelSubscription(customer_id, subscription_id, {at_period_end:mesg.at_period_end}, cb)
+                    @_stripe.subscriptions.update(subscription_id, {cancel_at_period_end:mesg.at_period_end}, cb)
                 (cb) =>
                     @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id, cb: cb)
             ], (err) =>

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -60,7 +60,7 @@
     "sharp": "^0.20.8",
     "snappy": "^6.0.1",
     "start-stop-daemon": "^0.1.1",
-    "stripe": "^4.0.0",
+    "stripe": "^6.19.0",
     "temp": "^0.8.3",
     "typescript": "^3.2.2",
     "underscore": "^1.7.0",

--- a/src/smc-hub/stripe/connect.coffee
+++ b/src/smc-hub/stripe/connect.coffee
@@ -4,7 +4,7 @@ The stripe connection object, which communicates with the remote stripe server.
 Configure via the admin panel in account settings of an admin user.
 ###
 
-DEFAULT_VERSION = '2017-08-15'
+DEFAULT_VERSION = '2018-11-08'
 
 async = require('async')
 

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -34,6 +34,7 @@ _             = require('underscore')
 
 STUDENT_COURSE_PRICE = require('smc-util/upgrade-spec').upgrades.subscription.student_course.price.month4
 
+# TODO: Upgrade to v3 and Stripe Elements
 load_stripe = (cb) ->
     if Stripe?
         cb()

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1701,7 +1701,7 @@ Invoice = rclass
         invoice = @props.invoice
         username = @props.redux.getStore('account').get_username()
         misc_page = require('./misc_page')  # do NOT require at top level, since code in billing.cjsx may be used on backend
-        misc_page.download_file("#{window.app_base_url}/invoice/sagemathcloud-#{username}-receipt-#{new Date(invoice.date*1000).toISOString().slice(0,10)}-#{invoice.id}.pdf")
+        misc_page.download_file("#{window.app_base_url}/invoice/cocalc-#{username}-receipt-#{new Date(invoice.date*1000).toISOString().slice(0,10)}-#{invoice.id}.pdf")
 
     render_paid_status: ->
         if @props.invoice.paid


### PR DESCRIPTION
# Description
This will let me start looking into the "new" Stripe Billing for better flexibility (no more "trial" plan hack), metered subscription billing, and *maybe* make InvoiceNinja obsolete.
- [x] Update Stripe
- [x] Remove a usage of "sagemathcloud"

# Testing Steps
1. With a new user, add a billing method and a subscription
1. With a user with billing info, add another subscription
1. With a student, who has no billing info, pay for the student plan
1. With a student, who has billing info, pay for the student plan
1. Fetch data from Admin panel
1. Change user subscriptions in at dashboard.stripe.com and use Admin panel to sync.
1. Test plans that should automatically cancel at period end
1. Test a user manually canceling a plan
1. Add a second payment method.
1. Change the default payment method.
1. Test with a Washington card for sales tax.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
