### PR TITLE
fix edge 18 incompatibiltiy in url-regex lib

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -8,8 +8,6 @@ COPYRIGHT : (c) 2017 SageMath, Inc.
 LICENSE   : AGPLv3
 ###
 
-require('ts-node').register()
-
 # limit for async.map or async.paralleLimit, esp. to avoid high concurrency when querying in parallel
 MAP_LIMIT = 5
 

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -8,6 +8,8 @@ COPYRIGHT : (c) 2017 SageMath, Inc.
 LICENSE   : AGPLv3
 ###
 
+require('ts-node').register()
+
 # limit for async.map or async.paralleLimit, esp. to avoid high concurrency when querying in parallel
 MAP_LIMIT = 5
 
@@ -16,6 +18,7 @@ async   = require('async')
 random_key = require("random-key")
 
 misc_node = require('smc-util-node/misc_node')
+misc2_node = require('smc-util-node/misc2_node')
 
 misc2 = require('smc-util/misc2')
 {defaults} = misc = require('smc-util/misc')
@@ -307,7 +310,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
         dbg()
 
         for name in ['first_name', 'last_name']
-            test = misc2.is_valid_username(opts[name])
+            test = misc2_node.is_valid_username(opts[name])
             if test?
                 opts.cb("#{name} not valid: #{test}")
                 return

--- a/src/smc-hub/postgres/syncdoc-history.ts
+++ b/src/smc-hub/postgres/syncdoc-history.ts
@@ -25,7 +25,7 @@ async function get_users(db: PostgreSQL, where): Promise<User[]> {
   }
   const account_ids: string[] = results.rows[0].users
     ? results.rows[0].users
