### PR TITLE
weabpp/frame editor: codemirror Ctrl-P does not pass down frame ID 

### DIFF
--- a/src/smc-webapp/frame-editors/codemirror/cm-options.ts
+++ b/src/smc-webapp/frame-editors/codemirror/cm-options.ts
@@ -176,7 +176,7 @@ export function cm_options(
       extraKeys[k] = v;
     }
     if (opts.bindings !== "emacs") {
-      extraKeys["Ctrl-P"] = () => actions.print();
+      extraKeys["Ctrl-P"] = () => actions.print(frame_id);
     }
   }
 


### PR DESCRIPTION

# Description
I think #3539 is pretty straight forward to fix.

# Testing Steps
1. see ticket: tex file → cursor in source → Ctrl-p

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
