### PR TITLE
files listing: split flex divs to avoid #3904

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -60,6 +60,7 @@ ROW_INFO_STYLE = Object.freeze
     height     : '22px'
     margin     : '5px 3px'
 
+
 {FileListing, TERM_MODE_CHAR} = require("./project/file-listing")
 
 feature = require('./feature')
@@ -1819,46 +1820,58 @@ exports.ProjectFiles = rclass ({name}) ->
             {start_index, end_index} = pager_range(file_listing_page_size, @props.page_number)
             visible_listing = listing[start_index...end_index]
 
-        flex_row_style =
+        FLEX_ROW_STYLE =
             display: 'flex'
             flexFlow: 'row wrap'
             justifyContent: 'space-between'
             alignItems: 'stretch'
 
-        <div style={display: "flex", flexDirection: "column", padding:'5px', height: '100%'}>
-            {if pay? then @render_course_payment_warning(pay)}
-            {@render_error()}
-            {@render_activity()}
-            {@render_control_row(public_view, visible_listing)}
-            {<AskNewFilename
-                actions            = {@props.actions}
-                current_path       = {@props.current_path}
-                ext_selection      = {@props.ext_selection}
-                new_filename       = {@props.new_filename}
-                other_settings     = {@props.other_settings}
-            /> if @props.ext_selection}
-            {@render_new()}
 
-            <div style={flex_row_style}>
-                <div style={flex: '1 0 auto', marginRight: '10px', minWidth: '20em'}>
-                    {@render_files_actions(listing, public_view, project_is_running) if listing?}
+        # be careful with adding height:'100%'. it could cause flex to miscalc. see #3904
+        <div
+            style={flex: "1", display: "flex", flexDirection: "column", height: "100%"}
+        >
+            <div
+                style={flex: "0", display: "flex", flexDirection: "column", padding:'5px 5px 0 5px'}
+            >
+                {if pay? then @render_course_payment_warning(pay)}
+                {@render_error()}
+                {@render_activity()}
+                {@render_control_row(public_view, visible_listing)}
+                {<AskNewFilename
+                    actions            = {@props.actions}
+                    current_path       = {@props.current_path}
+                    ext_selection      = {@props.ext_selection}
+                    new_filename       = {@props.new_filename}
+                    other_settings     = {@props.other_settings}
+                /> if @props.ext_selection}
+                {@render_new()}
+
+                <div style={FLEX_ROW_STYLE}>
+                    <div style={flex: '1 0 auto', marginRight: '10px', minWidth: '20em'}>
+                        {@render_files_actions(listing, public_view, project_is_running) if listing?}
+                    </div>
+                    {@render_project_files_buttons(public_view)}
                 </div>
-                {@render_project_files_buttons(public_view)}
+
+                {@render_custom_software_reset() if project_is_running}
+
+                {@render_library() if @props.show_library}
+
+                {if @props.checked_files.size > 0 and @props.file_action?
+                    <Row>
+                        {@render_files_action_box(file_map, public_view)}
+                    </Row>
+                }
             </div>
+            <div
+                style={flex: "1", display: "flex", flexDirection: "column", padding:'0 5px 5px 5px'}
+            >
 
-            {@render_custom_software_reset() if project_is_running}
-
-            {@render_library() if @props.show_library}
-
-            {if @props.checked_files.size > 0 and @props.file_action?
-                <Row>
-                    {@render_files_action_box(file_map, public_view)}
-                </Row>
-            }
-
-            {### Only show the access error if there is not another error. ###}
-            {@render_access_error() if public_view and not error}
-            {@render_file_listing(visible_listing, file_map, error, project_state, public_view)}
-            {@render_paging_buttons(Math.ceil(listing.length / file_listing_page_size)) if listing?}
+                {### Only show the access error if there is not another error. ###}
+                {@render_access_error() if public_view and not error}
+                {@render_file_listing(visible_listing, file_map, error, project_state, public_view)}
+                {@render_paging_buttons(Math.ceil(listing.length / file_listing_page_size)) if listing?}
+            </div>
         </div>
 


### PR DESCRIPTION
# Description
this is a way how #3904 is fixed for me, tested in chrome and firefox. from trial/error I discovered, that the 100% height style in conjunction with the vertical flex directives are causing the problem. my idea is to split this up into two divs, where the bottom one expands and holds the files.

I marked this as careful, because if this fix works for me it doesn't mean I'm breaking it for others.

# Testing Steps
I tested this for chrome 76.0.3809.36 and Firefox  67.0.3 
1. +new button shows the dialog
1. library shows up
1. uploading a file creates that area showing the upload process
1. file listing shows up, and if there are more files than your page limit, you have these buttons at the bottom

# Screenshots

## Before

![Screenshot from 2019-07-05 16-14-13](https://user-images.githubusercontent.com/207405/60728202-0f01a480-9f40-11e9-8621-c151c8af29c4.png)

## With this patch

![Screenshot from 2019-07-05 16-14-32](https://user-images.githubusercontent.com/207405/60728219-15901c00-9f40-11e9-8bbd-aca31479d4c3.png)

## With this patch, default view (as a reference)

![Screenshot from 2019-07-05 16-14-50](https://user-images.githubusercontent.com/207405/60728238-1de85700-9f40-11e9-96be-4ff6f3dc3328.png)


### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
