### PR TITLE
webapp: reverting #3616 and adding two npm targets for removing or resetting all lock files

### DIFF
--- a/src/install.py
+++ b/src/install.py
@@ -96,7 +96,8 @@ def install_webapp(*args):
         cmd("git submodule update --init")
         cmd("cd examples && env OUTDIR=../webapp-lib/examples make")
         # clean up all package-lock files in cocalc's codebase (before running npm install again)
-        cmd("git ls-files '../*/package-lock.json' | xargs rm -f")
+        # DISABLED -- causes troubles building
+        #cmd("git ls-files '../*/package-lock.json' | xargs rm -f")
         for path in [
                 '.', 'smc-util', 'smc-util-node', 'smc-webapp',
                 'smc-webapp/jupyter'

--- a/src/package.json
+++ b/src/package.json
@@ -88,7 +88,9 @@
     "webpack-static": "cd $SALVUS_ROOT; scripts/update_color_scheme.coffee; scripts/update_react_static && CC_STATICPAGES=true NODE_ENV=development webpack --debug --output-pathinfo --progress --colors",
     "install-all": "scripts/smc-install-all",
     "make": "npm run install-all",
-    "clean": "git ls-files '../*/package-lock.json' | xargs rm -f; find $SMC_ROOT -type d -name node_modules | xargs rm -rf; rm -rf $SMC_ROOT/static"
+    "delete-package-lock" : "git ls-files '../*/package-lock.json' | xargs rm -f",
+    "restore-package-lock" : "git ls-files '../*/package-lock.json' | xargs git checkout --",
+    "clean": "find $SMC_ROOT -type d -name node_modules | xargs rm -rf; rm -rf $SMC_ROOT/static"
   },
   "repository": {
     "type": "git",

--- a/src/scripts/smc-install-all
+++ b/src/scripts/smc-install-all
@@ -7,7 +7,8 @@ cd `dirname $0`/..
 . smc-env
 
 # step 1: get rid of package-lock files
-git ls-files '../*/package-lock.json' | xargs rm -f
+# DISABLED: causes build issues
+#git ls-files '../*/package-lock.json' | xargs rm -f
 
 cd $SMC_ROOT
 npm install


### PR DESCRIPTION
# Description

reverting #3616, and adding two targets to get some control over these lock files for further debugging of that problem

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
