### PR TITLE
hub: ban api access for banned user account

### DIFF
--- a/src/smc-hub/api/handler.coffee
+++ b/src/smc-hub/api/handler.coffee
@@ -11,6 +11,8 @@ misc = require('smc-util/misc')
 
 messages = require('smc-util/message')
 
+{ HELP_EMAIL } = require("smc-util/theme")
+
 {Client} = require('../client')
 
 log = (name, logger) ->
@@ -104,6 +106,20 @@ get_client = (opts) ->
                             auth_cache[opts.api_key] = account_id
                             setTimeout((->delete auth_cache[opts.api_key]), 60000)
                             cb()
+
+        (cb) ->
+            # check if user is banned:
+            opts.database.is_banned_user
+                account_id : account_id
+                cb         : (err, is_banned) ->
+                    if err
+                        cb(err)
+                        return
+                    if is_banned
+                        cb("User is BANNED.  If this is a mistake, please contact #{HELP_EMAIL}")
+                        return
+                    cb()
+
     ], (err) ->
         if err
             opts.cb(err)

--- a/src/smc-hub/api/handler.coffee
+++ b/src/smc-hub/api/handler.coffee
@@ -6,6 +6,9 @@ AGPLv3, (c) 2017, SageMath, Inc.
 
 async = require('async')
 
+Cache = require('expiring-lru-cache')
+auth_cache = new Cache(size:5000, expiry:60000)
+
 misc = require('smc-util/misc')
 {defaults, required} = misc
 
@@ -78,7 +81,6 @@ exports.http_message_api_v1 = (opts) ->
         opts.cb(err, resp)
     )
 
-auth_cache = {}
 get_client = (opts) ->
     opts = defaults opts,
         api_key        : required
@@ -89,7 +91,7 @@ get_client = (opts) ->
         cb             : required
     dbg = log('get_client', opts.logger)
 
