### PR TITLE
webapp build: cleanup all of "our" package-lock files

### DIFF
--- a/src/install.py
+++ b/src/install.py
@@ -96,7 +96,7 @@ def install_webapp(*args):
         cmd("git submodule update --init")
         cmd("cd examples && env OUTDIR=../webapp-lib/examples make")
         # clean up all package-lock files in cocalc's codebase (before running npm install again)
-        cmd("git ls-files '*/package-lock.json' | xargs rm -f")
+        cmd("git ls-files '../*/package-lock.json' | xargs rm -f")
         for path in [
                 '.', 'smc-util', 'smc-util-node', 'smc-webapp',
                 'smc-webapp/jupyter'

--- a/src/install.py
+++ b/src/install.py
@@ -95,6 +95,8 @@ def install_webapp(*args):
     if 'build' in action:
         cmd("git submodule update --init")
         cmd("cd examples && env OUTDIR=../webapp-lib/examples make")
+        # clean up all package-lock files in cocalc's codebase (before running npm install again)
+        cmd("git ls-files '*/package-lock.json' | xargs rm -f")
         for path in [
                 '.', 'smc-util', 'smc-util-node', 'smc-webapp',
                 'smc-webapp/jupyter'

--- a/src/package.json
+++ b/src/package.json
@@ -88,7 +88,7 @@
     "webpack-static": "cd $SALVUS_ROOT; scripts/update_color_scheme.coffee; scripts/update_react_static && CC_STATICPAGES=true NODE_ENV=development webpack --debug --output-pathinfo --progress --colors",
     "install-all": "scripts/smc-install-all",
     "make": "npm run install-all",
-    "clean": "git ls-files '*/package-lock.json' | xargs rm -f; find $SMC_ROOT -type d -name node_modules | xargs rm -rf; rm -rf $SMC_ROOT/static"
+    "clean": "git ls-files '../*/package-lock.json' | xargs rm -f; find $SMC_ROOT -type d -name node_modules | xargs rm -rf; rm -rf $SMC_ROOT/static"
   },
   "repository": {
     "type": "git",

--- a/src/package.json
+++ b/src/package.json
@@ -88,7 +88,7 @@
     "webpack-static": "cd $SALVUS_ROOT; scripts/update_color_scheme.coffee; scripts/update_react_static && CC_STATICPAGES=true NODE_ENV=development webpack --debug --output-pathinfo --progress --colors",
     "install-all": "scripts/smc-install-all",
     "make": "npm run install-all",
-    "clean": "find $SMC_ROOT -type d -name node_modules | xargs rm -rf; rm -rf $SMC_ROOT/static"
+    "clean": "git ls-files '*/package-lock.json' | xargs rm -f; find $SMC_ROOT -type d -name node_modules | xargs rm -rf; rm -rf $SMC_ROOT/static"
   },
   "repository": {
     "type": "git",

--- a/src/scripts/smc-install-all
+++ b/src/scripts/smc-install-all
@@ -7,7 +7,7 @@ cd `dirname $0`/..
 . smc-env
 
 # step 1: get rid of package-lock files
-git ls-files '*/package-lock.json' | xargs rm -f
+git ls-files '../*/package-lock.json' | xargs rm -f
 
 cd $SMC_ROOT
 npm install

--- a/src/scripts/smc-install-all
+++ b/src/scripts/smc-install-all
@@ -6,6 +6,9 @@ set -v
 cd `dirname $0`/..
 . smc-env
 
+# step 1: get rid of package-lock files
+git ls-files '*/package-lock.json' | xargs rm -f
+
 cd $SMC_ROOT
 npm install
 npm install --only=dev


### PR DESCRIPTION
# Description
This removes all of "our" (in the cocalc codebase) package-lock files, upon running a full installation or cleaning up.  That way, we can eliminate certain side effects of  these files lying around after a previous build.

My motivation is my previous PR about updating pdfjs, because even after changing back to my master branch (with an older pdfjs), npm installed the newer version.

and well, also install.py, that's what kucalc uses

# Testing Steps
There isn't much to test, because the overall install behavior just getting closer to a "fresh" install

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
