### PR TITLE
hub/api: attempt to fix #3916 (not tested)

### DIFF
--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -1975,6 +1975,7 @@ class exports.Client extends EventEmitter
                 @database.get_stripe_customer_id
                     account_id : @account_id
                     cb         : (err, customer_id) =>
+                        # note: customer_id could be undefined
                         @stripe_customer_id = customer_id  # cache for later
                         for x in @_stripe_customer_id_cbs
                             {id, cb} = x
@@ -2007,7 +2008,7 @@ class exports.Client extends EventEmitter
                 cb(err); return
             cb(undefined, customer_id)
 
-    # id : user's CoCalc account id
+    # id : message.id
     stripe_get_customer: (id, cb) =>
         dbg = @dbg("stripe_get_customer")
         dbg("getting id")
@@ -2626,13 +2627,8 @@ class exports.Client extends EventEmitter
         locals = {}
         async.series([
             (cb) =>
-                dbg("get stripe id")
-                @stripe_get_customer_id @account_id, (err, id) =>
-                    locals.id = id
-                    cb(err)
-            (cb) =>
                 dbg("get stripe customer data")
-                @stripe_get_customer locals.id, (err, stripe_customer) =>
+                @stripe_get_customer mesg.id, (err, stripe_customer) =>
                     locals.stripe_data = stripe_customer?.subscriptions?.data
                     cb(err)
             (cb) =>


### PR DESCRIPTION
# Description
This is my attempt to fix #3916 --- I've not tested this, because I'm not sure about all moving parts and stop here. However, all changes are definitely related to inconsistencies, etc. I've also got rid of one step in `mesg_get_available_upgrades`, because `stripe_get_customer` is already querying the stripe ID.

# Testing Steps
1. see ticket, i.e. for stripe setup, querying available upgrades for an account with a stripe ID and without one (!) should return. In the second case, it is an error to explain the user that there is no customer info (guessing from the code, it's probably `"no customer_id set yet"`)

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
