### PR TITLE
minor updates to sagews pytest and api mocha

### DIFF
--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -85,7 +85,7 @@
   "scripts": {
     "test": "(npm run testpg && npm run testapi && npm run testmisc && npm run testkucalc); rc=$?; ../scripts/mocha_clean.sh; exit $rc",
     "testpg": "echo 'TEST POSTGRES'; SMC_DB_RESET=true SMC_TEST=true time node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/postgres/*.coffee",
-    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/ts-mocha -p ../tsconfig.json ${BAIL} --reporter ${REPORTER:-progress} test/api/a*.coffee",
+    "testapi": "echo 'TEST API'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/api/*.coffee",
     "testmisc": "echo 'TEST MISC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/misc/*.coffee",
     "testkucalc": "echo 'TEST KUCALC'; SMC_DB_RESET=true SMC_TEST=true node_modules/.bin/mocha --reporter ${REPORTER:-progress} test/kucalc/*.coffee",
     "coverage": "rm -rf ./coverage/; SMC_TEST=true node_modules/.bin/mocha --require ./coffee-coverage-loader.js && node_modules/.bin/istanbul report text html",

--- a/src/smc-hub/test/api/text_files.coffee
+++ b/src/smc-hub/test/api/text_files.coffee
@@ -26,7 +26,7 @@ describe 'testing text file operations -- ', ->
                 done(err)
 
     it "creates a text file in a project", (done) ->
-        @timeout(15000)
+        @timeout(20000)
         api.call
             event : 'write_text_file_to_project'
             body  :
@@ -39,7 +39,7 @@ describe 'testing text file operations -- ', ->
                 done(err)
 
     it "reads a text file in a project", (done) ->
-        @timeout(15000)
+        @timeout(20000)
         api.call
             event : 'read_text_file_from_project'
             body  :

--- a/src/smc-hub/test/api/text_files.coffee
+++ b/src/smc-hub/test/api/text_files.coffee
@@ -95,7 +95,7 @@ describe 'testing text file operations -- ', ->
                 done(err)
 
     it "reads a public text file in a project", (done) ->
-        @timeout(15000)
+        @timeout(20000)
         api.call
             event : 'public_get_text_file'
             body  :

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -29,7 +29,7 @@ class TestLex:
 class TestSageVersion:
     def test_sage_vsn(self, exec2):
         code = "sage.misc.banner.banner()"
-        patn = "version 8.4"
+        patn = "version 8.6"
         exec2(code, pattern = patn)
 
 class TestDecorators:


### PR DESCRIPTION
# Description

- update sage version in **sagews pytest** to 8.6
- backout ts workaround (no longer works) & increase timeouts for text file tests in **api mocha tests**

# Testing Steps

## sagews pytest
1. check out patch for this PR
1. in a .term:
```
cd cocalc/src/smc_sagews/smc_sagews/tests
python -m pytest
# ==>
# == 178 passed, 9 skipped in 323.19 seconds ==
```

## api mocha
1. check out patch for this PR
1. in one .term:
```
cd ~/cocalc/src
npm run clean
npm run make
. smc-env
dev/project/start_postgres.py
```
3. in another .term:
```
cd ~/cocalc/src
. smc-env
. dev/project/postgres-env
cd smc-hub
npm run testapi
# ==>
#   101 passing (1m)
```
4. There may be timeouts on the first testapi run. If that happens, repeat the last step, `npm run testapi`.

No changes to production code.


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
