### PR TITLE
project/jupyter: set environment only for sage kernels

### DIFF
--- a/src/smc-project/jupyter/jupyter.ts
+++ b/src/smc-project/jupyter/jupyter.ts
@@ -237,13 +237,16 @@ export class JupyterKernel extends EventEmitter
     dbg("spawning kernel...");
 
     const opts: any = { detached: true, stdio: "ignore" };
-    if (this.name.indexOf("sage")) {
-      // special environment for sage-based kernels
+
+    if (this.name.indexOf("sage") == 0) {
+      dbg("setting special environment for sage.* kernels");
       opts.env = SAGE_JUPYTER_ENV;
     }
+
     if (this._directory !== "") {
       opts.cwd = this._directory;
     }
+
     try {
       dbg("launching kernel interface...");
       this._kernel = await require("spawnteract").launch(this.name, opts);


### PR DESCRIPTION
# Description
Only set the environment of a kernel, if it is a sage kernel. (starting with `sage...`).

The result of this is, that a kernel config file for a python kernel containing

```
{
 [...]
  "env": {    "CUSTOM_VAR": "123"  }
}
```

will end up as 

![screenshot from 2019-02-08 21-52-06](https://user-images.githubusercontent.com/207405/52505444-cee60200-2beb-11e9-8fda-ced8cff38eda.png)


# Testing Steps
There isn't much to test, since it doesn't change anything for sage kernels and fixes all other cases.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
