### PR TITLE
webapp/pdfjs: show page number between pages again

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/pdfjs-page.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/pdfjs-page.tsx
@@ -19,6 +19,7 @@ import {
 import { SyncHighlight } from "./pdfjs-annotation";
 
 export const PAGE_GAP: number = 20;
+const BG_COL = "#525659";
 
 interface PageProps {
   actions: any;
@@ -38,11 +39,12 @@ export class Page extends Component<PageProps, {}> {
 
   shouldComponentUpdate(next_props: PageProps): boolean {
     return (
-      is_different(
-        this.props,
-        next_props,
-        ["n", "renderer", "scale", "sync_highlight"]
-      ) ||
+      is_different(this.props, next_props, [
+        "n",
+        "renderer",
+        "scale",
+        "sync_highlight"
+      ]) ||
       this.props.doc.pdfInfo.fingerprint !== next_props.doc.pdfInfo.fingerprint
     );
   }
@@ -81,6 +83,7 @@ export class Page extends Component<PageProps, {}> {
         style={{
           textAlign: "center",
           color: "white",
+          backgroundColor: BG_COL,
           height: `${PAGE_GAP}px`
         }}
       >
@@ -90,7 +93,8 @@ export class Page extends Component<PageProps, {}> {
   }
 
   click(event): void {
-    if (!this.props.actions.synctex_pdf_to_tex) {  // no support for synctex for whatever is using this.
+    if (!this.props.actions.synctex_pdf_to_tex) {
+      // no support for synctex for whatever is using this.
       return;
     }
     let x: number = event.nativeEvent.offsetX / this.props.scale;
@@ -127,10 +131,7 @@ export class Page extends Component<PageProps, {}> {
     return (
       <div>
         {this.render_page_number()}
-        <div
-          style={{ background: "#525659" }}
-          onDoubleClick={e => this.click(e)}
-        >
+        <div style={{ background: BG_COL }} onDoubleClick={e => this.click(e)}>
           {this.render_content()}
         </div>
       </div>


### PR DESCRIPTION
# Description
Fix the gap between pages in pdfjs, such that the page number shows up again.

![screenshot from 2019-01-18 14-08-22](https://user-images.githubusercontent.com/207405/51388738-9f7f3080-1b2a-11e9-9ce6-58f701394a7a.png)


# Testing Steps
1. look at the pdf preview of a latex document with more than 1 page.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
