### PR TITLE
webapp: update react-sortable-hoc due to #3438

### DIFF
--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -88,7 +88,7 @@
     "react-json-inspector": "^7.0.1",
     "react-redux": "^5.0.7",
     "react-select": "^1.3.0",
-    "react-sortable-hoc": "^0.6.8",
+    "react-sortable-hoc": "^1.3.1",
     "react-timeago": "^3.1.3",
     "react-widgets": "^4.4.6",
     "react-widgets-globalize": "^4.0.2",


### PR DESCRIPTION
# Description
This is motivated by https://github.com/sagemathinc/cocalc/issues/3438 ← which happens quite frequently.
After updating it, I noticed that `smc-webapp/node_modules/react-sortable-hoc/dist/` already contains compiled files, which suggests to me that this incompatibility could be taken care of.

Maybe what I did update is nice, but doesn't solve the issue.

# Testing Steps
1. I don't really know what to test ... it must be related to `.tex` files (according to the stacktraces), but the code doesn't suggest so (it's for draggable navigation and tasks). Hmm. Dragging editor tabs, projects and tasks around works for me, though.
2. just compiling it in my cc-in-cc project and opening a `.tex` file works

# Relevant Issues
https://github.com/sagemathinc/cocalc/issues/3438

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
