### PR TITLE
Refactor all backend stripe api code out of smc-hub/client.coffee; rewrite in Typescript with async/await

### DIFF
--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -14,7 +14,6 @@ misc                 = require('smc-util/misc')
 {defaults, required, to_safe_str} = misc
 {JSON_CHANNEL}       = require('smc-util/client')
 message              = require('smc-util/message')
-compute_upgrades     = require('smc-util/upgrades')
 base_url_lib         = require('./base-url')
 access               = require('./access')
 clients              = require('./clients').get_clients()

--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -24,7 +24,7 @@ password             = require('./password')
 local_hub_connection = require('./local_hub_connection')
 sign_in              = require('./sign-in')
 hub_projects         = require('./projects')
-{get_stripe}         = require('./stripe/connect')
+{StripeClient}       = require('./stripe/client')
 {get_support}        = require('./support')
 {send_email}         = require('./email')
 {api_key_action}     = require('./api/manage')
@@ -1931,617 +1931,64 @@ class exports.Client extends EventEmitter
     ###
     Stripe-integration billing code
     ###
-
-    stripe_get_customer_id: (id, cb) =>  # id = message id
-        # cb(err, customer_id)
-        #  - if err, then an error message with id the given id is sent to the
-        #    user, so client code doesn't have to
-        #  - if no customer info yet with stripe, then NOT an error; instead,
-        #    customer_id is undefined.
-        dbg = @dbg("stripe_get_customer_id")
-        dbg()
-        if not @account_id?
-            err = "You must be signed in to use billing related functions."
-            @error_to_client(id:id, error:err)
-            cb(err)
-            return
-        @_stripe = get_stripe()
-        if not @_stripe?
-            err = "stripe billing not configured"
-            dbg(err)
-            @error_to_client(id:id, error:err)
-            cb(err)
-        else
-            if @stripe_customer_id?
-                dbg("using cached @stripe_customer_id")
-                cb(undefined, @stripe_customer_id)
-            else
-                if @_stripe_customer_id_cbs?
-                    @_stripe_customer_id_cbs.push({id:id, cb:cb})
-                    return
-                @_stripe_customer_id_cbs = [{id:id, cb:cb}]
-                dbg('getting stripe_customer_id from db...')
-                @database.get_stripe_customer_id
-                    account_id : @account_id
-                    cb         : (err, customer_id) =>
-                        # note: customer_id could be undefined
-                        @stripe_customer_id = customer_id  # cache for later
-                        for x in @_stripe_customer_id_cbs
-                            {id, cb} = x
-                            if err
-                                dbg("fail -- #{err}")
-                                @error_to_client(id:id, error:err)
-                                cb(err)
-                            else
-                                dbg("got result #{customer_id}")
-                                cb(undefined, customer_id)
-                        delete @_stripe_customer_id_cbs
-
-                        # Log that the user is requesting this info, which means
-                        # they are billing the subscription page.  This is
-                        # potentially useful to record.
-                        @database.log
-                            event : 'billing'
-                            value : {account_id: @account_id}
-
-    stripe_need_customer_id: (id, cb) =>
-        # Like stripe_get_customer_id, except sends an error to the
-        # user if they aren't registered yet, instead of returning undefined.
-        @dbg("stripe_need_customer_id")()
-        @stripe_get_customer_id id, (err, customer_id) =>
-            if err
-                cb(err); return
-            if not customer_id?
-                err = "customer not defined"
-                @stripe_error_to_client(id:id, error:err)
-                cb(err); return
-            cb(undefined, customer_id)
-
-    # id : message.id
-    stripe_get_customer: (id, cb) =>
-        dbg = @dbg("stripe_get_customer")
-        dbg("getting id")
-        @stripe_get_customer_id id, (err, customer_id) =>
-            if err
-                dbg("failed -- #{err}")
-                cb(err)
-                return
-            if not customer_id?
-                dbg("no customer_id set yet")
-                cb(undefined, undefined)
-                return
-            dbg("now getting stripe customer object")
-            @_stripe.customers.retrieve customer_id, (err, customer) =>
-                if err
-                    dbg("failed -- #{err}")
-                    @error_to_client(id:id, error:err)
-                    cb(err)
-                else
-                    dbg("got it")
-                    cb(undefined, customer)
-
-    stripe_error_to_client: (opts) =>
-        opts = defaults opts,
-            id    : required
-            error : required
-        err = opts.error
-        if typeof(err) != 'string'
-            if err.stack?
-                err = err.stack.split('\n')[0]
-            else
-                err = misc.to_json(err)
-        @dbg("stripe_error_to_client")(err)
-        @error_to_client(id:opts.id, error:err)
+    handle_stripe_mesg: (mesg) =>
+        try
+            await @_stripe_client ?= new StripeClient(@)
+        catch err
+            @error_to_client(id:mesg.id, error:"${err}")
+        @_stripe_client.handle_mesg(mesg)
 
     mesg_stripe_get_customer: (mesg) =>
