### PR TITLE
sagews pytest: sage-8.7, sagemath doctest

### DIFF
--- a/src/smc_sagews/smc_sagews/tests/README.md
+++ b/src/smc_sagews/smc_sagews/tests/README.md
@@ -23,6 +23,15 @@
 
 ### Running the Tests
 
+Use `runtests.sh` to set up environment for doctests, otherwise they will be skipped.
+
+```
+cd smc/src/smc_sagews/smc_sagews/tests
+./runtests.sh
+```
+
+to skip doctests:
+
 ```
 cd smc/src/smc_sagews/smc_sagews/tests
 python -m pytest

--- a/src/smc_sagews/smc_sagews/tests/README.md
+++ b/src/smc_sagews/smc_sagews/tests/README.md
@@ -26,14 +26,14 @@
 Use `runtests.sh` to set up environment for doctests, otherwise they will be skipped.
 
 ```
-cd smc/src/smc_sagews/smc_sagews/tests
+cd ~/cocalc/src/smc_sagews/smc_sagews/tests
 ./runtests.sh
 ```
 
 to skip doctests:
 
 ```
-cd smc/src/smc_sagews/smc_sagews/tests
+cd ~/cocalc/src/smc_sagews/smc_sagews/tests
 python -m pytest
 ```
 

--- a/src/smc_sagews/smc_sagews/tests/runtests.sh
+++ b/src/smc_sagews/smc_sagews/tests/runtests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 export SAGE_ROOT=/ext/sage/sage
-. /ext/sage/sage/src/bin/sage-env
+. $SAGE_ROOT/src/bin/sage-env
 python -m pytest $@

--- a/src/smc_sagews/smc_sagews/tests/runtests.sh
+++ b/src/smc_sagews/smc_sagews/tests/runtests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export SAGE_ROOT=/ext/sage/sage
+. /ext/sage/sage/src/bin/sage-env
+python -m pytest $@

--- a/src/smc_sagews/smc_sagews/tests/runtests.sh
+++ b/src/smc_sagews/smc_sagews/tests/runtests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export SAGE_ROOT=/ext/sage/sage
+export SAGE_ROOT=${SAGE_ROOT:-${EXT:-/ext}/sage/sage}
 . $SAGE_ROOT/src/bin/sage-env
 python -m pytest $@

--- a/src/smc_sagews/smc_sagews/tests/test_doctests.py
+++ b/src/smc_sagews/smc_sagews/tests/test_doctests.py
@@ -1,0 +1,86 @@
+# run doctests for selected sagemath source files in sagews server
+import socket
+import conftest
+import os
+import re
+
+from textwrap import dedent
+
+
+import pytest
+import future
+import doctest
+
+# doctests need sagemath env settings
+# skip this entire module if not set
+dtvar = 'SAGE_LOCAL'
+if not dtvar in os.environ:
+    pytest.skip("skipping doctests, {} not defined".format(dtvar), allow_module_level=True)
+
+
+@pytest.mark.parametrize("src_file", [
+    ('/ext/sage/sage/local/lib/python2.7/site-packages/sage/symbolic/units.py'),
+    ('/ext/sage/sage/local/lib/python2.7/site-packages/sage/misc/flatten.py'),
+    ('/ext/sage/sage/local/lib/python2.7/site-packages/sage/misc/banner.py')
+])
+class TestDT:
+    def test_dt_file(self, test_id, sagews, src_file):
+        print("src_file=",src_file)
+        import sys
+
+        from sage.doctest.sources import FileDocTestSource
+        from sage.doctest.control import DocTestDefaults
+
+        FDS = FileDocTestSource(src_file,DocTestDefaults())
+        doctests, extras = FDS.create_doctests(globals())
+        id = test_id
+        excount = 0
+        dtn = 0
+        print "{} doctests".format(len(doctests))
+        for dt in doctests:
+            print "doctest number", dtn
+            dtn += 1
+            exs = dt.examples
+            excount += len(exs)
+            for ex in exs:
+                c = ex.sage_source
+                print("code",c)
+                w = ex.want
+                print("want",w)
+                use_pattern = False
+                # handle ellipsis in wanted output
+                if '...' in w:
+                    use_pattern = True
+                    # special case for bad "want" value at end of banner()
+                    wf = w.find('"help()" for help')
+                    if wf > 0:
+                        w = w[:wf]+'...'
+                m = conftest.message.execute_code(code = c, id = id)
+                sagews.send_json(m)
+
+                if len(w) > 0:
+                    typ, mesg = sagews.recv()
+                    assert typ == 'json'
+                    assert mesg['id'] == id
+                    if 'stdout' in mesg:
+                    #assert 'stdout' in mesg
+                        output = mesg['stdout']
+                        print("outp",output)
+                    elif 'stderr' in mesg:
+                        output = mesg['stderr']
+                        # bypass err line number reporting in CoCalc
+                        if w.startswith('Traceback'):
+                            otf = output.find('Traceback')
+                            if otf > 0:
+                                output = output[otf:]
+                        print("outp",output)
+                    else:
+                        assert 0
+                    if use_pattern:
+                        assert doctest._ellipsis_match(w ,output)
+                    else:
+                        assert output.strip() == w.strip()
+                conftest.recv_til_done(sagews, id)
+                id += 1
+        print "{} examples".format(excount)
+        conftest.test_id.id = id

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -35,7 +35,7 @@ class TestLex:
 class TestSageVersion:
     def test_sage_vsn(self, exec2):
         code = "sage.misc.banner.banner()"
-        patn = "version 8.6"
+        patn = "version 8.[67]"
         exec2(code, pattern=patn)
 
 

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -47,12 +47,16 @@ class TestSingularMode:
 import pytest
 import platform
 
+# this comparison doesn't work in sage env
+# because the distro version is spoofed
+# platform.linux_distribution()[1] == "18.04",
 
 @pytest.mark.skipif(
-    platform.linux_distribution()[1] == "18.04",
+    True,
     reason="scala jupyter kernel broken in 18.04")
 class TestScalaMode:
     def test_scala_list(self, exec2):
+        print("linux version {}".format(platform.linux_distribution()[1]))
         exec2(
             "%scala\nList(1,2,3)",
             html_pattern="res0.*List.*Int.*List.*1.*2.*3",
@@ -60,7 +64,7 @@ class TestScalaMode:
 
 
 @pytest.mark.skipif(
-    platform.linux_distribution()[1] == "18.04",
+    True,
     reason="scala jupyter kernel broken in 18.04")
 class TestScala211Mode:
     # example from ScalaTour-1.6, p. 31, Pattern Matching


### PR DESCRIPTION
# Description

- Update sagews pytest for sage-8.7. (trivial)
- Also add initial doctest integration, to see if doctests for a few sagemath files run as expected in sagews environment.
- Tested in experimental software environment (sage-8.7) and default software environment (sage-8.6)
- No changes to code that runs in production.

# Testing Steps
1. Note in README.md, test invocation has `runtests.sh` wrapper now.
1. Apply the patch.
1. `cd ~/cocalc/src/smc_sagews/smc_sagews/tests`
1. `./runtests.sh -x`. Expected result:
```
collected 190 items                                                                                                             
test_00_timing.py ....                                                                               [  2%]
test_doctests.py ...                                                                                 [  3%]
test_env.py ........                                                                                 [  7%]
test_graphics.py ..........                                                                          [ 13%]
test_sagews.py sssss................................................................................ [ 57%]
test_sagews_modes.py .....ssss..............................................................         [ 95%]
test_unicode.py .........                                                                            [100%]

======== 181 passed, 9 skipped in 394.85 seconds =========
```

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
