### PR TITLE
webapp/video chat: there could be no video window

### DIFF
--- a/src/smc-webapp/video-chat.cjsx
+++ b/src/smc-webapp/video-chat.cjsx
@@ -108,6 +108,8 @@ class VideoChat
         title = "CoCalc Video Chat: #{misc.trunc_middle(@path, 30)}"
         url   = "#{VIDEO_CHAT_SERVER}/#{room_id}"
         w     = video_window(title, url)
+        # https://github.com/sagemathinc/cocalc/issues/3648
+        return if not w?
         video_windows[room_id] = w
         # disabled -- see https://github.com/sagemathinc/cocalc/issues/1899
         #w.addEventListener "unload", =>


### PR DESCRIPTION
# Description
This should deal with that

# Relevant Issues
* #3648 

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
