### PR TITLE
update katex 0.10.2

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -41,7 +41,7 @@
     "jstransformer-markdown-it": "^2.0.0",
     "jstransformer-sass": "^1.0.0",
     "jstransformer-typescript": "^1.1.0",
-    "katex": "=0.10.1",
+    "katex": "=0.10.2",
     "less": "^3.9.0",
     "less-loader": "^4.1.0",
     "node-cjsx": "^1.0.0",

--- a/src/smc-webapp/frame-editors/frame-tree/print.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/print.ts
@@ -117,8 +117,8 @@ function html_with_deps(
 
         <link
             rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.1/katex.min.css"
-            integrity="sha256-9F0HwgWlvrVxc95krEjTN7gvwm1DLYuPhZA6piUYuNY="
+            href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.2/katex.min.css"
+            integrity="sha256-uT5rNa8r/qorzlARiO7fTBE7EWQiX/umLlXsq7zyQP8="
             crossorigin="anonymous" />
 
     </head>

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -65,7 +65,7 @@
     "jquery.scrollintoview": "^1.9",
     "js-cookie": "^2.2.0",
     "json-stable-stringify": "^1.0",
-    "katex": "=0.10.1",
+    "katex": "=0.10.2",
     "langs": "^2.0.0",
     "latex.js": "^0.11.1",
     "lodash": "^4.17.11",

--- a/src/smc-webapp/share/page.cjsx
+++ b/src/smc-webapp/share/page.cjsx
@@ -84,8 +84,8 @@ exports.Page = rclass
                 {### Katex CDN ###}
                 <link
                     rel="stylesheet"
-                    href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.1/katex.min.css"
-                    integrity="sha256-9F0HwgWlvrVxc95krEjTN7gvwm1DLYuPhZA6piUYuNY="
+                    href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.2/katex.min.css"
+                    integrity="sha256-uT5rNa8r/qorzlARiO7fTBE7EWQiX/umLlXsq7zyQP8="
                     crossorigin="anonymous" />
 
                 {@render_favicon()}

--- a/src/webapp-lib/_inc_head.pug
+++ b/src/webapp-lib/_inc_head.pug
@@ -24,6 +24,6 @@ meta(name="theme-color", content="#fbb635")
 // See https://github.com/sagemathinc/cocalc/issues/2510
 link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css", integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=", crossorigin="anonymous")
 
-link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.1/katex.min.css", integrity="sha256-9F0HwgWlvrVxc95krEjTN7gvwm1DLYuPhZA6piUYuNY=", crossorigin="anonymous")
+link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.2/katex.min.css", integrity="sha256-uT5rNa8r/qorzlARiO7fTBE7EWQiX/umLlXsq7zyQP8=", crossorigin="anonymous")
 
 link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/mocha/5.2.0/mocha.min.css", integrity="sha256-Flo6sV8k+IPfHh6Hx97ReUJDLOwIwvhdGlKOz3UgHRE=", crossorigin="anonymous")


### PR DESCRIPTION
# Description
updating katex to exactly 0.10.2

The trick to remember is to also update these security has tokens :champagne:  

I also noticed, there is `latex-editor/experimental/latexjs.jsx:23:import { parse } from "latex.js";` which has an old version of katex as a dependency. Is this used?  Maybe comment out everything related to latexjs and remove the package?

# Testing Steps
There are new features, e.g. a special bracket. i.e. `$\lBrace 1+2 \rBrace_{\infty}$` doesn't work in prod, but here is a screenshot after the update:

![Screenshot from 2019-05-13 12-51-09](https://user-images.githubusercontent.com/207405/57616299-03b47d00-757e-11e9-977d-6b3a5f991d51.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
