### PR TITLE
webapp/jupyter: ihaskell → haskell substition for codemirror mode

### DIFF
--- a/src/smc-webapp/jupyter/actions.ts
+++ b/src/smc-webapp/jupyter/actions.ts
@@ -24,7 +24,10 @@ import * as awaiting from "awaiting";
 import { three_way_merge } from "../../smc-util/sync/editor/generic/util";
 
 import { KernelInfo } from "./types";
-import { Parser, format_parser_for_extension } from "../../smc-util/code-formatter";
+import {
+  Parser,
+  format_parser_for_extension
+} from "../../smc-util/code-formatter";
 
 import { Actions } from "../app-framework";
 import {
@@ -2283,7 +2286,7 @@ export class JupyterActions extends Actions<JupyterStoreState> {
           return; // no-op on these.
         }
         try {
-          const parser : Parser = format_parser_for_extension(ext);
+          const parser: Parser = format_parser_for_extension(ext);
           options = { parser };
         } catch (err) {
           return; // no parser available.

--- a/src/smc-webapp/jupyter/cm_options.ts
+++ b/src/smc-webapp/jupyter/cm_options.ts
@@ -29,6 +29,9 @@ export function cm_options(
   if (mode.name === "singular") {
     mode.name = "clike"; // better than nothing
   }
+  if (mode.name === "ihaskell") {
+    mode.name = "haskell";
+  }
 
   const options: any = {
     mode,


### PR DESCRIPTION
# Description
There are conflicting modes, and a substition like there are already others helps.

# Testing Steps
check if e.g. `putStr "abc"` is highlighted in a juypter notebook

# Relevant Issues
#3887

![Screenshot from 2019-06-12 10-06-04](https://user-images.githubusercontent.com/207405/59333954-b7359c00-8cf9-11e9-9f68-f4c3aa452814.png)


### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
