### PR TITLE
Track various user interactions via Google Analytics

### DIFF
--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -33,6 +33,7 @@ misc = require('smc-util/misc')
 {FileUsePage} = require('./file_use')
 {AdminPage} = require('./admin')
 {show_announce_end} = require('./redux_account')
+{analytics_event} = require('./tracker')
 
 ACTIVE_BG_COLOR = COLORS.TOP_BAR.ACTIVE
 feature = require('./feature')
@@ -78,9 +79,11 @@ exports.NavTab = rclass
         inner_style     : rtypes.object
         add_inner_style : rtypes.object
         show_label      : rtypes.bool
+        is_project      : rtypes.bool
 
     getDefaultProps: ->
         show_label : true
+        is_project : false
 
     shouldComponentUpdate: (next) ->
         if @props.children?
@@ -106,6 +109,12 @@ exports.NavTab = rclass
     on_click: (e) ->
         if @props.name?
             @actions('page').set_active_tab(@props.name)
+            if @props.is_project
+                analytics_event('topNav', 'opened_a_project');
+            else
+                analytics_event('topNav', @props.name)
+        else if @props.label?
+            analytics_event('topNav', @props.label)
         @props.on_click?()
 
     render: ->

--- a/src/smc-webapp/chat-indicator.cjsx
+++ b/src/smc-webapp/chat-indicator.cjsx
@@ -23,6 +23,7 @@
 
 misc = require('smc-util/misc')
 
+{analytics_event} = require('./tracker')
 {React, ReactDOM, rclass, redux, rtypes, Redux, COLOR} = require('./app-framework')
 {Icon, Tip, Loading, Space} = require('./r_misc')
 
@@ -67,8 +68,10 @@ exports.ChatIndicator = rclass
         a = redux.getProjectActions(@props.project_id)
         if @props.is_chat_open
             a.close_chat({path:@props.path})
+            analytics_event('side_chat', 'close')
         else
             a.open_chat({path:@props.path})
+            analytics_event('side_chat', 'open')
 
     is_new_chat: ->
         return redux.getStore('file_use')?.get_file_info(@props.project_id, @props.path)?.is_unseenchat ? false

--- a/src/smc-webapp/project/file-tab.cjsx
+++ b/src/smc-webapp/project/file-tab.cjsx
@@ -12,6 +12,8 @@ misc = require('smc-util/misc')
 
 {COLORS, HiddenXS, Icon, Tip} = require('../r_misc')
 
+{analytics_event} = require("../tracker")
+
 exports.DEFAULT_FILE_TAB_STYLES =
     width        : 250
     borderRadius : "5px 5px 0px 0px"
@@ -60,11 +62,13 @@ exports.FileTab = rclass
     click: (e) ->
         actions = @actions(project_id: @props.project_id)
         if @props.file_tab and (e.ctrlKey or e.shiftKey or e.metaKey)
+            analytics_event('project_navigation', 'opened_a_file')
             # shift/ctrl/option clicking on *file* tab opens in a new popout window.
             actions.open_file
                 path               : misc.tab_to_path(@props.name)
                 new_browser_window : true
         else
+            analytics_event('project_navigation', 'opened_' + @props.name)
             actions.set_active_tab(@props.name)
 
     # middle mouse click closes

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -323,7 +323,6 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     this._last_history_state = local_url;
     const { set_url } = require("./history");
     set_url(this._url_in_project(local_url));
