### PR TITLE
Disable sign up intents

### DIFF
--- a/src/smc-webapp/sign-up.tsx
+++ b/src/smc-webapp/sign-up.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactDOM, Rendered, redux} from "./app-framework";
+import { ReactDOM, Rendered, redux } from "./app-framework";
 import { Passports } from "./passports";
 import { List } from "immutable";
 
@@ -61,8 +61,7 @@ export class SignUp extends React.Component<Props, State> {
         ReactDOM.findDOMNode(this.refs.last_name).value,
         ReactDOM.findDOMNode(this.refs.email).value,
         ReactDOM.findDOMNode(this.refs.password).value,
-        this.state.user_token,
-        ReactDOM.findDOMNode(this.refs.question).value
+        this.state.user_token
       );
   };
 
@@ -230,7 +229,6 @@ export class SignUp extends React.Component<Props, State> {
           style={{ marginTop: 20, marginBottom: 20 }}
           onSubmit={this.make_account}
         >
-          {this.render_question()}
           {this.render_first_name()}
           {this.render_last_name()}
           {this.render_email()}


### PR DESCRIPTION
# Description
Simply removes the component from being rendered.
Back to a simpler UI.
<img width="552" alt="screen shot 2019-02-19 at 10 56 06 am" src="https://user-images.githubusercontent.com/618575/53041014-ba013e00-3437-11e9-8e33-490ec63602ce.png">



# Testing Steps
1. Create a new account
1. Check that sign up intents is empty in the database

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
