### PR TITLE
webapp/quotas: make sure all quotas exist in the dict of upgrades to avoid NaN vals

### DIFF
--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -41,6 +41,8 @@ markdown = require('./markdown')
 {BillingPageSimplifiedRedux} = require('./billing')
 {UsersViewing} = require('./other-users')
 {PROJECT_UPGRADES} = require('smc-util/schema')
+{fromPairs} = require('lodash')
+ZERO_QUOTAS = fromPairs(Object.keys(PROJECT_UPGRADES.params).map(((x) -> [x, 0])))
 
 { reuseInFlight } = require("async-await-utils/hof")
 
@@ -778,7 +780,8 @@ class ProjectsStore extends Store
         users = @getIn(['project_map', project_id, 'users'])?.toJS()
         if not users?
             return
-        upgrades = {}
+        # clone zeroed quota upgrades, to make sure they're always defined
+        upgrades = Object.assign({}, ZERO_QUOTAS)
         for account_id, info of users
             for prop, val of info.upgrades ? {}
                 upgrades[prop] = (upgrades[prop] ? 0) + val


### PR DESCRIPTION
# Description
the idea is simple: init all keys with zero, then sum up, etc. 

# Testing Steps
testing is tricky. all fields are set in the dev project. so, in order to trigger this, I crippled the "settings" field and removed the user upgrades. e.g. `update projects set settings = '{"project_id": "...", "member_host": 0, "memory_request": 0}'::JSONB where project_id = ...` and so on. Below are screenshot from "master" and with that patch.

### before

![Screenshot from 2019-06-18 11-35-50](https://user-images.githubusercontent.com/207405/59671303-bac79800-91bd-11e9-897d-ab3523925d6e.png)

### after

![Screenshot from 2019-06-18 11-36-21](https://user-images.githubusercontent.com/207405/59671318-bef3b580-91bd-11e9-88f0-349e2aaa88be.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
