### PR TITLE
Fix message length problems in chat rooms

### DIFF
--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -1322,7 +1322,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
           </Col>
         </Row>
         <Row style={{ display: "flex", maxWidth: "100vw"}}>
-          <Col style={{ flex: "1", padding: "0px 2px 0px 2px", width: "250px" }}>
+          <Col style={{ flex: "1", padding: "0px 2px 0px 2px", width: "250px", maxHeight: "120px"}}>
             <SMC_Dropwrapper
               ref={node => (this.dropzoneWrapperRef = node)}
               project_id={this.props.project_id}

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -1321,8 +1321,8 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
             </Well>
           </Col>
         </Row>
-        <Row style={{ display: "flex" }}>
-          <Col style={{ flex: "1", padding: "0px 2px 0px 2px" }}>
+        <Row style={{ display: "flex", maxWidth: "100vw"}}>
+          <Col style={{ flex: "1", padding: "0px 2px 0px 2px", width: "250px" }}>
             <SMC_Dropwrapper
               ref={node => (this.dropzoneWrapperRef = node)}
               project_id={this.props.project_id}

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -1263,7 +1263,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
       maxWidth: "1200px",
       display: "flex",
       flexDirection: "column",
-      width: IS_MOBILE ? "100%" : undefined
+      width: "100%"
     };
 
     const chat_log_style: React.CSSProperties = {


### PR DESCRIPTION
# Description
Long single line message:
<img width="1273" alt="Screen Shot 2019-03-13 at 10 49 18 AM" src="https://user-images.githubusercontent.com/618575/54302257-c6337380-457d-11e9-96a1-16328bfb84ea.png">

Long vertical message:
<img width="1363" alt="Screen Shot 2019-03-13 at 10 49 54 AM" src="https://user-images.githubusercontent.com/618575/54302255-c59add00-457d-11e9-98d3-764737171f3c.png">

# Testing Steps
1. Type a long one line message into a chatroom without any spaces
1. Create a chat message with a lot of line breaks to have long 

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
