### PR TITLE
webapp/jupyter2: output "message" can be null

### DIFF
--- a/src/smc-webapp/jupyter/cell-output-message.tsx
+++ b/src/smc-webapp/jupyter/cell-output-message.tsx
@@ -607,7 +607,7 @@ const message_component = function(message: immutable.Map<any, any>) {
 };
 
 interface CellOutputMessageProps {
-  message: immutable.Map<any, any>;
+  message?: immutable.Map<any, any>;
   project_id?: string;
   directory?: string;
   actions?: any; // optional  - not needed by most messages
@@ -617,6 +617,7 @@ interface CellOutputMessageProps {
 
 export class CellOutputMessage extends Component<CellOutputMessageProps> {
   render() {
+    if (this.props.message == null) return;
     const C: any = message_component(this.props.message);
     return (
       <C


### PR DESCRIPTION
#  Description

evidence provided by #3601, that's all. I've no idea "why"...

# Testing Steps
I don't know how this could happen, so, no idea.

# Relevant Issues
* #3601

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
