### PR TITLE
webapp/frame editor: fix overlapping buttons v2

### DIFF
--- a/src/smc-webapp/frame-editors/_style.sass
+++ b/src/smc-webapp/frame-editors/_style.sass
@@ -1,7 +1,9 @@
 // make buttons and button-groups wrap with a larger vertical space (not 0 px)
 .cc-frame-tree-title-bar-buttons
-  >div.btn-group,
-  >button.btn
+  overflow: hidden
+
+  > div.btn-group,
+  > button.btn
     margin-bottom: 20px
 
 // same for the format bar, see

--- a/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
@@ -16,16 +16,12 @@ const {
   MenuItem
 } = require("react-bootstrap");
 import { get_default_font_size } from "../generic/client";
-const {
-  VisibleMDLG,
-  EditorFileInfoDropdown
-} = require("smc-webapp/r_misc");
+const { VisibleMDLG, EditorFileInfoDropdown } = require("smc-webapp/r_misc");
 
 import { r_join } from "smc-webapp/r_misc/r_join";
 import { Icon } from "smc-webapp/r_misc/icon";
 import { Space } from "smc-webapp/r_misc/space";
 import { Tip } from "smc-webapp/r_misc/tip";
-
 
 const { IS_TOUCH } = require("smc-webapp/feature");
 const misc = require("smc-util/misc");
@@ -41,10 +37,13 @@ import { ConnectionStatus, EditorSpec } from "./types";
 
 import { Available as AvailableFeatures } from "../../project_configuration";
 
+const COL_BAR_BACKGROUND = "#f8f8f8";
+const COL_BAR_BACKGROUND_DARK = "#ddd";
+const COL_BAR_BORDER = "rgb(204,204,204)";
 
 const title_bar_style: CSS.Properties = {
-  background: "#ddd",
-  border: "1px solid rgb(204,204,204)",
+  background: COL_BAR_BACKGROUND_DARK,
+  border: `1px solid ${COL_BAR_BORDER}`,
   padding: "1px"
 };
 
@@ -257,8 +256,14 @@ export class FrameTitleBar extends Component<Props, State> {
 
   render_control(): Rendered {
     const is_active = this.props.active_id === this.props.id;
+    const style: CSS.Properties = {
+      float: "right" as "right",
+      zIndex: 1,
+      paddingLeft: "5px",
+      background: is_active ? COL_BAR_BACKGROUND : COL_BAR_BACKGROUND_DARK
+    };
     return (
-      <ButtonGroup style={{ float: "right" }} key={"close"}>
+      <ButtonGroup style={style} key={"close"}>
         {is_active ? this.render_types() : undefined}
         {is_active && !this.props.is_full ? this.render_split_row() : undefined}
         {is_active && !this.props.is_full ? this.render_split_col() : undefined}
@@ -859,7 +864,10 @@ export class FrameTitleBar extends Component<Props, State> {
 
   render_format(): Rendered {
     if (!this.is_visible("format")) return;
-    let desc : any = this.props.actions.has_format_support(this.props.id, this.props.available_features);
+    let desc: any = this.props.actions.has_format_support(
+      this.props.id,
+      this.props.available_features
+    );
     if (!desc) return;
     if (desc === true) {
       desc = "Canonically format the entire document.";
@@ -1085,12 +1093,10 @@ export class FrameTitleBar extends Component<Props, State> {
       // extra buttons are cleanly not visible when frame is thin.
       style = {
         maxHeight: "30px",
-        flex: 1
       };
     } else {
       style = {
         maxHeight: "34px",
-        flex: 1,
         marginLeft: "2px"
       };
     }
@@ -1272,7 +1278,7 @@ export class FrameTitleBar extends Component<Props, State> {
     const is_active = this.props.id === this.props.active_id;
     if (is_active) {
       style = misc.copy(title_bar_style);
-      style.background = "#f8f8f8";
+      style.background = COL_BAR_BACKGROUND;
       if (!this.props.is_only && !this.props.is_full) {
         style.maxHeight = "34px";
       }

--- a/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
@@ -258,7 +258,6 @@ export class FrameTitleBar extends Component<Props, State> {
     const is_active = this.props.active_id === this.props.id;
     const style: CSS.Properties = {
       float: "right" as "right",
-      zIndex: 1,
       paddingLeft: "5px",
       background: is_active ? COL_BAR_BACKGROUND : COL_BAR_BACKGROUND_DARK
     };


### PR DESCRIPTION
# Description

#4000

# Testing Steps
I tested this in my beta-chrome, chromium stable and firefox. works as before and the menu shows up properly.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
