### PR TITLE
webapp/file listing: for admins, always assume project is running 

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1975,13 +1975,22 @@ exports.ProjectFiles = rclass ({name}) ->
         if pay? and pay <= webapp_client.server_time()
             return @render_course_payment_required()
 
-        public_view = @props.get_my_group(@props.project_id) == 'public'
+        my_group = @props.get_my_group(@props.project_id)
 
-        if not public_view
+        # regardless of consequences, for admins a project is always running
+        # see https://github.com/sagemathinc/cocalc/issues/3863
+        if my_group == 'admin'
+            project_state = immutable.Map('state': 'running')
+            project_is_running = true
+        # next, we check if this is a common user (not public)
+        else if my_group != 'public'
             project_state = @props.project_map?.getIn([@props.project_id, 'state'])
             project_is_running = project_state?.get('state') and project_state.get('state') in ['running', 'saving']
         else
             project_is_running = false
+
+        # enables/disables certain aspects if project is viewed publicly by a non-collaborator
+        public_view = my_group == 'public'
 
         {listing, error, file_map} = @props.displayed_listing
 


### PR DESCRIPTION
# Description

# Testing Steps
In my cc-in-cc environment, I made a project for a normal user "A", created a project. Then, as my usual admin user, I opened that project. With that patch, the listing is always there or it attempts to load it. To actually see the project's state, open settings → project control.

# Relevant Issues
#3863

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
