### PR TITLE
Fix scroll margins

### DIFF
--- a/src/smc-webapp/course/assignments_panel.tsx
+++ b/src/smc-webapp/course/assignments_panel.tsx
@@ -391,7 +391,7 @@ export const AssignmentsPanel = rclass<AssignmentsPanelReactProps>(
       );
 
       return (
-        <div className="smc-vfill" style={{ margin: "5px" }}>
+        <div className={"smc-vfill"}>
           {header}
           {shown_assignments.length > 0
             ? this.render_assignment_table_header()

--- a/src/smc-webapp/course/handouts_panel.tsx
+++ b/src/smc-webapp/course/handouts_panel.tsx
@@ -337,7 +337,7 @@ export let HandoutsPanel = rclass<HandoutsPanelReactProps>(
       );
 
       return (
-        <div className="smc-vfill" style={{ margin: "5px" }}>
+        <div className={"smc-vfill"}>
           {header}
           <div style={{ marginTop: "5px" }} />
           {this.render_handouts(shown_handouts)}

--- a/src/smc-webapp/course/main.tsx
+++ b/src/smc-webapp/course/main.tsx
@@ -167,7 +167,7 @@ const remove_redux = function(course_filename, redux, course_project_id) {
 
 const COURSE_EDITOR_STYLE: CSSProperties = {
   height: "100%",
-  overflowY: "scroll",
+  overflowY: "auto",
   overflowX: "hidden"
 };
 

--- a/src/smc-webapp/jupyter/cell-list.tsx
+++ b/src/smc-webapp/jupyter/cell-list.tsx
@@ -372,7 +372,7 @@ export class CellList extends Component<CellListProps> {
   private render_list_of_cells(): Rendered | Rendered[] {
     const style: React.CSSProperties = {
       backgroundColor: "#fff",
-      padding: "5px"
+      paddingLeft: "5px"
     };
 
     if (this.use_windowed_list) {

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -1000,7 +1000,10 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
       this.props.path
     );
     this.props.actions.send_chat(input);
-    if (this.input_ref.current != null && this.input_ref.current.focus != null) {
+    if (
+      this.input_ref.current != null &&
+      this.input_ref.current.focus != null
+    ) {
       this.input_ref.current.focus();
     }
   };
@@ -1022,9 +1025,8 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
       overflowX: "hidden",
       margin: "0",
       padding: "0",
-      paddingRight: "10px",
       background: "white",
-      flex: 1
+      flex: "1 0 auto"
     };
 
     // the immutable.Map() default is because of admins:


### PR DESCRIPTION
# Description
removing a couple of margins and paddings, such that scrollbars which should be on the right hand side are actually on the right hand side. there was also a case where an inactive bar is shown (and the active one is nested inside right next to it)

# Testing Steps
* chat window
* course: assignments + handouts, and config is scrollable
* jupyter cell list

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
