### PR TITLE
api: query status of copy path operation

### DIFF
--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -1769,6 +1769,28 @@ Folder \`A\` will be created in target project if it does not exist already.
   })
 );
 
+API(
+  message2({
+    event: "copy_path_status",
+    fields: {
+      copy_path_id: {
+        init: undefined,
+        desc: "A unique UUID for a copy path operation"
+      }
+    },
+    desc: `\
+Retrieve status information about a copy operation for the given ID,
+which was returned by \`copy_path_between_projects\` earlier.
+`
+  })
+);
+
+message({
+  event: "copy_path_status_response",
+  id: required,
+  data: required
+});
+
 //############################################
 // Admin Functionality
 //############################################


### PR DESCRIPTION
# Description
This adds an API endpoint to query the status of a previous copy operation. 

# Testing Steps
Well, I am not sure if this is a suitable implementation. What I did is to insert an artificial DB entry in my dev project's copy path table:

```
-[ RECORD 2 ]-----+-------------------------------------
id                | 6f3439af-3716-4217-b116-cf34b27ef946
time              | 2019-07-31 12:59:53.616663
source_project_id | bc6f81b3-25ad-4d58-ae4a-65649fae4fa5
source_path       | 
target_project_id | e24ba30d-edcd-479f-8a26-bbe81f38296c
target_path       | 
overwrite_newer   | 
delete_missing    | 
backup            | t
bwlimit           | 
timeout           | 
started           | 
finished          | 
error             | no error
```

Then this works:

```
$ curl -X POST -u sk_[...]: -d copy_path_id=6f3439af-3716-4217-b116-cf34b27ef946 http://localhost:56754/[...]/port/[...]/api/v1/copy_path_status
```

```{json}
{
 "event":"copy_path_status_response",
 "id":"699237d9-ca92-43d4-b2ae-597c2fbfc6ab",
 "data":{
  "time":"2019-07-31T12:59:53.616Z",
  "source_project_id":"bc6f81b3-25ad-4d58-ae4a-65649fae4fa5",
  "target_project_id":"e24ba30d-edcd-479f-8a26-bbe81f38296c",
  "backup":true,
  "error":"no error"
 }
}
``` 

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
