### PR TITLE
webapp/landing: doc page is more informative than landing page

### DIFF
--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -36,7 +36,7 @@ DESC_FONT = 'sans-serif'
 {reset_password_key} = require('./password-reset')
 
 misc = require('smc-util/misc')
-{APP_TAGLINE} = require('smc-util/theme')
+{APP_TAGLINE, DOC_URL} = require('smc-util/theme')
 {APP_ICON, APP_ICON_WHITE, APP_LOGO_NAME, APP_LOGO_NAME_WHITE} = require('./art')
 {APP_BASE_URL} = require('./misc_page')
 $.get window.app_base_url + "/registration", (obj, status) ->
@@ -625,7 +625,7 @@ exports.LandingPage = rclass
                         {
                             if not @props.get_api_key
                                 <div>
-                                    <a href={APP_BASE_URL + "/"}>Learn more about CoCalc...</a>
+                                    <a href={DOC_URL}>Learn more about CoCalc...</a>
                                 </div>
                         }
                     </div>


### PR DESCRIPTION
# Description

# Testing Steps
well, click the link

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