-    : [];   // syncdoc exists, but not used yet.
+    : []; // syncdoc exists, but not used yet.
   const project_id: string = results.rows[0].project_id;
   const project_title: string = trunc(
     (await callback2(db.get_project, {

--- a/src/smc-util-node/misc2_node.ts
+++ b/src/smc-util-node/misc2_node.ts
@@ -1,0 +1,21 @@
+const urlRegex = require("url-regex");
+import { to_human_list } from "smc-util/misc";
+
+// used to test for URLs in a string
+const re_url = urlRegex({ exact: false, strict: false });
+
+// returns undefined if ok, otherwise an error message
+export function is_valid_username(str: string): string | undefined {
+  const name = str.toLowerCase();
+
+  const found = name.match(re_url);
+  if (found) {
+    return `URLs are not allowed. Found ${to_human_list(found)}`;
+  }
+
+  if (name.indexOf("mailto:") != -1 && name.indexOf("@") != -1) {
+    return "email addresses are not allowed";
+  }
+
+  return;
+}

--- a/src/smc-util-node/package-lock.json
+++ b/src/smc-util-node/package-lock.json
@@ -615,6 +615,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
+    "ip-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+    },
     "is-arrow-function": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
@@ -1501,6 +1506,11 @@
         }
       }
     },
+    "tlds": {
+      "version": "1.203.1",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
+      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw=="
+    },
     "tmatch": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
@@ -1572,6 +1582,15 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
+      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
+      "requires": {
+        "ip-regex": "^4.1.0",
+        "tlds": "^1.203.0"
       }
     },
     "util-deprecate": {

--- a/src/smc-util-node/package.json
+++ b/src/smc-util-node/package.json
@@ -20,6 +20,7 @@
     "shell-escape": "^0.2.0",
     "sqlite3": "^4.0.4",
     "temp": "^0.8.3",
+    "url-regex": "^5.0.0",
     "winston": "^1.1.1"
   },
   "repository": {

--- a/src/smc-util-node/test/misc_node-test.coffee
+++ b/src/smc-util-node/test/misc_node-test.coffee
@@ -1,8 +1,12 @@
+
+require('ts-node').register()
+
 expect = require('expect')
 
 misc = require('smc-util/misc')
 
 misc_node = require('../misc_node')
+misc2_node = require('../misc2_node')
 
 describe 'computing a sha1 hash: ', ->
     expect(misc_node.sha1("SageMathCloud")).toBe('31acd8ca91346abcf6a49d2b1d88333f439d57a6')
@@ -183,3 +187,27 @@ describe 'check sales tax work', ->
             lower_bound = 0.0650
             expect(v).toBeLessThan(upper_bound, "sales tax for #{zip} was #{v} but should be less than #{upper_bound}")
             expect(v).toBeGreaterThan(lower_bound, "sales tax for #{zip} was #{v} but should be greater than #{lower_bound}")
+
+
+describe 'do not allow URLs in names', ->
+    {is_valid_username} = misc2_node
+
+    it 'works for usual names', ->
+        expect(is_valid_username("harald")).toBe(undefined)
+        expect(is_valid_username("ABC FOO-BAR")).toBe(undefined)
+        # DNS-like substrings easily trigger a violoation. these are fine, though
+        expect(is_valid_username("is.test.ok")).toBe(undefined)
+        expect(is_valid_username("is.a.test")).toBe(undefined)
+
+    it 'blocks suspicious names', ->
+        expect(is_valid_username("OPEN http://foo.com")).toExist()
+        expect(is_valid_username("https://earn-money.cc is good" )).toExist()
+        expect(is_valid_username("OPEN mailto:bla@bar.de")).toExist()
+
+    it 'is not fooled to easily', ->
+        expect(is_valid_username("OPEN hTTp://foo.com")).toExist()
+        expect(is_valid_username("httpS://earn-money.cc is good" )).toExist()
+        expect(is_valid_username("OPEN MAILTO:bla@bar.de")).toExist()
+        expect(is_valid_username("test.account.dot")).toInclude("test.account.dot")
+        expect(is_valid_username("no spam EARN-A-LOT-OF.money Now")).toInclude(".money")
+        expect(is_valid_username("spam abc.co earn")).toInclude(".co")

--- a/src/smc-util/misc2.ts
+++ b/src/smc-util/misc2.ts
@@ -8,8 +8,6 @@ it in a more modern ES 2018/Typescript/standard libraries approach.
 */
 
 const underscore = require("underscore");
-const urlRegex = require("url-regex");
-import { to_human_list } from "./misc";
 
 interface SplittedPath {
   head: string;
@@ -479,23 +477,4 @@ export function bind_methods(obj: any, method_names: string[]): void {
   for (let method_name of method_names) {
     obj[method_name] = obj[method_name].bind(obj);
   }
-}
-
-// used to test for URLs in a string
-const re_url = urlRegex({ exact: false, strict: false });
-
-// returns undefined if ok, otherwise an error message
-export function is_valid_username(str: string): string | undefined {
-  const name = str.toLowerCase();
-
-  const found = name.match(re_url);
-  if (found) {
-    return `URLs are not allowed. Found ${to_human_list(found)}`;
-  }
-
-  if (name.indexOf("mailto:") != -1 && name.indexOf("@") != -1) {
-    return "email addresses are not allowed";
-  }
-
-  return;
 }

--- a/src/smc-util/package-lock.json
+++ b/src/smc-util/package-lock.json
@@ -3561,11 +3561,6 @@
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
-    "ip-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
-    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -6828,11 +6823,6 @@
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
-    "tlds": {
-      "version": "1.203.1",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
-      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw=="
-    },
     "tmatch": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
@@ -7113,15 +7103,6 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
-    },
-    "url-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
-      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
-      "requires": {
-        "ip-regex": "^4.1.0",
-        "tlds": "^1.203.0"
-      }
     },
     "use": {
       "version": "3.1.1",

--- a/src/smc-util/package.json
+++ b/src/smc-util/package.json
@@ -25,7 +25,6 @@
     "prop-types": "^15.5.10",
     "sha1": "^1.1.1",
     "underscore": "^1.9.1",
-    "url-regex": "^5.0.0",
     "uuid": "^3.0.1"
   },
   "repository": {

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -1534,23 +1534,3 @@ describe 'test closest kernel matching method', ->
         expect(misc.closest_kernel_match("ir35",kernels)).toEqual(ir)
     it 'suggests R over ir-35', ->
         expect(misc.closest_kernel_match("ir-35",kernels)).toEqual(ir)
-
-
-describe 'do not allow URLs in names', ->
-    it 'works for usual names', ->
-        expect(misc2.is_valid_username("harald")).toBe(undefined)
-        expect(misc2.is_valid_username("ABC FOO-BAR")).toBe(undefined)
-        # DNS-like substrings easily trigger a violoation. these are fine, though
-        expect(misc2.is_valid_username("is.test.ok")).toBe(undefined)
-        expect(misc2.is_valid_username("is.a.test")).toBe(undefined)
-    it 'blocks suspicious names', ->
-        expect(misc2.is_valid_username("OPEN http://foo.com")).toExist()
-        expect(misc2.is_valid_username("https://earn-money.cc is good" )).toExist()
-        expect(misc2.is_valid_username("OPEN mailto:bla@bar.de")).toExist()
-    it 'is not fooled to easily', ->
-        expect(misc2.is_valid_username("OPEN hTTp://foo.com")).toExist()
-        expect(misc2.is_valid_username("httpS://earn-money.cc is good" )).toExist()
-        expect(misc2.is_valid_username("OPEN MAILTO:bla@bar.de")).toExist()
-        expect(misc2.is_valid_username("test.account.dot")).toInclude("test.account.dot")
-        expect(misc2.is_valid_username("no spam EARN-A-LOT-OF.money Now")).toInclude(".money")
-        expect(misc2.is_valid_username("spam abc.co earn")).toInclude(".co")

--- a/src/smc-webapp/frame-editors/settings/__tests__/__snapshots__/editor.test.tsx.snap
+++ b/src/smc-webapp/frame-editors/settings/__tests__/__snapshots__/editor.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`renders a list of languages 1`] = `
      Editor Settings
   </h3>
   <SpellCheck
+    available={true}
     key="spell"
     set={[Function]}
     value="Value"

--- a/src/smc-webapp/frame-editors/settings/__tests__/editor.test.tsx
+++ b/src/smc-webapp/frame-editors/settings/__tests__/editor.test.tsx
@@ -14,6 +14,7 @@ test("renders a list of languages", () => {
 
   const render = shallow(
     <Settings
+      available={true}
       actions={actions}
       settings={settings}
       available_features={available_features}

--- a/src/smc-webapp/frame-editors/settings/__tests__/editor.test.tsx
+++ b/src/smc-webapp/frame-editors/settings/__tests__/editor.test.tsx
@@ -14,11 +14,10 @@ test("renders a list of languages", () => {
 
   const render = shallow(
     <Settings
-      available={true}
       actions={actions}
       settings={settings}
       available_features={available_features}
-      id="unused??"
+      id={"unused??"}
     />
   );
 


### PR DESCRIPTION
# Description
basically: moving function from  smc-util → smc-util-node

# Testing Steps
1. `npm run test` in smc-util-node
1. I'll deploy in test namespace.

# Relevant Issues
#3850

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
