### PR TITLE
Kucalc: API copy status, Take 2

### DIFF
--- a/src/dev/project/start_hub.py
+++ b/src/dev/project/start_hub.py
@@ -17,8 +17,9 @@ util.chdir()
 ports = util.get_ports()
 base_url = util.base_url()
 
+kucalc = '--kucalc' if len(sys.argv) > 1 and sys.argv[1] == 'kucalc' else ''
 
-cmd = "cd ../../ && . smc-env &&  service_hub.py --dev --foreground --hostname=0.0.0.0 --port={hub_port} --share_port=0 --proxy_port=0 --gap=0 --mentions --base_url={base_url} {test} start".format(
-    base_url=base_url, hub_port=ports['hub'], test=util.test())
+cmd = "cd ../../ && . smc-env &&  service_hub.py --dev --foreground --hostname=0.0.0.0 --port={hub_port} --share_port=0 --proxy_port=0 --gap=0 --mentions --base_url={base_url} {test} {kucalc} start".format(
+    base_url=base_url, hub_port=ports['hub'], test=util.test(), kucalc=kucalc)
 print(cmd)
 util.cmd(cmd)

--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -1146,11 +1146,14 @@ class exports.Client extends EventEmitter
                                 timeout           : mesg.timeout
                                 exclude_history   : mesg.exclude_history
                                 cb                : cb
-        ], (err) =>
+        ], (err, copy_id) =>
             if err
                 @error_to_client(id:mesg.id, error:err)
             else
-                @push_to_client(message.success(id:mesg.id))
+                resp = message.copy_path_between_projects_response
+                                                        id           : mesg.id
+                                                        copy_path_id : copy_id
+                @push_to_client(resp)
         )
 
     mesg_copy_path_status: (mesg) =>
@@ -1866,7 +1869,7 @@ class exports.Client extends EventEmitter
                     exclude_history : mesg.exclude_history
                     backup          : mesg.backup
                     cb              : cb
-        ], (err) =>
+        ], (err, copy_id) =>
             if err
                 @error_to_client(id:mesg.id, error:err)
             else

--- a/src/smc-hub/compute-client.coffee
+++ b/src/smc-hub/compute-client.coffee
@@ -1969,7 +1969,7 @@ class ProjectClient extends EventEmitter
         ], (err) =>
             if err
                 dbg("error -- #{err}")
-            opts.cb(err)
+            opts.cb(err, null)
         )
 
     directory_listing: (opts) =>

--- a/src/smc-hub/compute-client.coffee
+++ b/src/smc-hub/compute-client.coffee
@@ -1881,6 +1881,7 @@ class ProjectClient extends EventEmitter
             exclude_history   : false
             timeout           : 5*60
             bwlimit           : undefined
+            wait_until_done   : undefined # not used, only relevant for the kucalc variant
             cb                : required
         dbg = @dbg("copy_path(#{opts.path} to #{opts.target_project_id})")
         dbg("copy a path using rsync from one project to another")
@@ -1969,7 +1970,7 @@ class ProjectClient extends EventEmitter
         ], (err) =>
             if err
                 dbg("error -- #{err}")
-            opts.cb(err, null)
+            opts.cb(err)
         )
 
     directory_listing: (opts) =>

--- a/src/smc-hub/kucalc/compute-client.coffee
+++ b/src/smc-hub/kucalc/compute-client.coffee
@@ -431,7 +431,7 @@ class Project extends EventEmitter
                     # but just in case, logically we have to check this case.
                     cb()
                     return
-                if opts.wait_until_done === 'true'
+                if opts.wait_until_done == 'true' or opts.wait_until_done == true
                     dbg('waiting for copy to finish...')
                     handle_change = =>
                         @active()
@@ -444,6 +444,7 @@ class Project extends EventEmitter
                             cb(obj.get('error'))
                     synctable.on('change', handle_change)
                 else
+                    dbg('NOT waiting for copy to finish...')
                     cb()
         ], (err) =>
             @active()

