### PR TITLE
hub startup: fix yet another error TS2581: Cannot find name "$".

### DIFF
--- a/src/smc-webapp/jupyter/cell-input.tsx
+++ b/src/smc-webapp/jupyter/cell-input.tsx
@@ -1,6 +1,9 @@
 /*
 React component that describes the input of a cell
 */
+
+declare const $: any;
+
 import { React, Component } from "../app-framework"; // TODO: this will move
 import { Map as ImmutableMap, fromJS } from "immutable";
 import { Button } from "react-bootstrap";


### PR DESCRIPTION
# Description
I hit that error after a clean rebuild of everything (npm update)

```
ensure the global variable window.CodeMirror is defined....
jsdom support loaded
2019-02-16T12:55:23.337Z - debug: BUG ****************************************************************************
2019-02-16T12:55:23.338Z - debug: Uncaught exception: TSError: ⨯ Unable to compile TypeScript:
../smc-webapp/jupyter/cell-input.tsx(48,9): error TS2581: Cannot find name '$'. Do you need to install type definitions for jQuery? Try `npm i @types/jquery` and then add `jquery` to the types field in your tsconfig.
../smc-webapp/jupyter/cell-input.tsx(55,7): error TS2581: Cannot find name '$'. Do you need to install type definitions for jQuery? Try `npm i @types/jquery` and then add `jquery` to the types field in your tsconfig.

2019-02-16T12:55:23.338Z - debug: TSError: ⨯ Unable to compile TypeScript:
../smc-webapp/jupyter/cell-input.tsx(48,9): error TS2581: Cannot find name '$'. Do you need to install type definitions for jQuery? Try `npm i @types/jquery` and then add `jquery` to the types field in your tsconfig.
../smc-webapp/jupyter/cell-input.tsx(55,7): error TS2581: Cannot find name '$'. Do you need to install type definitions for jQuery? Try `npm i @types/jquery` and then add `jquery` to the types field in your tsconfig.

    at createTSError (/home/user/smc/src/smc-hub/node_modules/ts-node/dist/index.js:272:13)
    at getOutput (/home/user/smc/src/smc-hub/node_modules/ts-node/dist/index.js:342:17)
    at Object.compile (/home/user/smc/src/smc-hub/node_modules/ts-node/dist/index.js:443:17)
    at Module.m._compile (/home/user/smc/src/smc-hub/node_modules/ts-node/dist/index.js:340:9)
    at Module._extensions..js (module.js:660:9)
    at Object.require.extensions.(anonymous function) [as .tsx] (/home/user/smc/src/smc-hub/node_modules/ts-node/dist/index.js:382:17)
    at Module.load (/home/user/smc/src/smc-hub/node_modules/coffeescript/lib/coffeescript/register.js:49:9)
    at tryModuleLoad (module.js:527:17)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:591:22)
    at require (internal/module.js:22:1)
...
```

# Testing Steps
1. after that, my local hub for cc-in-cc starts up fine again

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
