### PR TITLE
sagews a5 a2019

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -65,8 +65,8 @@ class JUPYTER(object):
         in a cell, click the "restart" button, and you have an anaconda worksheet.
 
             | %auto
-            | anaconda3 = jupyter('anaconda3')
-            | %default_mode anaconda3
+            | anaconda5 = jupyter('anaconda5')
+            | %default_mode anaconda5
 
         Each call to jupyter creates its own Jupyter kernel. So you can have more than
         one instance of the same kernel type in the same worksheet session.
@@ -301,8 +301,7 @@ def _jkmagic(kernel_name, **kwargs):
                 # but if code calls python3 input(), wait for message on stdin channel
                 if 'code' in content:
                     ccode = content['code']
-                    if kernel_name in ['python3', 'anaconda3',
-                                       'octave'] and re.match(
+                    if kernel_name.startswith(('python', 'anaconda', 'octave')) and re.match(
                                            '^[^#]*\W?input\(', ccode):
                         # FIXME input() will be ignored if it's aliased to another name
                         p('iopub input call: ', ccode)

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -17,10 +17,6 @@ class TestLatexMode:
 
 
 class TestP3Mode:
-    """
-    not the same as python3 mode, which is an alias for anaconda3
-    """
-
     def test_p3a(self, exec2):
         exec2("p3 = jupyter('python3')")
 
@@ -90,7 +86,7 @@ class TestScala211Mode:
             "%scala211\nutil.Properties.versionString", html_pattern="2.11.11")
 
 
-class TestAnacondaMode:
+class TestAnaconda5:
     def test_anaconda_version(self, exec2):
         exec2(
             "%anaconda\nimport sys\nprint(sys.version)",
@@ -98,7 +94,6 @@ class TestAnacondaMode:
 
     def test_anaconda_kernel_name(self, exec2):
         exec2("anaconda.jupyter_kernel.kernel_name", "anaconda5")
-
 
 class TestPython3Mode:
     def test_p3_max(self, exec2):
@@ -315,15 +310,15 @@ class TestOctaveDefaultMode:
         exec2("version()", pattern="4.2.2")
 
 
-class TestAnaconda3Mode:
-    def test_start_a3(self, exec2):
-        exec2('a3 = jupyter("anaconda3")')
+class TestAnaconda2019Mode:
+    def test_start_a2019(self, exec2):
+        exec2('a2019 = jupyter("anaconda2019")')
 
     def test_issue_862(self, exec2):
-        exec2('%a3\nx=1\nprint("x = %s" % x)\nx', 'x = 1\n')
+        exec2('%a2019\nx=1\nprint("x = %s" % x)\nx', 'x = 1\n')
 
-    def test_a3_error(self, exec2):
-        exec2('%a3\nxyz*', html_pattern='span style.*color')
+    def test_a2019_error(self, exec2):
+        exec2('%a2019\nxyz*', html_pattern='span style.*color')
 
 
 class TestAnaconda5Mode:


### PR DESCRIPTION
# Description

1. Drop anaconda3 from sagews and its pytests. 
1. Update jupyter bridge code to handle any kernel name starting with 'anaconda'.
1. Update pytest to test for anaconda5 and anaconda2019.

# Testing Steps
1. Compute image must support anaconda2019. Just now, I tested with `experimental`.
1. Load the patch for this PR.
1. Run tests:
    ```
    cd ~/cocalc/src/smc_sagews/smc_sagews/tests
    python -m pytest
      ==>
    == 178 passed, 10 skipped in 373.82 seconds ==
    ```

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
