### PR TITLE
make projects nodejs 8 and 10 compatible

### DIFF
--- a/src/smc-project/package-lock.json
+++ b/src/smc-project/package-lock.json
@@ -4008,11 +4008,18 @@
       "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw="
     },
     "node-pty": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.7.8.tgz",
-      "integrity": "sha512-2c2tZtGnvIJUWw8fDipxO953Mytqc5/IdRZK+YF52NtFMNTuWCQ41QDLEx76W64MEZkfDMoZyah6KPmyW1LO7g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.8.1.tgz",
+      "integrity": "sha512-j+/g0Q5dR+vkELclpJpz32HcS3O/3EdPSGPvDXJZVJQLCvgG0toEbfmymxAEyQyZEpaoKHAcoL+PvKM+4N9nlw==",
       "requires": {
-        "nan": "2.10.0"
+        "nan": "2.12.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+          "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+        }
       }
     },
     "nssocket": {

--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -29,7 +29,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
     "node-cleanup": "^2.1.2",
-    "node-pty": "^0.7.8",
+    "node-pty": "^0.8.1",
     "pidusage": "^1.2.0",
     "posix": "^4.0.0",
     "prettier": "^1.16.0",

--- a/src/smc-util-node/memory.coffee
+++ b/src/smc-util-node/memory.coffee
@@ -1,4 +1,4 @@
-memwatch = require('memwatch-next')
+memwatch = require('node-memwatch')
 
 exports.init = (log) ->
     memwatch.on 'leak', (info) ->

--- a/src/smc-util-node/package-lock.json
+++ b/src/smc-util-node/package-lock.json
@@ -910,15 +910,6 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "memwatch-next": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/memwatch-next/-/memwatch-next-0.3.0.tgz",
-      "integrity": "sha1-IREFD5qQbgqi1ypOwPAInHhyb48=",
-      "requires": {
-        "bindings": "^1.2.1",
-        "nan": "^2.3.2"
-      }
-    },
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
@@ -1058,6 +1049,15 @@
         "debug": "^2.1.2",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
+      }
+    },
+    "node-memwatch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-memwatch/-/node-memwatch-1.0.1.tgz",
+      "integrity": "sha512-wr9NhxVN9Suan67oLgdekA6395lraIulUWYd4Zk62sEANxzJOhaz9ASMzM3esOmXaaBXYMwPbuR7BdpT+uR5XA==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.3.2"
       }
     },
     "node-pre-gyp": {

--- a/src/smc-util-node/package.json
+++ b/src/smc-util-node/package.json
@@ -16,7 +16,7 @@
     "coffee-register-cache": "0.0.0",
     "coffeescript": "^2.1.0",
     "jsdom": "^7.2.2",
-    "memwatch-next": "^0.3.0",
+    "node-memwatch": "^1.0.1",
     "shell-escape": "^0.2.0",
     "sqlite3": "^4.0.4",
     "temp": "^0.8.3",


### PR DESCRIPTION
# Description
This whole exercise here is to make projects work with node 10. One package needs updating, another one is no longer maintained (3y old) and has a newer fork. I've also checked in the lock files, because they are short and easy to understand.

# Testing Steps
1. a clean build in kucalc (using node 8) works.
2. dev projects (in node 8) work (we can't test node 10 dev projects yet)

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
