### PR TITLE
webapp/editor: available features could be undefined

### DIFF
--- a/src/smc-webapp/frame-editors/settings/editor.tsx
+++ b/src/smc-webapp/frame-editors/settings/editor.tsx
@@ -11,6 +11,7 @@ import { is_different } from "smc-util/misc2";
 // import from icon only necessary for testing via Jest
 // Change to import from r_misc when it's all typescript
 import { Icon } from "../../r_misc/icon";
+import { Loading } from "../../r_misc/loading";
 
 import { SpellCheck } from "./spell-check";
 
@@ -20,7 +21,7 @@ interface Props {
   id: string;
   actions: any;
   settings: Map<string, any>;
-  available_features: AvailableFeatures;
+  available_features?: AvailableFeatures;
 }
 
 export class Settings extends Component<Props, {}> {
@@ -29,6 +30,10 @@ export class Settings extends Component<Props, {}> {
   }
 
   render_settings(): Rendered[] {
+    const af = this.props.available_features;
+    if (af == null) {
+      return [<Loading key={"loading"} />];
+    }
     const v: Rendered[] = [];
     this.props.settings.forEach((value, key) => {
       switch (key) {
@@ -37,7 +42,7 @@ export class Settings extends Component<Props, {}> {
             <SpellCheck
               key={key}
               value={value}
-              available={this.props.available_features.spellcheck}
+              available={af.spellcheck}
               set={value => this.props.actions.set_settings({ [key]: value })}
             />
           );


### PR DESCRIPTION
# Description

Fix for a stacktrace like that:

firefox: `Mozilla/5.0 (Windows NT 6.1; WOW64; rv:60.0) Gecko/20100101 Firefox/60.0`

smc_git_rev: d7f6b8c903205aa3d32de047d8fad290e93d3c56

Date: 2019-06-18 15:39:47.842917

`e.props.available_features is undefined`

```
l</t.prototype.render_settings/<@https://cocalc.com/static/smc-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:5:456076
e.exports</Be.prototype.__iterate/<@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:301470
e.exports</Ge.prototype.iterate@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:307221
e.exports</Be.prototype.__iterate@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:301428
forEach@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:334320
l</t.prototype.render_settings@https://cocalc.com/static/smc-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:5:455943
l</t.prototype.render@https://cocalc.com/static/smc-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:5:456572
Eo@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4555152
Ao@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4554949
Io@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4558796
qa@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4582865
Wa@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4583249
Es@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4590136
Ms@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4589516
Os@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4590891
Mr@https://cocalc.com/static/0-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:6:4522695
g/e._wrapper@https://cocalc.com/static/smc-cee5077c3cc91ca45d70.cacheme.js?cee5077c3cc91ca45d70:5:734684

```

# Testing Steps
1. md file, config panel, spellcheck shows up

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
