### PR TITLE
wip poc: xterm: hotkey for editor change

### DIFF
--- a/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
@@ -58,6 +58,7 @@ export class Terminal {
   readonly rendererType: "dom" | "canvas";
   private terminal: XTerminal;
   private is_paused: boolean = false;
+  private meta_pressed: boolean = false;
   private keyhandler_initialized: boolean = false;
   /* We initially have to ignore when rendering the initial history.
     To TEST this, do this in a terminal, then reconnect:
@@ -369,6 +370,31 @@ export class Terminal {
       if (event.type === "keypress") {
         // ignore this
         return true;
+      }
+
+      if (event.ctrlKey && event.key === "i") {
+        this.meta_pressed = true;
+        // ignore this
+        return true;
+      }
+
+      if (this.meta_pressed) {
+        // TODO: ignore ctrl up, allow C-i, 1 ; right now requires C-i C-1
+        this.meta_pressed = false;
+        if (event.key >= '1' && event.key <= '9') {
+          // switch tabs
+          const project_actions = this.actions._get_project_actions();
+          // const names = project_actions.get_store()!.selectors.displayed_listing.fn().listing.map(x => x.name!);
+          let names : string[] = [];
+          const store = project_actions.get_store()!;
+          const open_files = store.get("open_files")!;
+          open_files.forEach(({}, path) => names.push(path));
+          const index : number = event.key.charCodeAt(0) - '1'.charCodeAt(0);
+          const name = names[index % names.length];
+          project_actions.set_active_tab("editor-" + name);  // TODO: function providing tab_to_path?
+          // ignore this
+          return true;
+        }
       }
 
       if (


### PR DESCRIPTION
## Please do not merge this! I am just seeking input on this solution at this point, it does not solve the whole problem and the solution is not pretty, see the patch and more below)

# Description

Github issue: #618 (also #3897)

The purpose is to have a global hot key for switching between open files of a project.

This patch provides it only for xterminals.

I tried installing a keydown event handler on a top level div but it missed all the events
that the xterm was grabbing, so I went with changing the event handler for the xterm.

For other editors this might have to be done as well - this is an unfortunate solution
since it is invasive, a single top level global key handler would be easier to reason about.

This functionality can however be extracted and reused between editors.

I'd like feedback:
 - is this approach reasonable?
 - do you have a different approach in mind for the issue?

# Testing Steps
1. Open new project with two terminals
1. Press Ctrl-i Ctrl-1 (i.e. press control, then i, then 1)
1. You should be switched to tab 1
1. Same with 2, you should be switched to tab 2

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
