### PR TITLE
webapp/project log: focus search box when clicks bubble up -- 

### DIFF
--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -282,11 +282,14 @@ class exports.Connection extends EventEmitter
                 @emit("data", channel, data)
         @_connected = false
 
-        # start pinging -- not used/needed for primus, but *is* needed for getting information about server_time
-        # In particular, this ping time is not reported to the user and is not used as a keep-alive, hence it
-        # can be fairly long.
-        @_ping_interval = 60000
-        @_ping()
+        # start pinging -- not used/needed for primus,
+        # but *is* needed for getting information about
+        # server_time skew and showing ping time
+        # to user.
+        @_ping_interval = 30000
+        # Starting pinging a few seconds after connecting the first time,
+        # after things have settled down a little (to not throw off ping time).
+        @once("connected", => setTimeout(@_ping, 5000))
 
     dbg: (f) =>
         return (m...) ->
@@ -300,26 +303,49 @@ class exports.Connection extends EventEmitter
             console.log("#{(new Date()).toISOString()} - Client.#{f}: #{s}")
 
     _ping: () =>
-        @_ping_interval ?= 60000 # frequency to ping
-        @_last_ping = new Date()
+        @_ping_interval ?= 30000 # frequency to ping
+        start = @_last_ping = new Date()
         @call
             allow_post : false
             message    : message.ping()
-            timeout    : 15     # CRITICAL that this timeout be less than the @_ping_interval
+            timeout    : 10     # CRITICAL that this timeout be less than the @_ping_interval
             cb         : (err, pong) =>
-                if not err
-                    now = new Date()
-                    # Only record something if success, got a pong, and the round trip is short!
-                    # If user messes with their clock during a ping and we don't do this, then
-                    # bad things will happen.
-                    if pong?.event == 'pong' and now - @_last_ping <= 1000*15
-                        @_last_pong = {server:pong.now, local:now}
-                        # See the function server_time below; subtract @_clock_skew from local time to get a better
-                        # estimate for server time.
-                        @_clock_skew = @_last_ping - 0 + ((@_last_pong.local - @_last_ping)/2) - @_last_pong.server
-                        misc.set_local_storage('clock_skew', @_clock_skew)
+                # console.log("response to ping message", err, pong)
+                if err
+                    # try again **sooner**
+                    setTimeout(@_ping, @_ping_interval/2)
+                    return
+                now = new Date()
+                # Only record something if success, got a pong, and the round trip is short!
+                # If user messes with their clock during a ping and we don't do this, then
+                # bad things will happen.
+                if pong?.event == 'pong' and now - @_last_ping <= 1000*15
+                    @_last_pong = {server:pong.now, local:now}
+                    # See the function server_time below; subtract @_clock_skew from local time to get a better
+                    # estimate for server time.
+                    @_clock_skew = @_last_ping - 0 + ((@_last_pong.local - @_last_ping)/2) - @_last_pong.server
+                    misc.set_local_storage('clock_skew', @_clock_skew)
+
+                this._emit_latency(now.valueOf() - start.valueOf(), @_clock_skew)
+
                 # try again later
                 setTimeout(@_ping, @_ping_interval)
+
+    _emit_latency: (latency, clock_skew) =>
+        # console.log("_emit_latency", latency, clock_skew)
+        if not window?.document?.hasFocus?()
+            # console.log("latency: not in focus")
+            return
+        # networking/pinging slows down when browser not in focus...
+        if latency > 10000
+            # console.log("latency: discarding huge latency", latency)
+            # We get some ridiculous values from Primus when the browser
+            # tab gains focus after not being in focus for a while (say on ipad but on many browsers)
+            # that throttle.  Just discard them, since otherwise they lead to ridiculous false
+            # numbers displayed in the browser.
+            return
+        @emit("ping", latency, clock_skew)
+
 
     # Returns (approximate) time in ms since epoch on the server.
     # NOTE:

--- a/src/smc-webapp/client_browser.coffee
+++ b/src/smc-webapp/client_browser.coffee
@@ -211,8 +211,8 @@ class Connection extends client.Connection
         @_idle_reset()
 
     _connect: (url, ondata) ->
-        log = (mesg) ->
-            console.log("websocket -", mesg)
+        log = (mesg...) ->
+            console.log("websocket -", mesg...)
         log("connect")
 
         @url = url
