### PR TITLE
Fix #3678 and memoize user data computation

### DIFF
--- a/src/smc-webapp/chat/actions.coffee
+++ b/src/smc-webapp/chat/actions.coffee
@@ -86,6 +86,7 @@ class ChatActions extends Actions
             date      : time_stamp
         @setState(last_sent: mesg)
         @save()
+        @set_input('')
 
     set_editing: (message, is_editing) =>
         if not @syncdb?
@@ -155,7 +156,7 @@ class ChatActions extends Actions
             webapp_client.mention({
                 project_id: project_id
                 path: path
-                target: mention.id
+                target: mention.get('id')
                 priority: 2
             })
         )

--- a/src/smc-webapp/chat/actions.coffee
+++ b/src/smc-webapp/chat/actions.coffee
@@ -147,6 +147,20 @@ class ChatActions extends Actions
     set_use_saved_position: (use_saved_position) =>
         @setState(use_saved_position:use_saved_position)
 
+    set_unsent_user_mentions: (user_mentions) =>
+        @setState(unsent_user_mentions: user_mentions)
+
+    submit_user_mentions: (project_id, path) =>
+        @store.get('unsent_user_mentions').map((mention) =>
+            webapp_client.mention({
+                project_id: project_id
+                path: path
+                target: mention.id
+                priority: 2
+            })
+        )
+        @setState(unsent_user_mentions: immutable.List())
+
     save_scroll_state: (position, height, offset) =>
         # height == 0 means chat room is not rendered
         if height != 0