-        dbg = @dbg("mesg_stripe_get_customer")
-        dbg("get information from stripe about this customer, e.g., subscriptions, payment methods, etc.")
-        @stripe_get_customer mesg.id, (err, customer) =>
-            if err
-                return
-            resp = message.stripe_customer
-                id                     : mesg.id
-                stripe_publishable_key : @_stripe?.publishable_key
-                customer               : customer
-            @push_to_client(resp)
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_create_source: (mesg) =>
-        dbg = @dbg("mesg_stripe_get_customer")
-        dbg("create a payment method (credit card) in stripe for this user")
-        if not @ensure_fields(mesg, 'token')
-            dbg("missing token field -- bailing")
-            return
-        dbg("looking up customer")
-        @stripe_get_customer_id mesg.id, (err, customer_id) =>
-            if err  # database or other major error (e.g., no stripe conf)
-                    # @get_stripe_customer sends error message to user
-                dbg("failed -- #{err}")
-                return
-            if not customer_id?
-                dbg("create new stripe customer (from card token)")
-                description = undefined
-                email = undefined
-                async.series([
-                    (cb) =>
-                        dbg("get identifying info about user")
-                        @database.get_account
-                            columns    : ['email_address', 'first_name', 'last_name']
-                            account_id : @account_id
-                            cb         : (err, r) =>
-                                if err
-                                    cb(err)
-                                else
-                                    email = r.email_address
-                                    description = "#{r.first_name} #{r.last_name}"
-                                    dbg("they are #{description} with email #{email}")
-                                    cb()
-                    (cb) =>
-                        dbg("creating stripe customer")
-                        x =
-                            source      : mesg.token
-                            description : description
-                            email       : email
-                            metadata    :
-                                account_id : @account_id
-                        @_stripe.customers.create x, (err, customer) =>
-                            if err
-                                cb(err)
-                            else
-                                customer_id = customer.id
-                                cb()
-                    (cb) =>
-                        dbg("success; now save customer id token to database")
-                        @database.set_stripe_customer_id
-                            account_id  : @account_id
-                            customer_id : customer_id
-                            cb          : cb
-                    (cb) =>
-                        dbg("success; sync user account with stripe")
-                        @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id,  cb: cb)
-                ], (err) =>
-                    if err
-                        dbg("failed -- #{err}")
-                        @stripe_error_to_client(id:mesg.id, error:err)
-                    else
-                        @success_to_client(id:mesg.id)
-                )
-            else
-                dbg("add card to existing stripe customer")
-                async.series([
-                    (cb) =>
-                        @_stripe.customers.createCard(customer_id, {card:mesg.token}, cb)
-                    (cb) =>
-                        dbg("success; sync user account with stripe")
-                        @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id,  cb: cb)
-                ], (err) =>
-                    if err
-                        @stripe_error_to_client(id:mesg.id, error:err)
-                    else
-                        @success_to_client(id:mesg.id)
-                )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_delete_source: (mesg) =>
-        dbg = @dbg("mesg_stripe_delete_source")
-        dbg("delete a payment method for this user")
-        if not @ensure_fields(mesg, 'card_id')
-            dbg("missing card_id field")
-            return
-        customer_id = undefined
-        async.series([
-            (cb) =>
-                @stripe_get_customer_id(mesg.id, (err, x) => customer_id = x; cb(err))
-            (cb) =>
-                if not customer_id?
-                    cb("no customer information so can't delete source")
-                else
-                    @_stripe.customers.deleteCard(customer_id, mesg.card_id, cb)
-            (cb) =>
-                @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id, cb: cb)
-        ], (err) =>
-            if err
-                @stripe_error_to_client(id:mesg.id, error:err)
-            else
-                @success_to_client(id:mesg.id)
-        )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_set_default_source: (mesg) =>
-        dbg = @dbg("mesg_stripe_set_default_source")
-        dbg("set a payment method for this user to be the default")
-        if not @ensure_fields(mesg, 'card_id')
-            dbg("missing field card_id")
-            return
-        customer_id = undefined
-        async.series([
-            (cb) =>
-                @stripe_get_customer_id(mesg.id, (err, x) => customer_id = x; cb(err))
-            (cb) =>
-                if not customer_id?
-                    cb("no customer information so can't update source")
-                else
-                    dbg("now setting the default source in stripe")
-                    @_stripe.customers.update(customer_id, {default_source:mesg.card_id}, cb)
-            (cb) =>
-                dbg("update database")
-                @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id,  cb: cb)
-        ], (err) =>
-            if err
-                dbg("failed -- #{err}")
-                @stripe_error_to_client(id:mesg.id, error:err)
-            else
-                dbg("success")
-                @success_to_client(id:mesg.id)
-        )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_update_source: (mesg) =>
-        dbg = @dbg("mesg_stripe_update_source")
-        dbg("modify a payment method")
-
-        if not @ensure_fields(mesg, 'card_id info')
-            return
-        if mesg.info.metadata?
-            @error_to_client(id:mesg.id, error:"you may not change card metadata")
-            return
-        customer_id = undefined
-        async.series([
-            (cb) =>
-                @stripe_get_customer_id(mesg.id, (err, x) => customer_id = x; cb(err))
-            (cb) =>
-                if not customer_id?
-                    cb("no customer information so can't update source")
-                else
-                    @_stripe.customers.updateCard(customer_id, mesg.card_id, mesg.info, cb)
-            (cb) =>
-                @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id, cb: cb)
-        ], (err) =>
-            if err
-                @stripe_error_to_client(id:mesg.id, error:err)
-            else
-                @success_to_client(id:mesg.id)
-        )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_get_plans: (mesg) =>
-        dbg = @dbg("mesg_stripe_get_plans")
-        dbg("get descriptions of the available plans that the user might subscribe to")
-        async.series([
-            (cb) =>
-                @stripe_get_customer_id(mesg.id, cb)   # ensures @_stripe is defined below
-            (cb) =>
-                @_stripe.plans.list (err, plans) =>
-                    if err
-                        @stripe_error_to_client(id:mesg.id, error:err)
-                    else
-                        @push_to_client(message.stripe_plans(id: mesg.id, plans: plans))
-        ])
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_create_subscription: (mesg) =>
-        dbg = @dbg("mesg_stripe_create_subscription")
-        dbg("create a subscription for this user, using some billing method")
-        if not @ensure_fields(mesg, 'plan')
-            @stripe_error_to_client(id:mesg.id, error:"missing field 'plan'")
-            return
-
-        schema = require('smc-util/schema').PROJECT_UPGRADES.subscription[mesg.plan.split('-')[0]]
-        if not schema?
-            @stripe_error_to_client(id:mesg.id, error:"unknown plan -- '#{mesg.plan}'")
-            return
-
-        @stripe_need_customer_id mesg.id, (err, customer_id) =>
-            if err
-                dbg("fail -- #{err}")
-                return
-            projects = mesg.projects
-            if not mesg.quantity?
-                mesg.quantity = 1
-
-            options =
-                plan     : mesg.plan
-                quantity : mesg.quantity
-                coupon   : mesg.coupon_id
-
-            subscription = undefined
-            tax_rate = undefined
-            async.series([
-                (cb) =>
-                    dbg('determine applicable tax')
-                    require('./stripe/sales-tax').stripe_sales_tax
-                        customer_id : customer_id
-                        cb          : (err, rate) =>
-                            tax_rate = rate
-                            dbg("tax_rate = #{tax_rate}")
-                            if tax_rate
-                                # CRITICAL: if we don't just multiply by 100, since then sometimes
-                                # stripe comes back with an error like this
-                                #    "Error: Invalid decimal: 8.799999999999999; must contain at maximum two decimal places."
-                                options.tax_percent = Math.round(tax_rate*100*100)/100
-                            cb(err)
-                (cb) =>
-                    dbg("add customer subscription to stripe")
-                    @_stripe.customers.createSubscription customer_id, options, (err, s) =>
-                        if err
-                            cb(err)
-                        else
-                            subscription = s
-                            cb()
-                (cb) =>
-                    if schema.cancel_at_period_end
-                        dbg("Setting subscription to cancel at period end")
-                        @_stripe.subscriptions.update(subscription.id, {cancel_at_period_end:true}, cb)
-                    else
-                        cb()
-                (cb) =>
-                    dbg("Successfully added subscription; now save info in our database about subscriptions....")
-                    @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id, cb: cb)
-                (cb) =>
-                    if not options.coupon
-                        cb()
-                        return
-                    dbg("add coupon to customer history")
-                    @validate_coupon options.coupon, (err, coupon, coupon_history) =>
-                        if err
-                            cb(err)
-                            return
-                        coupon_history[coupon.id] += 1
-                        @database.update_coupon_history
-                            account_id     : @account_id
-                            coupon_history : coupon_history
-                            cb             : cb
-            ], (err) =>
-                if err
-                    dbg("fail -- #{err}")
-                    @stripe_error_to_client(id:mesg.id, error:err)
-                else
-                    @success_to_client(id:mesg.id)
-            )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_cancel_subscription: (mesg) =>
-        dbg = @dbg("mesg_stripe_cancel_subscription")
-        dbg("cancel a subscription for this user")
-        if not @ensure_fields(mesg, 'subscription_id')
-            dbg("missing field subscription_id")
-            return
-        @stripe_need_customer_id mesg.id, (err, customer_id) =>
-            if err
-                return
-            projects        = undefined
-            subscription_id = mesg.subscription_id
-            async.series([
-                (cb) =>
-                    dbg("cancel the subscription at stripe")
-                    # This also returns the subscription, which lets
-                    # us easily get the metadata of all projects associated to this subscription.
-                    @_stripe.subscriptions.update(subscription_id, {cancel_at_period_end:mesg.at_period_end}, cb)
-                (cb) =>
-                    @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id, cb: cb)
-            ], (err) =>
-                if err
-                    @stripe_error_to_client(id:mesg.id, error:err)
-                else
-                    @success_to_client(id:mesg.id)
-            )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_update_subscription: (mesg) =>
-        dbg = @dbg("mesg_stripe_update_subscription")
-        dbg("edit a subscription for this user")
-        if not @ensure_fields(mesg, 'subscription_id')
-            dbg("missing field subscription_id")
-            return
-        subscription_id = mesg.subscription_id
-        @stripe_need_customer_id mesg.id, (err, customer_id) =>
-            if err
-                return
-            subscription = undefined
-            async.series([
-                (cb) =>
-                    dbg("Update the subscription.")
-                    changes =
-                        quantity : mesg.quantity
-                        plan     : mesg.plan
-                        coupon   : mesg.coupon_id
-                    @_stripe.customers.updateSubscription(customer_id, subscription_id, changes, cb)
-                (cb) =>
-                    @database.stripe_update_customer(account_id : @account_id, stripe : @_stripe, customer_id : customer_id, cb: cb)
-                (cb) =>
-                    if not mesg.coupon_id
-                        cb()
-
-                    if mesg.coupon_id
-                        @validate_coupon mesg.coupon_id, (err, coupon, coupon_history) =>
-                            if err
-                                cb(err)
-                                return
-                            coupon_history[coupon.id] += 1
-                            @database.update_coupon_history
-                                account_id     : @account_id
-                                coupon_history : coupon_history
-                                cb             : cb
-            ], (err) =>
-                if err
-                    @stripe_error_to_client(id:mesg.id, error:err)
-                else
-                    @success_to_client(id:mesg.id)
-            )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_get_subscriptions: (mesg) =>
-        dbg = @dbg("mesg_stripe_get_subscriptions")
-        dbg("get a list of all the subscriptions that this customer has")
-        @stripe_need_customer_id mesg.id, (err, customer_id) =>
-            if err
-                return
-            options =
-                limit          : mesg.limit
-                ending_before  : mesg.ending_before
-                starting_after : mesg.starting_after
-            @_stripe.customers.listSubscriptions customer_id, options, (err, subscriptions) =>
-                if err
-                    @stripe_error_to_client(id:mesg.id, error:err)
-                else
-                    @push_to_client(message.stripe_subscriptions(id:mesg.id, subscriptions:subscriptions))
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_get_coupon: (mesg) =>
-        dbg = @dbg("mesg_stripe_get_coupon")
-        dbg("get the coupon with id == #{mesg.coupon_id}")
-        if not @ensure_fields(mesg, 'coupon_id')
-            dbg("missing field coupon_id")
-            return
-        @validate_coupon mesg.coupon_id, (err, coupon) =>
-            if err
-                @stripe_error_to_client(id:mesg.id, error:err)
-            else
-                @push_to_client(message.stripe_coupon(id:mesg.id, coupon:coupon))
-
-    # Checks these coupon criteria:
-    # - Exists
-    # - Is valid
-    # - Used by this account less than the max per account (hard coded default is 1)
-    # Calls cb(err, coupon, coupon_history)
-    validate_coupon: (coupon_id, cb) =>
-        dbg = @dbg("validate_coupon")
-        @_stripe = get_stripe()
-        async.series([
-            (local_cb) =>
-                dbg("retrieve the coupon")
-                @_stripe.coupons.retrieve(coupon_id, local_cb)
-            (local_cb) =>
-                dbg("check account coupon_history")
-                @database.get_coupon_history
-                    account_id : @account_id
-                    cb         : local_cb
-        ], (err, [coupon, coupon_history]) =>
-            if err
-                cb(err)
-                return
-            if not coupon.valid
-                cb("Sorry! This coupon has expired.")
-                return
-            coupon_history ?= {}
-            times_used = coupon_history[coupon.id] ? 0
-            if times_used >= (coupon.metadata.max_per_account ? 1)
-                cb("You've already used this coupon.")
-                return
-
-            coupon_history[coupon.id] = times_used
-            cb(err, coupon, coupon_history)
-        )
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_get_charges: (mesg) =>
-        dbg = @dbg("mesg_stripe_get_charges")
-        dbg("get a list of charges for this customer.")
-        @stripe_need_customer_id mesg.id, (err, customer_id) =>
-            if err
-                return
-            options =
-                customer       : customer_id
-                limit          : mesg.limit
-                ending_before  : mesg.ending_before
-                starting_after : mesg.starting_after
-            @_stripe.charges.list options, (err, charges) =>
-                if err
-                    @stripe_error_to_client(id:mesg.id, error:err)
-                else
-                    @push_to_client(message.stripe_charges(id:mesg.id, charges:charges))
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_get_invoices: (mesg) =>
-        dbg = @dbg("mesg_stripe_get_invoices")
-        dbg("get a list of invoices for this customer.")
-        @stripe_need_customer_id mesg.id, (err, customer_id) =>
-            if err
-                return
-            options =
-                customer       : customer_id
-                limit          : mesg.limit
-                ending_before  : mesg.ending_before
-                starting_after : mesg.starting_after
-            @_stripe.invoices.list options, (err, invoices) =>
-                if err
-                    @stripe_error_to_client(id:mesg.id, error:err)
-                else
-                    @push_to_client(message.stripe_invoices(id:mesg.id, invoices:invoices))
+        @handle_stripe_mesg(mesg)
 
     mesg_stripe_admin_create_invoice_item: (mesg) =>
