### PR TITLE
hub/proxy: update http-proxy to 1.17

### DIFF
--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -26,7 +26,7 @@
     "express": "^4.11.2",
     "express-session": "^1.10.4",
     "formidable": "^1.0.17",
-    "http-proxy": "^1.12.0",
+    "http-proxy": "^1.17.0",
     "immutable": "^3.7.5",
     "jquery": "^3.4.0",
     "jsdom": "^11.3.0",


### PR DESCRIPTION
# Description
this updates http-proxy to 1.17. I've deployed this in "test" and ...

# Testing Steps
overall frontend, cocalc's jupyter notebook, terminal, x11, and the jupyter lab+classic server work. 

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
