### PR TITLE
test smc-util: fix ReferenceError: window is not defined

### DIFF
--- a/src/smc-webapp/project/websocket/synctable.ts
+++ b/src/smc-webapp/project/websocket/synctable.ts
@@ -207,7 +207,8 @@ class SyncTableChannel extends EventEmitter {
 // of a guranteed stable json.
 const cache: { [key: string]: SyncTableChannel } = {};
 
-(window as any).channel_cache = cache;
+const window = ((global as any).window as any);
+if (window != null) window.channel_cache = cache;
 
 function key(opts: Options): string {
   return `${opts.project_id}-${JSON.stringify(opts.query)}-${JSON.stringify(


### PR DESCRIPTION
# Description
This **attempts** to fix a failing test -- well -- essentially compiling TS. Just adding a  `declare const window ...` statement didn't work.

The full stacktrace is visible here: https://travis-ci.org/sagemathinc/cocalc/jobs/492544916#L689

# Testing Steps
I'm not sure how to test this. 

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
