### PR TITLE
restore invitation to free trial

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -2070,6 +2070,10 @@ BillingPage = rclass
         <span>
             <Space/> If you have any questions at all, email <HelpEmailLink /> immediately.
             <b>
+                <Space/> Contact us if you are purchasing a course subscription and need a short trial
+                to test things out first.<Space/>
+            </b>
+            <b>
                 <Space/> Customized course plans are available.<Space/>
             </b>
             If you do not see a plan that fits your needs,


### PR DESCRIPTION
# Description

Restore wording at top of Account > Subscriptions... page inviting free trial. No other changes.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
