### PR TITLE
firefox connection issue: 65 beta4 exhibits symptoms similar to #2875

### DIFF
--- a/src/webapp-lib/preflight-checks.ts
+++ b/src/webapp-lib/preflight-checks.ts
@@ -84,10 +84,10 @@ function preflight_check(): void {
       spec.buildID.length >= 8 &&
       spec.buildID.slice(0, 8) >= "20180903");
 
+  // 69 to 61 have issues, and 65beta4 (as of 2018-12-16) exhibits similar issues
   const buggyFF =
     spec.name === "Firefox" &&
-    59 <= spec.version &&
-    spec.version <= 61 &&
+    ((59 <= spec.version && spec.version <= 61) || spec.version == 65) &&
     !ff60esr;
 
   if (oldFF || oldIE || oldEdge || oldSafari || oldOpera || oldChrome) {
@@ -113,9 +113,10 @@ function preflight_check(): void {
           <p style="font-weight:bold">
              You cannot use CoCac with your current browser, because of
              <a href="https://github.com/sagemathinc/cocalc/issues/2875">issue #2875</a> caused by
-             <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1453204">firefox issue #1453204</a>!
+             <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1453204">firefox issue #1453204</a>
+             or <a href="https://github.com/sagemathinc/cocalc/issues/3423">issue #3423</a>!
           </p>
-          <p>Either update to at least Firefox version 62,
+          <p>Either update to at least Firefox version 62 – but not version 65! –
              switch to a recent version of <a target="_blank" href='https://google.com/chrome'>Google Chrome</a>,
              or tweak your TSL settings (we wouldn't recommend that, though):
              <a href="https://tinyurl.com/y9hphj39">https://tinyurl.com/y9hphj39</a> and


### PR DESCRIPTION
# Description
Firefox 65 beta4 exhibits similar symptoms as #2875 

To see it, install FF 65 beta4 and try to connect:

![screenshot from 2018-12-16 14-41-39](https://user-images.githubusercontent.com/207405/50054306-cf5ca200-0140-11e9-8dc8-dcecf3f0019d.png)


# Testing Steps
1. Well, to properly test this, we would have to deploy this branch on "test". I'm confident about the code, though …


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
