### PR TITLE
pyutil: fix link to sagetex help

### DIFF
--- a/src/smc_pyutil/smc_pyutil/templates/linux/default.tex
+++ b/src/smc_pyutil/smc_pyutil/templates/linux/default.tex
@@ -27,7 +27,7 @@
 \author{Name of Author}
 
 % Enable SageTeX to run SageMath code right inside this LaTeX file.
-% http://mirrors.ctan.org/macros/latex/contrib/sagetex/sagetexpackage.pdf
+% http://mirrors.ctan.org/macros/latex/contrib/sagetex/sagetex.pdf
 % \usepackage{sagetex}
 
 \begin{document}


### PR DESCRIPTION
# Description
The URL changed, that's all

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
