### PR TITLE
hub/stripe: propagate email changes from our DB to stripe 

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -828,10 +828,14 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     query : "SELECT email_address, first_name, last_name FROM accounts"
                     where : "account_id = $::UUID" : opts.account_id
                     cb    : one_result (err, x) ->
-                        locals.email_address = x.email_address
-                        locals.first_name = x.first_name ? ''
-                        locals.last_name  = x.last_name  ? ''
-                        cb(err)
+                        if err?
+                            cb(err)
+                            return
+                        else
+                            locals.email_address = x.email_address
+                            locals.first_name = x.first_name ? ''
+                            locals.last_name  = x.last_name  ? ''
+                            cb()
             (cb) =>
                 if not opts.customer_id?
                     cb(); return

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -1447,35 +1447,21 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                 @_query
                     query : "SELECT stripe_customer_id FROM accounts"
                     where : "account_id = $::UUID" : opts.account_id
-                    cb    : one_result (err, customer_id) ->
+                    cb    : one_result (err, x) =>
                         if err
                             cb(err)
                             return
-                        if customer_id
+                        if x.stripe_customer_id
                             @stripe_update_customer
                                 account_id  : opts.account_id
                                 stripe      : undefined
-                                customer_id : customer_id
+                                customer_id : x.stripe_customer_id
                                 cb          : cb
                         else
                             cb()
         ], (err) =>
-            if err
-                opts.cb(err)
+            opts.cb(err)
         )
-        @account_exists
-            email_address : opts.email_address
-            cb            : (err, exists) =>
-                if err
-                    opts.cb(err)
-                else if exists
-                    opts.cb("email_already_taken")
-                else
-                    @_query
-                        query : 'UPDATE accounts'
-                        set   : {email_address: opts.email_address}
-                        where : @_account_where(opts)
-                        cb    : opts.cb
 
     ###
     User auth token

--- a/src/smc-hub/stripe/client.ts
+++ b/src/smc-hub/stripe/client.ts
@@ -199,6 +199,7 @@ export class StripeClient {
     const x = {
       source: token,
       description,
+      name: description,
       email,
       metadata: {
         account_id: this.client.account_id

--- a/src/smc-hub/stripe/sync.coffee
+++ b/src/smc-hub/stripe/sync.coffee
@@ -19,6 +19,7 @@ exports.stripe_sync = (opts) ->
         database  : required
         target    : undefined
         limit     : 1  # number at once -- stripe will kick us out due to exceeding rate limit thresh if this is bigger than 1...
+        delay     : 10 # ms, additional delay to avoid rate limiting
         cb        : undefined
 
     dbg = (m) -> opts.logger?.debug("stripe_sync: #{m}")
@@ -57,7 +58,9 @@ exports.stripe_sync = (opts) ->
                     account_id  : x.account_id
                     stripe      : stripe
                     customer_id : x.stripe_customer_id
-                    cb          : cb
+                    cb          : (err) ->
+                        # rate limiting
+                        setTimeout(cb, opts.delay)
             async.mapLimit(users, opts.limit, f, cb)
     ], (err) ->
         if err

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -612,7 +612,7 @@ PaymentMethods = rclass
 
     propTypes :
         redux   : rtypes.object.isRequired
-        sources : rtypes.object.isRequired
+        sources : rtypes.object # could be undefined, if it is a customer and all sources are removed
         default : rtypes.string
 
     getInitialState: ->
@@ -657,6 +657,8 @@ PaymentMethods = rclass
         />
 
     render_payment_methods: ->
+        # this happens, when it is a customer but all credit cards are deleted!
+        return null if not @props.sources?
         for source in @props.sources.data
             @render_payment_method(source)
 
@@ -1736,7 +1738,7 @@ Subscriptions = rclass
 
     propTypes :
         subscriptions   : rtypes.object
-        sources         : rtypes.object.isRequired
+        sources         : rtypes.object # could be undefined, if it is a customer but all cards are removed
         selected_plan   : rtypes.string
         redux           : rtypes.object.isRequired
         applied_coupons : rtypes.immutable.Map
@@ -1753,7 +1755,7 @@ Subscriptions = rclass
     render_add_subscription_button: ->
         <Button
             bsStyle   = 'primary'
-            disabled  = {@state.state isnt 'view' or @props.sources.total_count is 0}
+            disabled  = {@state.state isnt 'view' or (@props.sources?.total_count ? 0) is 0}
             onClick   = {=>@setState(state : 'add_new')}
             className = 'pull-right' >
             <Icon name='plus-circle' /> Add Subscription or Course Package...
@@ -1778,6 +1780,7 @@ Subscriptions = rclass
         </Row>
 
     render_subscriptions: ->
+        return null if not @props.subscriptions?
         for sub in @props.subscriptions.data
             <Subscription key={sub.id} subscription={sub} redux={@props.redux} />
 


### PR DESCRIPTION
# Description
* Updates to a user's email address should propagate to stripe. See #3453
* `sync_stripe`
    - syncs the name to the `name` field in stripe (sounds like a good idea), if name or description changed. it also updates the description field.
    - of course, it also syncs over the email address
    - I saw the comment about rate limiting, that's why I added a short 10ms delay
* while testing and fiddling around with stripe directly, I ended up with exceptions about missing data on  fields. That's why I also added some purely defensive code to `billing.cjsx`.

# Testing Steps
everything I tested is for cc-in-cc against my own stripe API test token

1. running `hub --stripe_sync`
2. changing email address, checking stripe
3. changing name, running `stripe_sync`, checking if name changed
4. new user, creating stripe account, subscribing to standard
5. finally, also check if there is a valid entry in *our* DB, in the `stripe_customer` column

# Relevant Issues
#3453

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
