### PR TITLE
proj/x11 server: type spawn options

### DIFF
--- a/src/smc-project/x11/server.ts
+++ b/src/smc-project/x11/server.ts
@@ -6,7 +6,7 @@ TODO:
   - [ ] when stopping project, kill xpra's
 */
 
-import { spawn } from "child_process";
+import { spawn, SpawnOptions } from "child_process";
 import { callback } from "awaiting";
 const { abspath } = require("smc-util-node/misc_node");
 const { path_split } = require("smc-util/misc");
@@ -124,7 +124,7 @@ class X11Channel {
     const env = clone(process.env);
     env.DISPLAY = `:${this.display}`;
     const cwd = this.get_cwd();
-    const options = { cwd, env, detached: true, stdio: "ignore" };
+    const options: SpawnOptions = { cwd, env, detached: true, stdio: "ignore" };
     args = args != null ? args : [];
     try {
       const sub = spawn(command, args, options);


### PR DESCRIPTION
# Description
problem, my dev project never started. always:

```
TSError: ⨯ Unable to compile TypeScript:
home/user/cocalc/src/smc-project/x11/server.ts(9,18): error TS6133: 'SpawnOptions' is declared but its value is never read.
home/user/cocalc/src/smc-project/x11/server.ts(130,40): error TS2345: Argument of type '{ cwd: string; env: any; detached: boolean; stdio: string; }' is not assignable to parameter of type 'SpawnOptions | undefined'.
  Type '{ cwd: string; env: any; detached: boolean; stdio: string; }' is not assignable to type 'SpawnOptions'.
    Types of property 'stdio' are incompatible.
      Type 'string' is not assignable to type '"ignore" | "pipe" | "inherit" | (number | Stream | "ignore" | "pipe" | "inherit" | "ipc" | null |...'.
```

I tried all sorts of ideas. cleaning via that npm run task, touching all `.ts` files, `git clean -fdx` (don't do this without backing up your data dirs!), removing `~/.npm`, etc. No luck.

Instead, by just telling TS that this should be of type spawn option works. I don't see a drawback in doing that.

# Testing Steps
1. since it is in server.ts of x11,  it's worth a try if x11 apps start.

![screenshot from 2019-02-24 13-50-24](https://user-images.githubusercontent.com/207405/53299482-31214280-383b-11e9-8467-9d9d8bcb9159.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
