### PR TITLE
improve copy paths indexing

### DIFF
--- a/src/smc-util/db-schema.js
+++ b/src/smc-util/db-schema.js
@@ -1523,7 +1523,7 @@ schema.copy_paths = {
       desc: "if the copy failed or output any errors, they are put here."
     }
   },
-  pg_indexes: ["time"]
+  pg_indexes: ["time", "scheduled", "started IS NULL", "finished IS NULL"]
 };
 // TODO: for now there are no user queries -- this is used entirely by backend servers,
 // actually only in kucalc; later that may change, so the user can make copy


### PR DESCRIPTION
# Description

searching for scheduled rows means to look for all older ones which aren't finished. this avoid scanning an ever increasing pile.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
