### PR TITLE
static/landing: lazy loading all those images

### DIFF
--- a/src/webapp-lib/_base.pug
+++ b/src/webapp-lib/_base.pug
@@ -115,6 +115,8 @@ html.no-js(lang="en")
     style
       :sass
         @import "smc-webapp/_colors.sass"
+        img[data-src]
+          min-height: 50px
         nav.navbar.navbar-default
           border-bottom    : 2px solid $COL_GRAY
           background-color : $COL_GRAY_LL

--- a/src/webapp-lib/_inc_head.pug
+++ b/src/webapp-lib/_inc_head.pug
@@ -30,3 +30,5 @@ link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/mocha/5.2.0/
 
 link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css", integrity="sha256-BtbhCIbtfeVWGsqxk1vOHEYXS6qcvQvLMZqjtpWUEx8=", crossorigin="anonymous")
 // link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/fontawesome.min.css", integrity="sha256-H9ochMml3Lh6FE/KKTUFfw2hD7mxc9c8pXoqfIso5Zk=", crossorigin="anonymous")
+
+script(src="https://cdnjs.cloudflare.com/ajax/libs/lozad.js/1.9.0/lozad.min.js" integrity="sha256-50cmb3K6Zka/WMfXLFzqyo5+P+ue2JdsyEmSEsU58s4=" crossorigin="anonymous")

--- a/src/webapp-lib/doc/_terminal.pug
+++ b/src/webapp-lib/doc/_terminal.pug
@@ -38,7 +38,7 @@ mixin linux-software
         h2 Comprehensive software stack
       div.col-sm-6
         div
-          img(src="https://storage.googleapis.com/cocalc-extra/terminal-software.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/terminal-software.png").fit
       div.col-sm-6
         p.
           A lot of #[strong popular applications] are included.
@@ -72,7 +72,7 @@ mixin terminal-real-time
         h2 Real-time collaboration
       div.col-sm-6
         div
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-terminal-collab.gif").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-terminal-collab.gif").fit
         div.center.
           Synchronized Terminals
       div.col-sm-6
@@ -95,7 +95,7 @@ mixin linux-snapshot-backups
         h2 Snapshot backups
       div.col-sm-6
         div
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-snapshots.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-snapshots.png").fit
         div.center.
           List of Snapshots
       div.col-sm-6

--- a/src/webapp-lib/doc/jupyter-notebook.pug
+++ b/src/webapp-lib/doc/jupyter-notebook.pug
@@ -35,7 +35,7 @@ block content
   div.container
     div.row
       div.col-sm-6
-        img(src=require("webapp-lib/assets/cocalc-jupyter2-20170508.png")).fit
+        img(data-src=require("webapp-lib/assets/cocalc-jupyter2-20170508.png")).fit
       div.col-sm-6
         p.
           #{NAME} is an online web service where you can
@@ -83,7 +83,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-users] Collaborative editing
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-real-time-jupyter.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-real-time-jupyter.png")).fit
         div.col-md-6
           div.
             You can share your Jupyter notebooks privately with project collaborators.
@@ -128,7 +128,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-fw.cc-icon-jupyter] Native Jupyter Notebooks
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-jupyter2-20170508.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-jupyter2-20170508.png")).fit
         div.col-md-6
           div.
             #{NAME} offers a #[strong complete rewrite] of the classical #[a(href="http://jupyter.org/") Jupyter notebook] interface.
@@ -149,7 +149,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-comments-o] Chat panel
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-chat-jupyter-20171120-2.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-chat-jupyter-20171120-2.png")).fit
         div.col-md-6
           div.
             A #[strong #[a(href="https://doc.cocalc.com/chat.html") side-by-side chat]] for each Jupyter file
@@ -165,7 +165,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-heartbeat] Managed kernels
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-jupyter-kernels.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-jupyter-kernels.png")).fit
         div.col-md-6
           div.
             #{NAME} makes sure that your desired computational environment is available and ready to work with.
@@ -179,7 +179,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-thermometer-full] CPU and memory monitoring
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-jupyter2-memory-cpu.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-jupyter2-memory-cpu.png")).fit
         div.col-md-6
           div.
             Long running notebook sessions or intense computations might deplete available CPU or memory resources.
@@ -193,7 +193,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-camera-retro] Backups
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
         div.col-md-6
           div.
             Every couple of minutes, #[strong all files in your project are saved in consistent read-only snapshots].
