### PR TITLE
initialize less when in kiosk mode

### DIFF
--- a/src/smc-webapp/custom-software/init.ts
+++ b/src/smc-webapp/custom-software/init.ts
@@ -160,8 +160,8 @@ class ComputeImagesTable extends Table {
   }
 }
 
-// if (!COCALC_MINIMAL) {
-redux.createStore(NAME, ComputeImagesStore, {});
-redux.createActions(NAME, ComputeImagesActions);
-redux.createTable(NAME, ComputeImagesTable);
-//}
+if (!COCALC_MINIMAL) {
+  redux.createStore(NAME, ComputeImagesStore, {});
+  redux.createActions(NAME, ComputeImagesActions);
+  redux.createTable(NAME, ComputeImagesTable);
+}

--- a/src/smc-webapp/custom-software/init.ts
+++ b/src/smc-webapp/custom-software/init.ts
@@ -1,6 +1,7 @@
 // Manage DB <-> UI integration of available *custom* compute images
 // TODO: also get rid of hardcoded official software images
 
+import { COCALC_MINIMAL } from "../fullscreen";
 const { redux, Store, Actions, Table } = require("../app-framework");
 import { Map as iMap } from "immutable";
 import { CUSTOM_IMG_PREFIX } from "./util";
@@ -159,6 +160,8 @@ class ComputeImagesTable extends Table {
   }
 }
 
+// if (!COCALC_MINIMAL) {
 redux.createStore(NAME, ComputeImagesStore, {});
 redux.createActions(NAME, ComputeImagesActions);
 redux.createTable(NAME, ComputeImagesTable);
+//}

--- a/src/smc-webapp/entry-point.coffee
+++ b/src/smc-webapp/entry-point.coffee
@@ -4,6 +4,8 @@ Complete 100% top-level react rewrite of CoCalc.
 Explicitly set FULLY_REACT=true in src/webapp-smc.coffee to switch to this.
 ###
 
+fullscreen = require('./fullscreen')
+
 # FUTURE: This is needed only for the old non-react editors; will go away.
 html = require('./console.html') + require('./editor.html') + require('./jupyter.html') + require('./sagews/interact.html') + require('./sagews/3d.html') + require('./sagews/d3.html')
 $('body').append(html)
@@ -32,7 +34,9 @@ require('./init_app')
 # Initialize the account store.
 require('./account')
 
-require('./notifications').init(redux)
+notifications = require('./notifications')
+if not fullscreen.COCALC_MINIMAL
+    notifications.init(redux)
 
 require('./widget-markdown-input/main').init(redux)
 

--- a/src/smc-webapp/fullscreen.ts
+++ b/src/smc-webapp/fullscreen.ts
@@ -1,0 +1,5 @@
+// enable fullscreen mode upon a URL like /app?fullscreen and additionally kiosk-mode upon /app?fullscreen=kiosk
+import { QueryParams } from "./misc_page2";
+export const COCALC_FULLSCREEN = QueryParams.get("fullscreen");
+export const COCALC_MINIMAL = COCALC_FULLSCREEN === "kiosk";
+if (COCALC_MINIMAL) console.log("Starting CoCalc in Minimal Mode");

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -28,6 +28,9 @@ history                 = require('./history')
 
 {alert_message}         = require('./alerts')
 
+{QueryParams} = require('./misc_page2')
+{COCALC_FULLSCREEN, COCALC_MINIMAL} = require('./fullscreen')
+
 # Ephemeral websockets mean a browser that kills the websocket whenever
 # the page is backgrounded.  So far, it seems that maybe all mobile devices
 # do this.  The only impact is we don't show a certain error message for
@@ -232,6 +235,10 @@ class PageActions extends Actions
         @set_fullscreen(if redux.getStore('page').get('fullscreen')? then undefined else 'default')
 
     set_session: (val) =>
+        # no sessions in minimal mode
+        #if COCALC_MINIMAL
+        #    return
+
         # If existing different session, close it.
         if val != redux.getStore('page')?.get('session')
             @_session_manager?.close()
@@ -430,16 +437,14 @@ webapp_client.on 'new_version', (ver) ->
     redux.getActions('page').set_new_version(ver)
 
 # enable fullscreen mode upon a URL like /app?fullscreen and additionally kiosk-mode upon /app?fullscreen=kiosk
-misc_page = require('./misc_page')
-fullscreen_query_value = misc_page.get_query_param('fullscreen')
-if fullscreen_query_value
-    if fullscreen_query_value == 'kiosk'
+if COCALC_FULLSCREEN
+    if COCALC_FULLSCREEN == 'kiosk'
         redux.getActions('page').set_fullscreen('kiosk')
     else
         redux.getActions('page').set_fullscreen('default')
 
 # setup for frontend mocha testing.