--- a/src/smc-webapp/chat/input.tsx
+++ b/src/smc-webapp/chat/input.tsx
@@ -35,13 +35,21 @@ export class ChatInput extends React.PureComponent<Props> {
 
   input_style = memoizeOne(font_size => {
     return {
+      height: "100%",
+
       "&multiLine": {
         highlighter: {
           padding: 5
         },
 
+        control: {
+          height: "100%",
+          backgroundColor: 'white',
+          leftMargin:'2px'
+        },
+
         input: {
-          height: "90px",
+          height: "100%",
           fontSize: font_size,
           border: "1px solid #ccc",
           borderRadius: "4px",

--- a/src/smc-webapp/chat/input.tsx
+++ b/src/smc-webapp/chat/input.tsx
@@ -1,0 +1,164 @@
+import * as React from "react";
+import memoizeOne from "memoize-one";
+import * as immutable from "immutable";
+import { MentionsInput, Mention } from "react-mentions";
+
+import { cmp_Date } from "smc-util/misc2";
+const { Space } = require("../r_misc");
+const { Avatar } = require("../other-users");
+const { IS_MOBILE, isMobile } = require("../feature");
+
+const USER_MENTION_MARKUP =
+  '<span class="user-mention" account-id=__id__ >@__display__</span>';
+
+interface Props {
+  input: string;
+  input_ref: any;
+  input_style?: any; // Used to override defaults
+  enable_mentions: boolean;
+  project_users: any;
+  user_store: any;
+  font_size: number;
+  on_paste: (e) => void;
+  on_change: (value, mentions) => void;
+  on_send: (value) => void;
+  on_clear: () => void;
+  on_set_to_last_input: () => void;
+  account_id: string;
+}
+
+export class ChatInput extends React.PureComponent<Props> {
+  static defaultProps = {
+    enable_mentions: true,
+    font_size: 14
+  };
+
+  input_style = memoizeOne(font_size => {
+    return {
+      "&multiLine": {
+        highlighter: {
+          padding: 5
+        },
+
+        input: {
+          height: "90px",
+          fontSize: font_size,
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+          boxShadow: "inset 0 1px 1px rgba(0,0,0,.075)",
+          overflow: "auto",
+          padding: "5px 10px"
+        }
+      },
+
+      suggestions: {
+        list: {
+          backgroundColor: "white",
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+          fontSize: font_size,
+          position: "absolute",
+          bottom: "10px",
+          overflow: "auto",
+          maxHeight: "145px",
+          width: "max-content",
+          display: "flex",
+          flexDirection: "column"
+        },
+
+        item: {
+          padding: "5px 15px 5px 10px",
+          borderBottom: "1px solid rgba(0,0,0,0.15)",
+
+          "&focused": {
+            backgroundColor: "rgb(66, 139, 202, 0.4)"
+          }
+        }
+      }
+    };
+  });
+
+  mentions_data = memoizeOne((project_users: immutable.Map<string, any>) => {
+    const user_array = project_users
+      .keySeq()
+      .filter(account_id => {
+        return account_id !== this.props.account_id;
+      })
+      .map(account_id => {
+        return {
+          id: account_id,
+          display: this.props.user_store.get_name(account_id),
+          last_active: this.props.user_store.get_last_active(account_id)
+        };
+      })
+      .toJS();
+
+    user_array.sort((x, y) => -cmp_Date(x.last_active, y.last_active));
+
+    return user_array;
+  });
+
+  on_change = (e, _, __, mentions) => {
+    this.props.on_change(e.target.value, mentions);
+  };
+
+  on_keydown = (e: any) => {
+    // TODO: Add timeout component to is_typing
+    if (e.keyCode === 13 && e.shiftKey) {
+      e.preventDefault();
+      if (this.props.input.length && this.props.input.trim().length >= 1) {
+        this.props.on_send(this.props.input);
+      }
+    } else if (e.keyCode === 38 && this.props.input === "") {
+      // Up arrow on an empty input
+      this.props.on_set_to_last_input();
+    } else if (e.keyCode === 27) {
+      // Esc
+      this.props.on_clear();
+    }
+  };
+
+  render_user_suggestion = (entry: { id: string; display: string }) => {
+    return (
+      <span>
+        <Avatar size={this.props.font_size + 12} account_id={entry.id} />
+        <Space />
+        <Space />
+        {entry.display}
+      </span>
+    );
+  };
+
+  render() {
+    const user_array = this.mentions_data(this.props.project_users);
+
+    const style =
+      this.props.input_style || this.input_style(this.props.font_size);
+
+    return (
+      <MentionsInput
+        autoFocus={!IS_MOBILE || isMobile.Android()}
+        displayTransform={(_, display) => "@" + display}
+        style={style}
+        markup={USER_MENTION_MARKUP}
+        inputRef={this.props.input_ref}
+        onKeyDown={this.on_keydown}
+        value={this.props.input}
+        placeholder={
+          this.props.enable_mentions
+            ? "Type a message, @name..."
+            : "Type a message..."
+        }
+        onPaste={this.props.on_paste}
+        onChange={this.on_change}
+      >
+        <Mention
+          trigger="@"
+          data={user_array}
+          appendSpaceOnAdd={true}
+          renderSuggestion={this.render_user_suggestion}
+        />
+      </MentionsInput>
+    );
+  }
+}

--- a/src/smc-webapp/chat/input.tsx
+++ b/src/smc-webapp/chat/input.tsx
@@ -44,8 +44,8 @@ export class ChatInput extends React.PureComponent<Props> {
 
         control: {
           height: "100%",
-          backgroundColor: 'white',
-          leftMargin:'2px'
+          backgroundColor: "white",
+          leftMargin: "2px"
         },
 
         input: {

--- a/src/smc-webapp/chat/input.tsx
+++ b/src/smc-webapp/chat/input.tsx
@@ -19,7 +19,7 @@ interface Props {
   project_users: any;
   user_store: any;
   font_size: number;
-  on_paste: (e) => void;
+  on_paste?: (e) => void;
   on_change: (value, mentions) => void;
   on_send: (value) => void;
   on_clear: () => void;

--- a/src/smc-webapp/chat/store.ts
+++ b/src/smc-webapp/chat/store.ts
@@ -20,7 +20,7 @@ interface ChatState {
   is_saving: boolean;
   has_uncommitted_changes: boolean;
   has_unsaved_changes: boolean;
-  unsent_user_mentions: immutable.List<{id: string, display: string}>;
+  unsent_user_mentions: immutable.List<{ id: string; display: string }>;
 }
 
 export class ChatStore extends Store<ChatState> {

--- a/src/smc-webapp/chat/store.ts
+++ b/src/smc-webapp/chat/store.ts
@@ -20,6 +20,7 @@ interface ChatState {
   is_saving: boolean;
   has_uncommitted_changes: boolean;
   has_unsaved_changes: boolean;
+  unsent_user_mentions: immutable.List<{id: string, display: string}>;
 }
 
 export class ChatStore extends Store<ChatState> {
@@ -39,7 +40,8 @@ export class ChatStore extends Store<ChatState> {
       add_collab: true,
       is_saving: false,
       has_uncommitted_changes: false,
-      has_unsaved_changes: false
+      has_unsaved_changes: false,
+      unsent_user_mentions: immutable.List()
     };
   };
 }

--- a/src/smc-webapp/editor_chat.cjsx
+++ b/src/smc-webapp/editor_chat.cjsx
@@ -183,17 +183,6 @@ exports.get_user_name = get_user_name = (account_id, user_map) ->
         account_name = "Unknown"
 
 ### ChatRoom Methods ###
-exports.send_chat = send_chat = (e, log_container, mesg, actions) ->
-    scroll_to_bottom(log_container, actions)
-    e.preventDefault()
-    # block sending empty messages
-    if mesg.length? and mesg.trim().length >= 1
-        actions.send_chat(mesg)
-        clear_input(actions)
-
-exports.clear_input = clear_input = (actions) ->
-    actions.set_input('')
-
 exports.is_at_bottom = is_at_bottom = (saved_position, offset, height) ->
     # 20 for covering margin of bottom message
     saved_position + offset + 20 > height

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -70,6 +70,7 @@
     "markdown-it-mathjax": "^2.0.0",
     "mathjax": "2.7.4",
     "md5": "^2",
+    "memoize-one": "^5.0.0",
     "node-forge": "^0.7.6",
     "nodeunit": "^0.11.3",
     "octicons": "^3.5.0",

--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -531,47 +531,6 @@ ChatRoom = rclass ({name}) ->
 
         mark_as_read = underscore.throttle(@mark_as_read, 3000)
 
-        input_style =
-            width: "85%"
-
-            "&multiLine":
-                control:
-                    backgroundColor: 'white'
-                    height:'100%'
-                    leftMargin:'2px'
-                    fontSize: @props.font_size
-
-                highlighter:
-                    padding: 5
-
-                input:
-                    border: "1px solid #ccc"
-                    borderRadius: "4px"
-                    boxShadow: "inset 0 1px 1px rgba(0,0,0,.075)",
-                    overflow: "auto",
-                    padding: "5px 10px"
-
-            suggestions:
-                list:
-                    backgroundColor: "white"
-                    border: "1px solid #ccc"
-                    borderRadius: "4px"
-                    fontSize: @props.font_size
-                    position: "absolute"
-                    bottom: "10px"
-                    overflow: "auto"
-                    maxHeight: "145px"
-                    width: "max-content"
-                    display: "flex"
-                    flexDirection: "column"
-
-                item:
-                    padding: "5px 15px"
-                    borderBottom: "1px solid rgba(0,0,0,0.15)"
-
-                    "&focused":
-                        backgroundColor: "rgb(66, 139, 202, 0.4)"
-
         # WARNING: making autofocus true would interfere with chat and terminals -- where chat and terminal are both focused at same time sometimes (esp on firefox).
 
         <div style       = {height:'100%', width:'100%', position:'absolute', display:'flex', flexDirection:'column', backgroundColor:'#efefef'}
@@ -594,20 +553,21 @@ ChatRoom = rclass ({name}) ->
             </div>
             <div style={marginTop:'auto', padding:'5px', paddingLeft:'15px', paddingRight:'15px'}>
                 <div style={display:'flex', height:'6em'}>
-                    <ChatInput
-                        input                = {@props.input}
-                        input_ref            = {@input_ref}
-                        input_style          = {input_style}
-                        enable_mentions      = {has_collaborators}
-                        project_users        = {project_users}
-                        user_store           = {@props.redux.getStore("users")}
-                        font_size            = {@props.font_size}
-                        on_change            = {@on_input_change}
-                        on_clear             = {@on_clear}
-                        on_send              = {@on_input_send}
-                        on_set_to_last_input = {@props.actions.set_to_last_input}
-                        account_id           = {@props.account_id}
-                    />
+                    <div style={width:'85%', height:'100%'}>
+                        <ChatInput
+                            input                = {@props.input}
+                            input_ref            = {@input_ref}
+                            enable_mentions      = {has_collaborators}
+                            project_users        = {project_users}
+                            user_store           = {@props.redux.getStore("users")}
+                            font_size            = {@props.font_size}
+                            on_change            = {@on_input_change}
+                            on_clear             = {@on_clear}
+                            on_send              = {@on_input_send}
+                            on_set_to_last_input = {@props.actions.set_to_last_input}
+                            account_id           = {@props.account_id}
+                        />
+                    </div>
                     <Button
                         style    = {width:'15%', height:'100%'}
                         onClick  = {@on_send_click}

--- a/src/smc-webapp/smc-dropzone.cjsx
+++ b/src/smc-webapp/smc-dropzone.cjsx
@@ -100,6 +100,7 @@ exports.SMC_Dropwrapper = rclass
         show_upload      : rtypes.bool                 # Whether or not to show upload area
         on_close         : rtypes.func
         disabled         : rtypes.bool
+        style            : rtypes.object               # css styles to apply to the containing div
 
     getDefaultProps: ->
         config         : {}
@@ -215,7 +216,7 @@ exports.SMC_Dropwrapper = rclass
         </div>
 
     render: ->
-        <div>
+        <div style={@props.style}>
             {@render_preview() if not @props.disabled}
             {@props.children}
         </div>

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -932,10 +932,10 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     }
   };
 
-  on_send_button_click = (e) => {
+  on_send_button_click = e => {
     e.preventDefault();
     this.on_send(this.props.input);
-  }
+  };
 
   button_scroll_to_bottom = () => {
     scroll_to_bottom(this.refs.log_container, this.props.actions);
@@ -1245,7 +1245,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   };
 
   on_send = input => {
-    scroll_to_bottom(this.refs.log_container, this.props.actions)
+    scroll_to_bottom(this.refs.log_container, this.props.actions);
     this.props.actions.submit_user_mentions(
       this.props.project_id,
       this.props.path
@@ -1255,8 +1255,8 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   };
 
   on_clear = () => {
-    this.props.actions.set_input('');
-  }
+    this.props.actions.set_input("");
+  };
 
   render_body() {
     const grid_style: React.CSSProperties = {
@@ -1336,7 +1336,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
                 complete: this.append_file,
                 sending: this.start_upload
               }}
-              style={{height: "100%"}}
+              style={{ height: "100%" }}
             >
               <ChatInput
                 input={this.props.input}

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -21,7 +21,7 @@
 
 // standard non-CoCalc libraries
 import * as immutable from "immutable";
-const { IS_MOBILE, IS_TOUCH, isMobile } = require("./feature");
+const { IS_MOBILE, IS_TOUCH } = require("./feature");
 import { debounce } from "underscore";
 
 // CoCalc libraries
@@ -29,15 +29,13 @@ const { Avatar } = require("./other-users");
 const misc = require("smc-util/misc");
 const misc_page = require("./misc_page");
 
-import { cmp_Date } from "smc-util/misc2";
-
 import { SaveButton } from "./frame-editors/frame-tree/save-button";
 
-import { MentionsInput, Mention } from "react-mentions";
+import { ChatInput } from "./chat/input";
 
 // React libraries
 import { React, ReactDOM, Component, rclass, rtypes } from "./app-framework";
-const { Icon, Loading, SearchInput, Space, TimeAgo, Tip } = require("./r_misc");
+const { Icon, Loading, SearchInput, TimeAgo, Tip } = require("./r_misc");
 import {
   Alert,
   Button,
@@ -62,7 +60,6 @@ const {
   render_history_title,
   render_history_footer,
   render_history,
-  send_chat,
   is_at_bottom,
   scroll_to_bottom,
   scroll_to_position
@@ -918,26 +915,6 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     }
   }, 300);
 
-  keydown = (e: any) => {
-    // TODO: Add timeout component to is_typing
-    if (e.keyCode === 13 && e.shiftKey) {
-      this.props.actions.submit_user_mentions(
-        this.props.project_id,
-        this.props.path
-      );
-      // 13: enter key
-      return send_chat(
-        e,
-        this.refs.log_container,
-        this.props.input,
-        this.props.actions
-      );
-    } else if (e.keyCode === 38 && this.props.input === "") {
-      // Up arrow on an empty input
-      this.props.actions.set_to_last_input();
-    }
-  };
-
   componentWillUnmount() {
     this._is_mounted = false;
     this.save_scroll_position();
@@ -955,14 +932,10 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     }
   };
 
-  button_send_chat = e => {
-    this.props.actions.submit_user_mentions(
-      this.props.project_id,
-      this.props.path
-    );
-    send_chat(e, this.refs.log_container, this.props.input, this.props.actions);
-    this.input_ref.current.focus();
-  };
+  on_send_button_click = (e) => {
+    e.preventDefault();
+    this.on_send(this.props.input);
+  }
 
   button_scroll_to_bottom = () => {
     scroll_to_bottom(this.refs.log_container, this.props.actions);
@@ -973,7 +946,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     this.input_ref.current.focus();
   };
 
-  button_on_click = () => {
+  on_preview_button_click = () => {
     this.props.actions.set_is_preview(true);
     this.input_ref.current.focus();
     if (
@@ -1203,17 +1176,6 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     );
   }
 
-  render_user_suggestion = (entry: { id: string; display: string }) => {
-    return (
-      <span>
-        <Avatar size={this.props.font_size + 12} account_id={entry.id} />
-        <Space />
-        <Space />
-        {entry.display}
-      </span>
-    );
-  };
-
   generate_temp_upload_text = file => {
     return `[Uploading...]\(${file.name}\)`;
   };
@@ -1255,7 +1217,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
 
   private dropzoneWrapperRef: any;
 
-  handle_paste_event = (e: React.ClipboardEvent<MentionsInput>) => {
+  handle_paste_event = (e: React.ClipboardEvent<any>) => {
     const items = e.clipboardData.items;
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
@@ -1276,11 +1238,25 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     }
   };
 
-  on_input_change = (e, _, __, mentions) => {
+  on_input_change = (value, mentions) => {
+    console.log(value, mentions)
     this.props.actions.set_unsent_user_mentions(mentions);
-    this.props.actions.set_input(e.target.value);
+    this.props.actions.set_input(value);
     this.mark_as_read();
   };
+
+  on_send = input => {
+    this.props.actions.submit_user_mentions(
+      this.props.project_id,
+      this.props.path
+    );
+    this.props.actions.send_chat(input);
+    this.input_ref.current.focus();
+  };
+
+  on_clear = () => {
+    this.props.actions.set_input('');
+  }
 
   render_body() {
     const grid_style: React.CSSProperties = {
@@ -1300,75 +1276,13 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
       flex: 1
     };
 
-    const chat_input_style: {
-      [key: string]:
-        | string
-        | React.CSSProperties
-        | { [key: string]: React.CSSProperties };
-    } = {
-      "&multiLine": {
-        highlighter: {
-          padding: 5
-        },
-
-        input: {
-          height: "90px",
-          fontSize: this.props.font_size,
-          border: "1px solid #ccc",
-          borderRadius: "4px",
-          boxShadow: "inset 0 1px 1px rgba(0,0,0,.075)",
-          overflow: "auto",
-          padding: "5px 10px"
-        }
-      },
-
-      suggestions: {
-        list: {
-          backgroundColor: "white",
-          border: "1px solid #ccc",
-          borderRadius: "4px",
-          fontSize: this.props.font_size,
-          position: "absolute",
-          bottom: "10px",
-          overflow: "auto",
-          maxHeight: "145px",
-          width: "max-content",
-          display: "flex",
-          flexDirection: "column"
-        },
-
-        item: {
-          padding: "5px 15px 5px 10px",
-          borderBottom: "1px solid rgba(0,0,0,0.15)",
-
-          "&focused": {
-            backgroundColor: "rgb(66, 139, 202, 0.4)"
-          }
-        }
-      }
-    };
-
-    let has_collaborators = false;
-
-    const user_store = this.props.redux.getStore("users");
     // the immutable.Map() default is because of admins:
     // https://github.com/sagemathinc/cocalc/issues/3669
-    const user_array = this.props.project_map
-      .getIn([this.props.project_id, "users"], immutable.Map())
-      .keySeq()
-      .filter(account_id => {
-        return account_id !== this.props.account_id;
-      })
-      .map(account_id => {
-        has_collaborators = true;
-        return {
-          id: account_id,
-          display: user_store.get_name(account_id),
-          last_active: user_store.get_last_active(account_id)
-        };
-      })
-      .toJS();
-    user_array.sort((x, y) => -cmp_Date(x.last_active, y.last_active));
+    const project_users = this.props.project_map.getIn(
+      [this.props.project_id, "users"],
+      immutable.Map()
+    );
+    const has_collaborators = project_users.size > 1;
 
     return (
       <Grid fluid={true} className="smc-vfill" style={grid_style}>
@@ -1423,29 +1337,20 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
                 sending: this.start_upload
               }}
             >
-              <MentionsInput
-                autoFocus={!IS_MOBILE || isMobile.Android()}
-                displayTransform={(_, display) => "@" + display}
-                style={chat_input_style}
-                markup='<span class="user-mention" account-id=__id__ >@__display__</span>'
-                inputRef={this.input_ref}
-                onKeyDown={this.keydown}
-                value={this.props.input}
-                placeholder={
-                  has_collaborators
-                    ? "Type a message, @name..."
-                    : "Type a message..."
-                }
-                onPaste={this.handle_paste_event}
-                onChange={this.on_input_change}
-              >
-                <Mention
-                  trigger="@"
-                  data={user_array}
-                  appendSpaceOnAdd={true}
-                  renderSuggestion={this.render_user_suggestion}
-                />
-              </MentionsInput>
+              <ChatInput
+                input={this.props.input}
+                input_ref={this.input_ref}
+                enable_mentions={has_collaborators}
+                project_users={project_users}
+                user_store={this.props.redux.getStore("users")}
+                font_size={this.props.font_size}
+                on_paste={this.handle_paste_event}
+                on_change={this.on_input_change}
+                on_clear={this.on_clear}
+                on_send={this.on_send}
+                on_set_to_last_input={this.props.actions.set_to_last_input}
+                account_id={this.props.account_id}
+              />
             </SMC_Dropwrapper>
           </Col>
           <Col
@@ -1459,7 +1364,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
           >
             {!IS_MOBILE ? (
               <Button
-                onClick={this.button_on_click}
+                onClick={this.on_preview_button_click}
                 disabled={this.props.input === ""}
                 bsStyle="info"
                 style={{ height: "50%", width: "100%" }}
@@ -1470,7 +1375,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
               undefined
             )}
             <Button
-              onClick={this.button_send_chat}
+              onClick={this.on_send_button_click}
               disabled={this.props.input === ""}
               bsStyle="success"
               style={{ flex: 1, width: "100%" }}

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -1336,6 +1336,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
                 complete: this.append_file,
                 sending: this.start_upload
               }}
+              style={{height: "100%"}}
             >
               <ChatInput
                 input={this.props.input}

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -71,8 +71,6 @@ const {
 const { VideoChatButton } = require("./video-chat");
 const { SMC_Dropwrapper } = require("./smc-dropzone");
 
-const { webapp_client } = require("./webapp_client");
-
 interface MessageProps {
   actions?: any;
 
@@ -923,6 +921,10 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   keydown = (e: any) => {
     // TODO: Add timeout component to is_typing
     if (e.keyCode === 13 && e.shiftKey) {
+      this.props.actions.submit_user_mentions(
+        this.props.project_id,
+        this.props.path
+      );
       // 13: enter key
       return send_chat(
         e,
@@ -954,6 +956,10 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   };
 
   button_send_chat = e => {
+    this.props.actions.submit_user_mentions(
+      this.props.project_id,
+      this.props.path
+    );
     send_chat(e, this.refs.log_container, this.props.input, this.props.actions);
     this.input_ref.current.focus();
   };
@@ -1270,13 +1276,10 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     }
   };
 
-  on_mention = id => {
-    webapp_client.mention({
-      project_id: this.props.project_id,
-      path: this.props.path,
-      target: id,
-      priority: 2
-    });
+  on_input_change = (e, _, __, mentions) => {
+    this.props.actions.set_unsent_user_mentions(mentions);
+    this.props.actions.set_input(e.target.value);
+    this.mark_as_read();
   };
 
   render_body() {
@@ -1424,7 +1427,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
                 autoFocus={!IS_MOBILE || isMobile.Android()}
                 displayTransform={(_, display) => "@" + display}
                 style={chat_input_style}
-                markup='<span class="user-mention">@__display__</span>'
+                markup='<span class="user-mention" account-id=__id__ >@__display__</span>'
                 inputRef={this.input_ref}
                 onKeyDown={this.keydown}
                 value={this.props.input}
@@ -1434,15 +1437,11 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
                     : "Type a message..."
                 }
                 onPaste={this.handle_paste_event}
-                onChange={(e: any) => {
-                  this.props.actions.set_input(e.target.value);
-                  this.mark_as_read();
-                }}
+                onChange={this.on_input_change}
               >
                 <Mention
                   trigger="@"
                   data={user_array}
-                  onAdd={this.on_mention}
                   appendSpaceOnAdd={true}
                   renderSuggestion={this.render_user_suggestion}
                 />

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -1239,13 +1239,13 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
   };
 
   on_input_change = (value, mentions) => {
-    console.log(value, mentions)
     this.props.actions.set_unsent_user_mentions(mentions);
     this.props.actions.set_input(value);
     this.mark_as_read();
   };
 
   on_send = input => {
+    scroll_to_bottom(this.refs.log_container, this.props.actions)
     this.props.actions.submit_user_mentions(
       this.props.project_id,
       this.props.path


### PR DESCRIPTION
# Description
Add a simple memoization method so that mentions data is only recomputed when users on the project changes or when the entire chatroom is rendered.

The latter could be removed but it turns out my store memoization method is broken. Sooo I'm going to look into that after this.

In any case, this memoization method is really easy to follow.

Also fixes #3678

# Testing Steps
1. Open a project with 2 users
1. Have one user invite additional users while the other uses mentions. The list should update.
1. Check that styling hasn't regressed

# Relevant Issues
#3678

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
