### PR TITLE
webapp/jupyter classical: fix title offset

### DIFF
--- a/src/smc-webapp/editor_jupyter.coffee
+++ b/src/smc-webapp/editor_jupyter.coffee
@@ -313,7 +313,7 @@ class JupyterWrapper extends EventEmitter
 
         # FUTURE: Proper file rename with sync not supported yet
         # needs to work with sync system)
-        @frame.$("#notebook_name").unbind('click').css("line-height",'0em')
+        @frame.$("#notebook_name").unbind('click')
 
         # Get rid of file menu, which weirdly and wrongly for sync replicates everything.
         for cmd in ['new', 'open', 'copy', 'rename']


### PR DESCRIPTION
# Description
I remember vaguely there is a ticket, but didn't find it. However, here are before and after screenshots:


![screenshot from 2019-01-29 12-34-08](https://user-images.githubusercontent.com/207405/51905697-31582a80-23c2-11e9-8a8d-585edc873ec0.png)


![screenshot from 2019-01-29 12-32-09](https://user-images.githubusercontent.com/207405/51905686-24d3d200-23c2-11e9-940d-0d3afd1f5e9d.png)



# Testing Steps
1. check title offset

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