@@ -207,7 +207,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-camera-retro] Publishing
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-jupyter-share-20171218.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-jupyter-share-20171218.png")).fit
         div.col-md-6
           div.
             #{NAME} helps you #[strong sharing your work with the world].

--- a/src/webapp-lib/doc/latex-editor.pug
+++ b/src/webapp-lib/doc/latex-editor.pug
@@ -32,7 +32,7 @@ block content
       div.col-md-12.center
         h1 #{subtitle}
       div.col-sm-6
-        img(src="https://storage.googleapis.com/cocalc-extra/cocalc-latex-editor-2019.png").fit
+        img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-latex-editor-2019.png").fit
       div.col-sm-6
         p.
           Collaboratively #[strong edit #[a(href="https://www.latex-project.org/") LaTeX documents] right inside your browser],
@@ -68,7 +68,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-heartbeat] Managed LaTeX environments
         div.col-md-6
-          img(src=require("webapp-lib/assets/latex-custom-command-02.png")).fit
+          img(data-src=require("webapp-lib/assets/latex-custom-command-02.png")).fit
         div.col-md-6
           div.
             #{NAME} makes sure that your desired LaTeX engine is available and ready to use.
@@ -89,7 +89,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-users] Collaborative editing without limits
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-latex-concurrent-editing.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-latex-concurrent-editing.png")).fit
         div.col-md-6
           div.
             Privately share your project with #[strong any number of collaborators].
@@ -108,7 +108,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-laptop] Full computational environment
         div.col-md-6
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-latex-editor-2019.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-latex-editor-2019.png").fit
         div.col-md-6
           div.
             What sets #{NAME} apart from other online LaTeX editors is #[strong full access to computational software].
@@ -137,7 +137,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-heartbeat] SageTeX
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-sagetex.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-sagetex.png")).fit
         div.col-md-6
           div
             strong.
@@ -162,7 +162,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-heartbeat] PythonTeX
           div.col-md-6
-            img(src=require("webapp-lib/assets/cocalc-pythontex.png")).fit
+            img(data-src=require("webapp-lib/assets/cocalc-pythontex.png")).fit
           div
             strong.
               #[a(href="https://ctan.org/pkg/pythontex") PythonTeX] allows you to
@@ -180,7 +180,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-heartbeat] R/Knitr
         div.col-md-6
-          img(src=require("webapp-lib/assets/latex-editor-rnw-01.png")).fit
+          img(data-src=require("webapp-lib/assets/latex-editor-rnw-01.png")).fit
         div.col-md-6
           div.
             #{NAME}'s Latex editor also supports #[strong #[a(href="https://yihui.name/knitr/") Knitr .Rnw]] documents.
@@ -228,7 +228,7 @@ block content
           h2 #[i.fa.fa-history] Time-Travel
         div.col-md-6
           div
-            img(src=require("webapp-lib/assets/latex-editor-timetravel-01.png")).fit
+            img(data-src=require("webapp-lib/assets/latex-editor-timetravel-01.png")).fit
         div.col-md-6
           div.
             The #[strong #[a(href="https://doc.cocalc.com/time-travel.html") Time-travel feature]] is specific to the #{NAME} platform.
@@ -244,7 +244,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-comment] Side-Chat panel
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-latex-side-chat-v2.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-latex-side-chat-v2.png")).fit
         div.col-md-6
           div.
             A #[strong #[a(href="https://doc.cocalc.com/chat.html") side-by-side chat]] for each LaTeX file
@@ -261,7 +261,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-camera-retro] Backups
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
         div.col-md-6
           div.
             Every couple of minutes, #[strong all files in your project are saved in consistent read-only snapshots].
@@ -275,7 +275,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-bullhorn] Publishing
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-share-latex-document.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-share-latex-document.png")).fit
         div.col-md-6
           div.
             #{NAME} helps you #[strong sharing your work with the world].

--- a/src/webapp-lib/doc/linux.pug
+++ b/src/webapp-lib/doc/linux.pug
@@ -52,7 +52,7 @@ block content
         h2 Run Bash scripts
       div.col-sm-6
         div
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-shell-script-run.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-shell-script-run.png").fit
         div.center.
           Bash #[code script.sh] file (left), #[code bash -f script.sh] to run (right)
       div.col-sm-6
@@ -76,7 +76,7 @@ block content
         h2 Jupyter Bash kernel
       div.col-sm-6
         div
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-jupyter-bash.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-jupyter-bash.png").fit
         div.center.
           Jupyter Notebook running a bash kernel
       div.col-sm-6
