### PR TITLE
webapp: fix title notification count in (..)

### DIFF
--- a/src/smc-webapp/browser.coffee
+++ b/src/smc-webapp/browser.coffee
@@ -25,7 +25,9 @@
 # count to the left of the title; if called with no arguments just updates
 # the count, maintaining the previous title.
 notify_count = undefined
-exports.set_notify_count_function = (f) -> notify_count = f
+exports.set_notify_count_function = ->
+    store = redux.getStore('file_use')
+    notify_count = store.get_notify_count
 
 last_title = ''
 exports.set_window_title = (title) ->

--- a/src/smc-webapp/file-use/init.ts
+++ b/src/smc-webapp/file-use/init.ts
@@ -4,12 +4,10 @@ import { FileUseStore } from "./store";
 import { FileUseActions } from "./actions";
 import { FileUseTable } from "./table";
 
-const store = redux.createStore("file_use", FileUseStore, {});
+redux.createStore("file_use", FileUseStore, {});
 const actions = redux.createActions("file_use", FileUseActions);
 redux.createTable("file_use", FileUseTable);
 actions._init(); // must be after making store
 
 // Function to updates the browser's awareness of a notification
-require("../browser").set_notify_count_function(() => {
-  store.get_notify_count();
-});
+require("../browser").set_notify_count_function();


### PR DESCRIPTION
# Description
With that change I can see the `(<number>) <title>` in the titlebar for notifications again.

![screenshot from 2019-02-18 16-16-01](https://user-images.githubusercontent.com/207405/52960199-8cb18300-3398-11e9-86cf-a32fe97e9972.png)


# Testing Steps
1. chat with yourself across two accounts

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
