### PR TITLE
software: adding stable-2019-01-12 and tweaking descriptions a little bit

### DIFF
--- a/src/smc-util/compute-images.coffee
+++ b/src/smc-util/compute-images.coffee
@@ -6,8 +6,9 @@ exports.DEFAULT_COMPUTE_IMAGE = DEFAULT_COMPUTE_IMAGE
 
 exports.COMPUTE_IMAGES = COMPUTE_IMAGES =
     default: {title: "Default", descr: "Regularly updated, well tested."}
-    previous: {title: "Previous", descr: "Slightly behind 'default', updated less frequently"}
-    "stable-2018-08-27" : {title: "2018-08-27", descr: "Fixed at 2018-08-27 and no longer updated"}
+    previous: {title: "Previous", descr: "One or two weeks behind 'default'"}
+    "stable-2018-08-27" : {title: "2018-08-27", descr: "Frozen at 2018-08-27 and no longer updated"}
+    "stable-2019-01-12" : {title: "2019-01-12", descr: "Frozen at 2019-01-12 and no longer updated"}
     exp: {title: "Experimental", descr: "Cutting-edge software updates (could be broken)"}
     old: {title: "Old image", descr: "In use until Summer 2018. No longer maintained!"}
 


### PR DESCRIPTION
# Description
Since the semester starts and our latest "stable" snapshot is from a while ago, this adds a new one around the beginning of the next semester.

# Testing Steps
in my cc-in-cc dev project, which runs as kucalc=yes, here are the corresponding DB entry changes:

```
smc=# select compute_image from projects where project_id = 'bc6f81b3-25ad-4d58-ae4a-65649fae4fa5';
-[ RECORD 1 ]-+--------
compute_image | default

smc=# select compute_image from projects where project_id = 'bc6f81b3-25ad-4d58-ae4a-65649fae4fa5';
-[ RECORD 1 ]-+------------------
compute_image | stable-2019-01-12
```

and the image server:

```
root@image-server-m5hwp:/storage# ls -l stable-*
lrwxrwxrwx 1 root root 15 Aug 27 17:32 stable-2018-08-27 -> 2018-08-21_1804
lrwxrwxrwx 1 root root 18 Jan 14 09:55 stable-2019-01-12 -> 2019-01-12_1804_ro
```

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