-    account_id = auth_cache[opts.api_key]
+    account_id = auth_cache.get(opts.api_key)
     async.series([
         (cb) ->
             if account_id?
@@ -102,26 +104,31 @@ get_client = (opts) ->
                             cb(err)
                             return
                         if not a?
-                            cb("No account found. Is your API key wrong?")
+                            #cb("No account found. Is your API key wrong?"); return
+                            # continue without an account_id
+                            account_id = undefined
                         else
                             account_id = a
-                            # cache api key being valid for a minute
-                            auth_cache[opts.api_key] = account_id
-                            setTimeout((->delete auth_cache[opts.api_key]), 60000)
-                            cb()
+
+                        # cache api key being valid for a minute
+                        auth_cache.set(opts.api_key, account_id)
+                        cb()
 
         (cb) ->
-            # check if user is banned:
-            opts.database.is_banned_user
-                account_id : account_id
-                cb         : (err, is_banned) ->
-                    if err
-                        cb(err)
-                        return
-                    if is_banned
-                        cb("User is BANNED.  If this is a mistake, please contact #{HELP_EMAIL}")
-                        return
-                    cb()
+            if not account_id?
+                cb()
+            else
+                # check if user is banned:
+                opts.database.is_banned_user
+                    account_id : account_id
+                    cb         : (err, is_banned) ->
+                        if err
+                            cb(err)
+                            return
+                        if is_banned
+                            cb("User is BANNED.  If this is a mistake, please contact #{HELP_EMAIL}")
+                            return
+                        cb()
 
     ], (err) ->
         if err

--- a/src/smc-hub/api/handler.coffee
+++ b/src/smc-hub/api/handler.coffee
@@ -100,6 +100,9 @@ get_client = (opts) ->
                     cb      : (err, a) ->
                         if err
                             cb(err)
+                            return
+                        if not a?
+                            cb("No account found. Is your API key wrong?")
                         else
                             account_id = a
                             # cache api key being valid for a minute

--- a/src/smc-hub/auth.coffee
+++ b/src/smc-hub/auth.coffee
@@ -67,6 +67,8 @@ Cookies = require('cookies')
 
 express_session = require('express-session')
 
+{ HELP_EMAIL } = require("smc-util/theme")
+
 {defaults, required} = misc
 
 api_key_cookie_name = (base_url) ->
@@ -351,7 +353,7 @@ passport_login = (opts) ->
                         cb(err)
                         return
                     if is_banned
-                        cb("User is BANNED.  If this is a mistake, please content help@cocalc.com")
+                        cb("User is BANNED.  If this is a mistake, please contact #{HELP_EMAIL}")
                         return
                     cb()
         (cb) ->

--- a/src/smc-hub/test/api/apikey.coffee
+++ b/src/smc-hub/test/api/apikey.coffee
@@ -46,11 +46,14 @@ describe 'api key tests -- ', ->
             body          : {}
             cb            : (err, resp) ->
                 winston.info(err, resp)
-                if not err?
-                    done('there was no error')
-                else
-                    expect(err).toInclude('No account found.')
-                    done()
+                #if not err?
+                #    done('there was no error')
+                #else
+                #    expect(err).toInclude('No account found.')
+                #    done()
+                expect(err).toBe(undefined)
+                expect(resp).toBe({})
+                done(err)
 
     it 'blocks banned users', (done) ->
         async.series([

--- a/src/smc-hub/test/api/apikey.coffee
+++ b/src/smc-hub/test/api/apikey.coffee
@@ -1,0 +1,54 @@
+###
+Testing API functions relating to api keys itself
+
+COPYRIGHT : (c) 2017 SageMath, Inc.
+LICENSE   : AGPLv3
+###
+
+api   = require('./apitest')
+{setup, teardown, reset, winston} = api
+{http_message_api_v1} = require('../../api/handler')
+
+misc = require('smc-util/misc')
+
+async  = require('async')
+expect = require('expect')
+
+describe 'api key tests -- ', ->
+    @timeout(5000)
+    before(setup)
+    after(teardown)
+    beforeEach(reset)
+
+    it 'correct api key', (done) ->
+        http_message_api_v1
+            event         : 'ping'
+            database      : api.db
+            compute_server: api.compute_server
+            api_key       : api.api_key
+            ip_address    : '2.3.4.5'
+            logger        : api.logger
+            body          : {}
+            cb            : (err, resp) ->
+                winston.info(err, resp)
+                done(err)
+
+    it 'wrong api key', (done) ->
+        fake_key = 'sk_173r2rj32'
+
+        http_message_api_v1
+            event         : 'ping'
+            database      : api.db
+            compute_server: api.compute_server
+            api_key       : fake_key
+            ip_address    : '2.3.4.5'
+            logger        : api.logger
+            body          : {}
+            cb            : (err, resp) ->
+                winston.info(err, resp)
+                if not err?
+                    done('there was no error')
+                else
+                    expect(err).toInclude('No account found.')
+                    done()
+

--- a/src/smc-hub/test/api/apikey.coffee
+++ b/src/smc-hub/test/api/apikey.coffee
@@ -52,3 +52,35 @@ describe 'api key tests -- ', ->
                     expect(err).toInclude('No account found.')
                     done()
 
+    it 'blocks banned users', (done) ->
+        async.series([
+            (cb) ->
+                api.db.ban_user
+                    account_id     : api.account_id
+                    cb             : (err) ->
+                        cb(err)
+
+            (cb) ->
+                http_message_api_v1
+                    event         : 'ping'
+                    database      : api.db
+                    compute_server: api.compute_server
+                    api_key       : api.api_key
+                    ip_address    : '2.3.4.5'
+                    logger        : api.logger
+                    body          : {}
+                    cb            : (err, resp) ->
+                        winston.info(err, resp)
+                        if err?
+                            expect(err).toInclude('BANNED')
+                            cb()
+                        else
+                            cb('no banning error')
+
+        ], (err, resp) ->
+            winston.info(err, resp)
+            done(err)
+        )
+
+
+

--- a/src/smc-hub/test/api/apitest.coffee
+++ b/src/smc-hub/test/api/apitest.coffee
@@ -96,7 +96,7 @@ exports.teardown = (cb) ->
             rimraf(process.env.COCALC_PROJECT_PATH, cb)
     ], cb)
 
-logger =
+exports.logger = logger =
     debug   : pgtest.log
     info    : pgtest.log
     warning : pgtest.log

--- a/src/smc-hub/test/api/auth-token.coffee
+++ b/src/smc-hub/test/api/auth-token.coffee
@@ -10,6 +10,7 @@ describe 'tests creating an auth token via the api -- ', ->
     account_id2 = undefined
 
     it "uses api call to create a second account", (done) ->
+        @timeout(10000)
         api.call
             event : 'create_account'
             body  :
@@ -26,6 +27,7 @@ describe 'tests creating an auth token via the api -- ', ->
 
     auth_token = undefined
     it "obtains an auth token for the second account", (done) ->
+        @timeout(10000)
         api.call
             event : 'user_auth'
             body  :
@@ -40,6 +42,7 @@ describe 'tests creating an auth token via the api -- ', ->
                 done()
 
     it "check in the database that the token would work", (done) ->
+        @timeout(10000)
         api.db.get_auth_token_account_id
             auth_token : auth_token
             cb         : (err, account_id) ->
@@ -49,4 +52,15 @@ describe 'tests creating an auth token via the api -- ', ->
                     expect(account_id).toBe(account_id2)
                     done()
 
-                    
+    it "check that a wrong token does not work", (done) ->
+        fake_token = '12341234123'
+        @timeout(10000)
+        api.db.get_auth_token_account_id
+            auth_token : fake_token
+            cb         : (err, account_id) ->
+                if err
+                    done(err)
+                else
+                    expect(account_id).toBe(undefined)
+                    done()
+


### PR DESCRIPTION
# Description

* if an api key is associated with a banned account, block access
* expiring lru cache, instead of piling up timeouts
* more tests, i.e. the apikey test is a stub to nail down failure behavior
* this is live in prod, hence merging it to avoid confusion


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
