### PR TITLE
Message coffee comments

### DIFF
--- a/src/smc-hub/test/api/messages.coffee
+++ b/src/smc-hub/test/api/messages.coffee
@@ -2,7 +2,7 @@
 Test message and message2 definitions
 ###
 
-messages = require('../../../smc-util/message.coffee')
+messages = require('../../../smc-util/message.js')
 
 expect = require('expect')
 

--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -76,13 +76,13 @@ forums.
 
 - The [CoCalc API tutorial](https://cocalc.com/share/65f06a34-6690-407d-b95c-f51bbd5ee810/Public/README.md?viewer=share) illustrates API calls in Python.
 - The CoCalc PostgreSQL schema definition
-[src/smc-util/db-schema.coffee](https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/db-schema.coffee)
+[src/smc-util/db-schema.js](https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/db-schema.js)
 has information on tables and fields used with the API \`query\` request.
 - The API test suite
 [src/smc-hub/test/api/](https://github.com/sagemathinc/cocalc/tree/master/src/smc-hub/test/api)
 contains mocha unit tests for the API messages.
 - The CoCalc message definition file
-[src/smc-util/message.coffee](https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/message.coffee)
+[src/smc-util/message.js](https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/message.js)
 contains the source for this guide.
 
 ### API Message Reference

--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -2082,9 +2082,9 @@ message({
   lineNumber: undefined, // int
   columnNumber: undefined, // int
   severity: undefined, // string
-  browser: undefined, // string, how feature.coffee detected the browser
-  mobile: undefined, // boolean, feature.coffee::IS_MOBILE
-  responsive: undefined, // boolean, feature.coffee::is_responsive_mode
+  browser: undefined, // string, how feature.js detected the browser
+  mobile: undefined, // boolean, feature.js::IS_MOBILE
+  responsive: undefined, // boolean, feature.js::is_responsive_mode
   user_agent: undefined, // string
   smc_version: undefined, // string
   build_date: undefined, // string
@@ -2483,7 +2483,7 @@ Get title and description for a project, given the project id.
 Get info on all projects for the account whose security key is provided.
 The information returned may be any of the api-accessible fields in the
 \`projects\` table. These fields are listed in CoCalc source file
-src/smc-util/db-schema.coffee, under \`schema.projects.user_query\`.
+src/smc-util/db-schema.js, under \`schema.projects.user_query\`.
 In this example, project name and description are returned.
 
 Note: to get info only on projects active in the past 3 weeks, use
@@ -2671,10 +2671,10 @@ if you are only setting the \`jupyter_classic\` attribute because changes are me
 
 
 __NOTE:__ Information on which fields are gettable and settable in the database tables
-via API message is in file 'db-schema.coffee', in CoCalc sources on GitHub at
-https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/db-schema.coffee
+via API message is in file 'db-schema.js', in CoCalc sources on GitHub at
+https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/db-schema.js
 
-Within file 'db-schema.coffee':
+Within file 'db-schema.js':
 
 - for _project_ fields you can get, see the definition of
 \`schema.projects.user_query.get.fields\`
@@ -2838,7 +2838,7 @@ This request returns information on project upgrdes for the user
 whose API key appears in the request.
 Two objects are returned, total upgrades and available upgrades.
 
-See https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/upgrade-spec.coffee for units
+See https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/upgrade-spec.js for units
 
 Example:
 \`\`\`


### PR DESCRIPTION
# Description

1. Main reason for this PR is broken links under "Additional References" to `db_schema.coffee` and `message.coffee` in [api doc page](https://cocalc.com/doc/api.html).
1. Also `smc-hub` api test was requiring `message.coffee` instead of `message.js`.
1. Other `.coffee` mentions in comments were updated to `.js`.

No executable production code is changed. 

# Testing Steps
1. API test (basically a syntax check)
```
cd cocalc/src
. smc-env
npm run clean
npm run make
cd cocalc/src/smc-hub
node_modules/.bin/mocha test/api/messages.coffee
==>
13 passing (22ms)
```

2. Build API docs (assumes previous steps done). After the build, verify links under "Additional References" resolve to `db_schema.js` and `message.js`.
```
cd cocalc/src
npm run webpack-static
open static/doc/api.html
```

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
