### PR TITLE
webapp/share: fix updating info about listing & description

### DIFF
--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -2435,25 +2435,32 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     if (!store) {
       return;
     }
-    let now = misc.server_time();
-    const obj = {
-      project_id: this.project_id,
-      path,
-      description: opts.description || "",
-      disabled: false,
-      unlisted: opts.unlisted || false,
-      last_edited: now,
-      created: now
-    };
+    let cur_obj: any = {};
     // only set created if this obj is new; have to just linearly search through paths right now...
     if (store.get("public_paths") != null) {
-      store.get("public_paths").map(function(v) {
+      store.get("public_paths").forEach(function(v) {
         if (v.get("path") === path) {
-          delete obj.created;
-          return false;
+          cur_obj = v.toJS();
+          return false; // found it, exit forEach
+        } else {
+          return true; // next element
         }
       });
     }
+    const now = misc.server_time();
+    // unlisted and description are *optional*: fallback to already saved values if available
+    const unlisted = opts.unlisted != null ? opts.unlisted : cur_obj.unlisted;
+    const description =
+      opts.description != null ? opts.description : cur_obj.description;
+    const obj = {
+      project_id: this.project_id,
+      path,
+      description: description != null ? description : "",
+      disabled: false,
+      unlisted: unlisted != null ? unlisted : false,
+      last_edited: now,
+      created: cur_obj.created || now
+    };
     this.redux.getProjectTable(this.project_id, "public_paths").set(obj);
   }
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1658,7 +1658,7 @@ ProjectFilesActionBox = rclass
         </div>
 
     handle_sharing_options_change: (single_file_data) -> (e) =>
-        # The reason we need single_fie_data is because I think "set_public_path" does not
+        # The reason we need single_file_data is because I think "set_public_path" does not
         # merge the "options", so you have to pass in the current description.
         state = e.target.value
         if state == "private"


### PR DESCRIPTION
# Description
This is basically an issue, where an optional field resets an existing value in the DB. I fixed this in such a way, that it not only works for that "unlisted" boolean, but also for the "description"  field. Additionally, I think there was an inaccuracy when checking a defined field: `x || default` picks the default if x is defined but has the value "false". I made this more explicit.

# Testing Steps
In my cc-in-cc dev project, I ran `psql`, switched via `\x` to see this better, and then picked out the share in my dev project like that:

```
select * from public_paths where project_id = 'bc6f81b3-25ad-4d58-ae4a-65649fae4fa5' and path ILIKE 'latex/one%';
```

change the project id and the path prefix to match with what you have in your project.

# Relevant Issues
* #3485
* #2885

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
