### PR TITLE
kmz files are binary

### DIFF
--- a/src/smc-webapp/editor-data/generic.tsx
+++ b/src/smc-webapp/editor-data/generic.tsx
@@ -38,6 +38,8 @@ const INFO = {
   docx: microsoft_word,
   ppt: microsoft_ppt,
   pptx: microsoft_ppt,
+  kmz:
+    "Editing [KMZ files](https://developers.google.com/kml/documentation/kmzarchives) is not supported. You could `unzip` them in a [Terminal](https://doc.cocalc.com/terminal.html).",
   jar:
     "Run JAVA jar archives in a [Terminal](https://doc.cocalc.com/terminal.html) via `java -jar <filename.jar>`",
   raw:


### PR DESCRIPTION
# Description
there is a link to the documentation of that file type and a note about unzipping it

# Testing Steps
this is what I did
1.  `wget http://dl.google.com/developers/maps/buffetthawaiitour.kmz`
1. opening that file → info banner, that's it
1. terminal `unzip buffetthawaiitour.kmz` → deflated files
1. opening `doc.kml` (the main file there) opens up as an xml file, which is fine, because it is xml :100: 

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
