### PR TITLE
webapp/sagews: fix misc.get_extension is not a function

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1491,8 +1491,8 @@ class CodeMirrorEditor extends FileEditor
             )
         else
             @examples_dialog.show(lang)
-        analytics_event('editor_assistant', misc.get_extension(@filename), lang)
         @examples_dialog.set_handler(@example_insert_handler)
+        analytics_event('editor_assistant', @ext, lang)
 
     example_insert_handler: (insert) =>
         # insert : {lang: string, descr: string, code: string[]}


### PR DESCRIPTION
# Description
I don't know the original intention, but the lowercase version of the file extension is available as `@ext`.

high priority, because inserting anything at all is broken

also, moving that line down lowers any impact of errors

# Testing Steps
1. insert example in a sagews file

# Relevant Issues
* #3564


### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
