### PR TITLE
webapp: rename assistant to snippets

### DIFF
--- a/src/scripts/postgresql/cool-queries.md
+++ b/src/scripts/postgresql/cool-queries.md
@@ -198,7 +198,7 @@ Copied library entries .. timestamp is about when the feature was released
     GROUP BY title, docid
     ORDER BY count DESC;
 
-Usage of Assistant Examples
+Usage of Snippet Examples
 
     WITH stats AS (
         SELECT COUNT(*) AS cnt

--- a/src/smc-webapp/assistant/body.cjsx
+++ b/src/smc-webapp/assistant/body.cjsx
@@ -29,12 +29,12 @@ immutable = require('immutable')
 {CodeMirrorStatic} = require('../jupyter/codemirror-static');
 # cocalc libs
 {defaults, required, optional} = misc = require('smc-util/misc')
-# Assistant
+# Snippets
 {REPO_URL} = require('./common')
 
 
 exports.ExamplesBody = rclass
-    displayName : 'ExamplesBody'
+    displayName : 'SnippetsBody'
 
     propTypes:
         actions             : rtypes.object

--- a/src/smc-webapp/assistant/dialog.cjsx
+++ b/src/smc-webapp/assistant/dialog.cjsx
@@ -34,9 +34,9 @@ immutable = require('immutable')
 {ExamplesBody}   = require('./body')
 {ExamplesFooter} = require('./footer')
 
-# The root element of the Assistant dialog.
-exports.ExamplesDialog = rclass ({name}) ->
-    displayName : 'Examples'
+# The root element of the Snippets dialog.
+exports.SnippetsDialog = rclass ({name}) ->
+    displayName : 'SnippetsDialog'
 
     reduxProps :
         "#{name}" :

--- a/src/smc-webapp/assistant/footer.cjsx
+++ b/src/smc-webapp/assistant/footer.cjsx
@@ -28,7 +28,7 @@ immutable = require('immutable')
 {Loading, Icon, Markdown, Space} = require('../r_misc')
 # cocalc libs
 {defaults, required, optional} = misc = require('smc-util/misc')
-# Assistant
+# Snippets
 {REPO_URL} = require('./common')
 
 

--- a/src/smc-webapp/assistant/header.cjsx
+++ b/src/smc-webapp/assistant/header.cjsx
@@ -114,7 +114,7 @@ exports.ExamplesHeader = rclass
                 <h2>
                     <Icon name={ICON_NAME} />
                     <Space/>
-                    {misc.jupyter_language_to_name(@props.lang) if not @props.lang_select} Assistant
+                    {misc.jupyter_language_to_name(@props.lang) if not @props.lang_select} Snippets
                 </h2>
             </div>
             <div style={nav_style}>

--- a/src/smc-webapp/assistant/legacy.cjsx
+++ b/src/smc-webapp/assistant/legacy.cjsx
@@ -25,12 +25,12 @@
 {React, ReactDOM, redux, Redux} = require('../app-framework')
 
 # Assistant functions
-{ExamplesDialog} = require('./dialog')
+{SnippetsDialog} = require('./dialog')
 {redux_name, init_action_and_store} = require('./main')
 
 # This is a legacy wrapper, which is used in editor.coffee for sagews worksheets.
 # "target" is a DOM element somewhere in the buttonbar of the editor's html
-exports.render_examples_dialog = (opts) ->
+exports.render_snippets_dialog = (opts) ->
     opts = defaults opts,
         target     : required
         project_id : required
@@ -43,7 +43,7 @@ exports.render_examples_dialog = (opts) ->
     actions.init(opts.lang)
     actions.set(lang_select:true)
     dialog = <Redux redux={redux}>
-                 <ExamplesDialog actions={actions} name={name}/>
+                 <SnippetsDialog actions={actions} name={name}/>
              </Redux>
     ReactDOM.render(dialog, opts.target)
     return actions

--- a/src/smc-webapp/assistant/main.coffee
+++ b/src/smc-webapp/assistant/main.coffee
@@ -19,7 +19,7 @@
 #
 ###############################################################################
 
-# Examples Dialog
+# Snippets Dialog
 # This is a modal dialog, which downloads a hierarchical collection of code snippets
 # with descriptions. It returns an object, containing the code and the language:
 # {"code": "...", "lang" : "..."} via a given callback.
@@ -28,18 +28,18 @@
 # https://github.com/sagemathinc/cocalc-assistant
 #
 # Usage:
-# w = render_examples_dialog(target, project_id, filename, lang)
+# w = render_snippets_dialog(target, project_id, filename, lang)
 #     * target: jquery dom object, where react is put into
 #     * project_id and filename to make state in redux unique
 #     * lang is the mode (sage, r, python, ...)
 # use 'w.set_handler' to set the handler that's used for inserting the selected document
-# API (implemented in ExamplesActions)
+# API (implemented in SnippetsActions)
 # w.show([lang]) -- show dialog again (same state!) and in csae a language given, a selection of it is triggered
 
 # cocalc libs
 {defaults, required, optional} = misc = require('smc-util/misc')
 {redux, Redux} = require('../app-framework')
-# assistant libs
+# snippets related libs
 {ExamplesStore} = require('./store')
 {ExamplesActions}   = require('./actions')
 
@@ -57,7 +57,7 @@ exports.init_action_and_store = (name, project_id, path) ->
 ### Public API ###
 
 # The following two exports are used in jupyter/main and ./register
-exports.instantiate_assistant = (project_id, path) ->
+exports.instantiate_snippets = (project_id, path) ->
     name = exports.redux_name(project_id, path)
     actions = redux.getActions(name)
     if not actions?

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -67,7 +67,7 @@ syncdoc  = require('./syncdoc')
 sagews   = require('./sagews/sagews')
 printing = require('./printing')
 
-{render_examples_dialog} = require('./assistant/legacy')
+{render_snippets_dialog} = require('./assistant/legacy')
 
 copypaste = require('./copy-paste-buffer')
 {extra_alt_keys} = require('mobile/codemirror')
@@ -621,7 +621,7 @@ class CodeMirrorEditor extends FileEditor
         if misc.filename_extension(@filename)?.toLowerCase() == 'sagews'
             @init_sagews_edit_buttons()
 
-        @examples_dialog = null
+        @snippets_dialog = null
 
     programmatical_goto_line: (line) =>
         cm = @codemirror_with_last_focus
@@ -1475,23 +1475,23 @@ class CodeMirrorEditor extends FileEditor
                 # needed so that dropdown menu closes when clicked.
                 return true
 
-    examples_dialog_handler: () =>
-        # @examples_dialog is an ExampleActions object, unique for each editor instance
+    snippets_dialog_handler: () =>
+        # @snippets_dialog is an ExampleActions object, unique for each editor instance
         lang = @_current_mode
         # special case sh → bash
         if lang == 'sh' then lang = 'bash'
 
-        if not @examples_dialog?
+        if not @snippets_dialog?
             $target = @mode_display.parent().find('.react-target')
-            @examples_dialog = render_examples_dialog(
+            @snippets_dialog = render_snippets_dialog(
                 target     : $target[0]
                 project_id : @project_id
                 path       : @filename
                 lang       : lang
             )
         else
-            @examples_dialog.show(lang)
-        @examples_dialog.set_handler(@example_insert_handler)
+            @snippets_dialog.show(lang)
+        @snippets_dialog.set_handler(@example_insert_handler)
         analytics_event('editor_assistant', @ext, lang)
 
     example_insert_handler: (insert) =>
@@ -1646,7 +1646,7 @@ class CodeMirrorEditor extends FileEditor
         # show the assistant button to reveal the dialog for example selection
         @element.find('.webapp-editor-codeedit-buttonbar-assistant').show()
         assistant_button = @element.find('a[href="#assistant"]')
-        assistant_button.click(@examples_dialog_handler)
+        assistant_button.click(@snippets_dialog_handler)
 
         # The code below changes the bar at the top depending on where the cursor
         # is located.  We only change the edit bar if the cursor hasn't moved for

--- a/src/smc-webapp/editor.html
+++ b/src/smc-webapp/editor.html
@@ -182,7 +182,7 @@ Editor for files in a project
                         <span class="webapp-editor-codeedit-buttonbar-assistant pull-right hide">
                             <a href="#assistant" class="btn btn-default"
                                data-toggle="tooltip" data-placement="bottom" title="Insert examples">
-                               <i class="fa fa-magic"></i> <span class="hidden-sm">Assistant</span>
+                               <i class="fa fa-magic"></i> <span class="hidden-sm">Snippets</span>
                             </a>
                         </span>
                     </div>

--- a/src/smc-webapp/frame-editors/sagews-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/sagews-editor/editor.ts
@@ -68,7 +68,7 @@ const EDITOR_SPEC = {
 - Exporting to different formats
 - Slideshow
 - Sage documentation (e.g., the entire reference manual)
-- Assistant
+- Snippets
 - Terminal (interface to running sage server)
 - List of variables you have defined
 

--- a/src/smc-webapp/jupyter/browser-actions.ts
+++ b/src/smc-webapp/jupyter/browser-actions.ts
@@ -8,13 +8,13 @@ import { merge_copy, uuid } from "smc-util/misc";
 import { JupyterActions as JupyterActions0 } from "./actions";
 import { WidgetManager } from "./widgets/manager";
 import { CursorManager } from "./cursor-manager";
-const { instantiate_assistant } = require("../assistant/main");
+const { instantiate_snippets } = require("../assistant/main");
 const { commands } = require("./commands");
 
 export class JupyterActions extends JupyterActions0 {
   public widget_manager?: WidgetManager;
   private cursor_manager: CursorManager;
-  private assistant_actions: any;
+  private snippet_actions: any;
   private _account_change_editor_settings: any;
   private _commands: any;
   private update_keyboard_shortcuts: any;
@@ -72,9 +72,9 @@ export class JupyterActions extends JupyterActions0 {
     this.syncdb.on("cursor_activity", this.syncdb_cursor_activity);
     this.cursor_manager = new CursorManager();
 
-    // this initializes actions+store for the assistant
+    // this initializes actions+store for the snippet dialog
     // this is also only a UI specific action
-    this.assistant_actions = instantiate_assistant(this.project_id, this.path);
+    this.snippet_actions = instantiate_snippets(this.project_id, this.path);
 
     if (window != null && (window as any).$ != null) {
       // frontend browser client with jQuery
@@ -123,27 +123,27 @@ export class JupyterActions extends JupyterActions0 {
     }
   };
 
-  show_code_assistant = () => {
-    if (this.assistant_actions == null) {
+  show_code_snippets = () => {
+    if (this.snippet_actions == null) {
       return;
     }
     this.blur_lock();
 
     const lang = this.store.get_kernel_language();
 
-    this.assistant_actions.init(lang);
-    return this.assistant_actions.set({
+    this.snippet_actions.init(lang);
+    return this.snippet_actions.set({
       show: true,
       lang,
       lang_select: false,
-      handler: this.code_assistant_handler
+      handler: this.code_snippet_handler
     });
   };
 
-  code_assistant_handler = (data: { code: string[]; descr?: string }): void => {
+  code_snippet_handler = (data: { code: string[]; descr?: string }): void => {
     this.focus_unlock();
     const { code, descr } = data;
-    //if DEBUG then console.log("assistant data:", data, code, descr)
+    //if DEBUG then console.log("snippet data:", data, code, descr)
 
     if (descr != null) {
       const descr_cell = this.insert_cell(1);

--- a/src/smc-webapp/jupyter/commands.ts
+++ b/src/smc-webapp/jupyter/commands.ts
@@ -6,7 +6,7 @@ Comprehensive list of Jupyter notebook (version 5) command,
 
 // for now we also use require here (see comment in actions.ts)
 
-const ASSISTANT_ICON_NAME = require("smc-webapp/assistant/common").ICON_NAME;
+const SNIPPET_ICON_NAME = require("smc-webapp/assistant/common").ICON_NAME;
 
 const FORMAT_SOURCE_ICON = require("smc-webapp/frame-editors/frame-tree/config")
   .FORMAT_SOURCE_ICON;
@@ -673,10 +673,10 @@ export function commands(actions: any) {
       f: () => actions.show_keyboard_shortcuts()
     },
 
-    "show code assistant": {
-      i: ASSISTANT_ICON_NAME,
-      m: "Show code assistant",
-      f: () => actions.show_code_assistant()
+    "show code snippets": {
+      i: SNIPPET_ICON_NAME,
+      m: "Show code snippets",
+      f: () => actions.show_code_snippets()
     },
 
     "show toolbar": {

--- a/src/smc-webapp/jupyter/main.tsx
+++ b/src/smc-webapp/jupyter/main.tsx
@@ -22,7 +22,7 @@ const { KernelSelector } = require("./select-kernel");
 const { KeyboardShortcuts } = require("./keyboard-shortcuts");
 const { JSONView } = require("./json-view");
 const { RawEditor } = require("./raw-editor");
-const { ExamplesDialog } = require("smc-webapp/assistant/dialog");
+const { SnippetsDialog } = require("smc-webapp/assistant/dialog");
 import { Kernel as KernelType, Kernels as KernelsType } from "./util";
 
 const KERNEL_STYLE: React.CSSProperties = {
@@ -398,11 +398,11 @@ class JupyterEditor0 extends Component<JupyterEditorProps> {
     );
   }
 
-  render_assistant_dialog() {
+  render_snippets_dialog() {
     return (
-      <ExamplesDialog
-        name={this.props.actions.assistant_actions.name}
-        actions={this.props.actions.assistant_actions}
+      <SnippetsDialog
+        name={this.props.actions.snippet_actions.name}
+        actions={this.props.actions.snippet_actions}
       />
     );
   }
@@ -481,7 +481,7 @@ class JupyterEditor0 extends Component<JupyterEditorProps> {
         {this.render_edit_cell_metadata()}
         {this.render_find_and_replace()}
         {this.render_keyboard_shortcuts()}
-        {this.render_assistant_dialog()}
+        {this.render_snippets_dialog()}
         {this.render_confirm_dialog()}
         {this.render_heading()}
         {this.render_main()}

--- a/src/smc-webapp/jupyter/register.ts
+++ b/src/smc-webapp/jupyter/register.ts
@@ -82,12 +82,12 @@ export function register() {
         return;
       }
 
-      // cleanup assistant
-      if (actions.assistant_actions != null) {
-        const assistant_name = actions.assistant_actions.name;
-        delete redux.getStore(assistant_name).state;
-        redux.removeStore(assistant_name);
-        redux.removeActions(assistant_name);
+      // cleanup snippets
+      if (actions.snippets_actions != null) {
+        const snippets_name = actions.snippets_actions.name;
+        delete redux.getStore(snippets_name).state;
+        redux.removeStore(snippets_name);
+        redux.removeActions(snippets_name);
       }
 
       // cleanup main store/actions
@@ -112,4 +112,3 @@ require("./register-nbviewer").register(webapp_client);
 
 // Temporary so long as we support jupyter classic
 require("./jupyter-classic-support");
-

--- a/src/smc-webapp/jupyter/store.ts
+++ b/src/smc-webapp/jupyter/store.ts
@@ -450,7 +450,7 @@ export class JupyterStore extends Store<JupyterStoreState> {
   // canonicalize the language of the kernel
   get_kernel_language = (): string | undefined => {
     let lang;
-    // special case: sage is language "python", but the assistant needs "sage"
+    // special case: sage is language "python", but the snippet dialog needs "sage"
     if (misc.startswith(this.get("kernel"), "sage")) {
       lang = "sage";
     } else {

--- a/src/smc-webapp/jupyter/top-buttonbar.tsx
+++ b/src/smc-webapp/jupyter/top-buttonbar.tsx
@@ -230,10 +230,10 @@ export class TopButtonbar0 extends Component<TopButtonbarProps> {
     return this.render_button("0", "show keyboard shortcuts");
   }
 
-  render_assistant() {
-    return this.render_button("assistant", {
-      name: "show code assistant",
-      label: <VisibleMDLG>Assistant</VisibleMDLG>
+  render_snippets() {
+    return this.render_button("snippets", {
+      name: "show code snippets",
+      label: <VisibleMDLG>Snippets</VisibleMDLG>
     });
   }
 
@@ -330,7 +330,7 @@ export class TopButtonbar0 extends Component<TopButtonbarProps> {
         >
           <Icon name="history" /> <VisibleMDLG>TimeTravel</VisibleMDLG>
         </Button>
-        {this.render_assistant()}
+        {this.render_snippets()}
         {this.render_close_and_halt()}
         {/*this.render_switch_button()*/}
       </ButtonGroup>


### PR DESCRIPTION
# Description

Except for the subdirectory itself, this renames occurrences of "assistant" to "snippets". 

# Testing Steps
1. sagews: button exists, it opens the dialog, and you can insert code
2. jupyter: same as above

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
