### PR TITLE
announce options for custom plans

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1390,6 +1390,19 @@ exports.ExplainPlan = ExplainPlan = rclass
                 However, we find that many data science and computational science courses
                 run much smoother with the additional RAM and CPU found in the standard plan.
 
+                <h4>Custom Course Plans</h4>
+                In addition to the plans listed on this page, we can offer the following on a custom basis:
+                    <ul>
+                        <li>start on a specified date after payment</li>
+                        <li>customized duration</li>
+                        <li>customized number of students</li>
+                        <li>bundle several courses with different start dates</li>
+                        <li>transfer upgrades from purchasing account to course administrator account</li>
+                    </ul>
+                To learn more about these options, email us at <HelpEmailLink/> with a description
+                of your specific requirements.
+                <br/>
+
                 <br/>
 
             </div>


### PR DESCRIPTION
# Description

Add a section under **Basic or Standard?** on pricing page inviting customers to email with custom requirements.

No changes outside of html in the pricing page.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
