### PR TITLE
update prettier to be in sync with system-wide version

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -46,6 +46,7 @@
     "node-cjsx": "^1.0.0",
     "node-glob": "^1.2.0",
     "node-sass": "^4.8.2",
+    "prettier": "^1.15.3",
     "pug": "^2.0.1",
     "pug-loader": "^2.3.0",
     "react-test-renderer": "^16.5.2",

--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -32,7 +32,7 @@
     "node-pty": "^0.7.8",
     "pidusage": "^1.2.0",
     "posix": "^4.0.0",
-    "prettier": "^1.14.2",
+    "prettier": "^1.15.3",
     "prom-client": "^11.1.3",
     "prometheus-gc-stats": "^0.6.0",
     "primus": "^7.2.2",


### PR DESCRIPTION
# Description
Compare with

```
$ /usr/bin/prettier --version
1.15.3
```

... and the entry in the global package.json is because as some dependency, a version 1.11 would be installed. this makes sure all of them are the same.

# Testing Steps
1. I tested formatting an Rmd file and a cell in a python3 jupyter notebook.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
