### PR TITLE
doc: little extractor to get a serialized representation of the api doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ src/static/*.min.js
 src/static/*.map.js
 
 src/scripts/skel/.sagemathcloud
+src/scripts/export-api-doc.js
 
 src/src/*cassandra*
 src/src/*.tar.gz

--- a/src/scripts/export-api-doc.ts
+++ b/src/scripts/export-api-doc.ts
@@ -1,0 +1,12 @@
+// run via
+// $ tsc export-api-doc.ts  && nodejs export-api-doc.js
+// then copy 'api.json' over to the root of cocalc-doc
+
+
+import { writeFileSync } from "fs";
+
+const api_root = "/api/v1/";
+const api_doc = require("../smc-util/message").documentation;
+api_doc.root = api_root;
+
+writeFileSync('api.json', JSON.stringify(api_doc, null, 2))


### PR DESCRIPTION
no need to review, this is just a helper to get the data from point A to B without having to depend on the entire repository