-    require("./misc_page").analytics_pageview(window.location.pathname);
   }
 
   move_file_tab(opts): void {

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -29,6 +29,7 @@ SearchInput, TimeAgo, ErrorDisplay, Space, Tip, Loading, LoginLink, Footer, Cour
 {FileTypeSelector, NewFileButton} = require('./project_new')
 {SiteName} = require('./customize')
 {file_actions} = require('./project_store')
+{analytics_event} = require('./tracker')
 
 STUDENT_COURSE_PRICE = require('smc-util/upgrade-spec').upgrades.subscription.student_course.price.month4
 
@@ -516,10 +517,13 @@ NoFiles = rclass
     handle_click: ->
         if @props.file_search.length == 0
             @props.actions.set_active_tab('new')
+            analytics_event('project_files', 'listing_create_button', 'empty')
         else if @props.file_search[@props.file_search.length - 1] == '/'
             @props.create_folder()
+            analytics_event('project_files', 'listing_create_button', 'folder')
         else
             @props.create_file()
+            analytics_event('project_files', 'listing_create_button', 'file')
 
     # Returns the full file_search text in addition to the default extension if applicable
     full_path_text: ->
@@ -2072,10 +2076,13 @@ ProjectFilesNew = rclass
     on_create_button_clicked: ->
         if @props.file_search.length == 0
             @props.actions.set_active_tab('new')
+            analytics_event('project_files', 'search_create_button', 'empty')
         else if @props.file_search[@props.file_search.length - 1] == '/'
             @props.create_folder()
+            analytics_event('project_files', 'search_create_button', 'folder')
         else
             @props.create_file()
+            analytics_event('project_files', 'search_create_button', 'file')
 
     render: ->
         <SplitButton id='new_file_dropdown'

--- a/src/smc-webapp/projects/create-project.tsx
+++ b/src/smc-webapp/projects/create-project.tsx
@@ -1,6 +1,7 @@
 /*
 Create a new project
 */
+import { analytics_event } from "../tracker";
 
 import { Component, React, ReactDOM, redux } from "../app-framework";
 
@@ -27,7 +28,7 @@ interface Props {
 interface State {
   state: "edit" | "view" | "saving";
   title_text: string;
-  error: string
+  error: string;
 }
 
 export class NewProjectCreator extends Component<Props, State> {
@@ -78,6 +79,7 @@ export class NewProjectCreator extends Component<Props, State> {
       title: this.state.title_text,
       token
     });
+    analytics_event("create_project", "created_new_project");
     redux
       .getStore("projects")
       .wait_until_project_created(token, 30, (err, project_id) => {

--- a/src/smc-webapp/projects/project-row.tsx
+++ b/src/smc-webapp/projects/project-row.tsx
@@ -5,6 +5,7 @@ Render a single project entry, which goes in the list of projects
 import * as immutable from "immutable";
 import { AppRedux, Component, React, rclass, rtypes } from "../app-framework";
 import { ProjectUsers } from "./project-users";
+import { analytics_event } from "../tracker";
 
 const { Row, Col, Well } = require("react-bootstrap");
 const { Icon, Markdown, ProjectState, Space, TimeAgo } = require("../r_misc");
@@ -167,6 +168,7 @@ export const ProjectRow = rclass<ReactProps>(
         switch_to: !(e.which === 2 || (e.ctrlKey || e.metaKey))
       });
       e.preventDefault();
+      analytics_event('projects_page', 'opened_a_project')
     };
 
     open_project_settings = e => {

--- a/src/smc-webapp/projects_nav.cjsx
+++ b/src/smc-webapp/projects_nav.cjsx
@@ -122,6 +122,7 @@ ProjectTab = rclass
             active_top_tab = {@props.active_top_tab}
             style          = {flexShrink:'1', width:'200px', maxWidth:'200px', height:'36px', overflow: 'hidden', lineHeight:'1.75em', color:text_color}
             ref            = 'tab'
+            is_project     = {true}
         >
             <div style = {float:'right', whiteSpace:'nowrap', color:x_color}>
                 <span style={{paddingRight:'5px'}}>

--- a/src/smc-webapp/tracker/index.ts
+++ b/src/smc-webapp/tracker/index.ts
@@ -5,8 +5,8 @@
 const analytics = function(type, ...args) {
   // GoogleAnalyticsObject contains the possibly customized function name of GA.
   // It's a good idea to call it differently from the default 'ga' to avoid name clashes...
-  if (window.GoogleAnalyticsObject != undefined) {
-    const ga = window[window.GoogleAnalyticsObject];
+  if ((window as any).GoogleAnalyticsObject != undefined) {
+    const ga = window[(window as any).GoogleAnalyticsObject];
     if (ga != undefined) {
       switch (type) {
         case "event":

--- a/src/smc-webapp/tracker/index.ts
+++ b/src/smc-webapp/tracker/index.ts
@@ -2,7 +2,7 @@
 // for now, it either does nothing or works with GA
 // this API basically allows to send off events by name and category
 
-const analytics = function(type, ...args) {
+const analytics = function(type: "event" | "pageview", ...args) {
   // GoogleAnalyticsObject contains the possibly customized function name of GA.
   // It's a good idea to call it differently from the default 'ga' to avoid name clashes...
   if ((window as any).GoogleAnalyticsObject != undefined) {

--- a/src/smc-webapp/tracker/index.ts
+++ b/src/smc-webapp/tracker/index.ts
@@ -1,0 +1,23 @@
+// `analytics` is a generalized wrapper for reporting data to google analytics, pwiki, parsley, ...
+// for now, it either does nothing or works with GA
+// this API basically allows to send off events by name and category
+
+const analytics = function(type, ...args) {
+  // GoogleAnalyticsObject contains the possibly customized function name of GA.
+  // It's a good idea to call it differently from the default 'ga' to avoid name clashes...
+  if (window.GoogleAnalyticsObject != undefined) {
+    const ga = window[window.GoogleAnalyticsObject];
+    if (ga != undefined) {
+      switch (type) {
+        case "event":
+        case "pageview":
+          return ga("send", type, ...args);
+        default:
+          return console.warn(`unknown analytics event '${type}'`);
+      }
+    }
+  }
+};
+
+export const analytics_pageview = (...args) => analytics("pageview", ...args);
+export const analytics_event = (...args) => analytics("event", ...args);


### PR DESCRIPTION
# Description
Add more Google analytics events so that the events view becomes more useful.

<img width="519" alt="screen shot 2019-01-30 at 1 59 22 pm" src="https://user-images.githubusercontent.com/618575/52015648-494dae00-2497-11e9-9a7e-fb22293e6a9c.png">

- [x] Clicking on any top nav button (including a project tab)
- [x] Creating a project from projects page
- [x] Opening a project from the projects page
- [x] Clicking on any navigation tabs inside a project
- [x] Creating a file or folder from the big button in projects listing
- [x] Creating a file or folder from the Create button next to file listing search
- [x] Opening or closing side chat

# Testing Steps
1. Not sure. Is there a way to get a dev Google analytics in a test env?

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
