### PR TITLE
Load directly into target if possible

### DIFF
--- a/src/smc-webapp/history2.ts
+++ b/src/smc-webapp/history2.ts
@@ -20,10 +20,10 @@ export function parse_target(
   const segments = target.split("/");
   switch (segments[0]) {
     case "projects":
-      if (segments.length > 1) {
-        return { page: "project", target: segments.slice(1).join("/") };
-      } else {
+      if (segments.length < 2 || (segments.length == 2 && segments[1] == "")) {
         return { page: "projects" };
+      } else {
+        return { page: "project", target: segments.slice(1).join("/") };
       }
     case "settings":
       switch (segments[1]) {

--- a/src/smc-webapp/history2.ts
+++ b/src/smc-webapp/history2.ts
@@ -1,0 +1,58 @@
+/*
+String or undefined. undefined => 'account'
+*/
+export function parse_target(
+  target?: string
+):
+  | { page: "projects" | "help" | "file-use" | "notifications" | "admin" }
+  | { page: "project"; target: string }
+  | {
+      page: "account";
+      tab: "account" | "billing" | "upgrades" | "support" | "ssh-keys";
+    }
+  | {
+      page: "notifications";
+      tab: "mentions";
+    } {
+  if (target == undefined) {
+    return { page: "account", tab: "account" };
+  }
+  const segments = target.split("/");
+  switch (segments[0]) {
+    case "projects":
+      if (segments.length > 1) {
+        return { page: "project", target: segments.slice(1).join("/") };
+      } else {
+        return { page: "projects" };
+      }
+    case "settings":
+      switch (segments[1]) {
+        case "account":
+        case "billing":
+        case "upgrades":
+        case "support":
+        case "ssh-keys":
+          return {
+            page: "account",
+            tab: segments[1] as
+              | "account"
+              | "billing"
+              | "upgrades"
+              | "support"
+              | "ssh-keys"
+          };
+        default:
+          return { page: "account", tab: "account" };
+      }
+    case "notifications":
+      return { page: "notifications" };
+    case "help":
+      return { page: "help" };
+    case "file-use":
+      return { page: "file-use" };
+    case "admin":
+      return { page: "admin" };
+    default:
+      return { page: "account", tab: "account" };
+  }
+}

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -280,7 +280,8 @@ class PageActions extends Actions
     sign_in: =>
         false
 
-redux.createStore('page', {active_top_tab: 'account'})
+{parse_target} = require("./history2")
+redux.createStore('page', {active_top_tab: parse_target(window.smc_target).page})
 redux.createActions('page', PageActions)
 ###
     name: 'page'

--- a/src/smc-webapp/test/history2.test.ts
+++ b/src/smc-webapp/test/history2.test.ts
@@ -1,10 +1,128 @@
 import { parse_target } from "../history2";
 
 describe("Testing inputs", () => {
+  test("projects", () => {
+    const matched_paths = ["projects/", "projects"];
+    const account_settings_descriptor = { page: "projects" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("a single project with no additional target and a trailing slash", () => {
+    const account_settings_descriptor = {
+      page: "project",
+      target: "some-kind-of-uuid/"
+    };
+    expect(parse_target("projects/some-kind-of-uuid/")).toEqual(
+      account_settings_descriptor
+    );
+  });
+
+  test("a single project with no additional target and no trailing slash", () => {
+    const account_settings_descriptor = {
+      page: "project",
+      target: "some-kind-of-uuid"
+    };
+    expect(parse_target("projects/some-kind-of-uuid")).toEqual(
+      account_settings_descriptor
+    );
+  });
+
+  test("a single project with a target and a trailing slash", () => {
+    const account_settings_descriptor = {
+      page: "project",
+      target: "some-kind-of-uuid/path-of/target/"
+    };
+    expect(parse_target("projects/some-kind-of-uuid/path-of/target/")).toEqual(
+      account_settings_descriptor
+    );
+  });
+
+  test("a single project with a target and no trailing slash", () => {
+    const account_settings_descriptor = {
+      page: "project",
+      target: "some-kind-of-uuid/path-of/target"
+    };
+    expect(parse_target("projects/some-kind-of-uuid/path-of/target")).toEqual(
+      account_settings_descriptor
+    );
+  });
+
   test("settings account", () => {
-    const matched_paths = ["settings/", "settings/account", undefined];
+    const matched_paths = [
+      "settings/",
+      "settings",
+      "settings/account",
+      "settings/account/",
+      undefined
+    ];
     const account_settings_descriptor = { page: "account", tab: "account" };
-    for (path of matched_paths) {
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("settings billing", () => {
+    const matched_paths = ["settings/billing/", "settings/billing/"];
+    const account_settings_descriptor = { page: "account", tab: "billing" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("settings upgrades", () => {
+    const matched_paths = ["settings/upgrades/", "settings/upgrades/"];
+    const account_settings_descriptor = { page: "account", tab: "upgrades" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("settings support", () => {
+    const matched_paths = ["settings/support/", "settings/support/"];
+    const account_settings_descriptor = { page: "account", tab: "support" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("settings ssh-keys", () => {
+    const matched_paths = ["settings/ssh-keys/", "settings/ssh-keys/"];
+    const account_settings_descriptor = { page: "account", tab: "ssh-keys" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("notifications", () => {
+    const matched_paths = ["notifications/", "notifications"];
+    const account_settings_descriptor = { page: "notifications" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("help", () => {
+    const matched_paths = ["help/", "help"];
+    const account_settings_descriptor = { page: "help" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("file-use", () => {
+    const matched_paths = ["file-use/", "file-use"];
+    const account_settings_descriptor = { page: "file-use" };
+    for (let path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+
+  test("admin", () => {
+    const matched_paths = ["admin/", "admin"];
+    const account_settings_descriptor = { page: "admin" };
+    for (let path of matched_paths) {
       expect(parse_target(path)).toEqual(account_settings_descriptor);
     }
   });

--- a/src/smc-webapp/test/history2.test.ts
+++ b/src/smc-webapp/test/history2.test.ts
@@ -55,6 +55,7 @@ describe("Testing inputs", () => {
       "settings",
       "settings/account",
       "settings/account/",
+      "",
       undefined
     ];
     const account_settings_descriptor = { page: "account", tab: "account" };

--- a/src/smc-webapp/test/history2.test.ts
+++ b/src/smc-webapp/test/history2.test.ts
@@ -1,0 +1,11 @@
+import { parse_target } from "../history2";
+
+describe("Testing inputs", () => {
+  test("settings account", () => {
+    const matched_paths = ["settings/", "settings/account", undefined];
+    const account_settings_descriptor = { page: "account", tab: "account" };
+    for (path of matched_paths) {
+      expect(parse_target(path)).toEqual(account_settings_descriptor);
+    }
+  });
+});


### PR DESCRIPTION
# Description
Fix #3994 
The default page was account which would briefly load before being set correctly later to `window.smc_target`. This change sets the page appropriately if `window.smc_target` is defined. Defaults to the original behavior if not defined.

# Testing Steps
1. Load a URL pointed to a file. You should NOT see account settings.
1. Load other pages. Those should still work.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
