### PR TITLE
webapp/fix quota calculation

### DIFF
--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -156,7 +156,6 @@ QuotaConsole = rclass
                     </li>
                 upgrade_list.push(li)
 
-        amount = misc.round2(base_value * factor)
         if base_value
             # amount given by free project
             upgrade_list.unshift(<li key='free'>{text(base_value)} given by free project</li>)

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -783,11 +783,6 @@ class ProjectsStore extends Store
             for prop, val of info.upgrades ? {}
                 upgrades[prop] = (upgrades[prop] ? 0) + val
 
-        # Ensure every upgrade is at least set, possibly to the default.
-        for prop, val of require('smc-util/schema').DEFAULT_QUOTAS
-            if not upgrades[prop]?
-                upgrades[prop] = val
-
         return upgrades
 
     # The timestap (in server time) when this project will


### PR DESCRIPTION
# Description
so far, this is merely brainstorming ideas

* change 1: do not add default quotas when claiming to sum user contributions -- defaults are already in the settings (aka `base_values`)
  **edit:** ok, I'm starting to be comfortable about this change. The reason is, there are several very similar functions in projects.csjx. `get_total_project_quotas` sums up the `base_values` (which come from the settings) and `get_total_project_upgrades` (which is modified by this patch, and which should only sum the user contributions). Next, `get_total_project_quotas` ends up as `total_quotas` in the `render` method of `QuotaConsole` in the project settings. The slightly unpredictable behavior might be caused by setting values only when `if not upgrades[prop]?` is true in `get_total_project_upgrades` – I'm not really able to follow why, but that's my gut feeling about this.

What I haven't thought through is the implication for the quota upgrades in the course dialog. Maybe the fallback to the default quotas (i.e. what's removed with the patch right here), is necessary over there to give users a more sensible picture about what's going on. Beyond that, I don't think there are other implications.

**edit 2** I went through the relevant code in course, i.e. grep for `get_total_project_upgrades`. My interpretation is that this was also wrong. So, all good for courses. 


# Testing Steps
1.
1.
1.

# Relevant Issues
#3748

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
