### PR TITLE
webapp: adding rel="noopener" to external links

### DIFF
--- a/src/smc-webapp/account_ssh_keys.cjsx
+++ b/src/smc-webapp/account_ssh_keys.cjsx
@@ -48,7 +48,7 @@ exports.SSHKeysPage = rclass
                         style       = {marginBottom:'0px'}
                         />
                     <div style={marginTop:'10px'}>
-                        <a href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key" target="_blank">How to create SSH Keys...</a>
+                        <a href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key" target="_blank" rel="noopener">How to create SSH Keys...</a>
                     </div>
                 </Col>
             </Row>

--- a/src/smc-webapp/api-key.cjsx
+++ b/src/smc-webapp/api-key.cjsx
@@ -151,9 +151,9 @@ exports.APIKeySetting = rclass
         <div>
             <hr/>
             <span style={color:'#666'}>
-            NOTE: If you do not have a password set, there is <a href="https://github.com/sagemathinc/cocalc/wiki/password" target="_blank">a workaround to generate your API key.</a>
+            NOTE: If you do not have a password set, there is <a href="https://github.com/sagemathinc/cocalc/wiki/password" target="_blank" rel="noopener">a workaround to generate your API key.</a>
             <br/><br/>
-            See the <a href="#{window.app_base_url}/doc/api.html" target="_blank">CoCalc API documentation</a> to learn about the API.
+            See the <a href="#{window.app_base_url}/doc/api.html" target="_blank" rel="noopener">CoCalc API documentation</a> to learn about the API.
             </span>
         </div>
 

--- a/src/smc-webapp/assistant/body.cjsx
+++ b/src/smc-webapp/assistant/body.cjsx
@@ -244,7 +244,7 @@ exports.ExamplesBody = rclass
             <Col sm={12}>
                 Selected language <code>{@props.lang}</code> has no data.
                 You can help by contributing more content at{' '}
-                <a href={REPO_URL} target={'_blank'}>
+                <a href={REPO_URL} target={'_blank'} rel={"noopener"}>
                     {REPO_URL.split('/')[-2...].join('/')}
                 </a>.
             </Col>

--- a/src/smc-webapp/assistant/footer.cjsx
+++ b/src/smc-webapp/assistant/footer.cjsx
@@ -65,6 +65,7 @@ exports.ExamplesFooter = rclass
                 className  = {'contrib-link'}
                 href       = {REPO_URL}
                 target     = {'_blank'}
+                rel        = {"noopener"}
             >
                 <Icon name = {'code-fork'} /> Contribute
             </Button>

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -215,7 +215,7 @@ validate =
 
 powered_by_stripe = ->
     <span>
-        Powered by <a href="https://stripe.com/" target="_blank" style={top: '7px', position: 'relative', fontSize: '23pt'}><Icon name='cc-stripe'/></a>
+        Powered by <a href="https://stripe.com/" rel="noopener" target="_blank" style={top: '7px', position: 'relative', fontSize: '23pt'}><Icon name='cc-stripe'/></a>
     </span>
 
 
@@ -299,7 +299,7 @@ AddPaymentMethod = rclass
 
     render_input_cvc_help: ->
         if @state.cvc_help
-            <div>The <a href='https://en.wikipedia.org/wiki/Card_security_code' target='_blank'>security code</a> is
+            <div>The <a href='https://en.wikipedia.org/wiki/Card_security_code' target='_blank' rel="noopener">security code</a> is
             located on the back of credit or debit cards and is a separate group of 3 (or 4) digits to the right of
             the signature strip. <a href='' onClick={(e)=>e.preventDefault();@setState(cvc_help:false)}>(hide)</a></div>
         else
@@ -1251,7 +1251,7 @@ exports.ExplainResources = ExplainResources = rclass
 
                     <div style={fontWeight:"bold"}>
                         Please immediately email us at <HelpEmailLink/> {" "}
-                        {if not @props.is_static then <span> or read our <a target='_blank' href="#{PolicyPricingPageUrl}#faq">pricing FAQ</a> </span>}
+                        {if not @props.is_static then <span> or read our <a target='_blank' href="#{PolicyPricingPageUrl}#faq" rel="noopener">pricing FAQ</a> </span>}
                         if anything is unclear to you.
                     </div>
                     <Space/>
@@ -1312,7 +1312,7 @@ exports.ExplainPlan = ExplainPlan = rclass
                 <p>
                 We offer course packages to support teaching using <SiteName/>.
                 They start right after purchase and last for the indicated period and do <b>not auto-renew</b>.
