### PR TITLE
static: link to documentation pages from enhanced features page and the top level navbar

### DIFF
--- a/src/smc-util/theme.js
+++ b/src/smc-util/theme.js
@@ -59,6 +59,7 @@ const COLORS = {
     BLUE     : '#6690D2',
     BLUE_L   : '#80afff',
     BLUE_LL  : '#94B3E5',
+    BLUE_DOC : '#4375c1',  // the blue used in the documentation
     BRWN     : '#593E05',
     YELL_D   : '#bf7b00',
     YELL_L   : '#fbb635',

--- a/src/webapp-lib/_base.pug
+++ b/src/webapp-lib/_base.pug
@@ -113,6 +113,9 @@ html.no-js(lang="en")
           .get-started
             color        : $COL_BS_GREEN_DD
             font-weight  : bold
+          .documentation
+            color        : $COL_BLUE_DOC
+            font-weight  : bold
           .navbar-header
             margin-top     : 5px;
             img.icon
@@ -215,6 +218,8 @@ html.no-js(lang="en")
           font-size: 1.5rem
           padding-top: 5px
           padding-bottom: 5px
+          &.documentation
+            color: $COL_BLUE_DOC
 
     nav.navbar.navbar-default.navbar-fixed-top
       div.container
@@ -237,11 +242,11 @@ html.no-js(lang="en")
             li(class=navbar_highlight('pricing'))
               a(href=PREFIX + "policies/pricing.html") Pricing
 
-            li(class=navbar_highlight('api'))
-              a(href=PREFIX + "doc/api.html") API
-
             li(class=navbar_highlight("policies"))
               a(href=PREFIX + "policies/index.html") Policies
+
+            li
+              a.documentation(href="https://doc.cocalc.com/") Doc
 
             li
               a.get-started(href=PREFIX + "app") Sign In
@@ -257,6 +262,8 @@ html.no-js(lang="en")
                 a(href=PREFIX + "doc/r-statistical-software.html") R Statistics
               li(class=subnavbar_highlight('x11'))
                 a(href=PREFIX + "doc/x11.html") X11
+              li
+                a.documentation(href="https://doc.cocalc.com/api/") API
 
         if navbar_active == 'software'
           div.collapse.navbar-collapse

--- a/src/webapp-lib/doc/api.coffee
+++ b/src/webapp-lib/doc/api.coffee
@@ -1,4 +1,0 @@
-# vanilla.js client side code for communicating with the api endpoint
-
-API_URL = './api/1'
-

--- a/src/webapp-lib/doc/api.pug
+++ b/src/webapp-lib/doc/api.pug
@@ -1,4 +1,4 @@
-//- API documentation page
+//- API documentation page a redirect to https://doc.cocalc.com/api/
 
 extends ../_base.pug
 
@@ -6,62 +6,17 @@ block vars
   -
     navbar_active = 'api';
     var subtitle = "API";
-    var api_root = '/api/v1/';
-    var api_doc = require('smc-util/message').documentation;
-    var markdown = require('smc-webapp/markdown').markdown_to_html;
 
 block header
-  script(type="text/javascript")
-    include:coffee-script api.coffee
   meta(name="description" content=NAME + " " + subtitle)
+  meta(http-equiv="refresh" content="3; URL=https://doc.cocalc.com/api/")
+
 
 block content
 
-  div.container#top
-    div.row
+  div.container
+    div.row#top
       div.col-md-12
         h1 #{NAME} API
-        div!= markdown(api_doc.intro)
-      div.col-md-12
-    - var api_doc_keys = Object.keys(api_doc.events).sort()
-        h2 List of Endpoints:
-          ul
-    each key in api_doc_keys
-          li
-            a(href="#"+key) #{key}
-    h2 Endpoints:
-    each key in api_doc_keys
-      - var val = api_doc.events[key]
-      a(class="anchor" id=key)
-      div.row
-        div.col-md-12
-          h3.api-title
-            = api_root + key
-            a(class="marker" href="#"+key) ¶
-          if val.fields
-            table.table.fields
-              each descr, fld in val.fields
-                tr
-                  td #[code #{fld}]
-                  td!= markdown(descr)
-          p!= markdown(val.description)
-
-  //- CSS comes at the bottom: overwrites styles defined in the header
-  style
-    :sass
-      @import "smc-webapp/_colors.sass"
-      body > div.space
-        margin-top         : 5rem
-      div#top
-        margin-top         : 10rem
-      h3.api-title
-        font-weight        : bold
-        margin-top         : 2em
-      table.fields
-        width              : auto !important
-        tr, td
-          border           : none !important
-          padding          : 5px 10px 0px 0px !important
-        code
-          color            : $COL_GRAY_DD
-          background-color : $COL_GRAY_LLL
+        div(style="min-height: 75vh").
+          The API documentation moved permanently to #[a(href="https://doc.cocalc.com/api/") https://doc.cocalc.com/api/].

--- a/src/webapp-lib/doc/features.pug
+++ b/src/webapp-lib/doc/features.pug
@@ -16,12 +16,12 @@ block content
     :sass
       @import "smc-webapp/_colors.sass"
       div.row#top
-        min-height: 50vh
+        min-height: 75vh
         ul
           li
             margin-top    : 10px
             margin-bottom : 10px
-            a
+            > a:first-child
               font-weight   : bold
               padding-right : 10px
 
@@ -33,7 +33,9 @@ block content
       ul
         li
           a(href='jupyter-notebook.html') Jupyter Notebooks:
-          span #{NAME} offers a platform-specific edition of notebooks with real-time collaboration, chat, and precise edit-history
+          span.
+            #{NAME} offers a platform-specific edition of notebooks with real-time collaboration, chat, and precise edit-history.
+            Explore it in more detail in #[a(href="https://doc.cocalc.com/jupyter.html") the documentation].
 
         li
           a(href='r-statistical-software.html') R statistical software:
@@ -41,13 +43,30 @@ block content
 
         li
           a(href='latex-editor.html') LaTeX Editor:
-          span learn how #{NAME}'s LaTeX editor can help you being a productive author online
+          span.
+             learn how #{NAME}'s LaTeX editor can help you being a productive author online,
+             or check out #[a(href="https://doc.cocalc.com/latex.html") its documentation].
 
         li
           a(href='x11.html') Graphical Software:
-          span run graphical applications in #{NAME}'s remote virtual display environment
+          span.
+            run graphical applications in #{NAME}'s remote virtual display environment.
+            Read more about it in the #[a(href="https://doc.cocalc.com/x11.html") X11 documentation].
 
         li
-          span There is much more to explore. Just to name a few, there are Sage Worksheets, Course management, Task management, Chat, etc.
+          a(href="https://doc.cocalc.com/terminal.html") Linux Terminal:
+          span work in a full remote Linux shell.
+
+        li
+          a(href='https://doc.cocalc.com/api/') API interface:
+          span programmatically control #{NAME} via your own software.
+
+        li
+          a(href='https://doc.cocalc.com/api/') There is much more to explore:
+          span.
+            Just to name a few, there are
+            #[a(href="https://doc.cocalc.com/sagews.html") Sage Worksheets],
+            #[a(href="https://doc.cocalc.com/teaching-instructors.html") Course management],
+            #[a(href="https://doc.cocalc.com/tasks.html") Task management], Chat, etc.
 
 


### PR DESCRIPTION
# Description
This links to more specific pages in the documentation (they're sufficient stable now), without disturbing the SEO pages. It  also links to the documentation directly from the top navbar, which should drive much more traffic over there. The old API page is left as a redirect to the new location.

# Testing Steps
well, easy, because if static pages build you just have to look at the features page.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
