### PR TITLE
webapp/jupyter: fix deletable icon indicator

### DIFF
--- a/src/smc-webapp/jupyter/cell-input.tsx
+++ b/src/smc-webapp/jupyter/cell-input.tsx
@@ -98,6 +98,7 @@ export class CellInput extends Component<CellInputProps> {
       nextProps.is_current !== this.props.is_current ||
       nextProps.font_size !== this.props.font_size ||
       nextProps.complete !== this.props.complete ||
+      nextProps.is_readonly !== this.props.is_readonly ||
       nextProps.cell_toolbar !== this.props.cell_toolbar ||
       (nextProps.cell_toolbar === "slideshow" &&
         nextProps.cell.get("slide") !== this.props.cell.get("slide"))

--- a/src/smc-webapp/jupyter/cell-list.tsx
+++ b/src/smc-webapp/jupyter/cell-list.tsx
@@ -252,17 +252,10 @@ export class CellList extends Component<CellListProps> {
 
     const v: any[] = [];
     this.props.cell_list.forEach((id: string) => {
-      let left, left1;
       const cell_data = this.props.cells.get(id);
       // is it possible/better idea to use the @actions.store here?
-      const editable =
-        (left = cell_data.getIn(["metadata", "editable"])) != null
-          ? left
-          : true;
-      const deletable =
-        (left1 = cell_data.getIn(["metadata", "deletable"])) != null
-          ? left1
-          : true;
+      const editable = cell_data.getIn(["metadata", "editable"], true);
+      const deletable = cell_data.getIn(["metadata", "deletable"], true);
       const cell = (
         <Cell
           key={id}

--- a/src/smc-webapp/jupyter/cell.tsx
+++ b/src/smc-webapp/jupyter/cell.tsx
@@ -29,7 +29,7 @@ interface CellProps {
   cell_toolbar?: string;
   trust?: boolean;
   editable?: boolean;
-  deleteable?: boolean;
+  deletable?: boolean;
 }
 
 export class Cell extends Component<CellProps> {
@@ -49,7 +49,7 @@ export class Cell extends Component<CellProps> {
       nextProps.cell_toolbar !== this.props.cell_toolbar ||
       nextProps.trust !== this.props.trust ||
       nextProps.editable !== this.props.editable ||
-      nextProps.deleteable !== this.props.deleteable ||
+      nextProps.deletable !== this.props.deletable ||
       (nextProps.complete !== this.props.complete &&
         (nextProps.is_current || this.props.is_current))
     );
@@ -145,8 +145,7 @@ export class Cell extends Component<CellProps> {
 
     return (
       <div style={style}>
-        {// TODO: WARNING: IMPORTANT: what is this? (I disabled it for now - Travis)
-        false && !this.props.deleteable ? (
+        {!this.props.deletable ? (
           <Tip
             title={"Protected from deletion"}
             placement={"right"}


### PR DESCRIPTION
# Description
Related to that recent question about edit/delete protection, I noticed that during rewriting the jupyter notebook the icon indicator got broken and cell input wasn't updated properly.

# Testing Steps
1. set metadata `{deletable:false}` or toggle it in the edit menu. just like with editable, an icon appears with a hover explanation.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
