### PR TITLE
webapp/jupyter: display errors in such a way that pre-formatted text works

### DIFF
--- a/src/smc-webapp/jupyter/main.tsx
+++ b/src/smc-webapp/jupyter/main.tsx
@@ -164,10 +164,16 @@ class JupyterEditor0 extends Component<JupyterEditorProps> {
 
   render_error() {
     if (this.props.error) {
+      const style = {
+        margin: "1ex",
+        whiteSpace: "pre" as "pre",
+        fontSize: "12px",
+        fontFamily: "monospace" as "monospace"
+      };
       return (
         <ErrorDisplay
           error={this.props.error}
-          style={{ margin: "1ex" }}
+          style={style}
           onClose={() => this.props.actions.set_error(undefined)}
         />
       );

--- a/src/smc-webapp/r_misc/error-display.tsx
+++ b/src/smc-webapp/r_misc/error-display.tsx
@@ -3,10 +3,10 @@ import * as misc from "smc-util/misc";
 import { Alert } from "react-bootstrap";
 import { CloseX } from "./close-x";
 
-const error_text_style = {
+const error_text_style: React.CSSProperties = {
   marginRight: "1ex",
   whiteSpace: "pre-line",
-  maxWidth: "80ex"
+  maxWidth: "100ex"
 };
 
 interface Props {


### PR DESCRIPTION
# Description

well, similar to https://github.com/sagemathinc/cocalc/pull/3995 ... something similar for jupyter. 

# Testing Steps

here are before/after screenshots

![Screenshot from 2019-08-07 10-08-14](https://user-images.githubusercontent.com/207405/62607047-b128f980-b8fd-11e9-8c22-2619b6d72ef3.png)

![Screenshot from 2019-08-07 10-23-06](https://user-images.githubusercontent.com/207405/62607060-b7b77100-b8fd-11e9-9ca4-cbf7bb3cd2e1.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
