### PR TITLE
Issue/3913

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1039,7 +1039,14 @@ export class Actions<T = CodeEditorState> extends BaseActions<
   }
 
   help(type: string): void {
-    const url = WIKI_HELP_URL + type + "-help";
+    const url: string = (function() {
+      switch (type) {
+        case "terminal":
+          return "https://doc.cocalc.com/terminal.html";
+        default:
+          return WIKI_HELP_URL + type + "-help";
+      }
+    })();
     open_new_tab(url);
   }
 


### PR DESCRIPTION
# Description
fixes the type-derived help url for terminal frames

# Testing Steps
1. click on the help button, terminal doc page shows up

# Relevant Issues

#3913

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
