### PR TITLE
associate .markdown files with markdown editor -- #3723

### DIFF
--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -179,7 +179,7 @@ file_associations["html"] = {
   name: "html"
 };
 
-file_associations["md"] = {
+file_associations["md"] = file_associations["markdown"] = {
   icon: "cc-icon-markdown",
   opts: { indent_unit: 4, tab_size: 4, mode: codemirror_associations["md"] },
   name: "markdown"

--- a/src/smc-webapp/frame-editors/markdown-editor/register.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/register.ts
@@ -6,8 +6,10 @@ import { Editor } from "./editor";
 import { Actions } from "./actions";
 import { register_file_editor } from "../frame-tree/register";
 
-register_file_editor({
-  ext: "md",
-  component: Editor,
-  Actions
-});
+["md", "markdown"].map(ext =>
+  register_file_editor({
+    ext,
+    component: Editor,
+    Actions
+  })
+);


### PR DESCRIPTION
# Description
boring PR, see #3723 

# Testing Steps
open
1. `.md` file
1. `.markdown` file

![Screenshot from 2019-04-01 13-27-50](https://user-images.githubusercontent.com/207405/55324361-1a958900-5482-11e9-8a06-491858e05cde.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
