### PR TITLE
Doc get api key

### DIFF
--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -57,12 +57,28 @@ generic HTML message rather than a JSON string.
 ## Authentication
 
 A valid API key is required on all API requests.
-To obtain a key, log into
+
+To obtain a key manually, log into
 CoCalc and click on Settings (gear icon next to user name at upper
 right), and look under \`Account Settings\`.
 With the \`API key\` dialogue, you can create a key,
 view a previously assigned key, generate a replacement key,
 and delete your key entirely.
+
+It is also possible to obtain an API key using an automated web client.
+This option is useful for applications that embed CoCalc
+in a custom environment, for example [juno.sh](https://juno.sh),
+the iOS application for Jupyter notebooks.
+Sending a request to :samp:\`https://cocalc.com/app?get_api_key=myapp\`,
+where "myapp" is an identifier for your application,
+returns a modified sign-in page with the banner
+"CoCalc API Key Access for Myapp".
+Your client needs be javascript-enabled and
+sign in at this point with credentials for the account in question.
+Response headers from successful sign-in will include a url of the form
+:samp:\`https://authenticated/?api_key=sk_abcdefQWERTY090900000000\`.
+The client should intercept this response and capture the string
+after the equals sign as the API key.
 
 Your API key carries access privileges, just like your login and password.
 __Keep it secret.__

--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -65,17 +65,17 @@ With the \`API key\` dialogue, you can create a key,
 view a previously assigned key, generate a replacement key,
 and delete your key entirely.
 
-It is also possible to obtain an API key using an automated web client.
+It is also possible to obtain an API key using a javascript-enabled automated web client.
 This option is useful for applications that embed CoCalc
 in a custom environment, for example [juno.sh](https://juno.sh),
 the iOS application for Jupyter notebooks.
-Sending a request to :samp:\`https://cocalc.com/app?get_api_key=myapp\`,
+Visiting the link :samp:\`https://cocalc.com/app?get_api_key=myapp\`,
 where "myapp" is an identifier for your application,
 returns a modified sign-in page with the banner
 "CoCalc API Key Access for Myapp".
-Your client needs be javascript-enabled and
-sign in at this point with credentials for the account in question.
-Response headers from successful sign-in will include a url of the form
+The web client must
+sign in with credentials for the account in question.
+Response headers from a successful sign-in will include a url of the form
 :samp:\`https://authenticated/?api_key=sk_abcdefQWERTY090900000000\`.
 The client should intercept this response and capture the string
 after the equals sign as the API key.


### PR DESCRIPTION
# Description

Add explanation of get_api_key.

No change to executable code. I checked syntax by building cc-in-cc and logging into the dev instance.

When this PR is merged, I can commit the new `api.json` file to the [cocalc-doc](https://github.com/sagemathinc/cocalc-doc) repo to make the new content show up in the user manual.

Screenshot of the new content:

![doc-get_api_key](https://user-images.githubusercontent.com/528072/59138412-9b757300-8952-11e9-921a-613b4dffa032.png)

