### PR TITLE
doc index entry for api user_auth

### DIFF
--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -2786,6 +2786,7 @@ API(
       }
     },
     desc: `\
+.. index:: pair: Token; Authentication
 Example:
 
 Obtain a temporary authentication token for an account, which


### PR DESCRIPTION
# Description

Add an index entry for sphinx docs to message.js. This is a test with one change before adding others.
- only change is inside a string parameter
- cc-in-cc builds & runs ok (projects start, ipynb widgets run)
- test build of docs shows the two new index entries

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
