### PR TITLE
project/formatter: node 10 fallout regarding fs.unlink

### DIFF
--- a/src/smc-project/formatters/bib-format.ts
+++ b/src/smc-project/formatters/bib-format.ts
@@ -77,7 +77,7 @@ export async function bib_format(
     return s;
   } finally {
     // logger.debug(`bibtex formatter done, unlinking ${input_path}`);
-    unlink(input_path);
-    unlink(output_path);
+    unlink(input_path, () => {});
+    unlink(output_path, () => {});
   }
 }

--- a/src/smc-project/formatters/clang-format.ts
+++ b/src/smc-project/formatters/clang-format.ts
@@ -37,9 +37,9 @@ export async function clang_format(
     // logger.debug(`clang_format tmp file: ${input_path}`);
     await callback(writeFile, input_path, input);
 
-    // spawn the html formatter
+    // spawn the c formatter
     let formatter;
-    let indent = options.tabWidth || 2;
+    const indent = options.tabWidth || 2;
 
     switch (options.parser) {
       case "clang-format":
@@ -57,7 +57,8 @@ export async function clang_format(
     formatter.stdout.on("data", data => (stdout += data.toString()));
     formatter.stderr.on("data", data => (stderr += data.toString()));
     // wait for subprocess to close.
-    let code = await callback(close, formatter);
+    const code = await callback(close, formatter);
+
     if (code >= 1) {
       const err_msg = `C/C++ code formatting utility "${
         options.parser
@@ -68,11 +69,12 @@ export async function clang_format(
 
     // all fine, we read from the temp file
     let output: Buffer = await callback(readFile, input_path);
+
     let s: string = output.toString("utf-8");
     // logger.debug(`clang_format output s ${s}`);
 
     return s;
   } finally {
-    unlink(input_path);
+    unlink(input_path, () => {});
   }
 }

--- a/src/smc-project/formatters/gofmt.ts
+++ b/src/smc-project/formatters/gofmt.ts
@@ -76,6 +76,6 @@ export async function gofmt(
 
     return s;
   } finally {
-    unlink(input_path); // don't wait and don't worry about any error.
+    unlink(input_path, () => {});
   }
 }

--- a/src/smc-project/formatters/html-format.ts
+++ b/src/smc-project/formatters/html-format.ts
@@ -99,6 +99,6 @@ export async function html_format(
     return s;
   } finally {
     // logger.debug(`html formatter done, unlinking ${input_path}`);
-    unlink(input_path);
+    unlink(input_path, () => {});
   }
 }

--- a/src/smc-project/formatters/latex-format.ts
+++ b/src/smc-project/formatters/latex-format.ts
@@ -1,4 +1,4 @@
-const { unlink, writeFile } = require("fs");
+const {  writeFile, unlink } = require("fs");
 const tmp = require("tmp");
 const { callback } = require("awaiting");
 const { spawn } = require("child_process");
@@ -58,6 +58,6 @@ export async function latex_format(
     }
     return output;
   } finally {
-    unlink(input_path);
+    unlink(input_path, () => {});
   }
 }

--- a/src/smc-project/formatters/python-format.ts
+++ b/src/smc-project/formatters/python-format.ts
@@ -1,4 +1,4 @@
-const { writeFile, readFile } = require("fs");
+const { writeFile, readFile, unlink } = require("fs");
 const tmp = require("tmp");
 const { callback } = require("awaiting");
 const { spawn } = require("child_process");
@@ -39,32 +39,35 @@ export async function python_format(
 ): Promise<string> {
   // create input temp file
   const input_path: string = await callback(tmp.file);
-  await callback(writeFile, input_path, input);
+  try {
+    await callback(writeFile, input_path, input);
 
-  // spawn the python formatter
-  const util = options.util || "yapf";
-  const py_formatter = yapf(input_path);
+    // spawn the python formatter
+    const util = options.util || "yapf";
+    const py_formatter = yapf(input_path);
 
-  // stdout/err capture
-  let stdout: string = "";
-  let stderr: string = "";
-  // read data as it is produced.
-  py_formatter.stdout.on("data", data => (stdout += data.toString()));
-  py_formatter.stderr.on("data", data => (stderr += data.toString()));
-  // wait for subprocess to close.
-  let code = await callback(close, py_formatter);
-  // only last line
-  // stdout = last_line(stdout);
-  stderr = last_line(stderr);
-  if (code) {
-    const err_msg = `Python formatter "${util}" exited with code ${code}:\n${stdout}\n${stderr}`;
-    logger.debug(`format python error: ${err_msg}`);
-    throw new Error(err_msg);
+    // stdout/err capture
+    let stdout: string = "";
+    let stderr: string = "";
+    // read data as it is produced.
+    py_formatter.stdout.on("data", data => (stdout += data.toString()));
+    py_formatter.stderr.on("data", data => (stderr += data.toString()));
+    // wait for subprocess to close.
+    let code = await callback(close, py_formatter);
+    // only last line
+    // stdout = last_line(stdout);
+    stderr = last_line(stderr);
+    if (code) {
+      const err_msg = `Python formatter "${util}" exited with code ${code}:\n${stdout}\n${stderr}`;
+      logger.debug(`format python error: ${err_msg}`);
+      throw new Error(err_msg);
+    }
+
+    // all fine, we read from the temp file
+    let output: Buffer = await callback(readFile, input_path);
+    let s: string =  output.toString("utf-8");
+    return s;
+  } finally {
+    unlink(input_path, () => {});
   }
-
-  // all fine, we read from the temp file
-  let output: Buffer = await callback(readFile, input_path);
-  let s: string = output.toString("utf-8");
-
-  return s;
 }

--- a/src/smc-project/formatters/xml-format.ts
+++ b/src/smc-project/formatters/xml-format.ts
@@ -90,6 +90,6 @@ export async function xml_format(
     return s;
   } finally {
     // logger.debug(`xml formatter done, unlinking ${input_path}`);
-    unlink(input_path);
+    unlink(input_path, () => {});
   }
 }


### PR DESCRIPTION
# Description
The `fs.unlink` api changed in node 10. Instead of using unlinkSync, I just added a pointless function. That's all. This patch also adds some missing temp file cleanup calls!

# Testing Steps
1. well, all those formatters which were changed should work now

# Relevant Issues
#3832

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
