### PR TITLE
SendGrid invite group ID uses variable instead of hardcode

### DIFF
--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -39,6 +39,8 @@ underscore = require('underscore')
 {project_has_network_access} = require('./postgres/project-queries')
 {is_paying_customer} = require('./postgres/account-queries')
 
+{SENDGRID_ASM_INVITES} = require('smc-util/theme')
+
 DEBUG2 = !!process.env.SMC_DEBUG2
 
 REQUIRE_ACCOUNT_TO_EXECUTE_CODE = false
@@ -1334,7 +1336,7 @@ class exports.Client extends EventEmitter
                     if not mesg.title?
                         subject = "Invitation to CoCalc for collaborating on a project"
 
-                    # asm_group: 699 is for invites https://app.sendgrid.com/suppressions/advanced_suppression_manager
+                    # asm_group for invites stored in theme.js https://app.sendgrid.com/suppressions/advanced_suppression_manager
                     opts =
                         to           : locals.email_address
                         bcc          : 'invites@cocalc.com'
@@ -1344,7 +1346,7 @@ class exports.Client extends EventEmitter
                         replyto_name : mesg.replyto_name
                         subject      : subject
                         category     : "invite"
-                        asm_group    : 699
+                        asm_group    : SENDGRID_ASM_INVITES
                         body         : email_body
                         cb           : (err) =>
                             if err
@@ -1476,7 +1478,7 @@ class exports.Client extends EventEmitter
                                 base_url = 'https://cocalc.com/'
                                 direct_link = ''
 
-                            # asm_group: 699 is for invites https://app.sendgrid.com/suppressions/advanced_suppression_manager
+                            # asm_group for invites is stored in theme.js https://app.sendgrid.com/suppressions/advanced_suppression_manager
                             opts =
                                 to           : email_address
                                 bcc          : 'invites@cocalc.com'
@@ -1486,7 +1488,7 @@ class exports.Client extends EventEmitter
                                 replyto_name : mesg.replyto_name
                                 subject      : subject
                                 category     : "invite"
-                                asm_group    : 699
+                                asm_group    : SENDGRID_ASM_INVITES
                                 body         : email + """<br/><br/>
                                                <b>To accept the invitation, please sign up at
                                                <a href='#{base_url}'>#{base_url}</a>


### PR DESCRIPTION
# Description
SendGrid unsubscribe group ID for invites is now set in theme.js 

A variable representing the INVITE group ID had already been defined (as 699) in `theme.js`, but didn't seem to be used anywhere -- unlike the variable for the NEWSLETTER group ID, which is being used in `smc-hub/email`

With the `SENDGRID_ASM_INVITE` variable appearing in `smc-util/theme.js`, it gives the false impression that the INVITE group ID would be updated by changing this parameter. After all, that is also where one sets the SendGrid template ID and NEWSLETTER group ID. 

# Confirm Unintended Behavior
1. Create a _new_ SendGrid template (**legacy**, not one of the "new" dynamic ones) and note its ID
1. Create _new_ SendGrid unsubscribe groups for "Invites" and "Newsletters" (names actually unimportant) and note their IDs
1. Copy the new group IDs and the new template ID over to `smc-util/theme.js` (SENDGRID_ASM_INVITE, SENDGRID_ASM_NEWSLETTER, and SENDGRID_TEMPLATE_ID respectively)
1. Confirm that emails are functioning with the new settings by: `require('email').send_email(subject:'TEST MESSAGE', body:'body', to:'your.email@here.com', cb:console.log)`
1. Sign into CoCalc, attempt to invite brand new user (one who hasn't been invited within the past 7 weeks - if necessary, reset project invites in psql with `UPDATE projects SET invite = NULL WHERE project_id = '<Your Project ID>';`
1. assume invitation email reports as sent by CoCalc, but never delivered: check SendGrid recent activity (**filter category:** "invite" because neither email address nor subject will appear in SendGrid interface)
1. Find SendGrid "Not Delivered" invite with More Details -> Unsubscribe Group: 699 (despite our setting the INVITE ASM group ID to the new ID) and a "Dropped" error message from SendGrid that elaborates: _"This email was not sent because the SMTPAPI header was invalid."_

# Testing Steps (Post-PR)
1. Make sure the SENDGRID variables in `theme.js` are set to their _new_ values
1. Reset project whose invitation failed in pre-PR and re-attempt the invitation in CoCalc using the same project and email address from Pre-PR (not necessary, but über-scientific)
1. Confirm that the invitation email was received (or look on SendGrid if you don't have access to the invited email address).

# Relevant Issues

**Caveat:** I spent several hours tracking down this issue on my Docker installation of CoCalc, and I was able to confirm that the CoCalc Docker image is fixed by these changes. 

**Suggestion:** I am not well-versed in the creation of docker containers, but it seems like it might be rather straightforward to add these relevant SENDGRID variables to the list of Environment variables in Docker. Essentially, this PR makes it possible to use SendGrid with the cocalc-docker container, but expanding the environment variables would mean that docker users could more easily configure their SendGrid email from the initial installation.

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [X] No debugging console.log messages.
- [X] All new code is actually used.
- [X] Non-obvious code has some sort of comments. 

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.