### PR TITLE
sagews: %julia 1.1

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -4298,7 +4298,7 @@ def julia(code=None, **kwargs):
 
     """
     if julia.jupyter_kernel is None:
-        julia.jupyter_kernel = jupyter("julia-0.7")
+        julia.jupyter_kernel = jupyter("julia-1.1")
     return julia.jupyter_kernel(code, **kwargs)
 
 

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -282,5 +282,5 @@ class TestJuliaMode:
         exec2('%julia\nquadratic(a, sqr_term, b) = (-b + sqr_term) / 2a\nquadratic(2.0, -2.0, -12.0)', '2.5', timeout=40)
 
     def test_julia_version(self, exec2):
-        exec2("%julia\nVERSION", pattern='v"0.7.0"', timeout=40)
+        exec2("%julia\nVERSION", pattern=r'^v"1\.1\.\d+"', timeout=40)
 


### PR DESCRIPTION
# Description
This depends on this weekends software update.

# Testing Steps
I tested by running `j11 = jupyter("julia-1.1")` … which worked fine.

![screenshot from 2019-02-09 15-38-23](https://user-images.githubusercontent.com/207405/52522063-ca1f5d80-2c80-11e9-8f8a-bb57d2ea7d75.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
