### PR TITLE
Fix width styling and send button

### DIFF
--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -947,12 +947,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   };
 
   button_send_chat = e => {
-    send_chat(
-      e,
-      this.refs.log_container,
-      ReactDOM.findDOMNode(this.refs.input).value,
-      this.props.actions
-    );
+    send_chat(e, this.refs.log_container, this.props.input, this.props.actions);
     ReactDOM.findDOMNode(this.refs.input).focus();
   };
 
@@ -1268,6 +1263,13 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   };
 
   render_body() {
+    const grid_style: React.CSSProperties = {
+      maxWidth: "1200px",
+      display: "flex",
+      flexDirection: "column",
+      width: IS_MOBILE ? "100%" : undefined
+    };
+
     const chat_log_style: React.CSSProperties = {
       overflowY: "auto",
       overflowX: "hidden",
@@ -1285,7 +1287,6 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
         | { [key: string]: React.CSSProperties };
     } = {
       "&multiLine": {
-
         highlighter: {
           padding: 5
         },
@@ -1336,11 +1337,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
       .toJS();
 
     return (
-      <Grid
-        fluid={true}
-        className="smc-vfill"
-        style={{ maxWidth: "1200px", display: "flex", flexDirection: "column" }}
-      >
+      <Grid fluid={true} className="smc-vfill" style={grid_style}>
         {!IS_MOBILE ? this.render_button_row() : undefined}
         <Row className="smc-vfill">
           <Col


### PR DESCRIPTION
# Description
Clicking the send button works again.
Also fixed some css.

<img width="428" alt="screen shot 2019-03-06 at 9 24 29 pm" src="https://user-images.githubusercontent.com/618575/53934112-432e8c80-4056-11e9-8db7-5f631a2ea43f.png">

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
