### PR TITLE
x11: log launch button

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/actions.ts
@@ -571,6 +571,14 @@ export class Actions extends BaseActions<X11EditorState> {
     // Launch the command
     this.channel.write({ cmd: "launch", command, args });
     // TODO: wait for a status message back...
+
+    const project_actions = this._get_project_actions();
+    project_actions.log({
+      event: "x11",
+      action: "launch",
+      path: this.path,
+      command
+    });
   }
 
   set_physical_keyboard(layout: string, variant: string): void {

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -213,6 +213,10 @@ LogEntry = rclass
                 set <a onClick={@click_set} style={if @props.cursor then selected_item} href=''>{content}</a>
             </span>
 
+    render_x11: ->
+        return if not @props.event.action == 'launch'
+        <span>launched X11 app <code>{@props.event.command}</code> in {@file_link(@props.event.path, true, 0)}</span>
+
     render_library: ->
         return if not @props.event.target?
         <span>copied "{@props.event.title}" from the library to {@file_link(@props.event.target, true, 0)}</span>
@@ -301,6 +305,8 @@ LogEntry = rclass
                 return @render_library()
             when 'assistant'
                 return @render_assistant()
+            when 'x11'
+                return @render_x11()
             # ignore unknown -- would just look mangled to user...
             #else
             # FUTURE:


### PR DESCRIPTION
# Description
This records x11 button launches in the project log. I don't know how to record the same for terminal commands, but this is still better than nothing.

Technically, the entry looks like this:

```
smc=# select * from project_log where event ->> 'event' = 'x11' order by time desc limit 3;
-[ RECORD 1 ]--------------------------------------------------------------------------
id         | edf5ca80-9222-4f18-9a72-39b8a3eb5fd7
project_id | bc6f81b3-25ad-4d58-ae4a-65649fae4fa5
time       | 2019-02-06 22:27:50.866
account_id | be11b57a-40f7-4751-8841-9e40dfba5638
event      | {"path": "x11.x11", "event": "x11", "action": "launch", "command": "idle"}
```

and shows up like that

![screenshot from 2019-02-06 23-34-28](https://user-images.githubusercontent.com/207405/52378369-c4026480-2a67-11e9-856d-457b40993a94.png)


# Testing Steps
1. x11: click a button and see if it shows up in the log

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
