### PR TITLE
hub: create index expressions must be in in parenthesis 

### DIFF
--- a/src/smc-hub/postgres-base.coffee
+++ b/src/smc-hub/postgres-base.coffee
@@ -981,7 +981,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
         f = (info, cb) =>
             query = info.query
             # Shorthand index is just the part in parens.
-            query = "CREATE INDEX #{info.name} ON #{table} #{query}"
+            query = "CREATE INDEX #{info.name} ON #{table} (#{query})"
             @_query
                 query : query
                 cb    : cb
@@ -1121,7 +1121,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                     switch task.action
                         when 'create'
                             @_query
-                                query : "CREATE INDEX #{task.name} ON #{table} #{task.query}"
+                                query : "CREATE INDEX #{task.name} ON #{table} (#{task.query})"
                                 cb    : cb
                         when 'delete'
                             @_query

--- a/src/smc-util/db-schema.js
+++ b/src/smc-util/db-schema.js
@@ -1523,7 +1523,7 @@ schema.copy_paths = {
       desc: "if the copy failed or output any errors, they are put here."
     }
   },
-  pg_indexes: ["time"]
+  pg_indexes: ["time", "scheduled", "started IS NULL", "finished IS NULL"]
 };
 // TODO: for now there are no user queries -- this is used entirely by backend servers,
 // actually only in kucalc; later that may change, so the user can make copy


### PR DESCRIPTION
# Description

second take for PR #4005, trivial fix. 



# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