--- a/src/smc-hub/test/api/copy-api.sh
+++ b/src/smc-hub/test/api/copy-api.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# silly helper script to remind hsy how to query the DB from withing a cc-in-cc project
+
+set -evx
+
+PORT=${PORT:-56754}
+CCinCC=${CCinCC:-"14eed217-2d3c-4975-a381-b69edcb40e0e"}
+
+API=http://localhost:$PORT/$CCinCC/port/$PORT/api/v1
+Q() {
+    curl -X POST -u $KEY: $@
+}
+
+KEY=sk_XB003g8HHcyT1y4S3T5w9IW2
+
+## issue copy, needs hub in "kucalc" mode (if this works at all, though)
+SRC=bc6f81b3-25ad-4d58-ae4a-65649fae4fa5
+TAR=e24ba30d-edcd-479f-8a26-bbe81f38296c
+PTH=x.md
+Q -d src_project_id=$SRC -d src_path=$PTH -d target_project_id=$TAR -d wait_until_done=false $API/copy_path_between_projects
+
+
+## status
+## TODO: use jq to extract the copy_path_id from above, query, wait a few secs, and then query it again
+PATHID=002cdde3-e79c-4d46-a759-f6464a5360c9
+Q -d copy_path_id=$PATHID $API/copy_path_status
+
+echo "double check DB"
+psql -x -c "SELECT * FROM copy_paths WHERE id = '$PATHID';"

--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -1778,7 +1778,7 @@ message({
   event: "copy_path_between_projects_response",
   id: required,
   copy_path_id: undefined,
-  note: "Query copy_path_status to learn if the copy operation was successful."
+  note: "Query copy_path_status with the copy_path_id to learn if the copy operation was successful."
 });
 
 API(

--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -1738,6 +1738,11 @@ API(
       exclude_history: {
         init: false,
         desc: "if true, exclude all files of the form `*.sage-history`"
+      },
+      wait_until_done: {
+        init: true,
+        desc:
+          "if false, the operation returns immediately with the copy_path_id for querying copy_path_status"
       }
     },
     desc: `\
@@ -1768,6 +1773,13 @@ Folder \`A\` will be created in target project if it does not exist already.
 `
   })
 );
