### PR TITLE
Latex shell escape

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/build-command.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/build-command.tsx
@@ -21,7 +21,7 @@ import { split } from "smc-util/misc2";
 
 import { Engine, build_command } from "./latexmk";
 
-const ENGINES: Engine[] = ["PDFLaTeX", "XeLaTeX", "LuaTex"];
+const ENGINES: Engine[] = ["PDFLaTeX", "PDFLaTeX (shell-escape)", "XeLaTeX", "LuaTex"];
 
 interface Props {
   actions: any;

--- a/src/smc-webapp/frame-editors/latex-editor/clean.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/clean.ts
@@ -18,7 +18,9 @@ const EXTENSIONS: string[] = [
   ".sagetex.sout",
   ".pdfsync",
   "-concordance.tex",
-  ".pytxcode"
+  ".pytxcode",
+  ".pgf-plot.gnuplot",
+  ".pgf-plot.table"
 ];
 
 export async function clean(

--- a/src/smc-webapp/project_store.ts
+++ b/src/smc-webapp/project_store.ts
@@ -55,7 +55,7 @@ const MASKED_FILE_EXTENSIONS = {
   py: ["pyc"],
   java: ["class"],
   cs: ["exe"],
-  tex: "aux bbl blg fdb_latexmk fls glo idx ilg ind lof log nav out snm synctex.gz toc xyc synctex.gz(busy) sagetex.sage sagetex.sout sagetex.scmd sagetex.sage.py sage-plots-for-FILENAME pytxcode pythontex-files-BASEDASHNAME".split(
+  tex: "aux bbl blg fdb_latexmk fls glo idx ilg ind lof log nav out snm synctex.gz toc xyc synctex.gz(busy) sagetex.sage sagetex.sout sagetex.scmd sagetex.sage.py sage-plots-for-FILENAME pytxcode pythontex-files-BASEDASHNAME pgf-plot.gnuplot pgf-plot.table".split(
     " "
   ),
   rnw: ["tex", "NODOT-concordance.tex"],


### PR DESCRIPTION
# Description

This is adding an escape hatch for #3676, despite whatever we decide with that ticket. A picture says more than words:

![screenshot-cocalc com-2019 03 11-11-20-40](https://user-images.githubusercontent.com/207405/54117150-80957000-43f0-11e9-9c11-f5f9cc037f9f.png)

**bonus** also mask / clean those gnuplot files

![screenshot-cocalc com-2019 03 11-11-41-17](https://user-images.githubusercontent.com/207405/54118134-a6237900-43f2-11e9-9320-7f635afd39e4.png)


# Testing Steps
1. run a gnuplot example, with or without the shell-escape enabled engine
2. check the files listing and click the latex build clean button
3. make sure those other selectable engine commands do not add the pdflatex specific option


# Relevant Issues
#3676

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
