### PR TITLE
webapp/project log: fix sorting of log entries, especially when searching

### DIFF
--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -23,6 +23,7 @@ misc = require('smc-util/misc')
 misc_page = require('./misc_page')
 underscore = require('underscore')
 immutable  = require('immutable')
+lodash = require('lodash')
 
 {React, ReactDOM, Actions, Store, Table, rtypes, rclass, Redux}  = require('./app-framework')
 {Col, Row, Button, ButtonGroup, ButtonToolbar, FormControl, FormGroup, InputGroup, Panel, Well} = require('react-bootstrap')
@@ -366,7 +367,7 @@ LogMessages = rclass
         cursor     : rtypes.string    # id of the cursor
 
     render_entries: ->
-        for x, i in @props.log
+        for x, i in lodash.sortBy(@props.log, (el) -> -el.time)
             <LogEntry
                 key             = {x.id}
                 cursor          = {@props.cursor==x.id}
@@ -489,7 +490,7 @@ exports.ProjectLog = rclass ({name}) ->
                             @process_log_entry(x)
                             break
             if new_log.length > 1
-                new_log.sort((a,b) -> misc.cmp(b.time, a.time))
+                new_log = lodash.sortBy(new_log, (el) -> -el.time)
                 # combine redundant subsequent events that differ only by time
                 v = []
                 for i in [1...new_log.length]


### PR DESCRIPTION
# Description
This is a quite weird one, but I am able to reproduce #3465 in my dev project, and well, with that patch applied it looks like in the screenshot at the end (compared to the ticket).  There must be something  going on with timestamps which I don't understand. I'm also using lodash as a dependency because of #3466. I tried to sort that "log" array in the js-console, and it simply doesn't get sorted despite it should. What's also interesting, it only works when calling `lodash.sortBy( ... , <function>)`, and not by calling `lodash.sortBy(... , [ <function> ])`. The second one is [mentioned in the doc's example](https://lodash.com/docs/4.17.11#sortBy) but the arguments allow a plain function. Also, using `<date>.getTime()` didn't help either, which is even more obscure.

Still, this is an easy one, because not much has changed.

# Testing Steps
1. not sure what to test, my screenshot above shows that it basically works as before

# Relevant Issues
* #3465
* #3466 (not solved)

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.

![screenshot from 2019-01-15 11-18-46](https://user-images.githubusercontent.com/207405/51174124-5a06fd00-18b7-11e9-9d8b-87e1f7d79739.png)