### PR TITLE
webapp/projects listing: fix scrolling for custom software (on small screens)

### DIFF
--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1520,75 +1520,75 @@ exports.ProjectsPage = ProjectsPage = rclass
             else
                 return <div style={fontSize:'40px', textAlign:'center', color:'#999999'} > <Loading />  </div>
         visible_projects = @visible_projects()
-        <div className='container-content smc-vfill'>
-            <Grid fluid className='constrained smc-vfill' style={{minWidth:'90%'}}>
-                <Well className="smc-vfill" style={marginTop:'15px'}>
-                    <Row>
-                        <Col sm={4}>
-                            {@render_projects_title()}
-                        </Col>
-                        <Col sm={4}>
-                            <ProjectsFilterButtons
-                                hidden  = {@props.hidden}
-                                deleted = {@props.deleted}
-                                show_hidden_button = {@has_hidden_projects() or @props.hidden}
-                                show_deleted_button = {@has_deleted_projects() or @props.deleted} />
-                        </Col>
-                        <Col sm={4}>
-                            <UsersViewing style={width:'100%'}/>
-                        </Col>
-                    </Row>
-                    <Row>
-                        <Col sm={4}>
-                            <ProjectsSearch ref="search" search={@props.search} open_first_project={@open_first_project} />
-                        </Col>
-                        <Col sm={8}>
-                            <HashtagGroup
-                                hashtags          = {@hashtags()}
-                                selected_hashtags = {@props.selected_hashtags[@filter()]}
-                                toggle_hashtag    = {@toggle_hashtag} />
-                        </Col>
-                    </Row>
-                    <Row>
-                        <Col sm={12} style={marginTop:'1ex'}>
-                            <VisibleMDLG>
-                                <div style={maxWidth:'50%', float:'right'}>
-                                    <UpgradeStatus />
-                                </div>
-                            </VisibleMDLG>
-                            <NewProjectCreator
-                                start_in_edit_mode = {@project_list().length == 0}
-                                default_value={@props.search}
-                                images = {@props.images}
-                            />
-                        </Col>
-                    </Row>
-                    <Row>
-                        <Col sm={12}>
-                            <ProjectsListingDescription
-                                nb_projects       = {@project_list().length}
-                                visible_projects  = {visible_projects}
-                                hidden            = {@props.hidden}
-                                deleted           = {@props.deleted}
-                                search            = {@props.search}
-                                selected_hashtags = {@props.selected_hashtags[@filter()]}
-                                on_cancel         = {@clear_filters_and_focus_search_input}
-                            />
-                        </Col>
-                    </Row>
-                    <Row className="smc-vfill">
-                        <Col sm={12} className="smc-vfill">
-                            <ProjectList
-                                projects    = {visible_projects}
-                                user_map    = {@props.user_map}
-                                images      = {@props.images}
-                                load_all_projects_done = {@props.load_all_projects_done}
-                                redux       = {redux} />
-                        </Col>
-                    </Row>
-                </Well>
-            </Grid>
-        </div>
+        <Col sm={12} md={12} lg={10} lgOffset={1}
+            className={'container-content smc-vfill'}
+            style={overflowY:'auto', paddingTop:'20px'}
+        >
+            <Row>
+                <Col sm={4}>
+                    {@render_projects_title()}
+                </Col>
+                <Col sm={4}>
+                    <ProjectsFilterButtons
+                        hidden  = {@props.hidden}
+                        deleted = {@props.deleted}
+                        show_hidden_button = {@has_hidden_projects() or @props.hidden}
+                        show_deleted_button = {@has_deleted_projects() or @props.deleted}
+                    />
+                </Col>
+                <Col sm={4}>
+                    <UsersViewing style={width:'100%'}/>
+                </Col>
+            </Row>
+            <Row>
+                <Col sm={4}>
+                    <ProjectsSearch ref="search" search={@props.search} open_first_project={@open_first_project} />
+                </Col>
+                <Col sm={8}>
+                    <HashtagGroup
+                        hashtags          = {@hashtags()}
+                        selected_hashtags = {@props.selected_hashtags[@filter()]}
+                        toggle_hashtag    = {@toggle_hashtag} />
+                </Col>
+            </Row>
+            <Row>
+                <Col sm={12} style={marginTop:'1ex'}>
+                    <VisibleMDLG>
+                        <div style={maxWidth:'50%', float:'right'}>
+                            <UpgradeStatus />
+                        </div>
+                    </VisibleMDLG>
+                    <NewProjectCreator
+                        start_in_edit_mode = {@project_list().length == 0}
+                        default_value={@props.search}
+                        images = {@props.images}
+                    />
+                </Col>
+            </Row>
+            <Row>
+                <Col sm={12}>
+                    <ProjectsListingDescription
+                        nb_projects       = {@project_list().length}
+                        visible_projects  = {visible_projects}
+                        hidden            = {@props.hidden}
+                        deleted           = {@props.deleted}
+                        search            = {@props.search}
+                        selected_hashtags = {@props.selected_hashtags[@filter()]}
+                        on_cancel         = {@clear_filters_and_focus_search_input}
+                    />
+                </Col>
+            </Row>
+            <Row className="smc-vfill">
+                <Col sm={12} className="smc-vfill">
+                    <ProjectList
+                        projects    = {visible_projects}
+                        user_map    = {@props.user_map}
+                        images      = {@props.images}
+                        load_all_projects_done = {@props.load_all_projects_done}
+                        redux       = {redux} />
+                </Col>
+            </Row>
+        </Col>
 
 LoadAllProjects = rclass
     displayName: "LoadAllProjects"


