### PR TITLE
Change initial page view to match history.coffee

### DIFF
--- a/src/webapp-lib/_inc_analytics.pug
+++ b/src/webapp-lib/_inc_analytics.pug
@@ -17,7 +17,7 @@ if typeof GOOGLE_ANALYTICS !== "undefined" && GOOGLE_ANALYTICS !== null
         //- Creates a default tracker with automatic cookie domain configuration.
         google_analytics('create', '#{GOOGLE_ANALYTICS}', 'auto');
         //- Sends a pageview hit from the tracker just created.
-        google_analytics('send', 'pageview');
+        google_analytics('send', 'pageview', window.location.pathname);
 
     //- Sets the `async` attribute to load the script asynchronously.
     script(async src='//www.google-analytics.com/analytics.js')


### PR DESCRIPTION
Send the pathname instead of the default full url.

If this doesn't fix it, I'll dig deeper.