### PR TITLE
show more of python formatter errors

### DIFF
--- a/src/smc-project/formatters/python-format.ts
+++ b/src/smc-project/formatters/python-format.ts
@@ -22,7 +22,7 @@ function yapf(input_path) {
 }
 
 // from a full stacktrace, only show user the last line (encodes some reason and line number) ... everything else does not help.
-function last_line(str?: string): string {
+function tail(str?: string, lines = 4): string {
   if (str == null) {
     return "Problem running formatter.";
   } else {
@@ -30,8 +30,9 @@ function last_line(str?: string): string {
       str
         .trim()
         .split(/\r?\n/)
-        .slice(-1)
-        .pop() || ""
+        .slice(-lines)
+        .filter(x => x.trim().length > 0)
+        .join("\n") || ""
     );
   }
 }
@@ -79,7 +80,7 @@ export async function python_format(
         // ENOENT
         throw new Error(`Formatting utility "${util}" is not installed`);
       }
-      stderr = last_line(stderr);
+      stderr = tail(stderr);
       const err_msg = `Python formatter "${util}" exited with code ${code}:\n${stdout}\n${stderr}`;
       logger.debug(`format python error: ${err_msg}`);
       throw new Error(err_msg);

--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -229,6 +229,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
     if (this.props.errorstyle === "monospace") {
       style.fontFamily = "monospace";
       style.fontSize = "85%";
+      style.whiteSpace = "pre";
     }
     return (
       <ErrorDisplay


### PR DESCRIPTION


# Description
* show last lines of error, instead of only the last line
* change CSS to fix indentation:

instead of

![Screenshot from 2019-08-06 10-38-56](https://user-images.githubusercontent.com/207405/62525012-ef0f1a80-b836-11e9-8498-0acffdb1cc16.png)

it's now

![Screenshot from 2019-08-06 10-38-13](https://user-images.githubusercontent.com/207405/62525022-f2a2a180-b836-11e9-8faa-4f9542db195e.png)


# Testing Steps
1. py file with syntax error → see the line number somewhere
2. still formats if there is no syntax error

# Relevant Issues
#3992

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
