### PR TITLE
db: add a "scheduled" field to copy_path for future tasks

### DIFF
--- a/src/smc-util/db-schema.js
+++ b/src/smc-util/db-schema.js
@@ -1503,6 +1503,10 @@ schema.copy_paths = {
       desc:
         "fail if the transfer itself takes longer than this number of seconds (passed to rsync)"
     },
+    scheduled: {
+      type: "timestamp",
+      desc: "earliest time in the future, when the copy request should start (or null, for immediate execution)"
+    },
     started: {
       type: "timestamp",
       desc: "when the copy request actually started running"


### PR DESCRIPTION
# Description
This is just an additional column for scheduled copy operations. To avoid duplication, using the `started` field should be sufficient.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