-test_query_value = misc_page.get_query_param('test')
+test_query_value = QueryParams.get('test')
 if test_query_value
     # include entryway for running mocha tests.
     redux.getActions('page').setState(test: test_query_value)
@@ -456,14 +461,14 @@ if test_query_value
 # This makes it so the default session is 'default' and there is no
 # way to NOT have a session, except via session=, which is treated
 # as "no session" (also no session for kiosk mode).
-session = misc_page.get_query_param('session') ? 'default'
-if fullscreen_query_value == 'kiosk' or test_query_value
+session = QueryParams.get('session') ? 'default'
+if COCALC_FULLSCREEN == 'kiosk' or test_query_value
     # never have a session in kiosk mode, since you can't access the other files.
     session = ''
 
 redux.getActions('page').set_session(session)
 
-get_api_key_query_value = misc_page.get_query_param('get_api_key')
+get_api_key_query_value = QueryParams.get('get_api_key')
 if get_api_key_query_value
     redux.getActions('page').set_get_api_key(get_api_key_query_value)
     redux.getActions('page').set_fullscreen('kiosk')

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -235,10 +235,6 @@ class PageActions extends Actions
         @set_fullscreen(if redux.getStore('page').get('fullscreen')? then undefined else 'default')
 
     set_session: (val) =>
-        # no sessions in minimal mode
-        #if COCALC_MINIMAL
-        #    return
-
         # If existing different session, close it.
         if val != redux.getStore('page')?.get('session')
             @_session_manager?.close()

--- a/src/smc-webapp/misc_page2.ts
+++ b/src/smc-webapp/misc_page2.ts
@@ -1,5 +1,13 @@
 // functions ported from misc_page.coffee
 
