### PR TITLE
less restrictive email sending

### DIFF
--- a/src/smc-hub/email.ts
+++ b/src/smc-hub/email.ts
@@ -51,42 +51,43 @@ const {
   LIVE_DEMO_REQUEST
 } = require("smc-util/theme");
 
-export function escape_email_body(body: string): string {
-  const config = {
-    // in particular, no img and no anchor a
-    allowedTags: [
-      "h1",
-      "h2",
-      "h3",
-      "h4",
-      "h5",
-      "h6",
-      "blockquote",
-      "p",
-      "ul",
-      "ol",
-      "nl",
-      "li",
-      "b",
-      "i",
-      "strong",
-      "em",
-      "strike",
-      "code",
-      "hr",
-      "br",
-      "div",
-      "table",
-      "thead",
-      "caption",
-      "tbody",
-      "tr",
-      "th",
-      "td",
-      "pre"
-    ]
-  };
-  return sanitizeHtml(body, config);
+export function escape_email_body(body: string, allow_urls: boolean): string {
+  // in particular, no img and no anchor a
+  const allowedTags: string[] = [
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "blockquote",
+    "p",
+    "ul",
+    "ol",
+    "nl",
+    "li",
+    "b",
+    "i",
+    "strong",
+    "em",
+    "strike",
+    "code",
+    "hr",
+    "br",
+    "div",
+    "table",
+    "thead",
+    "caption",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "pre"
+  ];
+  if (allow_urls) {
+    allowedTags.push("a");
+  }
+  return sanitizeHtml(body, { allowedTags });
 }
 
 // constructs the email body, also containing sign up instructions pointing to a project.
@@ -96,7 +97,8 @@ function create_email_body(
   body,
   email_address,
   project_title,
-  link2proj
+  link2proj,
+  allow_urls_in_emails
 ): string {
   const base_url_tokens = link2proj.split("/");
   const base_url = `${base_url_tokens[0]}//${base_url_tokens[2]}`;
@@ -104,9 +106,9 @@ function create_email_body(
 
   let email_body = "";
   if (body) {
-    email_body = escape_email_body(body);
+    email_body = escape_email_body(body, allow_urls_in_emails);
     // we check if there are plain URLs, which can be used to send SPAM
-    if (contains_url(email_body)) {
+    if (!allow_urls_in_emails && contains_url(email_body)) {
       throw new Error("Sorry, links to specific websites are not allowed!");
     }
   } else {

--- a/src/smc-webapp/course/actions.ts
+++ b/src/smc-webapp/course/actions.ts
@@ -938,7 +938,7 @@ export class CourseActions extends Actions<CourseState> {
       table: "students",
       student_id
     });
-    await this.configure_project(student_id, undefined, project_id);
+    await this.configure_project(student_id, false, project_id);
   }
 
   private async configure_project_users(

--- a/src/smc-webapp/course/configuration_panel.tsx
+++ b/src/smc-webapp/course/configuration_panel.tsx
@@ -331,6 +331,7 @@ interface ConfigurationPanelProps {
   name: string;
   path: string;
   project_id: string;
+  allow_urls: boolean;
   settings: CourseSettingsRecord;
   project_map: ProjectMap;
   shared_project_id?: string;
@@ -644,7 +645,7 @@ export class ConfigurationPanel extends Component<
    */
 
   check_email_body(value) {
-    if (contains_url(value)) {
+    if (!this.props.allow_urls && contains_url(value)) {
       this.setState({
         email_body_error: "Sending URLs is not allowed. (anti-spam measure)"
       });

--- a/src/smc-webapp/course/main.tsx
+++ b/src/smc-webapp/course/main.tsx
@@ -447,12 +447,16 @@ export const CourseEditor = rclass<CourseReactProps>(
         this.props.redux != null &&
         this.props.settings != null
       ) {
+        const allow_urls = redux
+          .getStore("projects")
+          .allow_urls_in_emails(this.props.project_id);
         return (
           <ConfigurationPanel
             redux={this.props.redux}
             settings={this.props.settings}
             name={this.props.name}
             project_id={this.props.project_id}
+            allow_urls={allow_urls}
             path={this.props.path}
             shared_project_id={
               this.props.settings != null

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -849,6 +849,16 @@ class ProjectsStore extends Store
         upgrades = @get_total_project_upgrades(project_id)
         return misc.map_sum(base_values, upgrades)
 
+    # we allow URLs in projects, which have member hosting or internet access
+    # this must harmonize with smc-hub/client → mesg_invite_noncloud_collaborators
+    allow_urls_in_emails: (project_id) =>
+        quotas = @get_total_project_quotas(project_id)
+        if not quotas?
+            return false
+        else
+            return quotas.network or quotas.member_host
+
+
     # Return javascript mapping from project_id's to the upgrades for the given projects.
     # Only includes projects with at least one upgrade
     get_upgraded_projects: =>


### PR DESCRIPTION
# Description

allow  emailing noncloud users a sanitized email. paying customers can email any content.

# Testing Steps
* the previous iteration of this had a problem with inviting students to courses. this should help with that.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
