### PR TITLE
prettier 1.18.2: update and make consistent

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -49,7 +49,7 @@
     "node-cjsx": "^1.0.0",
     "node-glob": "^1.2.0",
     "node-sass": "^4.11.0",
-    "prettier": "^1.16.0",
+    "prettier": "^1.18.2",
     "pug": "^2.0.3",
     "pug-loader": "^2.3.0",
     "react-test-renderer": "^16.5.2",

--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -35,7 +35,7 @@
     "node-pty": "^0.8.1",
     "pidusage": "^1.2.0",
     "posix": "^4.0.0",
-    "prettier": "^1.17.0",
+    "prettier": "^1.18.2",
     "primus": "^7.3.2",
     "primus-multiplex": "github:STRML/primus-multiplex",
     "primus-responder": "^1.0.4",


### PR DESCRIPTION
# Description
Prettier will be updated to 1.18.2 with the next software update. This makes the one we install for development consistent with that. The overall motivation is to catch up on a couple of improvements, and also support new syntax. In particular, this will support the new `readonly` keyword in TypeScript.

# Testing Steps
I checked tsx, js, and markdown.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
