### PR TITLE
start of selenium tests for CoCalc

### DIFF
--- a/src/test/selenium/.gitignore
+++ b/src/test/selenium/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.yaml
+*.png

--- a/src/test/selenium/README.md
+++ b/src/test/selenium/README.md
@@ -1,0 +1,49 @@
+# front-end testing of CoCalc with pytest and selenium
+
+## Setup
+
+1. Checkout cocalc source and do
+
+    ```
+    cd cocalc/src/test/selenium
+    ```
+
+1. Prepare test site. TODO: automate this.
+
+    - create a test account in the instance to be tested
+    - create a test project in the test user account
+    - add test files to project home directory
+
+
+1. Create `<sitename>.yaml` file for the site to be tested. Place in directory above `tests` directory and do NOT add/commit to git. The `name` value can be any descriptive name. *Note: `*.yaml` is in .gitignore for this directory.*
+
+    ```
+    url: https://test.cocalc.com
+    email: testuser@example.com
+    passw: SoylentIsntGreen
+    name: test.cocalc.com
+    project: fe-test
+    ```
+
+## Running the tests
+
+Default operation is headless. Add `--display=yes` to view selenium test browser window. If running from CoCalc with display enabled, use an X11 xterm.
+
+```
+cd ~/cc-test/tests
+python3 -m pytest --site=../cocalc.yaml [--display=yes]
+```
+
+## What is tested
+
+1. Get landing page.
+1. Sign in with email and password.
+1. Open test project.
+1. Open sample files.
+
+## Limitations and caveats
+
+1. Test project must be created before testing.
+1. Test project must be in recent history and running.
+1. Initial URL must be specified with IP address.
+1. Password may be displayed during log & error output.

--- a/src/test/selenium/README.md
+++ b/src/test/selenium/README.md
@@ -45,5 +45,5 @@ python3 -m pytest --site=../cocalc.yaml [--display=yes]
 
 1. Test project must be created before testing.
 1. Test project must be in recent history and running.
-1. Initial URL must be specified with IP address.
+1. In some cases, test URL must be specified with IP address.
 1. Password may be displayed during log & error output.

--- a/src/test/selenium/tests/conftest.py
+++ b/src/test/selenium/tests/conftest.py
@@ -1,0 +1,97 @@
+import pytest
+import os
+import re
+import yaml
+import time
+from datetime import datetime
+
+from selenium import webdriver
+
+def log(*args):
+    mesg = "\n(%s): %s " % (datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3], ' '.join(args))
+    print(mesg)
+
+def show_attrs(el, d):
+    r"""
+    print attributes of webdriver element to stdout
+    for debugging
+    """
+    attrs = d.execute_script("var items = {}; for (index=0; index<arguments[0].attributes.length;++index) {items[arguments[0].attributes[index].name] = arguments[0].attributes[index].value }; return items;", el)
+    print(attrs)
+###
+# pass site file in on command line
+###
+def pytest_addoption(parser):
+    parser.addoption(
+        "--site", action="store", default="../cocalc.yaml", help="yaml file for test site"
+    )
+    parser.addoption(
+        "--display", action="store", default="no", help="yes for browser window"
+    )
+
+@pytest.fixture(scope="session")
+def site(request):
+    r"""
+    Return dict from yaml file name passed on command line.
+    """
+    fname = request.config.getoption("--site")
+    with open(fname,"r") as infile:
+        sdict = yaml.load(infile)
+    print(f"site name: {sdict['name']}")
+    return sdict
+
+@pytest.fixture(scope="session")
+def display(request):
+    r"""
+    Return Boolean; False (default) for headless, True for showing browser
+    """
+    dispval = request.config.getoption("--display")
+    return dispval in ["y","yes"]
+
+
+###
+# incremental testing
+###
+def pytest_runtest_makereport(item, call):
+    if "incremental" in item.keywords:
+        if call.excinfo is not None:
+            parent = item.parent
+            parent._previousfailed = item
+
+def pytest_runtest_setup(item):
+    if "incremental" in item.keywords:
+        previousfailed = getattr(item.parent, "_previousfailed", None)
+        if previousfailed is not None:
+            pytest.xfail("previous test failed (%s)" % previousfailed.name)
+###
+
+@pytest.fixture(scope="session")
+def driver(site, display):
+    r"""
+    start a selenium session with headless chrome
+    """
+    chrome_options = webdriver.ChromeOptions()
+    chrome_options.add_argument('--no-sandbox')
+    chrome_options.add_argument('--window-size=1420,1080')
+    if not display:
+        chrome_options.add_argument('--headless')
+    chrome_options.add_argument('--disable-gpu')
+    chrome_options.add_argument('--user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36"')
+    drvr = webdriver.Chrome(options=chrome_options)
+    drvr.implicitly_wait(10)
+    yield drvr
+
+    drvr.close()
+
+@pytest.fixture()
+def test_id(request):
+    r"""
+    Return increasing sequence of integers starting at 1. This number is used as
+    test id as well as message 'id' value so sage_server log can be matched
+    with pytest output.
+    """
+    test_id.id += 1
+    return test_id.id
+
+test_id.id = 1
+

