### PR TITLE
sagews: button bar broken comment icons in R and Julia

### DIFF
--- a/src/smc-webapp/buttonbar.coffee
+++ b/src/smc-webapp/buttonbar.coffee
@@ -1826,7 +1826,7 @@ initialize_sage_python_r_toolbar = () ->
     rbar = $(".webapp-editor-redit-buttonbar")
 
     r_basic = make_bar()
-    add_icon(r_basic, "<i class='fa'>#</i>", "#comment", "Comment selected text")
+    add_icon(r_basic, "#", "#comment", "Comment selected text")
     add_icon(r_basic, "$\\vec v$", "#vector", "Insert a vector")
 
     r_control = make_bar()
@@ -1899,7 +1899,7 @@ initialize_sage_python_r_toolbar = () ->
     julia_bar = $(".webapp-editor-julia-edit-buttonbar")
 
     julia_basic = make_bar()
-    add_icon(julia_basic, "<i class='fa'>#</i>", "#comment", "Comment selected text")
+    add_icon(julia_basic, "#", "#comment", "Comment selected text")
 
     julia_control = make_bar()
     julia_control_entries = ["Control", "Control structures",


### PR DESCRIPTION
# Description
Well, this screenshot shows a broken icon. This happens twice. Quick fix.

![screenshot from 2019-01-26 18-44-47](https://user-images.githubusercontent.com/207405/51790907-91b95300-219b-11e9-9946-4263f78d6c28.png)


# Testing Steps
1. sagews %r and %julia

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
