### PR TITLE
share: add audio file support

### DIFF
--- a/src/smc-webapp/share/extensions.coffee
+++ b/src/smc-webapp/share/extensions.coffee
@@ -17,8 +17,9 @@ set = (v) ->
 exports.image = set(['png', 'jpg', 'gif', 'svg', 'jpeg', 'bmp', 'apng', 'ico'])
 
 # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
-{VIDEO_EXTS} = require('smc-webapp/file-associations')
+{VIDEO_EXTS, AUDIO_EXTS} = require('smc-webapp/file-associations')
 exports.video = set(VIDEO_EXTS)
+exports.audio = set(AUDIO_EXTS)
 
 exports.pdf = set(['pdf'])
 

--- a/src/smc-webapp/share/public-path.cjsx
+++ b/src/smc-webapp/share/public-path.cjsx
@@ -60,6 +60,14 @@ exports.PublicPath = rclass
         else if extensions.video[ext]
             video_style = {maxWidth: '100%', height: 'auto'}
             return <video controls autoPlay loop style={video_style} src={src}/>
+        else if extensions.audio[ext]
+            return <audio
+                    src      = {src}
+                    autoPlay = {true}
+                    controls = {true}
+                    loop     = {false}
+                    volume   = {0.5}
+                   />
 
         if not @props.content?
             # This happens if the file is too big


### PR DESCRIPTION
# Description
this was missing when support for audiofiles was added.

# Testing Steps
1. `touch test.wav`, and it should show up via an audio tag

![Screenshot from 2019-05-09 15-37-23](https://user-images.githubusercontent.com/207405/57457739-5df8c980-7270-11e9-9dcb-f3fc10c80eaf.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