-        dbg = @dbg("mesg_stripe_admin_create_invoice_item")
-        @_stripe = get_stripe()
-        if not @_stripe?
-            err = "stripe billing not configured"
-            dbg(err)
-            @error_to_client(id:id, error:err)
-            return
-        customer_id = undefined
-        description = undefined
-        email       = undefined
-        new_customer = true
-        async.series([
-            (cb) =>
-                @assert_user_is_in_group('admin', cb)
-            (cb) =>
-                dbg("check for existing stripe customer_id")
-                @database.get_account
-                    columns       : ['stripe_customer_id', 'email_address', 'first_name', 'last_name', 'account_id']
-                    account_id    : mesg.account_id
-                    email_address : mesg.email_address
-                    cb            : (err, r) =>
-                        if err
-                            cb(err)
-                        else
-                            customer_id = r.stripe_customer_id
-                            email = r.email_address
-                            description = "#{r.first_name} #{r.last_name}"
-                            mesg.account_id = r.account_id
-                            cb()
-            (cb) =>
-                if customer_id?
-                    new_customer = false
-                    dbg("already signed up for stripe -- sync local user account with stripe")
-                    @database.stripe_update_customer
-                        account_id  : mesg.account_id
-                        stripe      : get_stripe()
-                        customer_id : customer_id
-                        cb          : cb
-                else
-                    dbg("create stripe entry for this customer")
-                    x =
-                        description : description
-                        email       : email
-                        metadata    :
-                            account_id : mesg.account_id
-                    @_stripe.customers.create x, (err, customer) =>
-                        if err
-                            cb(err)
-                        else
-                            customer_id = customer.id
-                            cb()
-            (cb) =>
-                if not new_customer
-                    cb()
-                else
-                    dbg("store customer id in our database")
-                    @database.set_stripe_customer_id
-                        account_id  : mesg.account_id
-                        customer_id : customer_id
-                        cb          : cb
-            (cb) =>
-                if not (mesg.amount? and mesg.description?)
-                    dbg("no amount or description -- not creating an invoice")
-                    cb()
-                else
-                    dbg("now create the invoice item")
-                    @_stripe.invoiceItems.create
-                        customer    : customer_id
-                        amount      : mesg.amount*100
-                        currency    : "usd"
-                        description : mesg.description
-                    ,
-                        (err, invoice_item) =>
-                            if err
-                                cb(err)
-                            else
-                                cb()
-        ], (err) =>
-            if err
-                @error_to_client(id:mesg.id, error:err)
-            else
-                @success_to_client(id:mesg.id)
-        )
+        @handle_stripe_mesg(mesg)
 
