### PR TITLE
sagews pytest 2019 07

### DIFF
--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -641,6 +641,14 @@ def execblob(request, sagews, test_id):
                    want_javascript=False,
                    file_type='png',
                    ignore_stdout=False):
+        r"""
+        fixture when test generates an image
+
+        INPUT:
+
+        - ``file_type`` -- string or list of strings, e.g. ["svg", "png"]
+
+        """
 
         SHA_LEN = 36
 
@@ -681,7 +689,14 @@ def execblob(request, sagews, test_id):
                     want_name = False
                     assert 'file' in mesg
                     print('got file name')
-                    assert file_type in mesg['file']['filename']
+                    if isinstance(file_type, str):
+                        assert file_type in mesg['file']['filename']
+                    elif isinstance(file_type, list):
+                        assert any([(f0 in mesg['file']['filename']) for f0 in file_type]), \
+                            "missing one of file types {} in response from sage_server".format(file_type)
+                    else:
+                        assert 0
+
 
         # final response is json "done" message
         typ, mesg = sagews.recv()

--- a/src/smc_sagews/smc_sagews/tests/test_graphics.py
+++ b/src/smc_sagews/smc_sagews/tests/test_graphics.py
@@ -67,7 +67,7 @@ class TestOctavePlot:
 
 class TestRPlot:
     def test_r_smallplot(self, execblob):
-        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type='svg')
+        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type=['svg','png'])
 
     def test_r_bigplot(self, execblob):
         "lots of points, do not overrun blob size limit"
@@ -76,7 +76,7 @@ N <- 100000
 xx <- rnorm(N, 5) + 3
 yy <- rnorm(N, 3) - 1
 plot(xx, yy, cex=.1)"""
-        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type='svg')
+        execblob("%r\nwith(mtcars,plot(wt,mpg))", file_type=['svg','png'])
 
 
 class TestShowGraphs:

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -34,7 +34,7 @@ class TestLex:
 class TestSageVersion:
     def test_sage_vsn(self, exec2):
         code = "sage.misc.banner.banner()"
-        patn = "version 8.[67]"
+        patn = "version 8.[6-8]"
         exec2(code, pattern=patn)
 
 


### PR DESCRIPTION
# Description

Update to sagews pytest suite for sage-8.8. Also extends graphics tests to allow multiple image file types.

No changes to production code. Tested with sage-8.6, 8.7, 8.8.

# Testing Steps
1. check out this patch
1. run this code
    ```
    cd cocalc/src/smc_sagews/smc_sagews/tests
    python -m pytest -x
      ==>
    === 178 passed, 10 skipped in 297.92 seconds ===
    ```

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
