### PR TITLE
configure sync's jest setup to run solo

### DIFF
--- a/src/smc-util/sync/jest.config.js
+++ b/src/smc-util/sync/jest.config.js
@@ -1,4 +1,11 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "smc-util/dmp": "<rootDir>/../dmp",
+    "smc-util/misc": "<rootDir>/../misc"
+  },
+  testMatch: ["**/__tests__/**/*.[tj]s?(x)", "**/?(*.)+(spec|test).[tj]s?(x)"],
+  testPathIgnorePatterns: ["/node_modules/"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"]
 };


### PR DESCRIPTION
# Description

This allows for running `npx jest` from inside of `src/smc-util/sync`.

Originally I borrowed from the jest config a few levels deep then realized I could trim out more config.

# Testing Steps
1. Have dev environment set up
1. `cd src/smc-util/sync`
1. `npx jest`

# Relevant Issues

Extracting sync into a new separate library -- #3582 

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):

- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.