### PR TITLE
webapp/miniterm: restrict max width to avoid being off screen

### DIFF
--- a/src/smc-webapp/project_miniterm.tsx
+++ b/src/smc-webapp/project_miniterm.tsx
@@ -61,7 +61,8 @@ export const output_style_miniterm: React.CSSProperties = {
   boxShadow: "0px 0px 7px #aaa",
   maxHeight: "450px",
   overflow: "auto",
-  right: 0
+  right: 0,
+  maxWidth: "80%"
 };
 
 const BAD_COMMANDS = {


### PR DESCRIPTION
# Description
This restricts the max width of the miniterm output area. 

## Before

![screenshot from 2019-02-27 15-19-50](https://user-images.githubusercontent.com/207405/53496973-7182f980-3aa3-11e9-96f9-acd5667b375b.png)


## After

![screenshot from 2019-02-27 15-21-13](https://user-images.githubusercontent.com/207405/53496987-79429e00-3aa3-11e9-8d88-3e7d061148dd.png)




# Testing Steps
I created a long line by running `echo foobar{1..100} | tr -d ' '`

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
