### PR TITLE
webapp/files: avoid unnecessary renderings

### DIFF
--- a/src/smc-webapp/project/file-listing/file-listing.tsx
+++ b/src/smc-webapp/project/file-listing/file-listing.tsx
@@ -7,7 +7,7 @@ import {
   CellMeasurerCache
 } from "react-virtualized";
 
-import { debounce } from "lodash";
+import { debounce, isEqual } from "lodash";
 
 const misc = require("smc-util/misc");
 const { Col, Row } = require("react-bootstrap");
@@ -69,9 +69,32 @@ export class FileListing extends React.Component<Props> {
     this.list_ref = React.createRef();
   }
 
+  shouldComponentUpdate(next) {
+    return (
+      !isEqual(this.props.listing, next.listing) ||
+      !isEqual(this.props.active_file_sort, next.active_file_sort) ||
+      misc.is_different(this.props, next, [
+        "file_search",
+        "checked_files",
+        "current_path",
+        "page_number",
+        "page_size",
+        "public_view",
+        "selected_file_index",
+        "project_id",
+        "other_settings",
+        "show_new",
+        "last_scroll_top"
+      ])
+    );
+  }
+
   // Restore scroll position if one was set.
   componentDidMount() {
-    if (this.props.last_scroll_top != undefined && this.list_ref.current != null) {
+    if (
+      this.props.last_scroll_top != undefined &&
+      this.list_ref.current != null
+    ) {
       this.list_ref.current.scrollToPosition(this.props.last_scroll_top);
       this.current_scroll_top = this.props.last_scroll_top;
     }


### PR DESCRIPTION
# Description
upon pressing a key in chat somewhere, a file listing rendering is triggered in the background of another project, which is showing a file listing. this patch avoids this, but it is just a defensive measurement. maybe there is something smarter to do?

# Testing Steps
1. add a debug line to the `render_rows` method to see when it is active. it shouldn't be drawing if you type in chat or somewhere else. also, I deliberately excluded this `shift key` check, because otherwise it would render if I press the shift key anywhere.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
