### PR TITLE
webapp/terminal: desc.get('args') could exist but is still undefined …

### DIFF
--- a/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/terminal.tsx
@@ -134,7 +134,7 @@ export class TerminalFrame extends Component<Props, {}> {
   render_command(): Rendered {
     const command = this.props.desc.get("command");
     if (!command) return;
-    const args = this.props.desc.get("args", []); // todo: need to quote if args have spaces...
+    const args: string[] | undefined = this.props.desc.get("args"); // TODO: need to quote if args have spaces...
     return (
       <div
         style={{
@@ -145,7 +145,7 @@ export class TerminalFrame extends Component<Props, {}> {
           overflow: "hidden"
         }}
       >
-        {command} {args.join(" ")}
+        {command} {args != null ? args.join(" ") : ""}
       </div>
     );
   }


### PR DESCRIPTION
# Description
simple fix for #3893

# Testing Steps
1. see ticket

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
