### PR TITLE
hub: handle unhandledRejection events and report them

### DIFF
--- a/src/smc-hub/hub.coffee
+++ b/src/smc-hub/hub.coffee
@@ -725,6 +725,13 @@ command_line = () ->
             database?.uncaught_exception(err)
             uncaught_exception_total?.inc(1)
 
+        process.on 'unhandledRejection', (reason, p) ->
+            winston.debug("BUG UNHANDLED REJECTION *********************************************************")
+            winston.debug('Unhandled Rejection at:', p, 'reason:', reason)
+            winston.debug("BUG UNHANDLED REJECTION *********************************************************")
+            database?.uncaught_exception(p)
+            uncaught_exception_total?.inc(1)
+
         if program.passwd
             winston.debug("Resetting password")
             reset_password(program.passwd, (err) -> process.exit())


### PR DESCRIPTION
# Description
report/monitor unhandledRejection errors. Not tested, I've not even restarted my hub. This is just the core idea how to make this work.

Node 10 doc: https://nodejs.org/docs/latest-v10.x/api/process.html#process_event_unhandledrejection

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
