### PR TITLE
webapp/latex: 4 min timeout latexmk

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/latexmk.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latexmk.ts
@@ -25,9 +25,9 @@ export async function latexmk(
     status([command].concat(args).join(" "));
   }
   return await exec({
-    bash: true,    // we use ulimit so that the timeout on the backend is *enforced* via ulimit!!
+    bash: true, // we use ulimit so that the timeout on the backend is *enforced* via ulimit!!
     allow_post: false, // definitely could take a long time to fully run latex
-    timeout: 60,
+    timeout: 4 * 60, // 4 minutes, on par with Overleaf
     command: command,
     args: args,
     project_id: project_id,


### PR DESCRIPTION
# Description
Pushes latexmk timeout to 4 minutes.

# Testing Steps
1. does latexmk still compile? (I don't see why not…)

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
