### PR TITLE
Block URLs in names

### DIFF
--- a/src/smc-hub/client/create-account.ts
+++ b/src/smc-hub/client/create-account.ts
@@ -252,7 +252,7 @@ export async function create_account(
       if (reason == null) {
         // generic reason
         reason = {
-          other: `Unable to create account.  Please try later.  ${err}`
+          other: `Unable to create account. Error: "${err}"`
         };
       }
       opts.client.push_to_client(

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -17,6 +17,7 @@ random_key = require("random-key")
 
 misc_node = require('smc-util-node/misc_node')
 
+misc2 = require('smc-util/misc2')
 {defaults} = misc = require('smc-util/misc')
 required = defaults.required
 
@@ -304,6 +305,10 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
 
         dbg = @_dbg("create_account(#{opts.first_name}, #{opts.last_name} #{opts.email_address}, #{opts.passport_strategy}, #{opts.passport_id}), #{opts.usage_intent}")
         dbg()
+
+        if (not misc2.is_valid_username(opts.first_name)) or (not misc2.is_valid_username(opts.last_name))
+            opts.cb("username is not valid")
+            return
 
         if opts.email_address? # canonicalize the email address, if given
             opts.email_address = misc.lower_email_address(opts.email_address)

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -306,9 +306,11 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
         dbg = @_dbg("create_account(#{opts.first_name}, #{opts.last_name} #{opts.email_address}, #{opts.passport_strategy}, #{opts.passport_id}), #{opts.usage_intent}")
         dbg()
 
-        if (not misc2.is_valid_username(opts.first_name)) or (not misc2.is_valid_username(opts.last_name))
-            opts.cb("username is not valid")
-            return
+        for name in ['first_name', 'last_name']
+            test = misc2.is_valid_username(opts[name])
+            if test?
+                opts.cb("#{name} not valid: #{test}")
+                return
 
         if opts.email_address? # canonicalize the email address, if given
             opts.email_address = misc.lower_email_address(opts.email_address)

--- a/src/smc-util/misc2.ts
+++ b/src/smc-util/misc2.ts
@@ -479,13 +479,18 @@ export function bind_methods(obj: any, method_names: string[]): void {
   }
 }
 
-export function is_valid_username(name: string): boolean {
+// returns undefined if ok, otherwise an error message
+export function is_valid_username(name: string): string | undefined {
   const blocked = ["http://", "https://"];
   for (const token of blocked) {
-    if (name.indexOf(token) != -1) return false;
+    if (name.indexOf(token) != -1) {
+      return "URLs are not allowed";
+    }
   }
 
-  if (name.indexOf("mailto:") != -1 && name.indexOf("@") != -1) return false;
+  if (name.indexOf("mailto:") != -1 && name.indexOf("@") != -1) {
+    return "email addresses are not allowed";
+  }
 
-  return true;
+  return;
 }

--- a/src/smc-util/misc2.ts
+++ b/src/smc-util/misc2.ts
@@ -479,4 +479,13 @@ export function bind_methods(obj: any, method_names: string[]): void {
   }
 }
 
+export function is_valid_username(name: string): boolean {
+  const blocked = ["http://", "https://"];
+  for (const token of blocked) {
+    if (name.indexOf(token) != -1) return false;
+  }
 
+  if (name.indexOf("mailto:") != -1 && name.indexOf("@") != -1) return false;
+
+  return true;
+}

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -6,6 +6,8 @@
 #
 ###############################################################################
 
+require('ts-node').register()
+
 misc = require('../misc')
 misc2 = require('../misc2')
 underscore = require('underscore')
@@ -1536,11 +1538,11 @@ describe 'test closest kernel matching method', ->
 
 describe 'do not allow URLs in names', ->
     it 'works for usual names', ->
-        expect(misc2.is_valid_username("harald")).toBe(true)
-        expect(misc2.is_valid_username("ABC FOO-BAR")).toBe(true)
-        expect(misc2.is_valid_username("test.account.dot")).toBe(true)
+        expect(misc2.is_valid_username("harald")).toBe(undefined)
+        expect(misc2.is_valid_username("ABC FOO-BAR")).toBe(undefined)
+        expect(misc2.is_valid_username("test.account.dot")).toBe(undefined)
     it 'blocks suspicious names', ->
-        expect(misc2.is_valid_username("OPEN http://foo.com")).toBe(false)
-        #expect(misc2.is_valid_username("https://earn-money.cc is good" )).toBe(false)
-        #expect(misc2.is_valid_username("OPEN mailto:bla@bar.de")).toBe(false)
+        expect(misc2.is_valid_username("OPEN http://foo.com")).toExist()
+        expect(misc2.is_valid_username("https://earn-money.cc is good" )).toExist()
+        expect(misc2.is_valid_username("OPEN mailto:bla@bar.de")).toExist()
 

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -7,6 +7,7 @@
 ###############################################################################
 
 misc = require('../misc')
+misc2 = require('../misc2')
 underscore = require('underscore')
 immutable = require('immutable')
 
@@ -998,7 +999,7 @@ describe "timestamp_cmp", ->
         tcmp(a, b).should.eql 1
         tcmp(b, a).should.eql -1
         # sometimes, that's -0 instead of 0
-        assert.strictEqual(tcmp(a, a), 0)
+        assert.strictEqual(Math.abs(tcmp(a, a)), 0)
 
     it "handles missing timestamps gracefully", ->
         tcmp(a, {}).should.eql -1
@@ -1531,4 +1532,15 @@ describe 'test closest kernel matching method', ->
         expect(misc.closest_kernel_match("ir35",kernels)).toEqual(ir)
     it 'suggests R over ir-35', ->
         expect(misc.closest_kernel_match("ir-35",kernels)).toEqual(ir)
+
+
+describe 'do not allow URLs in names', ->
+    it 'works for usual names', ->
+        expect(misc2.is_valid_username("harald")).toBe(true)
+        expect(misc2.is_valid_username("ABC FOO-BAR")).toBe(true)
+        expect(misc2.is_valid_username("test.account.dot")).toBe(true)
+    it 'blocks suspicious names', ->
+        expect(misc2.is_valid_username("OPEN http://foo.com")).toBe(false)
+        #expect(misc2.is_valid_username("https://earn-money.cc is good" )).toBe(false)
+        #expect(misc2.is_valid_username("OPEN mailto:bla@bar.de")).toBe(false)
 

--- a/src/smc-webapp/landing-page/sign-up.tsx
+++ b/src/smc-webapp/landing-page/sign-up.tsx
@@ -249,6 +249,7 @@ export class SignUp extends React.Component<Props, State> {
         {this.render_error("token")}
         {this.render_error("generic")}
         {this.render_error("account_creation_failed")}
+        {this.render_error("other")}
         {this.render_passports()}
         <form
           style={{ marginTop: 20, marginBottom: 20 }}


### PR DESCRIPTION
# Description
This is admittedly a bit simple, but I think it is sufficient. This
* adds a test for a valid username, with a test
* adds this as a precondition for creating an account
* fixes error reporting in the sign up form (otherwise, the screenshot below wouldn't have a red error message)

![Screenshot from 2019-05-15 15-39-18](https://user-images.githubusercontent.com/207405/57780351-5af65100-7728-11e9-8986-033bd56b89c8.png)


# Testing Steps
1. creating an account with a normal first and last name still works
1. trying to create an account where the first or last name contains `https://` or so throws an error

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
