### PR TITLE
New trial project page

### DIFF
--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -135,7 +135,7 @@ FreeProjectWarning = rclass ({name}) ->
 
     render_learn_more: (color) ->
         <Fragment>
-            {' &mdash; '}
+            {' '}&mdash;{' '}
             <a
                 href   = "https://doc.cocalc.com/trial.html"
                 target = "_blank"
@@ -149,8 +149,6 @@ FreeProjectWarning = rclass ({name}) ->
 
     render: ->
         if @props.other_settings?.get('no_free_warnings')
-            return null
-        if not @props.project_log?
             return null
         if not require('./customize').commercial
             return null
@@ -167,22 +165,22 @@ FreeProjectWarning = rclass ({name}) ->
         if not host and not internet
             return null
 
-        font_size = Math.min(18, 12 + Math.round((@props.project_log?.size ? 0) / 30))
+        font_size = Math.min(18, 10 + (@props.project_log?.size ? 0) / 30)
         styles =
-            padding      : "5px 30px"
+            padding      : "5px 10px"
             marginBottom : 0
             fontSize     : "#{font_size}pt"
 
-        if host
+        if host and font_size > 11
             styles.color      = 'white'
             styles.background = 'red'
 
         if host and internet
-            mesg = <span>Upgrade this project.  It is on an <b>unpaid trial server</b> and has no network access.  Expect very bad performance.</span>
+            mesg = <span>Upgrade this project. It is on an <b>unpaid trial server</b> and has no internet access.  Expect very bad performance.</span>
         else if host
-            mesg = <span>Upgrade this project.  It is on an <b>unpaid trial server</b>. Expect very bad performance.</span>
+            mesg = <span>Upgrade this project. It is on an <b>unpaid trial server</b>. Expect very bad performance.</span>
         else if internet
-            mesg = <span>This project does not have network access.</span>
+            mesg = <span>This project does not have access to the internet.</span>
 
         <Alert bsStyle='warning' style={styles}>
             <Icon name='exclamation-triangle' style={float:'right', marginTop: '3px'}/>

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -45,7 +45,7 @@ Draggable = require('react-draggable')
 project_file = require('./project_file')
 {file_associations} = require('./file-associations')
 
-{React, ReactDOM, rclass, redux, rtypes, Redux} = require('./app-framework')
+{React, ReactDOM, rclass, redux, rtypes, Redux, Fragment} = require('./app-framework')
 {DeletedProjectWarning, ErrorBoundary, Icon, Loading, Space} = require('./r_misc')
 
 {ChatIndicator} = require('./chat-indicator')
@@ -134,12 +134,17 @@ FreeProjectWarning = rclass ({name}) ->
         <a style={dismiss_styles} onClick={@actions(project_id: @props.project_id).close_free_warning}>×</a>
 
     render_learn_more: (color) ->
-        <a
-            href   = "https://github.com/sagemathinc/cocalc/wiki/TrialServer"
-            target = "_blank"
-            style  = {fontWeight : 'bold', color:color, cursor:'pointer'}>
-            <Space/> &mdash; more info... <Space/>
-        </a>
+        <Fragment>
+            {' &mdash; '}
+            <a
+                href   = "https://doc.cocalc.com/trial.html"
+                target = "_blank"
+                style  = {fontWeight : 'bold', color:color, cursor:'pointer'}
+            >
+                more info
+            </a>
+            {'...'}
+        </Fragment>
         #<a onClick={=>@actions(project_id: @props.project_id).show_extra_free_warning()} style={color:'white', cursor:'pointer'}> learn more...</a>
 
     render: ->


### PR DESCRIPTION
# Description
The goal if this here is to point to the new trial project page, but I discovered that displaying it depends on the project log -- which isn't loaded any more. Well, this restores it in all cases, i.e. in particular at the beginning of using a project as a smaller basic banner, and then grows with project usage. The remaining question is if the project log should be loaded in any case. My idea is to check there in the banner logic if it is a paid project (etc.). If not and the project log is empty, it loads it once (maybe with a bit of delay). I didn't code that, because I'm not sure about the actual performance implications.

# Testing Steps
1. new project, no upgrades, banner shows up (before that patch, it wouldn't)
2. after the project log is loaded and actually filled with a couple of entries and the banner renders again, it is red and grows in size.

![Screenshot from 2019-03-19 13-27-27](https://user-images.githubusercontent.com/207405/54605955-c4205780-4a4a-11e9-9746-bb50ab2cce4d.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