--- a/src/test/selenium/tests/test_landing.py
+++ b/src/test/selenium/tests/test_landing.py
@@ -1,0 +1,70 @@
+import conftest
+import pytest
+import time
+
+# suffix "xp" is for "xpath"
+
+@pytest.mark.incremental
+class TestStartCocalc:
+    def test_landing(self, driver, site):
+        r"""
+        Load initial landing page and click "Sign In".
+        """
+        url = site['url']
+        driver.get(url)
+        driver.save_screenshot('landing.png')
+        x = driver.find_element_by_class_name('get-started')
+        assert x.text == 'Sign In'
+        x.click()
+
+    def test_signin(self, driver, site):
+        r"""
+        Enter email address and password and click "Sign In"
+        """
+        els = driver.find_elements_by_name("email")
+        el = els[1]
+        email = site['email']
+        el.send_keys(email)
+
+        els = driver.find_elements_by_name("password")
+        el = els[1]
+        password = site['passw']
+        el.send_keys(password)
+
+        # find parent div of signin button
+        el0 = driver.find_element_by_class_name("col-xs-3")
+        # find signin button
+        el = el0.find_element_by_tag_name("button")
+        # conftest.show_attrs(el, driver)
+
+        el.submit()
+        time.sleep(1)
+
+
+    def test_searchproj(self, driver, site):
+        r"""
+        type in the name of the test project
+        """
+        els = driver.find_elements_by_tag_name("input")
+        phtext = "Search for projects..."
+        for x in els:
+            #conftest.show_attrs(x, driver)
+            if x.get_attribute("placeholder") == phtext:
+                break
+        else:
+            assert 0, f'Placeholder "{phtext}" not found'
+        
+        project = site.get('project')
+        x.send_keys(project)
+        time.sleep(1)
+        driver.save_screenshot('sfp.png')
+
+    def test_projitem(self, driver, site):
+        r"""
+        Click on test project name.
+        """
+        project = site.get('project')
+        x = driver.find_element_by_link_text(project)
+        x.click()
+        time.sleep(3)
+        driver.save_screenshot('projitem.png')


### PR DESCRIPTION
# Description

See `cocalc/src/test/selenium/README.md`.

This is a tiny start.

Nothing changes to production code.

# Testing Steps
1. Apply the patch.
1. Create `~/cocalc/src/test/selenium/mysite.yaml` per README.md. Use IP address if testing cocalc.com or test.cocalc.com.
1. Do
    cd ~/cocalc/src/test/selenium/tests
    python3 -m pytest --site=../mysite.yaml
    \# expect output:
    ...
    == 4 passed in 28.83 seconds ==


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
