### PR TITLE
open_new_tab emulates rel=noopener by removing the opener attribute

### DIFF
--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1871,13 +1871,12 @@ exports.open_new_tab = (url, popup=false, opts) ->
         scrollbars : 'yes'
         width      : '800'
         height     : '640'
-        noopener   : 'yes'
 
     if popup
         popup_opts = ("#{k}=#{v}" for k, v of opts when v?).join(',')
-        tab = window.open(url, '_blank', popup_opts)
+        tab = window.open("", '_blank', popup_opts)
     else
-        tab = window.open(url, '_blank', 'noopener')
+        tab = window.open("", '_blank')
     if not tab?.closed? or tab.closed   # either tab isn't even defined (or doesn't have close method) -- or already closed -- popup blocked
         {alert_message} = require('./alerts')
         if url
@@ -1890,6 +1889,11 @@ exports.open_new_tab = (url, popup=false, opts) ->
             type    : 'info'
             timeout : 15
         return null
+    # equivalent to rel=noopener, i.e. neither tabs know about each other via window.opener
+    # credits: https://stackoverflow.com/a/49276673/54236
+    tab.opener = null
+    # only *after* the above, we set the URL!
+    tab.location = url
     return tab
 
 exports.get_cookie = (name) ->


### PR DESCRIPTION
# Description
This fixes some oddities, but there are more "window.open" calls with "noopener". So, as of writing this it isn't done.

Regarding `open_new_tab`, it does indeed disconnect the new tab from the old one. `window.openenr` isn't defined, and cocalc's webapp also has no connection any more. 


# Testing Steps
1. open video chat → new window popup, and `window.opener` is null
1. share a file, and then click on the button to open the shared file. it openes a new tab (not window!) and again, `window.opener` isn't defined.


# Relevant Issues
#3504

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