+
+message({
+  event: "copy_path_between_projects_response",
+  id: required,
+  copy_path_id: undefined,
+  note: "Query copy_path_status to learn if the copy operation was successful."
+});
 
 API(
   message2({


### PR DESCRIPTION
# Kucalc API: copy a file without blocking 

The terminal session below is from my local computer hitting the test namespace. I've updated *all* hubs for that (but I think just the api hub is enough ... )

What's new is

*  `copy_path_between_projects` gets a switch `-d wait_until_done=false`
* `copy_path_status` with `-d copy_path_id=[copy_path_id]`

## copying an existing file from A to B

```
hsy@x1:~/d/cocalc/test$ curl -s -X POST -u `cat test_api`: -d src_project_id=`cat p1` -d target_project_id=`cat p2` -d wait_until_done=false -d src_path=x.md https://test.cocalc.com/api/v1/copy_path_between_projects | jq
{
  "event": "copy_path_between_projects_response",
  "id": "354f6977-47e0-435f-80c2-ccb3593f1217",
  "copy_path_id": "b83f8dbf-8c0c-49ab-913a-24a20d862792",
  "note": "Query copy_path_status with the copy_path_id to learn if the copy operation was successful."
}
```

## retrieving the status of the above -- no error!

```
hsy@x1:~/d/cocalc/test$ curl -s -X POST -u `cat test_api`: -d copy_path_id=b83f8dbf-8c0c-49ab-913a-24a20d862792  https://test.cocalc.com/api/v1/copy_path_status | jq{
  "event": "copy_path_status_response",
  "id": "e03a7e75-b70c-4d03-95b1-89106eb3c801",
  "data": {
    "time": "2019-08-02T14:00:03.786Z",
    "source_project_id": "c37fbd83-c4c3-4f92-b66c-37b8d2c8cdf1",
    "source_path": "x.md",
    "target_project_id": "9282d61d-8d27-4b9f-ae0f-2fc9bac64203",
    "target_path": "x.md",
    "overwrite_newer": false,
    "delete_missing": false,
    "backup": false,
    "started": "2019-08-02T14:00:03.798Z",
    "finished": "2019-08-02T14:00:04.190Z"
  }
}
```

## copying a file that does not exist from A to B

```
hsy@x1:~/d/cocalc/test$ curl -s -X POST -u `cat test_api`: -d src_project_id=`cat p1` -d target_project_id=`cat p2` -d wait_until_done=false -d src_path=unknown-path.md https://test.cocalc.com/api/v1/copy_path_between_projects | jq
{
  "event": "copy_path_between_projects_response",
  "id": "e09847d0-2ff0-46e2-90f9-810296e377e8",
  "copy_path_id": "510f5acd-7955-4067-af3d-d664584d6f45",
  "note": "Query copy_path_status with the copy_path_id to learn if the copy operation was successful."
}
```

## retrieving the error message of the event above

```
hsy@x1:~/d/cocalc/test$ curl -s -X POST -u `cat test_api`: -d copy_path_id=510f5acd-7955-4067-af3d-d664584d6f45  https://test.cocalc.com/api/v1/copy_path_status | jq{
  "event": "copy_path_status_response",
  "id": "f463e4c7-c347-4ae8-ba1d-ec3aa1bfc45a",
  "data": {
    "time": "2019-08-02T14:00:42.046Z",
    "source_project_id": "c37fbd83-c4c3-4f92-b66c-37b8d2c8cdf1",
    "source_path": "unknown-path.md",
    "target_project_id": "9282d61d-8d27-4b9f-ae0f-2fc9bac64203",
    "target_path": "unknown-path.md",
    "overwrite_newer": false,
    "delete_missing": false,
    "backup": false,
    "started": "2019-08-02T14:00:42.056Z",
    "finished": "2019-08-02T14:00:42.448Z",
    "error": "{\"errno\":-2,\"code\":\"ENOENT\",\"syscall\":\"lstat\",\"path\":\"/home/manage/projects/c37fbd83-c4c3-4f92-b66c-37b8d2c8cdf1/unknown-path.md\"}"
  }
}
```

## backwards compatible? synchronized copying

```
hsy@x1:~/d/cocalc/test$ time curl -s -X POST -u `cat test_api`: -d src_project_id=`cat p1` -d target_project_id=`cat p2`  -d src_path=unknown-path.md https://test.cocalc.com/api/v1/copy_path_between_projects | jq
{
  "event": "error",
  "id": "f429442c-6f23-4252-9f0f-879d19686f8b",
  "error": "{\"errno\":-2,\"code\":\"ENOENT\",\"syscall\":\"lstat\",\"path\":\"/home/manage/projects/c37fbd83-c4c3-4f92-b66c-37b8d2c8cdf1/unknown-path.md\"}"
}
```

## battle testing

to test this even further, I issued a copy to a project which doesn't exist. I immediately got the copy id, and a start time.... Then the process stupidly tries for 2 minutes, then finally gives up and records this:

```
hsy@x1:~/d/cocalc/test$ curl -s -X POST -u `cat test_api`: -d copy_path_id=46ead3df-87f1-4f3b-b115-9062b7c76951  https://test.cocalc.com/api/v1/copy_path_status | jq
{
  "event": "copy_path_status_response",
  "id": "f4c1d04d-f99a-4b7d-8dd9-1833a2829cb1",
  "data": {
    "time": "2019-08-02T14:13:59.563Z",
    "source_project_id": "c37fbd83-c4c3-4f92-b66c-37b8d2c8cdf1",
    "source_path": "x.md",
    "target_project_id": "fe36d5d7-b126-4431-a9ee-977d14de2b4b",
    "target_path": "x.md",
    "overwrite_newer": false,
    "delete_missing": false,
    "backup": false,
    "started": "2019-08-02T14:13:59.572Z",
    "finished": "2019-08-02T14:15:55.298Z",
    "error": "maximum time (=120000ms) exceeded - last error \"no project with given id in the database?!\""
  }
}
```

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
