### PR TITLE
share: base64 encode SVG images

### DIFF
--- a/src/smc-webapp/jupyter/cell-output-message.tsx
+++ b/src/smc-webapp/jupyter/cell-output-message.tsx
@@ -163,16 +163,32 @@ class Image extends Component<ImageProps, ImageState> {
   encoding = () => {
     switch (this.props.type) {
       case "image/svg+xml":
-        return "utf8";
+        // below, we explicitly encode SVG images
+        // otherwise set this to "utf8" -- #3197
+        return "base64";
       default:
         return "base64";
     }
   };
 
+  img_payload = () => {
+    // already checked, just to make TS happy
+    if (this.props.value == null) return "";
+
+    // not encoded SVG images appear broken
+    // https://github.com/sagemathinc/cocalc/issues/3197
+    switch (this.props.type) {
+      case "image/svg+xml":
+        return Buffer.from(this.props.value).toString("base64");
+      default:
+        return this.props.value;
+    }
+  };
+
   render_locally() {
-    const src = `data:${this.props.type};${this.encoding()},${
-      this.props.value
-    }`;
+    const src = `data:${
+      this.props.type
+    };${this.encoding()},${this.img_payload()}`;
     return (
       <img src={src} width={this.props.width} height={this.props.height} />
     );


### PR DESCRIPTION
# Description
Plaintext SVG is seemingly escaped by react, and I'm wondering how this ever worked – base64 to the rescue!

# Testing Steps
1. I don't know all the implications of changing anything related to the share server (that's why I added "careful"). I can just show the screenshots that it works for my cc-in-cc in Chrome 73 and FF 65

# Relevant Issues
* #3197

### chrome 73, before the fix

![screenshot from 2019-02-17 11-33-05](https://user-images.githubusercontent.com/207405/52911713-da01f780-32a7-11e9-8423-d838f3393f5d.png)


### chrome 73, showing source code after the fix

![screenshot from 2019-02-17 11-25-48](https://user-images.githubusercontent.com/207405/52911699-8e4f4e00-32a7-11e9-93eb-1e1c68a6cab8.png)


### firefox, afterwards

![screenshot from 2019-02-17 11-28-40](https://user-images.githubusercontent.com/207405/52911716-e1c19c00-32a7-11e9-9c76-6f2041a00665.png)



### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