+    mesg_get_available_upgrades: (mesg) =>
+        mesg.event = 'stripe_get_available_upgrades'  # for backward compat
+        @handle_stripe_mesg(mesg)
+
+    mesg_remove_all_upgrades: (mesg) =>
+        mesg.event = 'stripe_remove_all_upgrades'     # for backward compat
+        @handle_stripe_mesg(mesg)
+
+    #  END stripe-related functionality
 
     mesg_api_key: (mesg) =>
         api_key_action
@@ -2610,49 +2057,6 @@ class exports.Client extends EventEmitter
 
         client_metrics[@id] = metrics
         #dbg('RECORDED: ', misc.to_json(client_metrics[@id]))
-
-    mesg_get_available_upgrades: (mesg) =>
-        dbg = @dbg("mesg_get_available_upgrades")
-        locals = {}
-        async.series([
-            (cb) =>
-                dbg("get stripe customer data")
-                @stripe_get_customer mesg.id, (err, stripe_customer) =>
-                    locals.stripe_data = stripe_customer?.subscriptions?.data
-                    cb(err)
-            (cb) =>
-                dbg("get user project upgrades")
-                @database.get_user_project_upgrades
-                    account_id : @account_id
-                    cb         : (err, projects) =>
-                        locals.projects = projects
-                        cb(err)
-        ], (err) =>
-            if err
-                @error_to_client(id:mesg.id, error:err)
-            else
-                locals.x = compute_upgrades.available_upgrades(locals.stripe_data, locals.projects)
-                locals.resp = message.available_upgrades
-                    id        : mesg.id
-                    total     : compute_upgrades.get_total_upgrades(locals.stripe_data)
-                    excess    : locals.x.excess
-                    available : locals.x.available
-                @push_to_client(locals.resp)
-        )
-
-    mesg_remove_all_upgrades: (mesg) =>
-        dbg = @dbg("mesg_remove_all_upgrades")
-        if not @account_id?
-            @error_to_client(id:mesg.id, error:'you must be signed in')
-            return
-        @database.remove_all_user_project_upgrades
-            account_id : @account_id
-            projects   : mesg.projects
-            cb         : (err) =>
-                if err
-                    @error_to_client(id:mesg.id, error:err)
-                else
-                    @push_to_client(message.success(id:mesg.id))
 
     _check_project_access: (project_id, cb) =>
         if not @account_id?

--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -1931,17 +1931,6 @@ class exports.Client extends EventEmitter
     ###
     Stripe-integration billing code
     ###
-    ensure_fields: (mesg, fields) =>
-        if not mesg.id?
-            return false
-        if typeof(fields) == 'string'
-            fields = fields.split(' ')
-        for f in fields
-            if not mesg[f.trim()]?
-                err = "invalid message; must have #{f} field"
-                @error_to_client(id:mesg.id, error:err)
-                return false
-        return true
 
     stripe_get_customer_id: (id, cb) =>  # id = message id
         # cb(err, customer_id)

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -8,6 +8,7 @@
     "@passport-next/passport-google-oauth2": "^1.0.0",
     "@types/http-proxy": "^1.16.2",
     "async": "^1.4.2",
+    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "basic-auth": "^2.0.0",
     "bindings": "^1.3.0",

--- a/src/smc-hub/stripe/client.ts
+++ b/src/smc-hub/stripe/client.ts
@@ -441,7 +441,7 @@ export class StripeClient {
 
     const coupon_id: string = get_string_field(mesg, "coupon_id");
 
-    const coupon = await this.validate_coupon(coupon_id);
+    const { coupon } = await this.validate_coupon(coupon_id);
     return message.stripe_coupon({ coupon });
   }
 

