### PR TITLE
Fix pasting in an image and refocus

### DIFF
--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -602,7 +602,6 @@ ChatRoom = rclass ({name}) ->
                         style          = {input_style}
                         markup         = '<span class="user-mention">@__display__</span>'
                         autoFocus      = {false}
-                        ref            = 'input'
                         onKeyDown      = {(e) => mark_as_read(); @on_keydown(e)}
                         value          = {@props.input}
                         placeholder    = {if has_collaborators then "Type a message, @name..." else "Type a message..."}

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -776,7 +776,7 @@ interface ChatRoomState {
 class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   public static defaultProps = {
     font_size: 14
-  }
+  };
 
   public static reduxProps({ name }) {
     return {
@@ -822,9 +822,12 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     path: rtypes.string
   };
 
+  private input_ref: any;
+
   constructor(props: ChatRoomProps, context: any) {
     super(props, context);
     this.state = { preview: "" };
+    this.input_ref = React.createRef<HTMLTextAreaElement>();
   }
 
   private static preview_style: React.CSSProperties = {
@@ -925,10 +928,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
         this.props.input,
         this.props.actions
       );
-    } else if (
-      e.keyCode === 38 &&
-      ReactDOM.findDOMNode(this.refs.input).value === ""
-    ) {
+    } else if (e.keyCode === 38 && this.props.input === "") {
       // Up arrow on an empty input
       this.props.actions.set_to_last_input();
     }
@@ -953,7 +953,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
 
   button_send_chat = e => {
     send_chat(e, this.refs.log_container, this.props.input, this.props.actions);
-    ReactDOM.findDOMNode(this.refs.input).focus();
+    this.input_ref.current.focus();
   };
 
   button_scroll_to_bottom = () => {
@@ -962,12 +962,12 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
 
   button_off_click = () => {
     this.props.actions.set_is_preview(false);
-    ReactDOM.findDOMNode(this.refs.input).focus();
+    this.input_ref.current.focus();
   };
 
   button_on_click = () => {
     this.props.actions.set_is_preview(true);
-    ReactDOM.findDOMNode(this.refs.input).focus();
+    this.input_ref.current.focus();
     if (
       is_at_bottom(
         this.props.saved_position,
@@ -1211,13 +1211,13 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   };
 
   start_upload = file => {
-    const text_area = ReactDOM.findDOMNode(this.refs.input);
+    const text_area = this.input_ref.current;
     const temporary_insertion_text = this.generate_temp_upload_text(file);
     const temp_new_text =
       this.props.input.slice(0, text_area.selectionStart) +
       temporary_insertion_text +
       this.props.input.slice(text_area.selectionEnd);
-    return this.props.actions.set_input(temp_new_text);
+    this.props.actions.set_input(temp_new_text);
   };
 
   append_file = file => {
@@ -1242,12 +1242,12 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
       this.props.input.slice(0, start_index) +
       final_insertion_text +
       this.props.input.slice(end_index);
-    return this.props.actions.set_input(new_text);
+    this.props.actions.set_input(new_text);
   };
 
   private dropzoneWrapperRef: any;
 
-  handle_paste_event = (e: React.ClipboardEvent<FormControl>) => {
+  handle_paste_event = (e: React.ClipboardEvent<MentionsInput>) => {
     const items = e.clipboardData.items;
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
@@ -1418,7 +1418,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
                 displayTransform={(_, display) => "@" + display}
                 style={chat_input_style}
                 markup='<span class="user-mention">@__display__</span>'
-                ref="input"
+                inputRef={this.input_ref}
                 onKeyDown={this.keydown}
                 value={this.props.input}
                 placeholder={


### PR DESCRIPTION
# Description
Fix pasting in images.
<img width="540" alt="Screen Shot 2019-03-08 at 3 39 06 PM" src="https://user-images.githubusercontent.com/618575/54061997-59545e00-41b8-11e9-8f28-f968ec55ae04.png">

# Testing Steps
1. Type some text
1. Paste in an image at the beginning, middle, and end locations of input text.

# Relevant Issues
#3670

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
