### PR TITLE
webapp: add audio player for ogg, mp3, ...

### DIFF
--- a/src/smc-webapp/editor-data/generic.tsx
+++ b/src/smc-webapp/editor-data/generic.tsx
@@ -28,9 +28,6 @@ const microsoft_word =
 const microsoft_ppt =
   'Microsoft PowerPoint -- Create an ["X11" file](https://doc.cocalc.com/x11.html) and open the "Impress" application.';
 
-// We should obviously implement an audio player.  See https://github.com/sagemathinc/cocalc/issues/3685
-const audio_file = "This appears to be an audio file.  Download it to your computer to play it."
-
 // ext: markdown string.
 const INFO = {
   h4: hdf_file,
@@ -62,10 +59,6 @@ Read more: [Saving-Data-on-Unexpected-Exits](https://www.gnu.org/software/octave
   "noext-a.out":
     "This is a binary executable, which you can run in a Terminal by typing ./a.out."
 };
-
-for (let ext of ['wav', 'mp3', 'aiff', 'flac', 'asnd', 'aif', 'au', 'snd']) {
-  INFO[ext] = audio_file;
-}
 
 interface Props {
   project_id: string;

--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -287,9 +287,27 @@ for (let ext of ["png", "jpg", "jpeg", "gif", "svg", "bmp"]) {
 }
 
 // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
-exports.IMAGE_EXTS = ["jpg", "jpeg", "png", "bmp", "gif", "apng", "svg", "ico"];
+exports.IMAGE_EXTS = <ReadonlyArray<string>>(
+  Object.freeze(["jpg", "jpeg", "png", "bmp", "gif", "apng", "svg", "ico"])
+);
 
-exports.VIDEO_EXTS = ["webm", "mp4", "avi", "mkv", "ogv", "ogm", "3gp"];
+exports.VIDEO_EXTS = <ReadonlyArray<string>>(
+  Object.freeze(["webm", "mp4", "avi", "mkv", "ogv", "ogm", "3gp"])
+);
+
+exports.AUDIO_EXTS = <ReadonlyArray<string>>(
+  Object.freeze([
+    "wav",
+    "ogg",
+    "mp3",
+    "aiff",
+    "flac",
+    "asnd",
+    "aif",
+    "au",
+    "snd"
+  ])
+);
 
 file_associations["pdf"] = {
   editor: "pdf",

--- a/src/smc-webapp/media-viewer/register.coffee
+++ b/src/smc-webapp/media-viewer/register.coffee
@@ -4,7 +4,7 @@ Handle viewing images and videos
 
 {MediaViewer}            = require('./viewer')
 {register_file_editor}   = require('../project_file')
-{IMAGE_EXTS, VIDEO_EXTS} = require('../file-associations')
+{IMAGE_EXTS, VIDEO_EXTS, AUDIO_EXTS} = require('../file-associations')
 
 for is_public in [true, false]
     register_file_editor
@@ -18,4 +18,11 @@ for is_public in [true, false]
         icon      : 'file-video-o'
         component : MediaViewer
         is_public : is_public
+
+    register_file_editor
+        ext       : AUDIO_EXTS
+        icon      : 'file-audio-o'
+        component : MediaViewer
+        is_public : is_public
+
 

--- a/src/smc-webapp/media-viewer/viewer.cjsx
+++ b/src/smc-webapp/media-viewer/viewer.cjsx
@@ -9,7 +9,7 @@ Image viewer component -- for viewing standard image types.
 
 {ButtonBar}                       = require('./button-bar')
 
-{VIDEO_EXTS, IMAGE_EXTS}          = require('../file-associations')
+{VIDEO_EXTS, IMAGE_EXTS, AUDIO_EXTS} = require('../file-associations')
 
 exports.MediaViewer = rclass
     displayName : "MediaViewer"
@@ -22,11 +22,15 @@ exports.MediaViewer = rclass
         param : 0   # used to force reload when button explicitly clicked
 
     get_mode: ->
-        ext = filename_extension(@props.path)
+        ext = filename_extension(@props.path).toLowerCase()
         if ext in VIDEO_EXTS
             return 'video'
-        else
+        if ext in IMAGE_EXTS
             return 'image'
+        if ext in AUDIO_EXTS
+            return 'audio'
+        console.warn("Unknown media extension #{ext}")
+        return ''
 
     render_media: (url) ->
         switch @get_mode()
@@ -39,9 +43,17 @@ exports.MediaViewer = rclass
                     controls = {true}
                     autoPlay = {true}
                     loop     = {true}
-                    />
+                />
+            when 'audio'
+                <audio
+                    src      = {url}
+                    autoPlay = {true}
+                    controls = {true}
+                    loop     = {false}
+                    volume   = {0.5}
+                />
             else # should never happen
-                <div>Unknown type</div>
+                <div style={color:'white', fontSize:'200%'}>Unknown type</div>
 
     render_content: ->
         # the URL to the file:


### PR DESCRIPTION

# Description
* make it work for uppercase file extensions
* undo 87d3e8af6363c1675a43c76eaa21cdd29b830d31 
* and also add ogg support


# Testing Steps
1. I used https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg … if those other audio files open depends on the browser.
1. also make a file like `plot.SVG` with uppercase extension letters. with that patch, the image can be opened.

# Relevant Issues
* #3685

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
