### PR TITLE
multi_response query not supported by api

### DIFF
--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -2507,6 +2507,8 @@ Options for the 'query' API message must be sent as JSON object.
 A query is either _get_ (read from database), or _set_ (write to database).
 A query is _get_ if any query keys are null, otherwise the query is _set_.
 
+Note: queries with \`multi_response\` set to \`true\` are not supported.
+
 #### Examples of _get_ query:
 
 Get title and description for a project, given the project id.


### PR DESCRIPTION
# Description

No change to executable code.

Adds 1 line to API docs pointing out that multi_response API query is not supported, as per [src/smc-hub/api/handler.coffee](https://github.com/sagemathinc/cocalc/blob/3f4b15e6e7b9588f9297f493861352e6ead3cf8f/src/smc-hub/api/handler.coffee#L56)

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
