### PR TITLE
preflight check: block all Edge until #4056 is solved

### DIFF
--- a/src/webapp-lib/preflight-checks.ts
+++ b/src/webapp-lib/preflight-checks.ts
@@ -70,7 +70,7 @@ function preflight_check(): void {
   // this is for checking a minimum age
   const oldFF = spec.name === "Firefox" && spec.version < 54;
   const oldIE = spec.name === "MSIE" || spec.name === "IE"; // all of them are a problem
-  const oldEdge = spec.name === "Edge" && spec.version < 14;
+  const oldEdge = spec.name === "Edge"; // block all edge until #4056 is solved -- formerly: && spec.version < 14;
   const oldSafari = spec.name === "Safari" && spec.version < 10;
   const oldOpera = spec.name === "Opera" && spec.version < 55;
   const oldChrome = spec.name === "Chrome" && spec.version < 62;


### PR DESCRIPTION
# Description

see #4056

# Testing Steps
I'm building this in  "test", otherwise I have no way to check it → deployed and it does block Edge as expected

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