@@ -98,7 +98,7 @@ block content
         h2 Databases (PostgreSQL, MySQL, SQLite, ...)
       div.col-sm-6
         div
-          img(src="https://storage.googleapis.com/cocalc-extra/terminal-jupyter-postgresql.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/terminal-jupyter-postgresql.png").fit
         div.center.
           Jupyter Notebook interacting with a hosted PostgreSQL database
       div.col-sm-6

--- a/src/webapp-lib/doc/python.pug
+++ b/src/webapp-lib/doc/python.pug
@@ -37,7 +37,7 @@ block content
     div.row
       div.col-sm-6
         div
-          img(src="https://storage.googleapis.com/cocalc-extra/frame-editor-python.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/frame-editor-python.png").fit
         div.center.
           Edit and Run Python Code Online
       div.col-sm-6
@@ -82,7 +82,7 @@ block content
         h2 Collaborative Workspace
       div.col-sm-6
         div
-          img(src=require("webapp-lib/assets/cocalc-real-time-jupyter.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-real-time-jupyter.png")).fit
         div.center.
           Synchronized Jupyter Notebooks
       div.col-sm-6

--- a/src/webapp-lib/doc/r-statistical-software.pug
+++ b/src/webapp-lib/doc/r-statistical-software.pug
@@ -79,7 +79,7 @@ block content
         div.col-md-12
           h2 R in Jupyter Notebooks
         div.col-md-6
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-r-jupyter.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-r-jupyter.png").fit
         div.col-md-6
           div.
             #{NAME} offers a
@@ -101,7 +101,7 @@ block content
         div.col-md-12
           h2 Extensive LaTeX support for R
         div.col-md-6
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-r-latex.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-r-latex.png").fit
         div.col-md-6
           div.
             The fully integrated #[a(href="./latex-editor.html") #{NAME} latex editor]
@@ -146,7 +146,7 @@ block content
         div.col-md-12
           h2 RMarkdown support
         div.col-md-6
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-rmd-demo-R-python3-plotting.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-rmd-demo-R-python3-plotting.png").fit
         div.col-md-6
           div
             strong.
@@ -191,7 +191,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-users] Collaborative editing
         div.col-md-6
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-r-jupyter-collaborate.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-r-jupyter-collaborate.png").fit
         div.col-md-6
           div.
             You can share your files on #{NAME} with project collaborators.
@@ -210,7 +210,7 @@ block content
         div.col-md-12
           h2 Command-line support
         div.col-md-6
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-rcode.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-rcode.png").fit
         div.col-md-6
           div.
             All your existing R scripts run on the command line.
@@ -294,7 +294,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-camera-retro] Backups
         div.col-md-6
