### PR TITLE
x11: disable mDNS, xpra 2.5

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
@@ -109,6 +109,7 @@ export class XpraServer {
       //"-d",
       //"all",
       "--compression_level=9",
+      "--mdns=no", // disable dynamic dns via avahi
       "--socket-dir=/tmp/xpra",
       "--tray=no",
       "--mousewheel=on",


### PR DESCRIPTION
# Description
This is a leftover branch from when I thought xrpa 2.5 breaks cocalc's x11. The only change is an additional parameter that disables some dynamic dns lookup. I think it's ok to merge this, but worth a second pair of eyes.

```
    --mdns=yes|no       Publish the session information via mDNS. Default:  yes.
```


also, as of right now, I think it doesn't work in the containerized network environment.

```
~/cocalc/src/smc-webapp/frame-editors$ xpra --version
xpra v2.5-r22135

~/cocalc/src/smc-webapp/frame-editors$ xpra list-mdns
failed to connect to the system dbus: org.freedesktop.DBus.Error.FileNotFound: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
 either start a dbus session or disable mdns support
Looking for xpra services via mdns
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/xpra/net/mdns/avahi_listener.py", line 80, in start
    self.server = dbus.Interface(self.bus.get_object(avahi.DBUS_NAME, '/'), 'org.freedesktop.Avahi.Server')
AttributeError: AvahiListener instance has no attribute 'bus'
no services found
```


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
