### PR TITLE
webapp/latex: update pdfjs 2.0.943

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/pdfjs-annotation.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/pdfjs-annotation.tsx
@@ -78,7 +78,7 @@ export class AnnotationLayer extends Component<Props, State> {
         continue;
       }
       let [x1, y1, x2, y2] = PDFJS.Util.normalizeRect(annotation.rect);
-      let page_height = this.props.page.pageInfo.view[3];
+      let page_height = this.props.page.view[3];
       let left = x1 - 1,
         top = page_height - y2 - 1,
         width = x2 - x1 + 2,
@@ -116,7 +116,7 @@ export class AnnotationLayer extends Component<Props, State> {
       v.push(
         this.render_sync_highlight(
           scale,
-          this.props.page.pageInfo.view[2],
+          this.props.page.view[2],
           this.state.sync_highlight.y
         )
       );

--- a/src/smc-webapp/frame-editors/latex-editor/pdfjs-nonloaded-page.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/pdfjs-nonloaded-page.tsx
@@ -32,8 +32,7 @@ export class NonloadedPage extends Component<Props, {}> {
           display: "inline-block"
         }}
       >
-        <div style={{ width: width, height: height }}>
-        </div>
+        <div style={{ width: width, height: height }} />
       </div>
     );
   }

--- a/src/smc-webapp/frame-editors/latex-editor/pdfjs-page.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/pdfjs-page.tsx
@@ -44,8 +44,7 @@ export class Page extends Component<PageProps, {}> {
         "renderer",
         "scale",
         "sync_highlight"
-      ]) ||
-      this.props.doc.pdfInfo.fingerprint !== next_props.doc.pdfInfo.fingerprint
+      ]) || this.props.doc.fingerprint !== next_props.doc.fingerprint
     );
   }
 
@@ -116,7 +115,7 @@ export class Page extends Component<PageProps, {}> {
       // Internal link within the document.
       let dest = await this.props.doc.getDestination(annotation.dest);
       let page: number = (await this.props.doc.getPageIndex(dest[0])) + 1;
-      let page_height = this.props.page.pageInfo.view[3];
+      let page_height = this.props.page.view[3];
       this.props.actions.scroll_pdf_into_view(
         page,
         page_height - dest[3],

--- a/src/smc-webapp/frame-editors/latex-editor/pdfjs.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/pdfjs.tsx
@@ -102,30 +102,26 @@ class PDFJS extends Component<PDFJSProps, PDFJSState> {
     next_state: PDFJSState
   ): boolean {
     return (
-      is_different(
-        this.props,
-        next_props,
-        [
-          "reload",
-          "font_size",
-          "renderer",
-          "path",
-          "zoom_page_width",
-          "zoom_page_height",
-          "sync",
-          "scroll_pdf_into_view",
-          "is_current",
-          "status",
-          "derived_file_types"
-        ]
-      ) ||
+      is_different(this.props, next_props, [
+        "reload",
+        "font_size",
+        "renderer",
+        "path",
+        "zoom_page_width",
+        "zoom_page_height",
+        "sync",
+        "scroll_pdf_into_view",
+        "is_current",
+        "status",
+        "derived_file_types"
+      ]) ||
       is_different(this.state, next_state, [
         "loaded",
         "scrollTop",
         "missing",
         "restored_scroll"
       ]) ||
-      this.state.doc.pdfInfo.fingerprint != next_state.doc.pdfInfo.fingerprint
+      this.state.doc.fingerprint != next_state.doc.fingerprint
     );
   }
 
@@ -266,7 +262,7 @@ class PDFJS extends Component<PDFJSProps, PDFJSState> {
     const scale = this.scale();
     let s: number = PAGE_GAP + y * scale;
     for (let page of pages.slice(0, pages.length - 1)) {
-      s += scale * page.pageInfo.view[3] + PAGE_GAP;
+      s += scale * page.view[3] + PAGE_GAP;
     }
     let elt = $(ReactDOM.findDOMNode(this.refs.scroll));
     let height = elt.height();
@@ -349,7 +345,7 @@ class PDFJS extends Component<PDFJSProps, PDFJSState> {
     }
     let width = $(ReactDOM.findDOMNode(this.refs.scroll)).width();
     if (width === undefined) return;
-    let scale = (width - 10) / page.pageInfo.view[2];
+    let scale = (width - 10) / page.view[2];
     this.props.actions.set_font_size(this.props.id, this.font_size(scale));
   }
 
@@ -364,7 +360,7 @@ class PDFJS extends Component<PDFJSProps, PDFJSState> {
     }
     let height = $(ReactDOM.findDOMNode(this.refs.scroll)).height();
     if (height === undefined) return;
-    let scale = (height - 10) / page.pageInfo.view[3];
+    let scale = (height - 10) / page.view[3];
     this.props.actions.set_font_size(this.props.id, this.font_size(scale));
   }
 
@@ -424,7 +420,7 @@ class PDFJS extends Component<PDFJSProps, PDFJSState> {
           sync_highlight={sync_highlight}
         />
       );
-      top += scale * page.pageInfo.view[3] + PAGE_GAP;
+      top += scale * page.view[3] + PAGE_GAP;
     }
     if (!this.state.restored_scroll) {
       // Restore the scroll position after the pages get

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -73,7 +73,7 @@
     "nodeunit": "^0.11.3",
     "octicons": "^3.5.0",
     "onecolor": "^3.1.0",
-    "pdfjs-dist": "^2.0.489",
+    "pdfjs-dist": "^2.0.943",
     "pegjs": "^0.10.0",
     "pica": "^4.1.1",
     "pnotify": "^3.0.0",


### PR DESCRIPTION
# Description
Instead of a larger npm package update, this is just one part by itself. Less to worry.

The only substancial change here is this slight API change (a getter), e.g. https://github.com/mozilla/pdf.js/blob/master/src/display/api.js#L918

# Testing Steps
what I tested:
1. latex preview as pdfjs, including forward inverse search, and clicking around, dragging, etc.
2. opening the pdf in the stand alone viewer

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
