### PR TITLE
webapp: remove local storage warning and add exists function

### DIFF
--- a/src/smc-webapp/misc/__test__/local-storage.test.tsx
+++ b/src/smc-webapp/misc/__test__/local-storage.test.tsx
@@ -1,0 +1,48 @@
+/*
+This fails upon importing misc_page.
+
+To run it, change this in local-storage.ts:
+
+//const { APP_BASE_URL } = require("../misc_page");
+const APP_BASE_URL = "";
+
+*/
+
+// trivial test, otherwise jest also fails
+describe("Local Storage", () => {
+  test("NOT TESTED: FIXME!", () => {
+    expect(true).toBe(true);
+  });
+});
+
+/*
+import * as LS from "../local-storage";
+
+const KEY = "test";
+
+describe("Local Storage", () => {
+  test("set", () => {
+    expect(LS.set(KEY, 123)).toBe(true);
+  });
+
+  test("get", () => {
+    expect(LS.get(KEY)).toBe(123);
+  });
+
+  test("exists1", () => {
+    expect(LS.exists(KEY)).toBe(true);
+  });
+
+  test("del1", () => {
+    expect(LS.del(KEY)).toBe(123);
+  });
+
+  test("exists1", () => {
+    expect(LS.exists(KEY)).toBe(false);
+  });
+
+  test("del2", () => {
+    expect(LS.del(KEY)).toBe(undefined);
+  });
+});
+*/

--- a/src/smc-webapp/misc/local-storage.ts
+++ b/src/smc-webapp/misc/local-storage.ts
@@ -2,6 +2,8 @@
  * Typed wrapper around LocalStorage
  */
 
+const { APP_BASE_URL } = require("../misc_page");
+
 // tests at startup if localStorage exists and works. if not or disabled, uses memory as a fallback.
 
 const LS: { [k: string]: string | undefined } = (function() {
@@ -22,7 +24,6 @@ const LS: { [k: string]: string | undefined } = (function() {
 })();
 
 function make_key(keys: string[] | string): string {
-  const { APP_BASE_URL } = require("misc_page");
   const key = typeof keys == "string" ? keys : keys.join(".");
   return [APP_BASE_URL, key].join("::");
 }
@@ -31,7 +32,7 @@ function make_key(keys: string[] | string): string {
 export function del<T>(keys: string[] | string): T | undefined {
   const key = make_key(keys);
   try {
-    const val = get<T>(key);
+    const val = get<T>(keys);
     delete LS[key];
     return val;
   } catch (e) {

--- a/src/smc-webapp/misc/local-storage.ts
+++ b/src/smc-webapp/misc/local-storage.ts
@@ -39,6 +39,7 @@ export function del<T>(keys: string[] | string): T | undefined {
   }
 }
 
+// set an entry, and return true if it was successful
 export function set<T>(keys: string[] | string, value: T): boolean {
   const key = make_key(keys);
   try {
@@ -57,10 +58,21 @@ export function get<T>(keys: string[] | string): T | undefined {
     if (val != null) {
       return JSON.parse(val);
     } else {
-      console.warn(`localStorage unknown key "${key}"`);
+      return undefined;
     }
   } catch (e) {
     console.warn(`localStorage get("${key}"): ${e}`);
     del<T>(key);
+  }
+}
+
+export function exists(keys: string[] | string): boolean {
+  const key = make_key(keys);
+  // distinction between browser's localStorage and the fallback object
+  if (LS === window.localStorage) {
+    // test against null, see spec: https://www.w3.org/TR/webstorage/#dom-storage-getitem
+    return window.localStorage.getItem(key) !== null;
+  } else {
+    return LS[key] !== undefined;
   }
 }


### PR DESCRIPTION
# Description
This fixes https://github.com/sagemathinc/cocalc/issues/3515, adds an `exists` function, and fixes a bug.

# Testing Steps
1. I tried to write a test, but I wasn't able to make it work. With a bit of hardcoding it does, though. 
2. My actual test was to expose this temporarily by inserting
     ```
     import * as tls from "./misc/local-storage";
     window.smc.tls = tls;
     ```
     somewhere and checking it in the js console.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
