### PR TITLE
webapp/latex: showing errors of sagetex

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -192,7 +192,9 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
       this.props.build_logs.getIn(["knitr", "parse"]) !=
         props.build_logs.getIn(["knitr", "parse"]) ||
       this.props.build_logs.getIn(["pythontex", "parse"]) !=
-        props.build_logs.getIn(["pythontex", "parse"])
+        props.build_logs.getIn(["pythontex", "parse"])||
+      this.props.build_logs.getIn(["sagetex", "parse"]) !=
+        props.build_logs.getIn(["sagetex", "parse"])
     );
   }
 
@@ -244,12 +246,15 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
     if (!content) {
       return;
     }
+    const header = (
+      <>
+        <Icon name={spec.icon} style={{ color: spec.color }} />{" "}
+        {capitalize(group)} ({capitalize(tool)})
+      </>
+    );
     return (
       <div key={group}>
-        <h3>
-          <Icon name={spec.icon} style={{ color: spec.color }} />{" "}
-          {capitalize(group)} ({capitalize(tool)})
-        </h3>
+        {content.size == 0 ? <h5>{header}</h5> : <h3>{header}</h3>}
         {this.render_group_content(content)}
       </div>
     );
@@ -282,6 +287,7 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
         {["errors", "typesetting", "warnings"].map(group =>
           this.render_group("latex", group)
         )}
+        {this.render_group("sagetex", "errors")}
         {["errors", "warnings"].map(group => this.render_group("knitr", group))}
         {this.render_group("pythontex", "errors")}
       </div>


### PR DESCRIPTION
# Description
Since I made this already for pythontex and knitr, I knew what to tweak to also make sagetex errors show up. I haven't tested it well, but I'm leaving this here for now. This doesn't solve #3609 though, because there is no line info.

Additionally, I made the headers smaller if the message group has nothing to say. That way, it's less easy to overlook those which have errors -- this could be tweaked in a future ticket a bit more, I guess ...

# Testing Steps
make errors, check what's showing up, and check that they go away when the problem is resolved.

# Relevant Issues
 * #3609

![screenshot from 2019-02-20 21-31-50](https://user-images.githubusercontent.com/207405/53122735-9f25eb00-3557-11e9-816b-0262356c95ad.png)


### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
