### PR TITLE
webapp/frame editor: fix zoom dropdown 

### DIFF
--- a/src/smc-webapp/frame-editors/_style.sass
+++ b/src/smc-webapp/frame-editors/_style.sass
@@ -1,6 +1,5 @@
 // make buttons and button-groups wrap with a larger vertical space (not 0 px)
 .cc-frame-tree-title-bar-buttons
-  overflow: hidden
 
   > div.btn-group,
   > button.btn


### PR DESCRIPTION
# Description
... and probably other dropdowns as well

# Testing Steps
I checked in my chrome 77 and firefox 68, but it might be worth to try others as well.

Via browserstack, I checked the latest Safari and it also works fine.

I also tried Edge, but then https://github.com/sagemathinc/cocalc/issues/4056 happened

# Relevant Issues
#4044

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
