### PR TITLE
jupyter: make codemirror indentUnit and tabSize more robust 

### DIFF
--- a/src/smc-webapp/jupyter/cm_options.ts
+++ b/src/smc-webapp/jupyter/cm_options.ts
@@ -33,14 +33,25 @@ export function cm_options(
     mode.name = "haskell";
   }
 
+  // tabSize/indentUnit sanitization: make robust against missing/bad values
+  let tabSize = editor_settings.tab_size;
+  if (tabSize == null || tabSize <= 0) {
+    tabSize = 4;
+  }
+
+  let indentUnit = editor_settings.indent_unit;
+  if (indentUnit == null || indentUnit <= 0) {
+    indentUnit = tabSize;
+  }
+
   const options: any = {
     mode,
     firstLineNumber: editor_settings.first_line_number,
     showTrailingSpace:
       editor_settings.show_trailing_whitespace ||
       (mode && mode.name) === "gfm2",
-    indentUnit: editor_settings.indent_unit,
-    tabSize: editor_settings.tab_size,
+    indentUnit,
+    tabSize,
     smartIndent: editor_settings.smart_indent,
     electricChars: editor_settings.electric_chars,
     undoDepth: editor_settings.undo_depth,


### PR DESCRIPTION
# Description
make codemirror indentUnit and tabSize more robust against missing or bad values coming from the editor settings

# Testing Steps
I'm not sure how to test. What I saw at an account setting was a missing `indent_unit` entry in the settings dictionary. I wasn't able to replicate the problem, but this should help.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
