### PR TITLE
Catch the null case for params

### DIFF
--- a/src/smc-hub/hub_http_server.coffee
+++ b/src/smc-hub/hub_http_server.coffee
@@ -328,7 +328,7 @@ exports.init_express_http_server = (opts) ->
     # Save other paths in # part of URL then redirect to the single page app.
     router.get ['/projects*', '/help*', '/settings*', '/admin*', '/dashboard*', '/notifications*'], (req, res) ->
         url = require('url')
-        q = url.parse(req.url, true).search # gives exactly "?key=value,key=..."
+        q = url.parse(req.url, true).search || "" # gives exactly "?key=value,key=..."
         res.redirect(opts.base_url + "/app#" + req.path.slice(1) + q)
 
     # Return global status information about smc


### PR DESCRIPTION
# Description
Fixes #3894 / #3987 

# Testing Steps
1. Open up a cocalc file link without parameters eg. the url ends with `a.md`
1. This should NOT open up `a.mdnull`

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