### PR DESCRIPTION
# Description

this is an attempt to fix #4054. I wasn't able to fix the nested layout in such a way, that the windowed list works and also the custom software dialog can be scrolled. This simplifies all this.

# Testing Steps
I tested this on chrome 77 and firefox 68, for narrower windows, and also in cases where it has a smaller height (i.e. the scrollbars become necessary). both behave fine and in the same way.



# Relevant Issues

#4054

# screenshots

## firefox: default view, all projects and opening custom software dialog -- in the last two cases scrolling down a little bit

![Screenshot from 2019-08-31 10-59-20](https://user-images.githubusercontent.com/207405/64061694-908f4f00-cbde-11e9-84da-b83339b0cc52.png)
![Screenshot from 2019-08-31 10-59-35](https://user-images.githubusercontent.com/207405/64061698-92f1a900-cbde-11e9-9e68-e32c94e6b4b0.png)
![Screenshot from 2019-08-31 10-59-49](https://user-images.githubusercontent.com/207405/64061701-94bb6c80-cbde-11e9-8773-c028df0a99da.png)


## chrome, 1200px width: default view, all projects and opening custom software dialog -- in the last two cases scrolling down a little bit

![Screenshot from 2019-08-31 11-01-59](https://user-images.githubusercontent.com/207405/64061731-07c4e300-cbdf-11e9-8013-32f1e05f61f3.png)
![Screenshot from 2019-08-31 11-02-08](https://user-images.githubusercontent.com/207405/64061734-0abfd380-cbdf-11e9-92eb-70224563e190.png)
![Screenshot from 2019-08-31 11-02-30](https://user-images.githubusercontent.com/207405/64061736-0d222d80-cbdf-11e9-81ef-04e4160ded4c.png)

## chrome, small window, ~900x620px

![Screenshot from 2019-08-31 11-04-38](https://user-images.githubusercontent.com/207405/64061756-3ba00880-cbdf-11e9-9421-f2917c42576c.png)
![Screenshot from 2019-08-31 11-04-55](https://user-images.githubusercontent.com/207405/64061758-3e9af900-cbdf-11e9-9af4-1fce643ef612.png)

## chrome, large window

![Screenshot from 2019-08-31 11-11-04](https://user-images.githubusercontent.com/207405/64061838-0a740800-cbe0-11e9-8e6b-c37453fcc54f.png)

## chrome, simulated mobile

![Screenshot from 2019-08-31 11-09-47](https://user-images.githubusercontent.com/207405/64061839-1233ac80-cbe0-11e9-9afc-bd2ea043795e.png)



### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