-                Follow the <a href="https://doc.cocalc.com/teaching-instructors.html" target="_blank">instructor guide</a> to create a course file for your new course.
+                Follow the <a href="https://doc.cocalc.com/teaching-instructors.html" target="_blank" rel="noopener">instructor guide</a> to create a course file for your new course.
                 Each time you add a student to your course, a project will be automatically created for that student.
                 You can create and distribute assignments,
                 students work on assignments inside their project (where you can see their progress
@@ -1495,8 +1495,8 @@ FAQS =
     private:
         q: <span>Which plan offers <b>"private" file storage</b>?</span>
         a: <span>All our plans (free and paid) host your files privately by default.
-            Please read our <a target="_blank" href={PolicyPrivacyPageUrl}>Privacy Policy</a> and {" "}
-            <a target="_blank" href={PolicyCopyrightPageUrl}>Copyright Notice</a>.
+            Please read our <a target="_blank" href={PolicyPrivacyPageUrl} rel="noopener">Privacy Policy</a> and {" "}
+            <a target="_blank" href={PolicyCopyrightPageUrl} rel="noopener">Copyright Notice</a>.
            </span>
     git:
         q: <span>Can I work with <b>Git</b> &mdash; including GitHub, Bitbucket, GitLab, etc.?</span>
@@ -2030,7 +2030,7 @@ BillingPage = rclass
 
     render_info_link: ->
         <div style={marginTop:'1em', marginBottom:'1em', color:"#666"}>
-            We offer many <a href={PolicyPricingPageUrl} target='_blank'> pricing and subscription options</a>.
+            We offer many <a href={PolicyPricingPageUrl} target='_blank' rel="noopener"> pricing and subscription options</a>.
             <Space/>
             {@render_suggested_next_step()}
         </div>

--- a/src/smc-webapp/compute_environment.cjsx
+++ b/src/smc-webapp/compute_environment.cjsx
@@ -171,7 +171,7 @@ LanguageTable = rclass
                 <div style={style}>
                 {
                     if component_info.url
-                        <a target='_blank' href={component_info.url}>{component_info.name}</a>
+                        <a target='_blank' rel="noopener" href={component_info.url}>{component_info.name}</a>
                     else
                         component_info.name
                 }
@@ -314,7 +314,7 @@ ComputeEnvironment = rclass
                     The library{' '}
                     {
                         if url
-                            <a target='_blank' href={url}>{name}</a>
+                            <a target='_blank'  rel="noopener" href={url}>{name}</a>
                         else
                             name
                     }{' '}
@@ -337,7 +337,7 @@ ComputeEnvironment = rclass
                 <ul>
                     <li style={li_style}>selecting the appropriate Kernel in a Jupyter Notebook,</li>
                     <li style={li_style}>load it from within a SageMath Worksheet via the{' '}
-                        <a target='_blank' href={jupyter_bridge_url}>Jupyter Bridge</a>.
+                        <a target='_blank' rel="noopener" href={jupyter_bridge_url}>Jupyter Bridge</a>.
                         E.g. for Anaconda:
                         <pre>
                             %auto
@@ -412,7 +412,7 @@ ComputeEnvironment = rclass
                     info = execs[k]
                     <li key={k} style={li_style}>
                         <b>
-                            <a href={info.url} target='_blank'>{info.name}</a>{':'}
+                            <a href={info.url} rel="noopener" target='_blank'>{info.name}</a>{':'}
                         </b>
                         {' '}
                         {info.doc}

--- a/src/smc-webapp/course/help_box.tsx
+++ b/src/smc-webapp/course/help_box.tsx
@@ -35,13 +35,17 @@ export function HelpBox() {
       <span style={{ color: "#666", fontSize: "11pt" }}>
         <ul>
           <li>
-            <a href={LIVE_DEMO_REQUEST} target={"_blank"}>
+            <a href={LIVE_DEMO_REQUEST} target={"_blank"} rel={"noopener"}>
               Request a live demo <Icon name="external-link" />
             </a>{" "}
             (with a {SITE_NAME} specialist)
           </li>
           <li>
-            <a href="https://doc.cocalc.com/teaching-instructors.html" target="_blank">
+            <a
+              href={"https://doc.cocalc.com/teaching-instructors.html"}
+              target={"_blank"}
+              rel={"noopener"}
+            >
               Instructor Guide for using CoCalc for teaching{" "}
               <Icon name="external-link" />
             </a>
@@ -50,6 +54,7 @@ export function HelpBox() {
             <a
               href="http://www.beezers.org/blog/bb/2015/09/grading-in-sagemathcloud/"
               target="_blank"
+              rel={"noopener"}
             >
               Grading courses <Icon name="external-link" />
             </a>
@@ -58,6 +63,7 @@ export function HelpBox() {
             <a
               href="http://www.beezers.org/blog/bb/2016/01/pennies-a-day-for-sagemathcloud/"
               target="_blank"
+              rel={"noopener"}
             >
               Course plans and teaching experiences{" "}
               <Icon name="external-link" />
@@ -67,6 +73,7 @@ export function HelpBox() {
             <a
               href="http://blog.ouseful.info/2015/11/24/course-management-and-collaborative-jupyter-notebooks-via-sagemathcloud/"
               target="_blank"
+              rel={"noopener"}
             >
               Course management and collaborative Jupyter Notebooks{" "}
               <Icon name="external-link" />

--- a/src/smc-webapp/course/students_panel.tsx
+++ b/src/smc-webapp/course/students_panel.tsx
@@ -996,7 +996,7 @@ class Student extends Component<StudentProps, StudentState> {
   render_student_email() {
     const email = this.props.student.get("email_address");
     return (
-      <a target={"_blank"} href={`mailto:${email}`}>
+      <a target={"_blank"} href={`mailto:${email}`} rel={"noopener"}>
         {email}
       </a>
     );

--- a/src/smc-webapp/editor_archive.cjsx
+++ b/src/smc-webapp/editor_archive.cjsx
@@ -101,7 +101,7 @@ class ArchiveActions extends Actions
     set_unsupported: (ext) =>
         msg = <span>
                 <b>WARNING:</b> Support for decompressing {ext} archives is not yet implemented{' '}
-                (see <a href='https://github.com/sagemathinc/cocalc/issues/1720' target='_blank'>https://github.com/sagemathinc/cocalc/issues/1720</a>).
+                (see <a href='https://github.com/sagemathinc/cocalc/issues/1720' target='_blank' rel='noopener'>https://github.com/sagemathinc/cocalc/issues/1720</a>).
                 <br/>
                 Despite that, you can open up a Terminal ("Files" → "Create" dropdown, select "Terminal") and run the extraction command right there in the Linux shell.
               </span>

--- a/src/smc-webapp/editor_git.cjsx
+++ b/src/smc-webapp/editor_git.cjsx
@@ -741,7 +741,7 @@ Git = (name) -> rclass
                 </span>
             <Panel className="small" header={head}>
                 <p>{@props.current_github_issue.body}</p>
-                <a target="_blank" href={@props.current_github_issue.html_url}>Open on Github</a>
+                <a target="_blank" rel="noopener" href={@props.current_github_issue.html_url}>Open on Github</a>
             </Panel>
 
     render: ->

--- a/src/smc-webapp/editor_jupyter.coffee
+++ b/src/smc-webapp/editor_jupyter.coffee
@@ -1199,7 +1199,7 @@ class JupyterNotebook extends EventEmitter
             , 0
 
     info: () =>
-        t = "<h3><i class='fa fa-question-circle'></i> About <a href='https://jupyter.org/' target='_blank'>Jupyter Notebook</a></h3>"
+        t = "<h3><i class='fa fa-question-circle'></i> About <a href='https://jupyter.org/' target='_blank' rel='noopener'>Jupyter Notebook</a></h3>"
         t += "<h4>Enhanced with CoCalc Sync</h4>"
         t += "You are editing this document using the Jupyter Notebook enhanced with realtime synchronization and history logging."
         t += "<h4>Use Sage by pasting this into a cell</h4>"
@@ -1218,7 +1218,7 @@ class JupyterNotebook extends EventEmitter
 
     modern: () =>
         t = "<h3><i class='fa fa-exchange'></i> Switch to the CoCalc Jupyter Notebook</a></h3>"
-        t += "<br><br>Unfortunately, Jupyter classic does not work on Firefox; please switch back to the CoCalc Jupyter notebook server (or use Google Chrome or Safari).<br><br>The CoCalc Jupyter Notebook has <a href='http://blog.sagemath.com/jupyter/2017/05/05/jupyter-rewrite-for-smc.html' target='_blank'>many improvements</a> over the classical notebook, which you are currently using.  However, certain features are still not fully supported (notably, interactive widgets).  You can try opening your notebooks using the CoCalc notebook.  If it doesn't work for you, you can easily switch to the Classical Jupyter Notebook (please let us know what is missing so we can add it!). NOTE: multiple people simultaneously editing a notebook, with some using classical and some using the new mode, will NOT work well!<br><br><a href='" + require('smc-util/theme').JUPYTER_CLASSIC_MODERN + "' target='_blank'>More info and the latest status...</a>"
+        t += "<br><br>Unfortunately, Jupyter classic does not work on Firefox; please switch back to the CoCalc Jupyter notebook server (or use Google Chrome or Safari).<br><br>The CoCalc Jupyter Notebook has <a href='http://blog.sagemath.com/jupyter/2017/05/05/jupyter-rewrite-for-smc.html' target='_blank' rel='noopener'>many improvements</a> over the classical notebook, which you are currently using.  However, certain features are still not fully supported (notably, interactive widgets).  You can try opening your notebooks using the CoCalc notebook.  If it doesn't work for you, you can easily switch to the Classical Jupyter Notebook (please let us know what is missing so we can add it!). NOTE: multiple people simultaneously editing a notebook, with some using classical and some using the new mode, will NOT work well!<br><br><a href='" + require('smc-util/theme').JUPYTER_CLASSIC_MODERN + "' target='_blank' rel='noopener'>More info and the latest status...</a>"
         t += "<br><hr>"
         t += "<a href='#jupyter-switch-to-modern-notebook' class='btn btn-warning'>Switch to CoCalc Jupyter Notebook</a>"
         bootbox.alert(t)

--- a/src/smc-webapp/editor_pdf.cjsx
+++ b/src/smc-webapp/editor_pdf.cjsx
@@ -59,7 +59,7 @@ PublicPDF = rclass
                     <Icon name="refresh" /> Reload
                 </Button>
                 <Button
-                    target="_blank"
+                    target="_blank" rel="noopener"
                     href="#{get_url(@props.project_id, @props.path)}?random=#{Math.random()}">
                     <Icon name="external-link"/> Open in New Window
                 </Button>

--- a/src/smc-webapp/jupyter/about.tsx
+++ b/src/smc-webapp/jupyter/about.tsx
@@ -55,7 +55,7 @@ export class About extends Component<AboutProps> {
         <a href="https://github.com/sagemathinc/cocalc/wiki/sagejupyter" target="_new">
           documentation
         </a>, create a <ShowSupportLink />, or see the latest{" "}
-        <a href={JUPYTER_CLASSIC_MODERN} target="_blank">
+        <a href={JUPYTER_CLASSIC_MODERN} target="_blank" rel="noopener">
           status of Jupyter in CoCalc.
         </a>
       </span>
@@ -104,7 +104,7 @@ export class About extends Component<AboutProps> {
           <div style={{ color: "#666", margin: "0px 45px" }}>
             CoCalc Jupyter notebook is a complete open source rewrite by SageMath, Inc. of the
             classical Jupyter notebook client from the{" "}
-            <a href="http://jupyter.org/" target="_blank">
+            <a href="http://jupyter.org/" target="_blank" rel="noopener">
               Jupyter project
             </a>. CoCalc Jupyter notebook maintains full compatibility with the file format and
             general look and feel of the classical notebook. It improves on the classical notebook

--- a/src/smc-webapp/jupyter/nbconvert.tsx
+++ b/src/smc-webapp/jupyter/nbconvert.tsx
@@ -276,6 +276,7 @@ export class NBConvert extends Component<NBConvertProps> {
       <a
         href="http://nbconvert.readthedocs.io/en/latest/usage.html"
         target="_blank"
+        rel="noopener"
         className="pull-right"
       >
         <Icon name="external-link" /> nbconvert documentation
@@ -319,6 +320,7 @@ export class NBConvert extends Component<NBConvertProps> {
           slideshows is{" "}
           <a
             target="_blank"
+            rel="noopener"
             href="https://github.com/sagemathinc/cocalc/issues/2569#issuecomment-350940928"
           >
             not yet implemented

--- a/src/smc-webapp/jupyter/nbconvert.tsx
+++ b/src/smc-webapp/jupyter/nbconvert.tsx
@@ -17,9 +17,14 @@ const NAMES = {
   asciidoc: { ext: "asciidoc", display: "AsciiDoc" },
   slides: { ext: "slides.html", display: "Slides" },
   latex: { ext: "tex", display: "LaTeX", internal: true },
-  sagews: { ext: "sagews", display: "Sage Worksheet", internal: true, nolink: true },
+  sagews: {
+    ext: "sagews",
+    display: "Sage Worksheet",
+    internal: true,
+    nolink: true
+  },
   pdf: { ext: "pdf", display: "PDF" },
-  script: { ext: "txt", display: "Executable Script", internal: true },
+  script: { ext: "txt", display: "Executable Script", internal: true }
 };
 
 interface ErrorProps {
@@ -49,7 +54,10 @@ class Error extends Component<ErrorProps> {
   };
 
   render_time() {
-    const time = this.props.nbconvert != null ? this.props.nbconvert.get("time") : undefined;
+    const time =
+      this.props.nbconvert != null
+        ? this.props.nbconvert.get("time")
+        : undefined;
     if (time == null) {
       return;
     }
@@ -61,7 +69,10 @@ class Error extends Component<ErrorProps> {
   }
 
   render() {
-    const error = this.props.nbconvert != null ? this.props.nbconvert.get("error") : undefined;
+    const error =
+      this.props.nbconvert != null
+        ? this.props.nbconvert.get("error")
+        : undefined;
     if (!error) {
       return <span />;
     }
@@ -72,8 +83,8 @@ class Error extends Component<ErrorProps> {
       return (
         <span>
           <h3>Error</h3>
-          Running nbconvert failed with an error {this.render_time()}. Read the error log below,
-          update your Jupyter notebook, then try again.
+          Running nbconvert failed with an error {this.render_time()}. Read the
+          error log below, update your Jupyter notebook, then try again.
           <pre
             ref={node => (this.preNode = node)}
             style={{ maxHeight: "40vh", margin: "5px 30px" }}
@@ -129,7 +140,9 @@ export class NBConvert extends Component<NBConvertProps> {
     let ext: string;
     if (to === "script" && this.props.backend_kernel_info != null) {
       // special case where extension may be different
-      ext = this.props.backend_kernel_info.getIn(["language_info", "file_extension"], "").slice(1);
+      ext = this.props.backend_kernel_info
+        .getIn(["language_info", "file_extension"], "")
+        .slice(1);
       if (ext === "") {
         ext = "txt";
       }
@@ -153,13 +166,22 @@ export class NBConvert extends Component<NBConvertProps> {
   }
 
   render_result() {
-    if (this.props.nbconvert != null ? this.props.nbconvert.get("error") : undefined) {
-      return <Error actions={this.props.actions} nbconvert={this.props.nbconvert} />;
+    if (
+      this.props.nbconvert != null
+        ? this.props.nbconvert.get("error")
+        : undefined
+    ) {
+      return (
+        <Error actions={this.props.actions} nbconvert={this.props.nbconvert} />
+      );
     }
   }
 
   render_recent_run() {
-    let time = this.props.nbconvert != null ? this.props.nbconvert.get("time") : undefined;
+    let time =
+      this.props.nbconvert != null
+        ? this.props.nbconvert.get("time")
+        : undefined;
     if (time == null) {
       return;
     }
@@ -182,8 +204,7 @@ export class NBConvert extends Component<NBConvertProps> {
     );
     return (
       <div style={{ marginTop: "15px" }}>
-        Last exported {time}.
-        {this.render_cmd()}
+        Last exported {time}.{this.render_cmd()}
         {this.render_result()}
         <ButtonGroup>{this.render_download()}</ButtonGroup>
       </div>
@@ -196,7 +217,10 @@ export class NBConvert extends Component<NBConvertProps> {
     // change on the backend, as other code generates the cmd there. If this bugs you, refactor it!
     let cmd: any;
     const { tail = undefined } = misc.path_split(this.props.path) || {};
-    if (this.props.nbconvert_dialog != null && this.props.nbconvert_dialog.get("to") === "sagews") {
+    if (
+      this.props.nbconvert_dialog != null &&
+      this.props.nbconvert_dialog.get("to") === "sagews"
+    ) {
       cmd = shell_escape(["smc-ipynb2sagews", tail]);
     } else {
       const v = ["jupyter", "nbconvert"].concat(this.args());
@@ -208,7 +232,10 @@ export class NBConvert extends Component<NBConvertProps> {
   }
 
   render_started() {
-    const start = this.props.nbconvert != null ? this.props.nbconvert.get("start") : undefined;
+    const start =
+      this.props.nbconvert != null
+        ? this.props.nbconvert.get("start")
+        : undefined;
     if (start == null) {
       return;
     }
@@ -223,7 +250,10 @@ export class NBConvert extends Component<NBConvertProps> {
     if (this.props.nbconvert_dialog == null) {
       return;
     }
-    const state = this.props.nbconvert != null ? this.props.nbconvert.get("state") : undefined;
+    const state =
+      this.props.nbconvert != null
+        ? this.props.nbconvert.get("state")
+        : undefined;
     switch (state) {
       case "start":
         return (
@@ -256,7 +286,10 @@ export class NBConvert extends Component<NBConvertProps> {
     if (this.props.nbconvert_dialog == null) {
       return;
     }
-    const state = this.props.nbconvert != null ? this.props.nbconvert.get("state") : undefined;
+    const state =
+      this.props.nbconvert != null
+        ? this.props.nbconvert.get("state")
+        : undefined;
     return (
       <div>
         <Button
@@ -286,7 +319,9 @@ export class NBConvert extends Component<NBConvertProps> {
 
   target_name = () => {
     const to =
-      this.props.nbconvert_dialog != null ? this.props.nbconvert_dialog.get("to") : undefined;
+      this.props.nbconvert_dialog != null
+        ? this.props.nbconvert_dialog.get("to")
+        : undefined;
     if (to != null) {
       return NAMES[to] != null ? NAMES[to].display : undefined;
     } else {
@@ -301,7 +336,9 @@ export class NBConvert extends Component<NBConvertProps> {
   };
 
   slides_url = () => {
-    const base = misc.separate_file_extension(misc.path_split(this.props.path).tail).name;
+    const base = misc.separate_file_extension(
+      misc.path_split(this.props.path).tail
+    ).name;
     const name = base + ".slides.html#/";
     return `https://cocalc.com/${this.props.project_id}/server/18080/` + name;
   };
@@ -309,23 +346,28 @@ export class NBConvert extends Component<NBConvertProps> {
   render_slides_workaround() {
     // workaround until #2569 is fixed.
     return (
-      <Modal show={this.props.nbconvert_dialog != null} bsSize="large" onHide={this.close}>
+      <Modal
+        show={this.props.nbconvert_dialog != null}
+        bsSize="large"
+        onHide={this.close}
+      >
         <Modal.Header closeButton>
           <Modal.Title>
             <Icon name="slideshare" /> Jupyter Notebook Slideshow
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          Use View-->Slideshow to turn your Jupyter notebook into a slideshow. One click display of
-          slideshows is{" "}
+          Use View-->Slideshow to turn your Jupyter notebook into a slideshow.
+          One click display of slideshows is{" "}
           <a
             target="_blank"
             rel="noopener"
             href="https://github.com/sagemathinc/cocalc/issues/2569#issuecomment-350940928"
           >
             not yet implemented
-          </a>. However, you can start a slideshow by copying and pasting the following command in a
-          terminal in CoCalc (+New-->Terminal):
+          </a>
+          . However, you can start a slideshow by copying and pasting the
+          following command in a terminal in CoCalc (+New-->Terminal):
           <pre>{this.slides_command()}</pre>
           Then view your slides at
           <div style={{ textAlign: "center" }}>
@@ -343,7 +385,9 @@ export class NBConvert extends Component<NBConvertProps> {
 
   render() {
     const to =
-      this.props.nbconvert_dialog != null ? this.props.nbconvert_dialog.get("to") : undefined;
+      this.props.nbconvert_dialog != null
+        ? this.props.nbconvert_dialog.get("to")
+        : undefined;
     if (to == null) {
       return <span />;
     }
@@ -351,7 +395,11 @@ export class NBConvert extends Component<NBConvertProps> {
       return this.render_slides_workaround();
     }
     return (
-      <Modal show={this.props.nbconvert_dialog != null} bsSize="large" onHide={this.close}>
+      <Modal
+        show={this.props.nbconvert_dialog != null}
+        bsSize="large"
+        onHide={this.close}
+      >
         <Modal.Header closeButton>
           <Modal.Title>Download</Modal.Title>
         </Modal.Header>

--- a/src/smc-webapp/library.cjsx
+++ b/src/smc-webapp/library.cjsx
@@ -218,7 +218,7 @@ exports.Library = rclass ({name}) ->
                         overflow      : 'hidden'
                         textOverflow  : 'ellipsis'
                     <p style={color: COLORS.GRAY_D}>
-                        Website: <a style={website_style} target='_blank' href={doc.get('website')}>{doc.get('website')}</a>
+                        Website: <a style={website_style} target='_blank' rel='noopener' href={doc.get('website')}>{doc.get('website')}</a>
                     </p>
             }
             {

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1361,7 +1361,7 @@ exports.define_codemirror_extensions = () ->
                 title  = title.val().trim()
 
                 if target == "_blank"
-                    target = " target='_blank'"
+                    target = " target='_blank' rel='noopener'"
 
                 if title.length > 0
                     title = " title='#{title}'"
@@ -1880,7 +1880,7 @@ exports.open_new_tab = (url, popup=false, opts) ->
     if not tab?.closed? or tab.closed   # either tab isn't even defined (or doesn't have close method) -- or already closed -- popup blocked
         {alert_message} = require('./alerts')
         if url
-            message = "Either enable popups for this website or <a href='#{url}' target='_blank'>click on this link</a>."
+            message = "Either enable popups for this website or <a href='#{url}' target='_blank' rel='noopener'>click on this link</a>."
         else
             message = "Enable popups for this website and try again."
         alert_message

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1880,7 +1880,7 @@ exports.open_new_tab = (url, popup=false, opts) ->
     if not tab?.closed? or tab.closed   # either tab isn't even defined (or doesn't have close method) -- or already closed -- popup blocked
         {alert_message} = require('./alerts')
         if url
-            message = "Either enable popups for this website or <a href='#{url}' target='_blank' rel='noopener'>click on this link</a>."
+            message = "Either enable popups for this website or <a href='#{url}' target='_blank'>click on this link</a>."
         else
             message = "Enable popups for this website and try again."
         alert_message

--- a/src/smc-webapp/process-links.coffee
+++ b/src/smc-webapp/process-links.coffee
@@ -80,6 +80,7 @@ $.fn.process_smc_links = (opts={}) ->
                 else
                     # make links open in a new tab by default
                     a.attr("target","_blank")
+                    a.attr("rel", "noopener")
 
         # part #2: process <img>, <object> and <video>/<source> tags
         # make relative links to images use the raw server

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -899,7 +899,7 @@ SSHPanel = rclass
         <div>
             <span>Use the following username@host:</span>
             <pre>{addr}</pre>
-            <a href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key" target="_blank">
+            <a href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key" target="_blank" rel="noopener">
                 <Icon name='life-ring'/> How to create SSH keys
             </a>
         </div>

--- a/src/smc-webapp/r_help.cjsx
+++ b/src/smc-webapp/r_help.cjsx
@@ -277,10 +277,10 @@ CONNECT_LINKS =
         href : 'https://github.com/sagemathinc/cocalc'
         link : 'GitHub'
         text : <span>
-                 <a href='https://github.com/sagemathinc/cocalc/tree/master/src' target='_blank'>source code</a>,{' '}
-                 <a href='https://github.com/sagemathinc/cocalc/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AI-bug%20sort%3Acreated-asc%20-label%3Ablocked' target='_blank'>bugs</a>
+                 <a href='https://github.com/sagemathinc/cocalc/tree/master/src' target='_blank' rel='noopener'>source code</a>,{' '}
+                 <a href='https://github.com/sagemathinc/cocalc/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AI-bug%20sort%3Acreated-asc%20-label%3Ablocked' target='_blank' rel='noopener'>bugs</a>
                  {' and '}
-                 <a href='https://github.com/sagemathinc/cocalc/issues' target='_blank'>issues</a>
+                 <a href='https://github.com/sagemathinc/cocalc/issues' target='_blank' rel='noopener'>issues</a>
                </span>
 
 THIRD_PARTY =
@@ -299,11 +299,11 @@ THIRD_PARTY =
         href : 'http://www.scipy-lectures.org/'
         link : 'Scientific Python'
         text : <span>i.e.{' '}
-                    <a href='http://statsmodels.sourceforge.net/stable/' target='_blank'>Statsmodels</a>,{' '}
-                    <a href='http://pandas.pydata.org/pandas-docs/stable/' target='_blank'>Pandas</a>,{' '}
-                    <a href='http://docs.sympy.org/latest/index.html' target='_blank'>SymPy</a>,{' '}
-                    <a href='http://scikit-learn.org/stable/documentation.html' target='_blank'>Scikit Learn</a>,{' '}
-                    <a href='http://www.nltk.org/' target='_blank'>NLTK</a> and many more
+                    <a href='http://statsmodels.sourceforge.net/stable/' target='_blank' rel='noopener'>Statsmodels</a>,{' '}
+                    <a href='http://pandas.pydata.org/pandas-docs/stable/' target='_blank' rel='noopener'>Pandas</a>,{' '}
+                    <a href='http://docs.sympy.org/latest/index.html' target='_blank' rel='noopener'>SymPy</a>,{' '}
+                    <a href='http://scikit-learn.org/stable/documentation.html' target='_blank' rel='noopener'>Scikit Learn</a>,{' '}
+                    <a href='http://www.nltk.org/' target='_blank' rel='noopener'>NLTK</a> and many more
                </span>
     julia :
         icon : 'cc-icon-julia'
@@ -340,19 +340,19 @@ ABOUT_LINKS =
     developers :
         icon : 'keyboard-o'
         text : <span>
-                <a target='_blank' href='http://blog.sagemath.com/cocalc/2018/09/10/where-is-cocalc-from.html'>Core developers</a>: John Jeng,{' '}
-                <a target='_blank' href='http://harald.schil.ly/'>Harald Schilly</a>,{' '}
-                <a target="_blank" href='https://twitter.com/haldroid'>Hal Snyder</a>,{' '}
-                <a target='_blank' href='http://wstein.org'>William Stein</a>
+                <a target='_blank' rel='noopener' href='http://blog.sagemath.com/cocalc/2018/09/10/where-is-cocalc-from.html'>Core developers</a>: John Jeng,{' '}
+                <a target='_blank' rel='noopener' href='http://harald.schil.ly/'>Harald Schilly</a>,{' '}
+                <a target="_blank" rel='noopener' href='https://twitter.com/haldroid'>Hal Snyder</a>,{' '}
+                <a target='_blank' rel='noopener' href='http://wstein.org'>William Stein</a>
                </span>
     #funding :
     #    <span>
-    #        <SiteName/> currently funded by paying customers, private investment, and <a target='_blank'  href="https://cloud.google.com/developers/startups/">the Google startup program</a>
+    #        <SiteName/> currently funded by paying customers, private investment, and <a target='_blank' rel='noopener' href="https://cloud.google.com/developers/startups/">the Google startup program</a>
     #    </span>
     #launched :
     #    <span>
     #        <SiteName/> launched (as "SageMathCloud") April 2013 with support from the National Science Foundation and
-    #        <a target='_blank' href='https://research.google.com/university/relations/appengine/index.html'> the Google
+    #        <a target='_blank' rel='noopener' href='https://research.google.com/university/relations/appengine/index.html'> the Google
     #        Education Grant program</a>
     #    </span>
     incorporated :
@@ -380,9 +380,11 @@ LinkList = rclass
             style = misc.copy(li_style)
             if data.bold
                 style.fontWeight = 'bold'
+            is_target_blank = data.href?.indexOf('#') != 0
+
             <div key={name} style={style} className={if data.className? then data.className}>
                 <Icon name={data.icon} fixedWidth />{' '}
-                { <a target={if data.href.indexOf('#') != 0 then '_blank'} href={data.href}>
+                { <a target={if is_target_blank then '_blank'} rel={if is_target_blank then 'noopener'}  href={data.href}>
                    {data.link}
                 </a> if data.href}
                 {<span style={color:COLORS.GRAY_D}>

--- a/src/smc-webapp/r_help.cjsx
+++ b/src/smc-webapp/r_help.cjsx
@@ -307,7 +307,7 @@ THIRD_PARTY =
                </span>
     julia :
         icon : 'cc-icon-julia'
-        href : 'http://docs.julialang.org/en/stable/manual/introduction/'
+        href : 'https://www.julialang.org/'
         link : 'Julia'
         text : 'programming language for numerical computing'
     octave :

--- a/src/smc-webapp/r_misc/index.cjsx
+++ b/src/smc-webapp/r_misc/index.cjsx
@@ -222,9 +222,9 @@ exports.Footer = rclass
             <Space/>
             <SiteName/> by <CompanyName/>
             {' '} &middot; {' '}
-            <a target="_blank" href={PolicyIndexPageUrl}>Policies</a>
+            <a target="_blank" rel='noopener' href={PolicyIndexPageUrl}>Policies</a>
             {' '} &middot; {' '}
-            <a target="_blank" href={PolicyTOSPageUrl}>Terms of Service</a>
+            <a target="_blank" rel='noopener' href={PolicyTOSPageUrl}>Terms of Service</a>
             {' '} &middot; {' '}
             <HelpEmailLink />
             {' '} &middot; {' '}
@@ -1166,9 +1166,9 @@ exports.NonMemberProjectWarning = (opts) ->
     else if avail <= 0
         url = PolicyPricingPageUrl
         if total > 0
-            suggestion = <span>Your {total} members-only hosting {misc.plural(total,'upgrade')} are already in use on other projects.  You can <a href={url} target='_blank' style={cursor:'pointer'}>purchase further upgrades </a> by adding a subscription (you can add the same subscription multiple times), or disable member-only hosting for another project to free a spot up for this one.</span>
+            suggestion = <span>Your {total} members-only hosting {misc.plural(total,'upgrade')} are already in use on other projects.  You can <a href={url} target='_blank' rel='noopener' style={cursor:'pointer'}>purchase further upgrades </a> by adding a subscription (you can add the same subscription multiple times), or disable member-only hosting for another project to free a spot up for this one.</span>
         else
-            suggestion = <span><Space /><a href={url} target='_blank' style={cursor:'pointer'}>Subscriptions start at only $14/month.</a></span>
+            suggestion = <span><Space /><a href={url} target='_blank' rel='noopener' style={cursor:'pointer'}>Subscriptions start at only $14/month.</a></span>
 
     <Alert bsStyle='warning' style={marginTop:'10px'}>
         <h4><Icon name='exclamation-triangle'/>  Warning: this project is <strong>running on a free server</strong></h4>
@@ -1189,9 +1189,9 @@ exports.NoNetworkProjectWarning = (opts) ->
     else if avail <= 0
         url = PolicyPricingPageUrl
         if total > 0
-            suggestion = <span>Your {total} internet access {misc.plural(total,'upgrade')} are already in use on other projects.  You can <a href={url} target='_blank' style={cursor:'pointer'}>purchase further upgrades </a> by adding a subscription (you can add the same subscription multiple times), or disable an internet access upgrade for another project to free a spot up for this one.</span>
+            suggestion = <span>Your {total} internet access {misc.plural(total,'upgrade')} are already in use on other projects.  You can <a href={url} target='_blank' rel='noopener' style={cursor:'pointer'}>purchase further upgrades </a> by adding a subscription (you can add the same subscription multiple times), or disable an internet access upgrade for another project to free a spot up for this one.</span>
         else
-            suggestion = <span><Space /><a href={url} target='_blank' style={cursor:'pointer'}>Subscriptions start at only $14/month.</a></span>
+            suggestion = <span><Space /><a href={url} target='_blank' rel='noopener' style={cursor:'pointer'}>Subscriptions start at only $14/month.</a></span>
 
     <Alert bsStyle='warning' style={marginTop:'10px'}>
         <h4><Icon name='exclamation-triangle'/>  Warning: this project <strong>does not have full internet access</strong></h4>

--- a/src/smc-webapp/r_profile_image.tsx
+++ b/src/smc-webapp/r_profile_image.tsx
@@ -190,7 +190,7 @@ export class ProfileImageSelector extends Component<
           <Well style={{ marginTop: "10px", marginBottom: "10px" }}>
             Gravatar is a service for using a common avatar across websites. Go
             to the{" "}
-            <a href="https://en.gravatar.com" target="_blank">
+            <a href="https://en.gravatar.com" target="_blank" rel='noopener'>
               Wordpress Gravatar site
             </a>{" "}
             and sign in (or create an account) using {this.props.email_address}.
@@ -236,7 +236,7 @@ export class ProfileImageSelector extends Component<
           <Well style={{ marginTop: "10px", marginBottom: "10px" }}>
             Adorable creates a cute randomize monster face out of your email.
             See{" "}
-            <a href="http://avatars.adorable.io" target="_blank">
+            <a href="http://avatars.adorable.io" target="_blank" rel='noopener'>
               {"http://avatars.adorable.io"}
             </a>{" "}
             for more.

--- a/src/smc-webapp/r_upgrades.cjsx
+++ b/src/smc-webapp/r_upgrades.cjsx
@@ -54,7 +54,7 @@ exports.UpgradesPage = rclass
         <div style={margin:'10px 0'}>
             <h3>Thank you for supporting <SiteName/></h3>
             <span style={color:"#666"}>
-                We offer many <a href={PolicyPricingPageUrl} target='_blank'> pricing
+                We offer many <a href={PolicyPricingPageUrl} target='_blank' rel='noopener'> pricing
                 and subscription options</a>, which you can subscribe to in the Billing tab.
                 Your upgrades are listed below, along with how you have
                 applied them to projects.  You can adjust your project upgrades from

--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -536,7 +536,7 @@ ChatRoom = rclass ({name}) ->
                     </Button>
                 </div>
                 <div style={color:"#888", padding:'5px'}>
-                    Shift+enter to send. Double click to edit. Use <a href='https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/' target='_blank'>Markdown</a> and <a href="https://en.wikibooks.org/wiki/LaTeX/Mathematics" target='_blank'>LaTeX</a>.
+                    Shift+enter to send. Double click to edit. Use <a href='https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/' target='_blank' rel='noopener'>Markdown</a> and <a href="https://en.wikibooks.org/wiki/LaTeX/Mathematics" target='_blank' rel='noopener'>LaTeX</a>.
                 </div>
             </div>
         </div>

--- a/src/smc-webapp/support.cjsx
+++ b/src/smc-webapp/support.cjsx
@@ -354,7 +354,7 @@ SupportInfo = rclass
 
     created: () ->
         if @props.url?.length > 1
-            url = <a href={@props.url} target='_blank'>{@props.url}</a>
+            url = <a href={@props.url} target='_blank' rel='noopener'>{@props.url}</a>
         else
             url = 'no ticket'
         <div style={textAlign:'center'}>
@@ -391,26 +391,26 @@ SupportInfo = rclass
             <ul>
                 <li>
                     <b>Looking for documentation and help?</b> Go to
-                    the <a href="#{SmcWikiUrl}" target="_blank">CoCalc documentation</a>.
+                    the <a href="#{SmcWikiUrl}" target="_blank" rel="noopener">CoCalc documentation</a>.
                 </li>
                 <li>
                     <b>Trying to sign out?</b>  Click on Account on the top right, then click
                     "Sign out..." in Preferences.
                 </li>
                 <li>
-                    <a target="_blank" href="https://github.com/sagemathinc/cocalc/wiki/MySubscriptionDoesNotWork">Bought a subscription but it does not work?</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/sagemathinc/cocalc/wiki/MySubscriptionDoesNotWork">Bought a subscription but it does not work?</a>
                 </li>
                 <li>
-                    <a target="_blank" href="https://github.com/sagemathinc/cocalc/wiki/DeleteProject">Files or project seem gone?</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/sagemathinc/cocalc/wiki/DeleteProject">Files or project seem gone?</a>
                 </li>
                 <li>
-                    <a target="_blank" href="https://github.com/sagemathinc/cocalc/wiki/SageWorksheetWontRun">Sage worksheet or Jupyter notebook is very slow or will not run?</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/sagemathinc/cocalc/wiki/SageWorksheetWontRun">Sage worksheet or Jupyter notebook is very slow or will not run?</a>
                 </li>
                 <li>
-                    <a target="_blank" href="https://github.com/sagemathinc/cocalc/wiki/KernelTerminated">Jupyter notebook keeps crashing with "Kernel terminated"?</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/sagemathinc/cocalc/wiki/KernelTerminated">Jupyter notebook keeps crashing with "Kernel terminated"?</a>
                 </li>
                 <li>
-                    <a target="_blank" href="https://github.com/sagemathinc/cocalc/wiki/SageQuestion">Have a question about how to use Sage?</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/sagemathinc/cocalc/wiki/SageQuestion">Have a question about how to use Sage?</a>
                 </li>
                 <li>
                     <b>Requesting that we install software?</b> Fill out the form below and

--- a/src/webapp-lib/app.pug
+++ b/src/webapp-lib/app.pug
@@ -19,8 +19,8 @@ html(lang="en")
         div.message
           | Timeout while loading CoCalc.
           br/
-          | If the problem persists, try <a target='_blank' href="https://github.com/sagemathinc/cocalc/wiki/Connection-Timeout">these steps</a>
-          | or email <a href="mailto:help@sagemath.com" target="_blank">help@sagemath.com</a>.
+          | If the problem persists, try <a target="_blank" rel="noopener" href="https://github.com/sagemathinc/cocalc/wiki/Connection-Timeout">these steps</a>
+          | or email <a href="mailto:help@sagemath.com" target="_blank" rel="noopener">help@sagemath.com</a>.
 
     div#smc-startup-banner-status
       | Initializing ...

--- a/src/webapp-lib/doc/r-statistical-software.pug
+++ b/src/webapp-lib/doc/r-statistical-software.pug
@@ -147,7 +147,7 @@ block content
             li.
               Automatically processes
               #[strong #[code .Rnw] and #[code .Rtex] files] using
-              #[strong #[a(href="https://yihui.name/knitr/" target="_blank") Knitr]],
+              #[strong #[a(href="https://yihui.name/knitr/" target="_blank" rel="noopener") Knitr]],
             li.
               Supports #[strong forward and inverse search] to help you navigating in your document,
             li.

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -250,7 +250,7 @@ block content
                 li #[a(href="https://doc.cocalc.com/") CoCalc Manual]
                 li #[a(href="https://github.com/sagemathinc/cocalc/wiki/Teaching") Courses using #{htmlWebpackPlugin.options.title}]
             div.col-md-6
-              a.btn.btn-default.btn-lg.cc-create-account-btn(href=htmlWebpackPlugin.options.theme.LIVE_DEMO_REQUEST target="_blank") Request a live demo!
+              a.btn.btn-default.btn-lg.cc-create-account-btn(href=htmlWebpackPlugin.options.theme.LIVE_DEMO_REQUEST target="_blank" rel="noopener") Request a live demo!
 
   a.anchor#a-testimonials
   div#testimonials
@@ -408,4 +408,4 @@ block content
         div.col-sm-12.center(style="margin-top: 6rem")
           p Do you have any further questions or want to see how #{NAME} helps you with teaching?
           p
-            a.btn.btn-default.btn-lg.cc-create-account-btn(href=htmlWebpackPlugin.options.theme.LIVE_DEMO_REQUEST target="_blank") Request a live demo!
+            a.btn.btn-default.btn-lg.cc-create-account-btn(href=htmlWebpackPlugin.options.theme.LIVE_DEMO_REQUEST target="_blank" rel="noopener") Request a live demo!

--- a/src/webapp-lib/policies/copyright.pug
+++ b/src/webapp-lib/policies/copyright.pug
@@ -11,7 +11,7 @@ block content
 
   div.jumbotron
     div.container
-      h1 #[a(href=URL target="_blank") #{COMPANY_NAME}]
+      h1 #[a(href=URL) #{COMPANY_NAME}]
       h2 #{NAME} Copyright Policy (April 2, 2015)
       a.btn.btn-default(href="index.html" role="button") &laquo; Other Policies
 
@@ -30,7 +30,7 @@ block content
 
         p.
           In accordance with the Digital Millennium Copyright Act of 1998, the text of which may be found on the U.S. Copyright Office website at
-          <a target="_blank" href='http://www.copyright.gov/legislation/dmca.pdf'>http://www.copyright.gov/legislation/dmca.pdf</a>,
+          <a target="_blank" rel="noopener" href='http://www.copyright.gov/legislation/dmca.pdf'>http://www.copyright.gov/legislation/dmca.pdf</a>,
           SageMath will respond expeditiously to claims of copyright infringement committed using the SageMath website(s) (the "Sites")
           that are reported to SageMath's Designated Copyright Agent, identified in the sample notice below.
 

--- a/src/webapp-lib/policies/index.pug
+++ b/src/webapp-lib/policies/index.pug
@@ -11,7 +11,7 @@ block content
 
   div.jumbotron
     div.container
-      h1 #[a(href=URL target="_blank") #{COMPANY_NAME}]
+      h1 #[a(href=URL) #{COMPANY_NAME}]
       h2 Our terms of service, pricing, copyright and privacy policies.
       div.lighten.
         If you have any questions, email #[a(href="mailto:" + COMPANY_EMAIL) #{COMPANY_EMAIL}].

--- a/src/webapp-lib/policies/pricing.pug
+++ b/src/webapp-lib/policies/pricing.pug
@@ -11,7 +11,7 @@ block content
 
   div.jumbotron
     div.container
-      h1 #[a(href=URL target="_blank") #{COMPANY_NAME}]
+      h1 #[a(href=URL) #{COMPANY_NAME}]
       h2 #{NAME} Subscriptions and Pricing (March 2018)
       a.btn.btn-default(href="index.html" role="button") &laquo; Other Policies
 
@@ -23,7 +23,7 @@ block content
       Listed prices are in US dollars (when charging in local currency, the prices are converted into local currency using the
       conversion rates published by leading financial institutions).
     p.
-      When logged in, you may sign up for a subscription in #[a(target="_blank" href="/settings/billing") the billing tab]
-      and see a summary of upgrades in #[a(target="_blank" href="/settings/upgrades") the upgrades tab].
+      When logged in, you may sign up for a subscription in #[a(target="_blank" rel="noopener" href="/settings/billing") the billing tab]
+      and see a summary of upgrades in #[a(target="_blank" rel="noopener" href="/settings/upgrades") the upgrades tab].
 
     include _static_pricing_page.html

--- a/src/webapp-lib/policies/privacy.pug
+++ b/src/webapp-lib/policies/privacy.pug
@@ -11,7 +11,7 @@ block content
 
   div.jumbotron
     div.container
-      h1 #[a(href=URL target="_blank") #{COMPANY_NAME}]
+      h1 #[a(href=URL) #{COMPANY_NAME}]
       h2 #{NAME} Privacy Policy  (October 5, 2018)
       a.btn.btn-default(href="index.html" role="button") &laquo; Other Policies
 

--- a/src/webapp-lib/policies/terms.pug
+++ b/src/webapp-lib/policies/terms.pug
@@ -18,7 +18,7 @@ block content
       div.col-md-8
         p.
             Welcome to the #{htmlWebpackPlugin.options.theme.COMPANY_NAME} ("<b>SMI</b>") website located at
-            <a target="_blank" href="#{htmlWebpackPlugin.options.theme.DOMAIN_NAME}">
+            <a target="_blank" rel="noopener" href="#{htmlWebpackPlugin.options.theme.DOMAIN_NAME}">
                 #{htmlWebpackPlugin.options.theme.DOMAIN_NAME}
             </a>
             (the "<b>Site</b>").

--- a/src/webapp-lib/preflight-checks.ts
+++ b/src/webapp-lib/preflight-checks.ts
@@ -96,9 +96,9 @@ function preflight_check(): void {
       <h1 style="color:red;font-size:400%">&#9888;</h1>
       <h2>CoCalc does not support ${spec.name} version ${spec.version}.</h2>
       <div>
-          <p>We recommend that you use the newest version of <a target="_blank" href='https://google.com/chrome'>Google Chrome</a>.</p>
+          <p>We recommend that you use the newest version of <a target="_blank" rel="noopener" href='https://google.com/chrome'>Google Chrome</a>.</p>
           <p>Learn more about our
-            <a href="https://github.com/sagemathinc/cocalc/wiki/BrowserRequirements" target="_blank" >browser requirements</a>.
+            <a href="https://github.com/sagemathinc/cocalc/wiki/BrowserRequirements" target="_blank" rel="noopener">browser requirements</a>.
           </p>
           <p style="font-weight:bold; font-size: 115%">
             <a href="./app?${SKIP_TOKEN}">Try to use CoCalc anyways with my old browser...</a>
@@ -117,13 +117,13 @@ function preflight_check(): void {
              <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1453204">firefox issue #1453204</a>!
           </p>
           <p>Either update to at least Firefox version 62,
-             switch to a recent version of <a target="_blank" href='https://google.com/chrome'>Google Chrome</a>,
+             switch to a recent version of <a target="_blank" rel="noopener" href='https://google.com/chrome'>Google Chrome</a>,
              or tweak your TSL settings (we wouldn't recommend that, though):
              <a href="https://tinyurl.com/y9hphj39">https://tinyurl.com/y9hphj39</a> and
              <a href="https://tinyurl.com/yboeepsf">https://tinyurl.com/yboeepsf</a>.
           </p>
           <p>Learn more about our
-            <a href="https://github.com/sagemathinc/cocalc/wiki/BrowserRequirements" target="_blank" >browser requirements</a>.
+            <a href="https://github.com/sagemathinc/cocalc/wiki/BrowserRequirements" target="_blank" rel="noopener">browser requirements</a>.
           </p>
           <p style="font-weight:bold; font-size: 115%">
             <a href="./app?${SKIP_TOKEN}">Try to use CoCalc anyways with my broken browser...</a>


### PR DESCRIPTION
# Description
Basically https://developers.google.com/web/tools/lighthouse/audits/noopener

# Testing Steps
* this should be pretty safe to merge

what I didn't think about when I made this needs review:
* shift-click an editor tab to open in a small window
* open video chat window (that should definitely run independent of cocalc)

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