--- a/src/smc-hub/stripe/client.ts
+++ b/src/smc-hub/stripe/client.ts
@@ -1,0 +1,801 @@
+import { reuseInFlight } from "async-await-utils/hof";
+import { callback } from "awaiting";
+import { callback2 } from "async-utils";
+
+const { get_stripe } = require("./connect");
+
+interface HubClient {
+  public account_id: string;
+  dbg: (f: string) => Function;
+  database: any;
+}
+
+interface StripeConnection {}
+interface StripeCustomer {}
+
+type Message = any;
+
+function get_string_field(mesg: Message, name: string): string {
+  if (mesg == null) throw Error("invalid message; must not be null");
+  const x = mesg[name];
+  if (typeof x != "string") throw Error(`mesg[${name}] must be a string`);
+  return x;
+}
+
+function get_nonnull_field(mesg: Message, name: string): any {
+  if (mesg == null) throw Error("invalid message; must not be null");
+  const x = mesg[name];
+  if (x == null) throw Error(`mesg[${name}] must be defined`);
+  return x;
+}
+
+export class StripeClient {
+  private client: HubClient;
+  private stripe: StripeConnection;
+  private stripe_customer_id?: string;
+
+  constructor(client): void {
+    this.client = client;
+    this.stripe = get_stripe();
+    if (this.stripe == null) throw Error("stripe billing not configured");
+
+    this.get_customer_id = reuseInFlight(this.get_customer_id);
+  }
+
+  private dbg(f: string): Function {
+    return this.client.dbg(`stripe.${f}`);
+  }
+
+  // Returns the stripe customer id for this account from our database,
+  // or undefined if there is no known stripe customer id.
+  // Throws an error if something goes wrong.
+  // If called multiple times simultaneously, only does one DB query.
+  private async get_customer_id(): Promise<string | undefined> {
+    //  If no customer info yet with stripe, then NOT an error; instead,
+    //  customer_id is undefined (but will check every time in this case).
+    const dbg = this.dbg("get_customer_id");
+    dbg();
+    if (this.stripe_customer_id != null) {
+      dbg("using cached this.stripe_customer_id");
+      return this.stripe_customer_id;
+    }
+    const account_id = this.client.account_id;
+    if (account_id == null) {
+      throw Error("You must be signed in to use billing related functions.");
+    }
+    dbg("getting stripe_customer_id from database...");
+    const stripe_customer_id = await callback2(
+      this.client.database.get_stripe_customer_id,
+      { account_id }
+    );
+    if (stripe_customer_id != null) {
+      // cache it, since it won't change.
+      this.stripe_customer_id = stripe_customer_id;
+    }
+    return stripe_customer_id;
+  }
+
+  // Raise an exception if user is not yet registered with stripe.
+  private async need_customer_id(): Promise<string> {
+    this.dbg("need_customer_id")();
+    const customer_id = await this.get_customer_id();
+    if (customer_id == null) {
+      throw Error("stripe customer not defined");
+    }
+    return customer_id;
+  }
+
+  private async get_customer(): Promise<StripeCustomer> {
+    const dbg = this.dbg("get_customer");
+    dbg("getting customer id");
+    const customer_id: string = await this.get_customer_id();
+    dbg("now getting stripe customer object");
+    return await callback(this.stripe.customers.retrieve, customer_id);
+  }
+
+  public async handle_mesg(mesg: Message): Promise<void> {
+    try {
+      const f = this[`mesg_${mesg.event}`];
+      if (f == null) {
+        throw Error(`no such message type ${mesg.event}`);
+      } else {
+        let resp: any = await f(mesg);
+        if (resp == null) {
+          resp = {};
+        }
+        resp.id = mesg.id;
+        this.client.push_to_client(resp);
+      }
+    } catch (err) {
+      let e: string;
+      if (err.stack != null) {
+        e = err.stack.split("\n")[0];
+      } else {
+        e = `${err}`;
+      }
+      this.dbg("handle_mesg")("Error", e);
+      this.client.error_to_client({ id: mesg.id, error: e });
+    }
+  }
+
+  private async mesg_get_customer(mesg: Message): Promise<Message> {
+    const dbg = this.dbg("mesg_get_customer");
+    dbg("get information from stripe: subscriptions, payment methods, etc.");
+    const customer = await this.get_customer();
+    return message.stripe_customer({
+      stripe_publishable_key: this.stripe.publishable_key,
+      customer
+    });
+  }
+
+  private mesg_create_source(mesg: Message): Promise<void> {
+    const dbg = this.dbg("mesg_create_source");
+    dbg("create a payment method (credit card) in stripe for this user");
+    const token = get_string_field(mesg, "token");
+    dbg("looking up customer");
+    const customer_id = await this.stripe_get_customer_id();
+    if (customer_id == null) {
+      await this.create_new_stripe_customer_from_card_token(token);
+    } else {
+      await this.add_card_to_existing_stripe_customer(token);
+    }
+  }
+
+  private async create_new_stripe_customer_from_card_token(
+    token: string
+  ): Promise<void> {
+    const dbg = this.dbg("create_new_stripe_customer_from_card_token");
+    dbg("create new stripe customer from card token");
+
+    dbg("get identifying info about user");
+    const r = await callback2(this.database.get_account, {
+      columns: ["email_address", "first_name", "last_name"],
+      account_id: this.client.account_id
+    });
+    const email = r.email_address;
+    const description = `${r.first_name} ${r.last_name}`;
+    dbg(`they are ${description} with email ${email}`);
+
+    dbg("creating stripe customer");
+    const x = {
+      source: token,
+      description,
+      email,
+      metadata: {
+        account_id: this.client.account_id
+      }
+    };
+
+    const customer_id: string = (await callback(
+      this.stripe.customers.create,
+      x
+    )).id;
+
+    dbg("success; now save customer_id to database");
+    await callback2(this.database.set_stripe_customer_id, {
+      account_id: this.client.account_id,
+      customer_id
+    });
+
+    await this.update_database();
+  }
+
+  private async add_card_to_existing_stripe_customer(
+    token: string
+  ): Promise<void> {
+    const dbg = this.dbg("add_card_to_existing_stripe_customer");
+    dbg("add card to existing stripe customer");
+
+    await callback(this.stripe.customers.createCard, customer_id, {
+      card: token
+    });
+
+    await this.update_database();
+  }
+
+  private async mesg_delete_source(mesg: Message): Promise<void> {
+    const dbg = this.dbg("mesg_delete_source");
+    dbg("delete a payment method for this user");
+    if (!this.ensure_fields(mesg, "card_id")) {
+      dbg("missing card_id field");
+      return;
+    }
+    const card_id: string = get_string_field(mesg, "card_id");
+
+    const customer_id = await this.get_customer_id();
+    if (customer_id == null)
+      throw Error("no customer information so can't delete source");
+
+    await callback(this.stripe.customers.deleteCard, customer_id, card_id);
+    await this.update_database();
+  }
+
+  private async mesg_set_default_source(mesg: Message): Promise<void> {
+    const dbg = this.dbg("mesg_set_default_source");
+    dbg("set a payment method for this user to be the default");
+    const card_id: string = get_string_field(mesg, "card_id");
+    const customer_id = await this.get_customer_id();
+    if (customer_id == null)
+      throw Error("no customer information so can't set a default source");
+
+    dbg("now setting the default source in stripe");
+    await callback(this.stripe.customers.update, customer_id, {
+      default_source: mesg.card_id
+    });
+
+    await this.update_database();
+  }
+
+  private async update_database(): Promise<void> {
+    dbg("update_database")();
+    const customer_id = await this.get_customer_id();
+    if (customer_id == null) return;
+    await callback2(this.database.stripe_update_customer, {
+      account_id: this.client.account_id,
+      stripe: this.stripe,
+      customer_id
+    });
+  }
+
+  private async mesg_update_source(mesg: Message): Promise<void> {
+    const dbg = this.dbg("mesg_update_source");
+    dbg("modify a payment method");
+
+    const card_id: string = get_string_field(mesg, "card_id");
+
+    const info: any = get_nonnull_field(mesg, "info");
+    if (info.metadata != null) throw Error("can't change card metadata");
+
+    const customer_id = await this.get_customer_id();
+    if (customer_id == null)
+      throw Error("no customer information so can't update source");
+
+    await callback(
+      this.stripe.customers.updateCard,
+      customer_id,
+      card_id,
+      info
+    );
+
+    await this.update_database();
+  }
+
+  private async mesg_get_plans(mesg: Message): Promise<Message> {
+    const dbg = this.dbg("mesg_get_plans");
+    dbg("get descriptions of plans that the user might subscribe to");
+    const plans = await callback(this.stripe.plans.list);
+    return message.stripe_plans({ plans });
+  }
+
+  private async mesg_create_subscription(mesg: Message): Promise<void> {
+    const dbg = this.dbg("mesg_create_subscription");
+    dbg("create a subscription for this user, using some billing method");
+
+    const plan: string = get_string_field(mesg, "plan");
+
+    const schema = require("smc-util/schema").PROJECT_UPGRADES.subscription[
+      plan.split("-")[0]
+    ];
+    if (schema == null) throw Error(`unknown plan -- '${plan}'`);
+
+    const customer_id: string = await this.need_customer_id();
+
+    const quantity = mesg.quantity ? mesg.quantity : 1;
+
+    const options: any = {
+      plan,
+      quantity,
+      coupon: mesg.coupon_id
+    };
+
+    dbg("determine applicable tax");
+    const tax_rate = await callback2(
+      require("./stripe/sales-tax").stripe_sales_tax,
+      {
+        customer_id
+      }
+    );
+    dbg(`tax_rate = ${tax_rate}`);
+    if (tax_rate) {
+      // CRITICAL: if we don't just multiply by 100, since then sometimes
+      // stripe comes back with an error like this
+      //    "Error: Invalid decimal: 8.799999999999999; must contain at maximum two decimal places."
+      options.tax_percent = Math.round(tax_rate * 100 * 100) / 100;
+    }
+
+    dbg("add customer subscription to stripe");
+    const subscription = await callback(
+      this.stripe.customers.createSubscription,
+      customer_id,
+      options
+    );
+
+    if (schema.cancel_at_period_end) {
+      dbg("Setting subscription to cancel at period end");
+      await callback(this.stripe.subscriptions.update, subscription.id, {
+        cancel_at_period_end: true
+      });
+    }
+
+    dbg("added subscription; now save info in our database about it...");
+    await this.update_database();
+
+    if (options.coupon != null) {
+      dbg("add coupon to customer history");
+      const { coupon, coupon_history } = await callback(
+        this.validate_coupon,
+        options.coupon
+      );
+
+      // SECURITY NOTE: incrementing a counter... subject to attack?
+      // I.e., use a coupon more times than should be able to?
+      coupon_history[coupon.id] += 1;
+      await callback2(this.database.update_coupon_history, {
+        account_id: this.account_id,
+        coupon_history
+      });
+    }
+  }
+
+  private async mesg_cancel_subscription(mesg: Message): Promise<void> {
+    const dbg = this.dbg("mesg_cancel_subscription");
+    dbg("cancel a subscription for this user");
+
+    const subscription_id: string = get_string_field(mesg, "subscription_id");
+
+    const customer_id: string = await this.need_customer_id();
+
+    dbg("cancel the subscription at stripe");
+    // This also returns the subscription, which lets
+    // us easily get the metadata of all projects associated to this subscription.
+    await callback(this.stripe.subscriptions.update, subscription_id, {
+      cancel_at_period_end: mesg.at_period_end
+    });
+
+    await this.update_database();
+  }
+
+  private async mesg_update_subscription(mesg: Message): Promise<void> {
+    const dbg = this.dbg("mesg_update_subscription");
+    dbg("edit a subscription for this user");
+
+    const subscription_id: string = get_string_field(mesg, "subscription_id");
+    const customer_id: string = await this.need_customer_id();
+    dbg("Update the subscription.");
+    const changes = {
+      quantity: mesg.quantity,
+      plan: mesg.plan,
+      coupon: mesg.coupon_id
+    };
+    await callback(
+      this.stripe.customers.updateSubscription,
+      customer_id,
+      subscription_id,
+      changes
+    );
+    await this.update_database();
+    if (mesg.coupon_id != null) {
+      const { coupon, coupon_history } = await this.validate_coupon(
+        mesg.coupon_id
+      );
+      coupon_history[coupon.id] += 1;
+      await callback2(this.database.update_coupon_history, {
+        account_id: this.account_id,
+        coupon_history
+      });
+    }
+  }
+
+  private async mesg_get_subscriptions(mesg: Message): Promise<Message> {
+    const dbg = this.dbg("mesg_get_subscriptions");
+    dbg("get a list of all the subscriptions that this customer has");
+
+    const customer_id: string = await this.need_customer_id();
+
+    const options = {
+      limit: mesg.limit,
+      ending_before: mesg.ending_before,
+      starting_after: mesg.starting_after
+    };
+    const subscriptions = await callback(
+      this.stripe.customers.listSubscriptions,
+      customer_id,
+      options
+    );
+    return message.stripe_subscriptions({ subscriptions });
+  }
+
+  private async mesg_get_coupon(mesg: Message): Message {
+    const dbg = this.dbg("mesg_get_coupon");
+    dbg(`get the coupon with id=${mesg.coupon_id}`);
+
+    const coupon_id: string = get_string_field(mesg, "coupon_id");
+
+    const coupon = await callback(this.validate_coupon, mesg.coupon_id);
+    return message.stripe_coupon({ coupon });
+  }
+
+  // Checks these coupon criteria:
+  // - Exists
+  // - Is valid
+  // - Used by this account less than the max per account (hard coded default is 1)
+  // Calls cb(err, coupon, coupon_history)
+  validate_coupon(coupon_id, cb) {
+    const dbg = this.dbg("validate_coupon");
+    this.stripe = get_stripe();
+    return async.series(
+      [
+        local_cb => {
+          dbg("retrieve the coupon");
+          return this.stripe.coupons.retrieve(coupon_id, local_cb);
+        },
+        local_cb => {
+          dbg("check account coupon_history");
+          return this.database.get_coupon_history({
+            account_id: this.account_id,
+            cb: local_cb
+          });
+        }
+      ],
+      (err, [coupon, coupon_history]) => {
+        if (err) {
+          cb(err);
+          return;
+        }
+        if (!coupon.valid) {
+          cb("Sorry! This coupon has expired.");
+          return;
+        }
+        if (coupon_history == null) {
+          coupon_history = {};
+        }
+        const times_used =
+          coupon_history[coupon.id] != null ? coupon_history[coupon.id] : 0;
+        if (
+          times_used >=
+          (coupon.metadata.max_per_account != null
+            ? coupon.metadata.max_per_account
+            : 1)
+        ) {
+          cb("You've already used this coupon.");
+          return;
+        }
+
+        coupon_history[coupon.id] = times_used;
+        return cb(err, coupon, coupon_history);
+      }
+    );
+  }
+
+  mesg_get_charges(mesg) {
+    const dbg = this.dbg("mesg_get_charges");
+    dbg("get a list of charges for this customer.");
+    return this.stripe_need_customer_id(mesg.id, (err, customer_id) => {
+      if (err) {
+        return;
+      }
+      const options = {
+        customer: customer_id,
+        limit: mesg.limit,
+        ending_before: mesg.ending_before,
+        starting_after: mesg.starting_after
+      };
+      return this.stripe.charges.list(options, (err, charges) => {
+        if (err) {
+          return this.stripe_error_to_client({ id: mesg.id, error: err });
+        } else {
+          return this.push_to_client(
+            message.stripe_charges({ id: mesg.id, charges })
+          );
+        }
+      });
+    });
+  }
+
+  mesg_get_invoices(mesg) {
+    const dbg = this.dbg("mesg_get_invoices");
+    dbg("get a list of invoices for this customer.");
+    return this.stripe_need_customer_id(mesg.id, (err, customer_id) => {
+      if (err) {
+        return;
+      }
+      const options = {
+        customer: customer_id,
+        limit: mesg.limit,
+        ending_before: mesg.ending_before,
+        starting_after: mesg.starting_after
+      };
+      return this.stripe.invoices.list(options, (err, invoices) => {
+        if (err) {
+          return this.stripe_error_to_client({ id: mesg.id, error: err });
+        } else {
+          return this.push_to_client(
+            message.stripe_invoices({ id: mesg.id, invoices })
+          );
+        }
+      });
+    });
+  }
+
+  mesg_admin_create_invoice_item(mesg) {
+    const dbg = this.dbg("mesg_admin_create_invoice_item");
+    this.stripe = get_stripe();
+    if (this.stripe == null) {
+      const err = "stripe billing not configured";
+      dbg(err);
+      this.error_to_client({ id, error: err });
+      return;
+    }
+    let customer_id = undefined;
+    let description = undefined;
+    let email = undefined;
+    let new_customer = true;
+    return async.series(
+      [
+        cb => {
+          return this.assert_user_is_in_group("admin", cb);
+        },
+        cb => {
+          dbg("check for existing stripe customer_id");
+          return this.database.get_account({
+            columns: [
+              "stripe_customer_id",
+              "email_address",
+              "first_name",
+              "last_name",
+              "account_id"
+            ],
+            account_id: mesg.account_id,
+            email_address: mesg.email_address,
+            cb: (err, r) => {
+              if (err) {
+                return cb(err);
+              } else {
+                customer_id = r.stripe_customer_id;
+                email = r.email_address;
+                description = `${r.first_name} ${r.last_name}`;
+                mesg.account_id = r.account_id;
+                return cb();
+              }
+            }
+          });
+        },
+        cb => {
+          if (customer_id != null) {
+            new_customer = false;
+            dbg(
+              "already signed up for stripe -- sync local user account with stripe"
+            );
+            return this.database.stripe_update_customer({
+              account_id: mesg.account_id,
+              stripe: get_stripe(),
+              customer_id,
+              cb
+            });
+          } else {
+            dbg("create stripe entry for this customer");
+            const x = {
+              description,
+              email,
+              metadata: {
+                account_id: mesg.account_id
+              }
+            };
+            return this.stripe.customers.create(x, (err, customer) => {
+              if (err) {
+                return cb(err);
+              } else {
+                customer_id = customer.id;
+                return cb();
+              }
+            });
+          }
+        },
+        cb => {
+          if (!new_customer) {
+            return cb();
+          } else {
+            dbg("store customer id in our database");
+            return this.database.set_stripe_customer_id({
+              account_id: mesg.account_id,
+              customer_id,
+              cb
+            });
+          }
+        },
+        cb => {
+          if (!(mesg.amount != null && mesg.description != null)) {
+            dbg("no amount or description -- not creating an invoice");
+            return cb();
+          } else {
+            dbg("now create the invoice item");
+            return this.stripe.invoiceItems.create(
+              {
+                customer: customer_id,
+                amount: mesg.amount * 100,
+                currency: "usd",
+                description: mesg.description
+              },
+              (err, invoice_item) => {
+                if (err) {
+                  return cb(err);
+                } else {
+                  return cb();
+                }
+              }
+            );
+          }
+        }
+      ],
+      err => {
+        if (err) {
+          return this.error_to_client({ id: mesg.id, error: err });
+        } else {
+          return this.success_to_client({ id: mesg.id });
+        }
+      }
+    );
+  }
+
+  mesg_api_key(mesg) {
+    return api_key_action({
+      database: this.database,
+      account_id: this.account_id,
+      password: mesg.password,
+      action: mesg.action,
+      cb: (err, api_key) => {
+        if (err) {
+          return this.error_to_client({ id: mesg.id, error: err });
+        } else {
+          if (api_key != null) {
+            return this.push_to_client(
+              message.api_key_info({ id: mesg.id, api_key })
+            );
+          } else {
+            return this.success_to_client({ id: mesg.id });
+          }
+        }
+      }
+    });
+  }
+
+  mesg_user_auth(mesg) {
+    return auth_token.get_user_auth_token({
+      database: this.database,
+      account_id: this.account_id, // strictly not necessary yet... but good if user has to be signed in,
+      // since more secure and we can rate limit attempts from a given user.
+      user_account_id: mesg.account_id,
+      password: mesg.password,
+      cb: (err, auth_token) => {
+        if (err) {
+          return this.error_to_client({ id: mesg.id, error: err });
+        } else {
+          return this.push_to_client(
+            message.user_auth_token({ id: mesg.id, auth_token })
+          );
+        }
+      }
+    });
+  }
+
+  mesg_revoke_auth_token(mesg) {
+    return auth_token.revoke_user_auth_token({
+      database: this.database,
+      auth_token: mesg.auth_token,
+      cb: err => {
+        if (err) {
+          return this.error_to_client({ id: mesg.id, error: err });
+        } else {
+          return this.push_to_client(message.success({ id: mesg.id }));
+        }
+      }
+    });
+  }
+
+  // Receive and store in memory the latest metrics status from the client.
+  mesg_metrics(mesg) {
+    const dbg = this.dbg("mesg_metrics");
+    dbg();
+    if (!(mesg != null ? mesg.metrics : undefined)) {
+      return;
+    }
+    const { metrics } = mesg;
+    //dbg('GOT: ', misc.to_json(metrics))
+    if (!misc.is_array(metrics)) {
+      // client is messing with us...?
+      return;
+    }
+    for (let metric of metrics) {
+      if (!misc.is_array(metric != null ? metric.values : undefined)) {
+        // what?
+        return;
+      }
+      if (metric.values.length === 0) {
+        return;
+      }
+      for (let v of metric.values) {
+        if (!misc.is_object(v != null ? v.labels : undefined)) {
+          // what?
+          return;
+        }
+      }
+      switch (metric.type) {
+        case "gauge":
+          metric.aggregator = "average";
+          break;
+        default:
+          metric.aggregator = "sum";
+      }
+    }
+
+    return (client_metrics[this.id] = metrics);
+  }
+  //dbg('RECORDED: ', misc.to_json(client_metrics[@id]))
+
+  mesg_get_available_upgrades(mesg) {
+    const dbg = this.dbg("mesg_get_available_upgrades");
+    const locals = {};
+    return async.series(
+      [
+        cb => {
+          dbg("get stripe customer data");
+          return this.stripe_get_customer(mesg.id, (err, stripe_customer) => {
+            locals.stripe_data = __guard__(
+              stripe_customer != null
+                ? stripe_customer.subscriptions
+                : undefined,
+              x => x.data
+            );
+            return cb(err);
+          });
+        },
+        cb => {
+          dbg("get user project upgrades");
+          return this.database.get_user_project_upgrades({
+            account_id: this.account_id,
+            cb: (err, projects) => {
+              locals.projects = projects;
+              return cb(err);
+            }
+          });
+        }
+      ],
+      err => {
+        if (err) {
+          return this.error_to_client({ id: mesg.id, error: err });
+        } else {
+          locals.x = compute_upgrades.available_upgrades(
+            locals.stripe_data,
+            locals.projects
+          );
+          locals.resp = message.available_upgrades({
+            id: mesg.id,
+            total: compute_upgrades.get_total_upgrades(locals.stripe_data),
+            excess: locals.x.excess,
+            available: locals.x.available
+          });
+          return this.push_to_client(locals.resp);
+        }
+      }
+    );
+  }
+
+  mesg_remove_all_upgrades(mesg) {
+    const dbg = this.dbg("mesg_remove_all_upgrades");
+    if (this.account_id == null) {
+      this.error_to_client({ id: mesg.id, error: "you must be signed in" });
+      return;
+    }
+    return this.database.remove_all_user_project_upgrades({
+      account_id: this.account_id,
+      projects: mesg.projects,
+      cb: err => {
+        if (err) {
+          return this.error_to_client({ id: mesg.id, error: err });
+        } else {
+          return this.push_to_client(message.success({ id: mesg.id }));
+        }
+      }
+    });
+  }
+}

