### PR TITLE
wrap local storage for session save/restore

### DIFF
--- a/src/smc-webapp/misc/local-storage.ts
+++ b/src/smc-webapp/misc/local-storage.ts
@@ -23,13 +23,26 @@ const LS: { [k: string]: string | undefined } = (function() {
   }
 })();
 
-function make_key(keys: string[] | string): string {
-  const key = typeof keys == "string" ? keys : keys.join(".");
-  return [APP_BASE_URL, key].join("::");
+export class CustomKey {
+  constructor(private key: string) {}
+  getKey() {
+    return this.key;
+  }
+}
+
+type Keys = string[] | string | CustomKey;
+
+function make_key(keys: Keys): string {
+  if (keys instanceof CustomKey) {
+    return keys.getKey();
+  } else {
+    const key = typeof keys == "string" ? keys : keys.join(".");
+    return [APP_BASE_URL, key].join("::");
+  }
 }
 
 // returns the deleted value or undefined in case of a problem
-export function del<T>(keys: string[] | string): T | undefined {
+export function del<T>(keys: Keys): T | undefined {
   const key = make_key(keys);
   try {
     const val = get<T>(keys);
@@ -41,7 +54,7 @@ export function del<T>(keys: string[] | string): T | undefined {
 }
 
 // set an entry, and return true if it was successful
-export function set<T>(keys: string[] | string, value: T): boolean {
+export function set<T>(keys: Keys, value: T): boolean {
   const key = make_key(keys);
   try {
     LS[key] = JSON.stringify(value);
@@ -52,7 +65,7 @@ export function set<T>(keys: string[] | string, value: T): boolean {
   }
 }
 
-export function get<T>(keys: string[] | string): T | undefined {
+export function get<T>(keys: Keys): T | undefined {
   const key = make_key(keys);
   try {
     const val = LS[key];
@@ -67,7 +80,7 @@ export function get<T>(keys: string[] | string): T | undefined {
   }
 }
 
-export function exists(keys: string[] | string): boolean {
+export function exists(keys: Keys): boolean {
   const key = make_key(keys);
   // distinction between browser's localStorage and the fallback object
   if (LS === window.localStorage) {


### PR DESCRIPTION
# Description

Issue #3629

# Testing Steps
that's how I (successfully) tested this

1. in my cc-in-cc, be in the "master" branch (old code)
1. have a session with two projects and a file each
1. refresh while on master to check that projects and files restore.
1. switch to this branch, refresh browser
1. session should restore as before, double check `session.ts` file's source code to contain e.g. `_local_storage_name: LS.CustomKey` to be sure to really run the new code.
1. open/create yet another file, and refresh


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
