### PR TITLE
webapp/code editor: no syntax highlighting for ambience mobile

### DIFF
--- a/src/smc-webapp/codemirror/codemirror.coffee
+++ b/src/smc-webapp/codemirror/codemirror.coffee
@@ -59,7 +59,7 @@ require('codemirror/lib/codemirror.css')
 require('codemirror/theme/3024-day.css')
 require('codemirror/theme/3024-night.css')
 require('codemirror/theme/abcdef.css')
-require('codemirror/theme/ambiance-mobile.css')
+#require('codemirror/theme/ambiance-mobile.css') # doesn't highlight python, confusing
 require('codemirror/theme/ambiance.css')
 require('codemirror/theme/base16-dark.css')
 require('codemirror/theme/base16-light.css')

--- a/src/smc-webapp/frame-editors/codemirror/cm-options.ts
+++ b/src/smc-webapp/frame-editors/codemirror/cm-options.ts
@@ -8,6 +8,7 @@ const { file_associations } = require("smc-webapp/file-associations");
 const feature = require("smc-webapp/feature");
 import { path_split } from "smc-util/misc2";
 import { get_editor_settings } from "../generic/client";
+const { EDITOR_COLOR_SCHEMES } = require("../../r_account");
 
 const { filename_extension_notilde, defaults } = require("misc");
 
@@ -34,6 +35,15 @@ export function cm_options(
         : undefined
       : {};
 
+  let theme = editor_settings.get("theme");
+  // if we do not know the theme, fallback to default
+  if (EDITOR_COLOR_SCHEMES[theme] == null) {
+    console.warn(
+      `codemirror theme '${theme}' not known -- fallback to 'Default'`
+    );
+    theme = "default";
+  }
+
   let opts = defaults(default_opts, {
     undoDepth: 0, // we use our own sync-aware undo.
     mode: "txt",
@@ -58,7 +68,7 @@ export function cm_options(
     spaces_instead_of_tabs: editor_settings.get("spaces_instead_of_tabs", true),
     style_active_line: editor_settings.get("style_active_line", true),
     bindings: editor_settings.get("bindings"),
-    theme: editor_settings.get("theme")
+    theme: theme
   });
   if (opts.mode == null) {
     // to satisfy typescript

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -945,12 +945,12 @@ EditorSettingsFontSize = rclass
                 unit      = "px" />
         </LabeledRow>
 
-EDITOR_COLOR_SCHEMES =
+EDITOR_COLOR_SCHEMES = exports.EDITOR_COLOR_SCHEMES =
     'default'                 : 'Default'
     '3024-day'                : '3024 day'
     '3024-night'              : '3024 night'
     'abcdef'                  : 'abcdef'
-    'ambiance-mobile'         : 'Ambiance mobile'
+    #'ambiance-mobile'         : 'Ambiance mobile'  # doesn't highlight python, confusing
     'ambiance'                : 'Ambiance'
     'base16-dark'             : 'Base 16 dark'
     'base16-light'            : 'Base 16 light'
@@ -973,7 +973,6 @@ EDITOR_COLOR_SCHEMES =
     'lesser-dark'             : 'Lesser dark'
     'liquibyte'               : 'Liquibyte'
     'lucario'                 : 'Lucario'
-    'the-matrix'              : 'The Matrix'
     'material'                : 'Material'
     'mbo'                     : 'mbo'
     'mdn-like'                : 'MDN like'
@@ -994,6 +993,7 @@ EDITOR_COLOR_SCHEMES =
     'solarized dark'          : 'Solarized dark'
     'solarized light'         : 'Solarized light'
     'ssms'                    : 'ssms'
+    'the-matrix'              : 'The Matrix'
     'tomorrow-night-bright'   : 'Tomorrow Night - Bright'
     'tomorrow-night-eighties' : 'Tomorrow Night - Eighties'
     'ttcn'                    : 'ttcn'


### PR DESCRIPTION
# Description
... and also adding a simple fallback if the theme is not known

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