--- a/src/smc-hub/stripe/client.ts
+++ b/src/smc-hub/stripe/client.ts
@@ -115,10 +115,12 @@ export class StripeClient {
     return await callback(f.bind(obj), ...args);
   }
 
-  private async get_customer(): Promise<StripeCustomer> {
+  private async get_customer(customer_id?: string): Promise<StripeCustomer> {
     const dbg = this.dbg("get_customer");
-    dbg("getting customer id");
-    const customer_id: string = await this.need_customer_id();
+    if (customer_id == null) {
+      dbg("getting customer id");
+      customer_id = await this.need_customer_id();
+    }
     dbg("now getting stripe customer object");
     return await this.call_stripe_api("customers", "retrieve", customer_id);
   }
@@ -154,7 +156,11 @@ export class StripeClient {
   public async mesg_get_customer(_mesg: Message): Promise<Message> {
     const dbg = this.dbg("mesg_get_customer");
     dbg("get information from stripe: subscriptions, payment methods, etc.");
-    const customer = await this.get_customer();
+    const customer_id = await this.get_customer_id();
+    let customer: undefined | StripeCustomer;
+    if (customer_id != null) {
+      customer = await this.get_customer(customer_id);
+    }
     return message.stripe_customer({
       stripe_publishable_key: this.stripe.publishable_key,
       customer

--- a/src/smc-webapp/account_page.cjsx
+++ b/src/smc-webapp/account_page.cjsx
@@ -160,7 +160,7 @@ exports.AccountPage = rclass
         if not require('./customize').commercial
             return null
         v = []
-        v.push <Tab key='billing' eventKey="billing" title={<span><Icon name='money'/> {'Subscriptions/Course Packages'}</span>}>
+        v.push <Tab key='billing' eventKey="billing" title={<span><Icon name='money'/> {'Subscriptions and Course Packages'}</span>}>
             {<BillingPageRedux /> if @props.active_page == 'billing'}
         </Tab>
         v.push <Tab key='upgrades' eventKey="upgrades" title={<span><Icon name='arrow-circle-up'/> Upgrades</span>}>

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1216,6 +1216,14 @@ exports.ExplainResources = ExplainResources = rclass
         <div>
             <Row>
                 <Col md={8} sm={12}>
+                    <h4>Questions</h4>
+                    <div style={fontSize:'12pt'}>
+                        Please immediately email us at <HelpEmailLink/>, click the Help button above, {" "}
+                        {if not @props.is_static then <span> or read our <a target='_blank' href="#{PolicyPricingPageUrl}#faq" rel="noopener">pricing FAQ</a> </span>}
+                        if anything is unclear to you, or you just have a quick question and do not want to wade through all the text below.
+                    </div>
+                    <Space/>
+
                     <a name="projects"></a>
                     <h4>Projects</h4>
                     <div>
@@ -1261,12 +1269,6 @@ exports.ExplainResources = ExplainResources = rclass
                     </div>
                     <Space/>
 
-                    <div style={fontWeight:"bold"}>
-                        Please immediately email us at <HelpEmailLink/> {" "}
-                        {if not @props.is_static then <span> or read our <a target='_blank' href="#{PolicyPricingPageUrl}#faq" rel="noopener">pricing FAQ</a> </span>}
-                        if anything is unclear to you.
-                    </div>
-                    <Space/>
                 </Col>
                 <Col md={4} sm={12}>
                     <Row>

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1131,6 +1131,7 @@ CouponInfo = rclass
         coupon : rtypes.object
 
     render: ->
+        console.log("coupon = ", @props.coupon)
         <Row>
             <Col md={4}>
                 {@props.coupon.id}
@@ -1982,10 +1983,10 @@ BillingPage = rclass
     render_help_suggestion: ->
         <span>
             <Space/> If you have any questions at all, email <HelpEmailLink /> immediately.
-            <i>
-                <Space/> Contact us if you are purchasing a course subscription, but need a short trial
+            <b>
+                <Space/> Contact us if you are purchasing a course subscription and need a short trial
                 to test things out first.<Space/>
-            </i>
+            </b>
         </span>
 
     render_suggested_next_step: ->
@@ -1998,10 +1999,9 @@ BillingPage = rclass
             if subs == 0
                 # no payment sources yet; no subscriptions either: a new user (probably)
                 <span>
-                    Click "Add Payment Method..." to add your credit card, then
-                    click "Add Subscription or Course Package..." and
-                    choose from either a monthly, yearly or semester-long plan.
-                    You will <b>not be charged</b> until you select a specific subscription then click
+                    If you are teaching a course, choose one of the course packages.
+                    If you need to upgrade your projects, choosing a recurring subscription.
+                    You will <b>not be charged</b> until you explicitly click
                     "Add Subscription or Course Package".
                     {help}
                 </span>
@@ -2019,9 +2019,8 @@ BillingPage = rclass
         else if subs == 0
             # have a payment source, but no subscriptions
             <span>
-                Click "Add Subscription or Course Package...", then
-                choose from either a monthly, yearly or semester-long plan (you may sign up for the
-                same subscription more than once to increase the number of upgrades).
+                Click "Add Subscription or Course Package...".   If you are teaching a course, choose one of the course packages.
+                    If you need to upgrade your projects, choosing a recurring subscription.
                 You will be charged only after you select a specific subscription and click
                 "Add Subscription or Course Package".
                 {help}

--- a/src/smc-webapp/r_upgrades.cjsx
+++ b/src/smc-webapp/r_upgrades.cjsx
@@ -33,7 +33,8 @@ exports.UpgradesPage = rclass
     render_no_upgrades: ->
         {SubscriptionGrid, ExplainResources, ExplainPlan, FAQ} = require('./billing')
         <div>
-            <h3>Sign up for a subscription in the billing tab</h3>
+            <h3>Sign up</h3>
+            To sign up for a subscription, visit the "Subscriptions and Course Packages tab".
 
             <ExplainResources type='shared'/>
 


### PR DESCRIPTION
Some initial testing suggests this works.  I need to test it more carefully from scratch with a new user,  **test coupons**, test the api, and test various edge cases.  This code is motivated by https://github.com/sagemathinc/cocalc/pull/3917 -- namely how hearing about and seeing this old code I wrote disgusted me (!).   Also, this rewrite probably fixes many subtle bugs that we might not have noticed, since it's just far easier to write async/await typescript code that is correct, than long callback-hell chains in scope-hell coffeescript.