### PR TITLE
webapp/side_chat: analytics_event was undefined

### DIFF
--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -31,6 +31,7 @@ misc_page = require('./misc_page')
 {webapp_client} = require('./webapp_client')
 
 {alert_message} = require('./alerts')
+{analytics_event} = require('./tracker')
 
 # React libraries
 {React, ReactDOM, rclass, rtypes, Actions, Store, Redux}  = require('./app-framework')


### PR DESCRIPTION
# Description
trivial fix for  #3566

# Testing Steps
1. open chat next to e.g. sagews file → no longer stacktrace. 

# Relevant Issues
 *  #3566

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