+// see entry-point, and via this useful in all TS files
+declare global {
+  interface Window {
+    COCALC_FULLSCREEN: string | undefined;
+    COCALC_MINIMAL: boolean;
+  }
+}
+
 export namespace QueryParams {
   export interface Params {
     [k: string]: string | boolean | (string | boolean)[];

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -23,6 +23,8 @@ $          = window.$
 immutable  = require('immutable')
 underscore = require('underscore')
 
+{COCALC_MINIMAL} = require('./fullscreen')
+
 {analytics_event} = require('./tracker')
 {webapp_client} = require('./webapp_client')
 {alert_message} = require('./alerts')
@@ -878,7 +880,7 @@ class ProjectsAllTable extends Table
 
 all_projects_have_been_loaded = false
 load_all_projects = reuseInFlight =>
-    if all_projects_have_been_loaded
+    if all_projects_have_been_loaded # or COCALC_MINIMAL
         return
     all_projects_have_been_loaded = true  # used internally in this file only
     redux.removeTable('projects')
@@ -892,6 +894,7 @@ load_recent_projects = =>
     if redux.getTable('projects')._table.get().size == 0
         await load_all_projects()
 
+#if not COCALC_MINIMAL
 load_recent_projects()
 
 

--- a/src/smc-webapp/prom-client.coffee
+++ b/src/smc-webapp/prom-client.coffee
@@ -5,13 +5,9 @@ NOTE: We explicitly import inside the prom-client package, since the index.js
 in that package imports some things that make no sense in a browser.
 ###
 
-###
-console.log "not initializing prometheus"
-exports.enabled = false
-###
-
-console.log "initializing prometheus client"
-exports.enabled = true
+{COCALC_MINIMAL} = require('./fullscreen')
+exports.enabled = true and not COCALC_MINIMAL
+console.log("initializing prometheus client. enabled =", exports.enabled)
 
 exports.register           = require('prom-client/lib/registry').globalRegistry
 exports.Registry           = require('prom-client/lib/registry')

--- a/src/smc-webapp/redux_server_stats.coffee
+++ b/src/smc-webapp/redux_server_stats.coffee
@@ -6,8 +6,8 @@ Redux: server stats
 {Table, redux} = require('./app-framework')
 
 name    = 'server_stats'
-store   = undefined
-actions = undefined
+store   = redux.createStore(name, {loading:true})
+actions = redux.createActions(name)
 
 $ = window.$
 {BASE_URL} = require('misc_page')
@@ -15,16 +15,11 @@ get_stats = ->
     $.getJSON "#{BASE_URL}/stats", (data) ->
         data.time = new Date(data.time)
         data.loading = false
-        actions?.setState(data)
+        actions.setState(data)
     setTimeout(get_stats, 90 * 1000)
 
-init = ->
-    store   = redux.createStore(name, {loading:true})
-    actions = redux.createActions(name)
-    get_stats()
-
 if not COCALC_MINIMAL
-    init()
+    get_stats()
 
 #class StatsTable extends Table
 

--- a/src/smc-webapp/redux_server_stats.coffee
+++ b/src/smc-webapp/redux_server_stats.coffee
@@ -2,11 +2,12 @@
 Redux: server stats
 ###
 
+{COCALC_MINIMAL} = require ("./fullscreen")
 {Table, redux} = require('./app-framework')
 
 name    = 'server_stats'
-store   = redux.createStore(name, {loading:true})
-actions = redux.createActions(name)
+store   = undefined
+actions = undefined
 
 $ = window.$
 {BASE_URL} = require('misc_page')
@@ -14,10 +15,16 @@ get_stats = ->
     $.getJSON "#{BASE_URL}/stats", (data) ->
         data.time = new Date(data.time)
         data.loading = false
-        actions.setState(data)
+        actions?.setState(data)
     setTimeout(get_stats, 90 * 1000)
 
-get_stats()
+init = ->
+    store   = redux.createStore(name, {loading:true})
+    actions = redux.createActions(name)
+    get_stats()
+
+if not COCALC_MINIMAL
+    init()
 
 #class StatsTable extends Table
 

--- a/src/smc-webapp/system_notifications.coffee
+++ b/src/smc-webapp/system_notifications.coffee
@@ -1,6 +1,7 @@
 misc  = require('smc-util/misc')
 {defaults, required} = misc
 
+{COCALC_MINIMAL} = require("./fullscreen")
 {Actions, Store, Table, redux} = require('./app-framework')
 {alert_message} = require('./alerts')
 
@@ -21,6 +22,10 @@ class NotificationsActions extends Actions
             if not mesg.get('done')
                 table.set(id:id, done:true)
 
+store   = undefined
+actions = undefined
+
+#if not COCALC_MINIMAL
 store   = redux.createStore(name, {loading:true})
 actions = redux.createActions(name, NotificationsActions)
 
@@ -49,4 +54,5 @@ class NotificationsTable extends Table
                 delete s[id]
         misc.set_local_storage('system_notifications', misc.to_json(s))
 
+#if not COCALC_MINIMAL
 table = redux.createTable(name, NotificationsTable)

--- a/src/smc-webapp/system_notifications.coffee
+++ b/src/smc-webapp/system_notifications.coffee
@@ -22,10 +22,6 @@ class NotificationsActions extends Actions
             if not mesg.get('done')
                 table.set(id:id, done:true)
 
-store   = undefined
-actions = undefined
-
-#if not COCALC_MINIMAL
 store   = redux.createStore(name, {loading:true})
 actions = redux.createActions(name, NotificationsActions)
 
@@ -54,5 +50,5 @@ class NotificationsTable extends Table
                 delete s[id]
         misc.set_local_storage('system_notifications', misc.to_json(s))
 
-#if not COCALC_MINIMAL
-table = redux.createTable(name, NotificationsTable)
+if not COCALC_MINIMAL
+    table = redux.createTable(name, NotificationsTable)

--- a/src/smc-webapp/users.cjsx
+++ b/src/smc-webapp/users.cjsx
@@ -125,7 +125,8 @@ class UsersTable extends Table
             return false
         @redux.getActions('users').setState(user_map: user_map)
 
-#if not COCALC_MINIMAL
+## disabling this createTable effectively hides cursors of collaborators, etc.
+# if not COCALC_MINIMAL
 redux.createTable('users', UsersTable)
 
 #TODO: Make useable without passing in user_map

--- a/src/smc-webapp/users.cjsx
+++ b/src/smc-webapp/users.cjsx
@@ -21,6 +21,8 @@
 
 misc = require('smc-util/misc')
 
+{COCALC_MINIMAL} = require('./fullscreen')
+
 {React, Actions, Store, Table, redux, rtypes, rclass}  = require('./app-framework')
 
 {TimeAgo, Tip} = require('./r_misc')
@@ -123,6 +125,7 @@ class UsersTable extends Table
             return false
         @redux.getActions('users').setState(user_map: user_map)
 
+#if not COCALC_MINIMAL
 redux.createTable('users', UsersTable)
 
 #TODO: Make useable without passing in user_map


### PR DESCRIPTION
# Description

simple idea: when started in kiosk mode, the variable `COCALC_MINIMAL`  causes some aspects to not initialize. the effect is less network traffic and overhead, but I'm not sure if this really helps significantly or is just a drop on a hot stone. This is maybe just a first step.


# Testing Steps
1. I refreshed various pages, in particular a jupyter notebook. All seem to work fine.
1. normal pages and `fullscreen=default` do not trigger this mode, hence they work just like before.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
