### PR TITLE
update snippets (sage 3d plots, more 2d plots, renaming)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/examples"]
 	path = src/examples
-	url = https://github.com/sagemathinc/cocalc-assistant.git
+	url = https://github.com/sagemathinc/cocalc-snippets.git


### PR DESCRIPTION
# Description
* sage 3d plots, more 2d plots, renaming
* point the submodule to the renamed github repo

# Testing Steps
1. sagews: snippets → 3D
2. I also copied over the cython class example

for example, here is the icosahedron plot

![Screenshot from 2019-06-03 12-19-56](https://user-images.githubusercontent.com/207405/58795086-0bee5e00-85fa-11e9-81dd-d870d1e0574e.png)

![Screenshot from 2019-06-03 12-20-08](https://user-images.githubusercontent.com/207405/58795095-0f81e500-85fa-11e9-972f-6dd87e48e408.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
