### PR TITLE
webapp/new files: if no project config is available, fallback to offer all file extensions

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1619,7 +1619,10 @@ exports.ProjectFiles = rclass ({name}) ->
     create_file: (ext, switch_over=true) ->
         file_search = @props.file_search
         if not ext? and file_search.lastIndexOf(".") <= file_search.lastIndexOf("/")
-            disabled_ext = @props.configuration.get('main', {}).disabled_ext
+            if @props.configuration?
+                disabled_ext = @props.configuration.get('main', {}).disabled_ext
+            else
+                disabled_ext = []
             ext = default_ext(disabled_ext)
 
         @actions(name).create_file


### PR DESCRIPTION
# Description
See stacktrace in #3872. There is only one `get` call, and it just happend that there is no configuration yet available.

# Testing Steps
This is a trivial fix.

# Relevant Issues
#3872

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
