### PR TITLE
project/memory calc: no need to add rss_huge, and total_cache.

### DIFF
--- a/src/smc-project/kucalc.coffee
+++ b/src/smc-project/kucalc.coffee
@@ -161,8 +161,10 @@ cgroup_stats = (status, cb) ->
 
     }, (err, res) ->
         kib = 1024 # convert to kibibyte
-        status.memory.rss  += (res.memory.total_rss ? 0 + stats.total_rss_huge ? 0) / kib
-        status.memory.cache = (res.memory.cache ? 0) / kib
+        # total_rss includes total_rss_huge
+        # Ref: https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
+        status.memory.rss  += (res.memory.total_rss ? 0) / kib
+        status.memory.cache = (res.memory.total_cache ? 0) / kib
         status.memory.limit = (res.memory.hierarchical_memory_limit ? 0) / kib
         status.cpu.usage    = res.cpu
         status.oom_kills    = res.oom


### PR DESCRIPTION
# Description
I looked up what https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt has to say, and it seems like we don't have to add huge pages. "rss: #of bytes of anonymous and swap cache memory (includes		transparent hugepages).". Makes no difference, because it's 0 in our case (at least, I've never seen any other value. `total_cache` for consistency.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
