### PR TITLE
static: do not report query params to GA

### DIFF
--- a/src/webapp-lib/_inc_analytics.pug
+++ b/src/webapp-lib/_inc_analytics.pug
@@ -17,7 +17,7 @@ if typeof GOOGLE_ANALYTICS !== "undefined" && GOOGLE_ANALYTICS !== null
         //- Creates a default tracker with automatic cookie domain configuration.
         google_analytics('create', '#{GOOGLE_ANALYTICS}', 'auto');
         //- Sends a pageview hit from the tracker just created.
-        google_analytics('send', 'pageview');
+        google_analytics('send', 'pageview', location.pathname);
 
     //- Sets the `async` attribute to load the script asynchronously.
     script(async src='//www.google-analytics.com/analytics.js')


### PR DESCRIPTION
# Description
This is what I suggested on monday, but I haven't seen any changes yet. [see documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/pages)

# Testing Steps
the goal is that a url like `/app?query=123` is only reported as `/app`.

my only real issue is that I haven't figured out how to confirm this by testing it. inspecting the network traffic didn't help me.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
