### PR TITLE
enhance user-facing error msg when there is a sign in issue

### DIFF
--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -24,7 +24,7 @@ The Landing Page
 ###
 {rclass, React, ReactDOM, redux, rtypes} = require('./app-framework')
 {Alert, Button, ButtonToolbar, Col, Modal, Grid, Row, FormControl, FormGroup, Well, ClearFix, Checkbox} = require('react-bootstrap')
-{ErrorDisplay, Icon, Loading, ImmutablePureRenderMixin, Footer, UNIT, COLORS, ExampleBox, Space, Tip} = require('./r_misc')
+{ErrorDisplay, Icon, Loading, ImmutablePureRenderMixin, Footer, UNIT, Markdown, COLORS, ExampleBox, Space, Tip} = require('./r_misc')
 {HelpEmailLink, SiteName, SiteDescription} = require('./customize')
 {Passports} = require('./passports')
 {SignUp} = require('./sign-up')
@@ -72,8 +72,8 @@ SignIn = rclass
     display_error: ->
         if @props.sign_in_error?
             <ErrorDisplay
-                style   = {margin:'15px'}
-                error   = {@props.sign_in_error}
+                style   = {marginRight: 0}
+                error_component = {<Markdown value={@props.sign_in_error} />}
                 onClose = {=>@actions('account').setState(sign_in_error: undefined)}
             />
 
@@ -167,7 +167,7 @@ SignIn = rclass
                         {@render_passports()}
                     </Col>
                 </Row>
-                <Row className='form-inline pull-right' style={clear : "right"}>
+                <Row className={'form-inline pull-right'} style={clear : "right", width: '100%'}>
                     <Col xs={12}>
                         {@display_error()}
                     </Col>

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -59,6 +59,13 @@ class AccountActions extends Actions
             is_logged_in : user_type == 'signed_in'
 
     sign_in: (email, password) =>
+        doc_conn = '[connectivity issues](https://doc.cocalc.com/howto/connectivity-issues.html)'
+        err_help = """
+                   Please reload this browser tab and try again.
+
+                   If that doesn't work after a few minutes, consult #{doc_conn} or email #{help()}.
+                   """
+
         @setState(signing_in: true)
         webapp_client.sign_in
             email_address : email
@@ -71,7 +78,7 @@ class AccountActions extends Actions
             cb            : (error, mesg) =>
                 @setState(signing_in: false)
                 if error
-                    @setState(sign_in_error : "There was an error signing you in (#{error}).  Please try again; if that doesn't work after a few minutes, email #{help()}.")
+                    @setState(sign_in_error : "There was an error signing you in (#{error}). #{err_help}")
                     return
                 switch mesg.event
                     when 'sign_in_failed'

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -59,11 +59,11 @@ class AccountActions extends Actions
             is_logged_in : user_type == 'signed_in'
 
     sign_in: (email, password) =>
-        doc_conn = '[connectivity issues](https://doc.cocalc.com/howto/connectivity-issues.html)'
+        doc_conn = '[connectivity debugging tips](https://doc.cocalc.com/howto/connectivity-issues.html)'
         err_help = """
                    Please reload this browser tab and try again.
 
-                   If that doesn't work after a few minutes, consult #{doc_conn} or email #{help()}.
+                   If that doesn't work after a few minutes, try these #{doc_conn} or email #{help()}.
                    """
 
         @setState(signing_in: true)


### PR DESCRIPTION
# Description
Since this comes up in support at least once a week, I've enhanced the error message if there is a connection issue. It points to the connection debugging page and suggests to refresh the tab. There is also some style tweaking, because those shorter messages would be squeezed to the far right with line breaks.

# Testing Steps
1. To test this, I've made my email address wrong (by adding  `+'x'`) in the redux account `webapp_client.sign_in` call, and explicitly set `error = 'no conn...'` in the callback. Below are two screenshots.

![Screenshot from 2019-04-23 11-52-31](https://user-images.githubusercontent.com/207405/56572596-af8e2c80-65bf-11e9-9816-bb13f50ce75b.png)

![Screenshot from 2019-04-23 11-58-00](https://user-images.githubusercontent.com/207405/56572603-b2891d00-65bf-11e9-9cbe-a690d5808601.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