-          img(src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
+          img(data-src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
         div.col-md-6
           div.
             Every couple of minutes, #[strong all files in your project are saved in consistent read-only snapshots].
@@ -308,7 +308,7 @@ block content
         div.col-md-12
           h2 #[i.fa.fa-bullhorn] Publishing
         div.col-md-6
-          img(src="https://storage.googleapis.com/cocalc-extra/cocalc-r-share-notebook.png").fit
+          img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-r-share-notebook.png").fit
         div.col-md-6
           div.
             #{NAME} helps you #[strong share your work with the world].

--- a/src/webapp-lib/doc/teaching.pug
+++ b/src/webapp-lib/doc/teaching.pug
@@ -28,7 +28,7 @@ block content
         h1 #{subtitle}
         h3 A virtual online computer lab
       div.col-sm-6
-        img(src="https://storage.googleapis.com/cocalc-extra/cocalc-course-assignments-2019.png").fit
+        img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-course-assignments-2019.png").fit
       div.col-sm-6
         p.
           #[strong #{NAME} moves an entire computer lab into the cloud].
@@ -58,7 +58,7 @@ block content
           h1 Teaching a course online
         div.col-sm-6
           div
-            img(src="https://storage.googleapis.com/cocalc-extra/cocalc-teaching.svg.png").fit
+            img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-teaching.svg.png").fit
         div.col-sm-6
           p.
             Have you experienced the pain of setting up the software environments for your students?
@@ -104,7 +104,7 @@ block content
         div.row
           div.col-sm-4.col-sm-offset-4.center
             a(href="./jupyter-notebook.html")
-              img(src=require("webapp-lib/assets/jupyter-logo.svg")).fit
+              img(data-src=require("webapp-lib/assets/jupyter-logo.svg")).fit
         h3.center.
           #[a(href="./jupyter-notebook.html") Jupyter Notebooks]
         p.
@@ -118,7 +118,7 @@ block content
         div.row
           div.col-sm-4.col-sm-offset-4.center
             a(href="https://doc.cocalc.com/sagews.html")
-              img(src="http://www.sagemath.org/pix/sage-sticker-1x1_inch-small.png").fit
+              img(data-src="http://www.sagemath.org/pix/sage-sticker-1x1_inch-small.png").fit
         h3.center.
           #[a(href="https://doc.cocalc.com/sagews.html") Sage Worksheets]
         p.
@@ -130,7 +130,7 @@ block content
         div.row
           div.col-sm-6.col-sm-offset-3.center
             a(href="./latex-editor.html")
-              img(src=require("webapp-lib/assets/latex-logo.svg") style="padding: 10px 0").fit
+              img(data-src=require("webapp-lib/assets/latex-logo.svg") style="padding: 10px 0").fit
         h3.center.
           #[a(href="./latex-editor.html") LaTeX Documents]
         p.
@@ -143,7 +143,7 @@ block content
         div.row
           div.col-sm-4.col-sm-offset-4.center
             a(href="./terminal.html")
-              img(src=require("webapp-lib/assets/linux-logo.svg")).fit
+              img(data-src=require("webapp-lib/assets/linux-logo.svg")).fit
         h3.center.
           #[a(href="./terminal.html") Full Linux Terminal]
         p.

--- a/src/webapp-lib/index.coffee
+++ b/src/webapp-lib/index.coffee
@@ -127,7 +127,13 @@ init_magic_anchors = ->
             marker.appendChild(document.createTextNode('¶'))
             header.appendChild(marker)
 
+init_lozad = ->
+    imgs = document.querySelectorAll('img[data-src]')
+    observer = window.lozad(imgs)
+    observer.observe()
+
 document.addEventListener "DOMContentLoaded", ->
+    init_lozad()
     if document.getElementById('statstable')?
         get_stats()
     init_video()

--- a/src/webapp-lib/index.pug
+++ b/src/webapp-lib/index.pug
@@ -254,7 +254,7 @@ block content
             #[a(href="https://doc.cocalc.com/jupyter.html") Native Jupyter documentation]
           br/
           div
-            img(src=require("webapp-lib/assets/cocalc-jupyter2-20170508.png")).fit
+            img(data-src=require("webapp-lib/assets/cocalc-jupyter2-20170508.png")).fit
         div.col-md-6
           h2 #[i.fa.fa-comment] Chat rooms
           div.
@@ -266,7 +266,7 @@ block content
             #[a(href="https://doc.cocalc.com/chat.html") Chat documentation]
           br/
           div
-            img(src=require("webapp-lib/assets/smc-side-chat-20170508.png")).fit
+            img(data-src=require("webapp-lib/assets/smc-side-chat-20170508.png")).fit
       div.row
         div.col-md-6
           h2 #[i.fa.fa-history] Time-Travel
@@ -290,7 +290,7 @@ block content
             #[a(href="https://doc.cocalc.com/project-files.html#snapshot-backups") Snapshot backup documentation]
           br/
           div
-            img(src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
+            img(data-src=require("webapp-lib/assets/cocalc-backup-1.png")).fit
 
   a.anchor#a-authoring
   div.space#authoring
@@ -310,7 +310,7 @@ block content
             #[a(href="./doc/latex-editor.html#a-sagetex") SageTeX, PythonTeX and R's Knitr].
           br/
           div
-            img(src="https://storage.googleapis.com/cocalc-extra/cocalc-latex-editor-2019.png").fit
+            img(data-src="https://storage.googleapis.com/cocalc-extra/cocalc-latex-editor-2019.png").fit
         div.col-md-6
           h2 Markdown/HTML/Rmd
           div.
@@ -325,7 +325,7 @@ block content
             #[a(href="https://www.python.org/") Python] calculations and plots.
           br/
           div
-            img(src="https://storage.googleapis.com/cocalc-extra/smc-mdhtml-20170516.png").fit
+            img(data-src="https://storage.googleapis.com/cocalc-extra/smc-mdhtml-20170516.png").fit
 
   a.anchor#a-bottom
   div.space#bottom


### PR DESCRIPTION
# Description
This should speed up the page load time.

# Testing Steps
1. scrolling down on all landing pages and the images show up

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
