### PR TITLE
webapp/jupyter2: undefined store in clear_all_outputs

### DIFF
--- a/src/smc-webapp/jupyter/actions.ts
+++ b/src/smc-webapp/jupyter/actions.ts
@@ -489,6 +489,7 @@ export class JupyterActions extends Actions<JupyterStoreState> {
   };
 
   clear_all_outputs = (): void => {
+    if (this.store == null) return;
     let not_editable = 0;
     this.store.get("cells").forEach((cell, id) => {
       if (cell.get("output") != null || cell.get("exec_count")) {


### PR DESCRIPTION
# Description
No idea why this is happening, but it does: #3603 ... I wouldn't be surprised if there is something more fundamental to fix than just this simple test.

# Testing Steps
no idea

# Relevant Issues
* #3603 

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.
  
Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
