### PR TITLE
have projects_all example query in api doc

### DIFF
--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -2143,14 +2143,18 @@ The information returned may be any of the api-accessible fields in the
 `projects` table. These fields are listed in CoCalc source file
 src/smc-util/db-schema.coffee, under `schema.projects.user_query`.
 In this example, project name and description are returned.
+
+Note: to get info only on projects active in the past 3 weeks, use
+`projects` instead of `projects_all` in the query.
+
 ```
   curl -u sk_abcdefQWERTY090900000000: -H "Content-Type: application/json" \\
-    -d '{"query":{"projects":[{"project_id":null,"title":null,"description":null}]}}' \\
+    -d '{"query":{"projects_all":[{"project_id":null,"title":null,"description":null}]}}' \\
     https://cocalc.com/api/v1/query
   ==> {"event":"query",
        "id":"8ec4ac73-2595-42d2-ad47-0b9641043b46",
        "multi_response": False,
-       "query": {"projects": [{"description": "Synthetic Monitoring",
+       "query": {"projects_all": [{"description": "Synthetic Monitoring",
                          "project_id": "1fa1626e-ce25-4871-9b0e-19191cd03325",
                          "title": "SYNTHMON"},
                         {"description": "No Description",


### PR DESCRIPTION
# Description

Minor edit to API docs so that difference between `projects_all` and `projects` calls to the `query` command is explained. 

# Testing Steps
1. Check out the patch. 

2. mocha test to verify `smc-util/messages.coffee` still works with api calls
```
# in .term A:
cd ~/cocalc/src
## check out this branch..
. smc-env
npm run clean
npm run make
dev/project/start_postgres.py

# .term B:
cd ~/cocalc/src
. smc-env
. dev/project/postgres-env
cd smc-hub
npm run testapi
# or
SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/ts-mocha -p ../tsconfig.json test/api/messages.coffee
```

3. build the doc & view it
```
cd cocalc/src
npm run webpack-static
open static/doc/api.html
# visually inspect the change
```

# Relevant Issues

Relates to #3496.

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
