### PR TITLE
ask explicitly about filename, after selecting the type

### DIFF
--- a/src/smc-webapp/project/ask-filename.tsx
+++ b/src/smc-webapp/project/ask-filename.tsx
@@ -1,0 +1,106 @@
+import { Component, React, Rendered } from "../app-framework";
+const { default_filename } = require("../account.coffee");
+const { file_options } = require("../editor");
+const {
+  Col,
+  Row,
+  ButtonToolbar,
+  ControlLabel,
+  Button,
+  Form
+} = require("react-bootstrap");
+const { SearchInput } = require("../r_misc");
+const { IS_TOUCH } = require("../feature");
+
+interface Props {
+  actions: any;
+  ext_selection: string;
+  current_path: string;
+}
+interface State {
+  new_name: string;
+}
+
+export class AskNewFilename extends Component<Props, State> {
+  displayName = "ProjectFiles-AskNewFilename";
+  constructor(props) {
+    super(props);
+    this.state = {
+      new_name: default_filename()
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ new_name: default_filename() });
+  }
+
+  cancel = (): void => {
+    this.props.actions.setState({ ext_selection: undefined });
+  };
+
+  create = (name, focus): void => {
+    this.props.actions.setState({ ext_selection: undefined });
+    this.props.actions.create_file({
+      name: name,
+      ext: this.props.ext_selection,
+      current_path: this.props.current_path,
+      switch_over: focus
+    });
+  };
+
+  submit = (val: string, opts: any): void => {
+    this.create(val, !opts.ctrl_down);
+  };
+
+  create_click = (): void => {
+    this.create(this.state.new_name, true);
+  };
+
+  change = (val: string): void => {
+    this.setState({ new_name: val });
+  };
+
+  render_filename() {
+    const data: any = file_options(`foo.${this.props.ext_selection}`);
+    return data.name;
+  }
+
+  render(): Rendered {
+    return (
+      <Row>
+        <Col md={6} mdOffset={0} lg={4} lgOffset={0}>
+          <ControlLabel>
+            Enter name for new {this.render_filename()} file:
+          </ControlLabel>
+          <Form>
+            <SearchInput
+              autoFocus={!IS_TOUCH}
+              autoSelect={!IS_TOUCH}
+              ref={"new_filename2"}
+              key={"new_filename2"}
+              type={"text"}
+              value={this.state.new_name}
+              placeholder={"Enter filename..."}
+              on_submit={this.submit}
+              on_escape={this.cancel}
+              on_change={this.change}
+            />
+            <ButtonToolbar
+              style={{ whiteSpace: "nowrap", padding: "0" }}
+              className={"pull-right"}
+            >
+              <Button
+                bsStyle={"primary"}
+                onClick={this.create_click}
+                disabled={this.state.new_name.length == 0}
+              >
+                Create
+              </Button>
+              <Button onClick={this.cancel}>Cancel</Button>
+            </ButtonToolbar>
+          </Form>
+        </Col>
+      </Row>
+    );
+  }
+}

--- a/src/smc-webapp/r_misc/index.cjsx
+++ b/src/smc-webapp/r_misc/index.cjsx
@@ -420,6 +420,7 @@ exports.SearchInput = rclass
         on_up           : rtypes.func    # push up arrow
         on_down         : rtypes.func    # push down arrow
         on_clear        : rtypes.func    # invoked without arguments when input box is cleared (eg. via esc or clicking the clear button)
+
         clear_on_submit : rtypes.bool    # if true, will clear search box on every submit (default: false)
         buttonAfter     : rtypes.element
         input_class     : rtypes.string  # className for the InputGroup element


### PR DESCRIPTION
# Description
that's an implementation for my idea in #2919, in particular to overcome step 2&3 in the user story. basically instead of an error, show an explicit request for a filename in a panel. it's also less friction than before, because a timestamped-filename is inserted by default and return or one additional click is enough to get the file.

# Testing Steps
in "files" for each, do click "+new" dropdown → e.g. latex or jupyter
   1. press return → new file
   1. press esc → back to square one
   1. type some chars → uses that filename
   1. no filename: create not active, and return shows a specific error

# Relevant Issues
#2919

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