@@ -221,19 +221,6 @@ class Connection extends client.Connection
             return
 
         @ondata = ondata
-
-        ###
-        opts =
-            ping      : 25000  # used for maintaining the connection and deciding when to reconnect.
-            pong      : 12000  # used to decide when to reconnect
-            strategy  : 'disconnect,online,timeout'
-            reconnect :
-                max      : 5000
-                min      : 1000
-                factor   : 1.25
-                retries  : 100000  # why ever stop trying...?
-        conn = new Primus(url, opts)
-        ###
 
         opts =
             reconnect:
@@ -302,21 +289,6 @@ class Connection extends client.Connection
 
         conn.on 'reconnect', =>
             @emit("connecting")
-
-        conn.on 'incoming::pong', (time) =>
-            #log("pong latency=#{conn.latency}")
-            if not window.document.hasFocus? or window.document.hasFocus()
-                # networking/pinging slows down when browser not in focus...
-                if conn.latency > 10000
-                    # We get some ridiculous values from Primus when the browser
-                    # tab gains focus after not being in focus for a while (say on ipad but on many browsers)
-                    # that throttle.  Just discard them, since otherwise they lead to ridiculous false
-                    # numbers displayed in the browser.
-                    return
-                @emit "ping", conn.latency
-
-        #conn.on 'outgoing::ping', () =>
-        #    log(new Date() - 0, "sending a ping")
 
         @_write = (data) =>
             conn.write(data)

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -337,7 +337,7 @@ if prom_client.enabled
          {buckets : [50, 100, 150, 200, 300, 500, 1000, 2000, 5000]})
     prom_ping_time_last = prom_client.new_gauge('ping_last_ms', 'last reported ping time')
 
-webapp_client.on "ping", (ping_time) ->
+webapp_client.on "ping", (ping_time, clock_skew) ->
     ping_time_smooth = redux.getStore('page').get('avgping') ? ping_time
     # reset outside 3x
     if ping_time > 3 * ping_time_smooth or ping_time_smooth > 3 * ping_time
@@ -345,7 +345,9 @@ webapp_client.on "ping", (ping_time) ->
     else
         decay = 1 - Math.exp(-1)
         ping_time_smooth = decay * ping_time_smooth + (1-decay) * ping_time
-    redux.getActions('page').set_ping(ping_time, Math.round(ping_time_smooth))
+    page_actions = redux.getActions('page')
+    page_actions.set_ping(ping_time, Math.round(ping_time_smooth))
+    page_actions.setState(clock_skew:clock_skew)
 
     if prom_client.enabled
         prom_ping_time.observe(ping_time)

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -88,6 +88,7 @@ LogSearch = rclass
 
     render: ->
         <SearchInput
+            ref         = {"box"}
             autoFocus   = {true}
             autoSelect  = {true}
             placeholder = 'Search log...'
@@ -579,6 +580,10 @@ exports.ProjectLog = rclass ({name}) ->
             Load older log entries
         </Button>
 
+    focus_search_box: ->
+        input = @refs.search.refs.box.refs.input
+        ReactDOM.findDOMNode(input).focus()
+
     render_log_panel: ->
         # get visible log
         log = @visible_log()
@@ -594,10 +599,11 @@ exports.ProjectLog = rclass ({name}) ->
             cursor = undefined
             selected = undefined
 
-        <Panel>
+        <Panel onClick={@focus_search_box}>
             <Row>
                 <Col sm={4}>
                     <LogSearch
+                        ref              = {"search"}
                         actions          = {@actions(name)}
                         search           = {@props.search}
                         selected         = {selected}

--- a/src/smc-webapp/share/extensions.coffee
+++ b/src/smc-webapp/share/extensions.coffee
@@ -5,7 +5,6 @@ mimetype library)...
 
 ###
 
-
 {file_associations} = require('../file-associations')
 
 set = (v) ->


### PR DESCRIPTION
# Description
This makes sure the search box is focused, such that arrow keys and so on do work.

# Testing Steps
0. open log with more than one page of entries
1. click somewhere, and type in
2. similarly, up/down keys still work
3. clicking on a link opens the file as usual
4. also works after clicking on "next page"

# Relevant Issues
#3549

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
