### PR TITLE
Add disable mentions account option

### DIFF
--- a/src/smc-util/db-schema.js
+++ b/src/smc-util/db-schema.js
@@ -338,7 +338,8 @@ schema.accounts = {
           newsletter: false,
           time_ago_absolute: false,
           // if true, do not show warning when using non-member projects
-          no_free_warnings: false
+          no_free_warnings: false,
+          allow_mentions: true
         },
         first_name: "",
         last_name: "",

--- a/src/smc-webapp/chat/actions.coffee
+++ b/src/smc-webapp/chat/actions.coffee
@@ -151,7 +151,7 @@ class ChatActions extends Actions
     set_use_saved_position: (use_saved_position) =>
         @setState(use_saved_position:use_saved_position)
 
-    set_unsent_user_mentions: (user_mentions, message_plain_text) =>
+    set_unsent_user_mentions: (user_mentions = immutable.List(), message_plain_text = "") =>
         @setState(unsent_user_mentions: user_mentions, message_plain_text: message_plain_text)
 
     submit_user_mentions: (project_id, path) =>

--- a/src/smc-webapp/chat/input.tsx
+++ b/src/smc-webapp/chat/input.tsx
@@ -6,6 +6,7 @@ const sha1 = require("sha1");
 import { MentionsInput, Mention } from "react-mentions";
 import { USER_MENTION_MARKUP } from "./utils";
 import { cmp_Date } from "smc-util/misc2";
+const { FormControl } = require("react-bootstrap");
 const { Space } = require("../r_misc");
 const { Avatar } = require("../other-users");
 const { IS_MOBILE, isMobile } = require("../feature");
@@ -48,6 +49,7 @@ export class ChatInput extends React.PureComponent<Props> {
   // Without this, MentionsInput does not correctly update its internal representation.
   componentDidUpdate(prev_props) {
     if (
+      this.props.enable_mentions &&
       this.props.on_paste != undefined &&
       prev_props.input != this.props.input
     ) {
@@ -175,6 +177,22 @@ export class ChatInput extends React.PureComponent<Props> {
       id = sha1(this.props.name);
     }
 
+    if (!this.props.enable_mentions) {
+      return (
+        <FormControl
+          id={id}
+          autoFocus={!IS_MOBILE || isMobile.Android()}
+          componentClass="textarea"
+          ref={this.input_ref}
+          onKeyDown={this.on_keydown}
+          value={this.props.input}
+          placeholder={"Type a message..."}
+          onChange={this.on_change}
+          style={{height: "100%"}}
+        />
+      );
+    }
+
     return (
       <MentionsInput
         id={id}
@@ -186,11 +204,7 @@ export class ChatInput extends React.PureComponent<Props> {
         inputRef={this.props.input_ref}
         onKeyDown={this.on_keydown}
         value={this.props.input}
-        placeholder={
-          this.props.enable_mentions
-            ? "Type a message, @name..."
-            : "Type a message..."
-        }
+        placeholder={"Type a message, @name..."}
         onPaste={this.props.on_paste}
         onChange={this.on_change}
       >

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -1341,7 +1341,7 @@ OtherSettings = rclass
             ref      = 'allow_mentions'
             onChange = {(e)=>@on_change('allow_mentions', e.target.checked)}
         >
-            Allow mentioning and being mentioned in chats
+            Allow mentioning others in chats
         </Checkbox>
 
     render: ->

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -1335,6 +1335,15 @@ OtherSettings = rclass
             Hide free warnings: do <b><i>not</i></b> show a warning banner when using a free trial project {extra}
         </Checkbox>
 
+    render_allow_mentions: ->
+        <Checkbox
+            checked  = {!!@props.other_settings.get('allow_mentions')}
+            ref      = 'allow_mentions'
+            onChange = {(e)=>@on_change('allow_mentions', e.target.checked)}
+        >
+            Allow mentioning and being mentioned in chats
+        </Checkbox>
+
     render: ->
         if not @props.other_settings
             return <Loading />
@@ -1342,6 +1351,7 @@ OtherSettings = rclass
             {@render_confirm()}
             {@render_first_steps()}
             {@render_global_banner()}
+            {@render_allow_mentions()}
             {@render_time_ago_absolute()}
             {### @render_katex() ###}
             {@render_mask_files()}

--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -382,6 +382,7 @@ ChatRoom = rclass ({name}) ->
         account :
             account_id : rtypes.string
             font_size  : rtypes.number
+            other_settings : rtypes.immutable.Map
         file_use :
             file_use : rtypes.immutable
         projects :
@@ -557,7 +558,7 @@ ChatRoom = rclass ({name}) ->
                         <ChatInput
                             input                = {@props.input}
                             input_ref            = {@input_ref}
-                            enable_mentions      = {has_collaborators}
+                            enable_mentions      = {has_collaborators && @props.other_settings.get('allow_mentions')}
                             project_users        = {project_users}
                             user_store           = {@props.redux.getStore("users")}
                             font_size            = {@props.font_size}

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -767,6 +767,7 @@ interface ChatRoomReduxProps {
   has_unsaved_changes: boolean;
   has_uncommitted_changes: boolean;
   unsent_user_mentions: MentionList;
+  other_settings: Map<string, any>;
 }
 
 type ChatRoomProps = ChatRoomOwnProps & ChatRoomReduxProps;
@@ -808,7 +809,8 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
 
       account: {
         account_id: rtypes.string,
-        font_size: rtypes.number
+        font_size: rtypes.number,
+        other_settings: rtypes.immutable.Map
       },
 
       file_use: {
@@ -1021,9 +1023,7 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
     ) {
       return <span>(they may receive an email)</span>;
     } else {
-      return (
-        <span>(enable the Internet Access upgrade to send emails)</span>
-      );
+      return <span>(enable the Internet Access upgrade to send emails)</span>;
     }
   }
 
@@ -1375,7 +1375,10 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
                 name={this.props.name}
                 input={this.props.input}
                 input_ref={this.input_ref}
-                enable_mentions={has_collaborators}
+                enable_mentions={
+                  has_collaborators &&
+                  this.props.other_settings.get("allow_mentions")
+                }
                 project_users={project_users}
                 user_store={this.props.redux.getStore("users")}
                 font_size={this.props.font_size}


### PR DESCRIPTION
# Description
Add an option in account settings to disable sending mentions.
<img width="570" alt="Screen Shot 2019-05-24 at 2 57 55 PM" src="https://user-images.githubusercontent.com/618575/58358571-5884ad00-7e34-11e9-8cea-eeef693bb689.png">


# Testing Steps
1. Toggle mentions off in account settings
1. Create a project with collaborators
1. Create a chat room 
1. The help text should not say `@name`
1. Type `@`. Nothing special should happen
1. Sending messages should still work
1. Pasting images should still work
1. Test the above with side chats as well.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
