### PR TITLE
Change message for malformed account id

### DIFF
--- a/src/smc-webapp/users.cjsx
+++ b/src/smc-webapp/users.cjsx
@@ -182,7 +182,7 @@ exports.User = User = rclass
         info = @props.user_map?.get(@props.account_id)
         if not info?
             if not misc.is_valid_uuid_string(@props.account_id)
-                return <span>{@props.account_id} unsucessfully</span>
+                return <span>Unknown User {@props.account_id}</span>
             actions.fetch_non_collaborator(@props.account_id)
             return <span>Loading...</span>
         else


### PR DESCRIPTION
# Description
Broken mentions (and anywhere User is used) now have text that will read more correctly.

<img width="1003" alt="Screen Shot 2019-04-24 at 2 53 58 PM" src="https://user-images.githubusercontent.com/618575/56696541-f7d14b80-66a0-11e9-90ce-c4fc57862547.png">


# Testing Steps
1. Create a mention
1. In the hosting env, edit the database to remove the source column
eg.
```
update mentions
set source = null
```
1. Refresh the page.
1. You should see **Unknown User** instead of the person's name

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
