### PR TITLE
webapp: improve info text for select-file actions

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -961,14 +961,14 @@ ProjectFilesActions = rclass
         checked = @props.checked_files?.size ? 0
         total = @props.listing.length
         style =
-            color      : '#999'
+            color      : COLORS.GRAY
             height     : '22px'
-            margin     : '3px 20px'
+            margin     : '5px 3px'
 
         if checked is 0
             <div style={style}>
                 <span>{"#{total} #{misc.plural(total, 'item')}"}</span>
-                <div style={fontWeight:'200', display:'inline'}> -- Check an entry below to see options.</div>
+                <div style={display:'inline'}> &mdash; Click on the checkbox on the left of a file to copy, move, delete, download, etc.</div>
             </div>
         else
             <div style={style}>


### PR DESCRIPTION
# Description
This small change of the little help text above the files listing is mainly motivated by support questions. 


# Testing Steps
1. there isn't much to test at all, just the wording

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
