### PR TITLE
Add store getIn types

### DIFF
--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -2,20 +2,27 @@ const { defaults: tsjPreset } = require("ts-jest/presets");
 const path = require("path");
 
 module.exports = {
-  roots: ["<rootDir>/smc-webapp/"],
+  projects: [
+    {
+      displayName: "smc-webapp",
+      testMatch: ["<rootDir>/smc-webapp/**/*.ts"]
+    }
+  ],
   transform: {
     ...tsjPreset.transform
   },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   testPathIgnorePatterns: ["/node_modules/", "/test-mocha/"],
   modulePaths: [
+    "<rootDir>/..",
     path.resolve(__dirname, "smc-util"),
+    path.resolve(__dirname, "smc-util/misc"),
     path.resolve(__dirname, "smc-webapp"),
-    path.resolve(__dirname, "smc-webapp/node_modules"),
+    path.resolve(__dirname, "smc-webapp/node_modules")
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
 
   // Setup Enzyme
-  "snapshotSerializers": ["enzyme-to-json/serializer"],
-  "setupFilesAfterEnv": ["<rootDir>/setupEnzyme.ts"],
+  snapshotSerializers: ["enzyme-to-json/serializer"],
+  setupFilesAfterEnv: ["<rootDir>/setupEnzyme.ts"]
 };

--- a/src/package.json
+++ b/src/package.json
@@ -60,6 +60,7 @@
     "ts-jest": "^24.0.0",
     "ts-loader": "^4.4.1",
     "ts-node": "^7.0.0",
+    "tsd": "^0.7.4",
     "typescript": "^3.6.2",
     "uglify-js": "^2.6.2",
     "uglifyjs-webpack-plugin": "^1.2.4",

--- a/src/smc-webapp/app-framework/Store.ts
+++ b/src/smc-webapp/app-framework/Store.ts
@@ -93,11 +93,11 @@ export class Store<State> extends EventEmitter {
     return this.redux._redux_store.getState().get(this.name);
   }
 
-  get<K extends keyof State>(field: K): State[K];
-  get<K extends keyof State, NSV = State[K]>(
+  get<K extends keyof State>(field: K): DeepImmutable<State[K]>;
+  get<K extends keyof State, NSV>(
     field: K,
-    notSetValue?: NSV
-  ): State[K] | NSV;
+    notSetValue: NSV
+  ): DeepImmutable<State[K]> | NSV;
   get<K extends keyof State, NSV = State[K]>(
     field: K,
     notSetValue?: NSV

--- a/src/smc-webapp/app-framework/Store.ts
+++ b/src/smc-webapp/app-framework/Store.ts
@@ -96,6 +96,13 @@ export class Store<State> extends EventEmitter {
     return this.redux._redux_store.getState().get(this.name);
   }
 
+  get<K extends keyof State>(
+    field: K
+  ): State[K];
+  get<K extends keyof State, NSV = State[K]>(
+    field: K,
+    notSetValue?: NSV
+  ): State[K] | NSV
   get<K extends keyof State, NSV = State[K]>(
     field: K,
     notSetValue?: NSV
@@ -131,18 +138,25 @@ export class Store<State> extends EventEmitter {
   >;
   getIn<K1 extends keyof State, NSV>(
     path: [K1],
-    notSetValue?: NSV
+    notSetValue: NSV
   ): State[K1] | NSV;
-  getIn<K1 extends keyof State, K2 extends keyof State[K1], NSV>(
+  getIn<K1 extends keyof State, K2 extends keyof NonNullable<State[K1]>, NSV>(
     path: [K1, K2],
-    notSetValue?: NSV
-  ): State[K1][K2] | NSV;
+    notSetValue: NSV
+  ): CopyMaybe<State[K1], NonNullable<State[K1]>[K2]> | NSV;
   getIn<
     K1 extends keyof State,
-    K2 extends keyof State[K1],
-    K3 extends keyof State[K1][K2],
+    K2 extends keyof NonNullable<State[K1]>,
+    K3 extends keyof NonNullable<NonNullable<State[K1]>[K2]>,
     NSV
-  >(path: [K1, K2, K3], notSetValue?: NSV): State[K1][K2][K3] | NSV;
+  >(
+    path: [K1, K2, K3],
+    notSetValue: NSV
+  ): CopyAnyMaybe<
+    State[K1],
+    NonNullable<State[K1]>[K2],
+    NonNullable<NonNullable<State[K1]>[K2]>[K3] | NSV
+  >;
   getIn(path: any[], notSetValue?: any): any {
     return this.redux._redux_store
       .getState()

--- a/src/smc-webapp/app-framework/Store.ts
+++ b/src/smc-webapp/app-framework/Store.ts
@@ -20,6 +20,9 @@ export interface selector<State, K extends keyof State> {
   fn: () => State[K];
 }
 
+/**
+ *  
+ */
 export class Store<State> extends EventEmitter {
   public name: string;
   public getInitialState?: () => State;

--- a/src/smc-webapp/app-framework/Store.ts
+++ b/src/smc-webapp/app-framework/Store.ts
@@ -110,14 +110,25 @@ export class Store<State> extends EventEmitter {
   // https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape
   // If you need to describe a recurse data structure such as a binary tree, use unsafe_getIn.
   // Does not work with selectors.
+  getIn<K1 extends keyof State>(
+    path: [K1]
+  ): State[K1];
   getIn<K1 extends keyof State, NSV>(
     path: [K1],
     notSetValue?: NSV
   ): State[K1] | NSV;
+  getIn<K1 extends keyof State, K2 extends keyof State[K1]>(
+    path: [K1, K2]
+  ): State[K1][K2];
   getIn<K1 extends keyof State, K2 extends keyof State[K1], NSV>(
     path: [K1, K2],
     notSetValue?: NSV
   ): State[K1][K2] | NSV;
+  getIn<
+    K1 extends keyof State,
+    K2 extends keyof State[K1],
+    K3 extends keyof State[K1][K2]
+  >(path: [K1, K2, K3]): State[K1][K2][K3];
   getIn<
     K1 extends keyof State,
     K2 extends keyof State[K1],

--- a/src/smc-webapp/app-framework/TypedMap.ts
+++ b/src/smc-webapp/app-framework/TypedMap.ts
@@ -16,6 +16,7 @@ let sale2 = sale1.set("name", "Mocha");
 For more information see "app-framework/examples/"
 */
 import { Map } from "immutable";
+import { DeepImmutable } from "./immutable-types"
 
 export interface TypedMap<TProps extends Object> {
   size: number;
@@ -31,6 +32,11 @@ export interface TypedMap<TProps extends Object> {
    * notSetValue will be returned if provided. Note that this scenario would
    * produce an error when using Flow or TypeScript.
    */
+  get<K extends keyof TProps>(field: K): DeepImmutable<TProps[K]>;
+  get<K extends keyof TProps, NSV>(
+    field: K,
+    notSetValue: NSV
+  ): DeepImmutable<TProps[K]> | NSV;
   get<K extends keyof TProps>(key: K): TProps[K];
 
   // Reading deep values

--- a/src/smc-webapp/app-framework/__tests__/deep-immutable.type.test.ts
+++ b/src/smc-webapp/app-framework/__tests__/deep-immutable.type.test.ts
@@ -1,46 +1,43 @@
-import { expectType, expectError } from "tsd";
+import { expectType } from "tsd";
 import * as immutable from "immutable";
 import { TypedMap } from "../TypedMap";
 import { DeepImmutable } from "../immutable-types";
 
-function fromJS<T>(o: T): DeepImmutable<T> {
-  return immutable.fromJS(o);
-}
-
-interface state {
-  foo: {
-    bar: string[];
-    bar2?: { a?: number[]; b: number; c: number };
-    map: immutable.Map<string, any>;
-    list: immutable.List<string>;
-    typed_map: TypedMap<{ ok: string }>;
-    Date: Date;
-    Map: Map<any, any>;
-    Set: Set<any>;
-    WeakMap: WeakMap<any, any>;
-    WeakSet: WeakSet<any>;
-    Promise: Promise<any>;
-    ArrayBuffer: ArrayBuffer;
-  };
-}
-let values: state = {} as any;
-let result = fromJS(values)
-
-type FullConvert = TypedMap<{
-  foo: TypedMap<{
-    bar: immutable.List<string>;
-    bar2?: TypedMap<{ a?: immutable.List<number>; b: number; c: number }>;
-    map: immutable.Map<string, any>;
-    list: immutable.List<string>;
-    typed_map: TypedMap<{ ok: string }>;
-    Date: Date;
-    Map: Map<any, any>;
-    Set: Set<any>;
-    WeakMap: WeakMap<any, any>;
-    WeakSet: WeakSet<any>;
-    Promise: Promise<any>;
-    ArrayBuffer: ArrayBuffer;
-  }>;
-}>
-
-expectType<FullConvert>(result);
+test("Successfully converts a complex object", () => {
+  interface State {
+    foo: { 
+      bar: string[];
+      bar2?: { a?: number[]; b: number; c: number };
+      map: immutable.Map<string, any>;
+      list: immutable.List<string>;
+      typed_map: TypedMap<{ ok: string }>;
+      Date: Date;
+      Map: Map<any, any>;
+      Set: Set<any>;
+      WeakMap: WeakMap<object, any>;
+      WeakSet: WeakSet<any>;
+      Promise: Promise<any>;
+      ArrayBuffer: ArrayBuffer;
+    };
+  }
+  let result: DeepImmutable<State> = "" as any;
+  
+  type FullConvert = TypedMap<{
+    foo: TypedMap<{
+      bar: immutable.List<string>;
+      bar2?: TypedMap<{ a?: immutable.List<number>; b: number; c: number }>;
+      map: immutable.Map<string, any>;
+      list: immutable.List<string>;
+      typed_map: TypedMap<{ ok: string }>;
+      Date: Date;
+      Map: Map<any, any>;
+      Set: Set<any>;
+      WeakMap: WeakMap<object, any>;
+      WeakSet: WeakSet<any>;
+      Promise: Promise<any>;
+      ArrayBuffer: ArrayBuffer;
+    }>;
+  }>
+  
+  expectType<FullConvert>(result);
+})

--- a/src/smc-webapp/app-framework/__tests__/deep-immutable.type.test.ts
+++ b/src/smc-webapp/app-framework/__tests__/deep-immutable.type.test.ts
@@ -1,0 +1,46 @@
+import { expectType, expectError } from "tsd";
+import * as immutable from "immutable";
+import { TypedMap } from "../TypedMap";
+import { DeepImmutable } from "../immutable-types";
+
+function fromJS<T>(o: T): DeepImmutable<T> {
+  return immutable.fromJS(o);
+}
+
+interface state {
+  foo: {
+    bar: string[];
+    bar2?: { a?: number[]; b: number; c: number };
+    map: immutable.Map<string, any>;
+    list: immutable.List<string>;
+    typed_map: TypedMap<{ ok: string }>;
+    Date: Date;
+    Map: Map<any, any>;
+    Set: Set<any>;
+    WeakMap: WeakMap<any, any>;
+    WeakSet: WeakSet<any>;
+    Promise: Promise<any>;
+    ArrayBuffer: ArrayBuffer;
+  };
+}
+let values: state = {} as any;
+let result = fromJS(values)
+
+type FullConvert = TypedMap<{
+  foo: TypedMap<{
+    bar: immutable.List<string>;
+    bar2?: TypedMap<{ a?: immutable.List<number>; b: number; c: number }>;
+    map: immutable.Map<string, any>;
+    list: immutable.List<string>;
+    typed_map: TypedMap<{ ok: string }>;
+    Date: Date;
+    Map: Map<any, any>;
+    Set: Set<any>;
+    WeakMap: WeakMap<any, any>;
+    WeakSet: WeakSet<any>;
+    Promise: Promise<any>;
+    ArrayBuffer: ArrayBuffer;
+  }>;
+}>
+
+expectType<FullConvert>(result);

--- a/src/smc-webapp/app-framework/__tests__/store-get-in.type.test.ts
+++ b/src/smc-webapp/app-framework/__tests__/store-get-in.type.test.ts
@@ -1,0 +1,33 @@
+import { expectType } from "tsd";
+import { Store } from "../Store";
+import { DeepImmutable } from "../immutable-types";
+
+interface State {
+  deep?: { values: { cake: string } };
+}
+
+const one_maybes = new Store<State>("", {} as any);
+
+let oMvalue1 = one_maybes.getIn(["deep"]);
+expectType<DeepImmutable<{ values: { cake: string } } | undefined>>(oMvalue1);
+
+let oMvalue2 = one_maybes.getIn(["deep", "values"]);
+expectType<DeepImmutable<{ cake: string } | undefined>>(oMvalue2);
+
+let oMvalue3 = one_maybes.getIn(["deep", "values", "cake"]);
+expectType<string | undefined>(oMvalue3);
+
+const no_maybes = new Store<{ deep: { values: { cake: string } } }>(
+  "",
+  {} as any
+);
+
+let value1 = no_maybes.getIn(["deep"]);
+expectType<DeepImmutable<{ values: { cake: string } }>>(value1);
+
+let value2 = no_maybes.getIn(["deep", "values"]);
+expectType<DeepImmutable<{ cake: string }>>(value2);
+
+let value3 = no_maybes.getIn(["deep", "values", "cake"]);
+expectType<string>(value3);
+

--- a/src/smc-webapp/app-framework/__tests__/store-get-in.type.test.ts
+++ b/src/smc-webapp/app-framework/__tests__/store-get-in.type.test.ts
@@ -1,33 +1,42 @@
 import { expectType } from "tsd";
 import { Store } from "../Store";
 import { DeepImmutable } from "../immutable-types";
+import { AppRedux } from "../../app-framework";
 
-interface State {
-  deep?: { values: { cake: string } };
-}
+test("Mapping with maybes in state", () => {
+  interface State {
+    deep?: { values: { cake: string } };
+  }
+  const redux = new AppRedux();
 
-const one_maybes = new Store<State>("", {} as any);
+  const one_maybes = new Store<State>("", redux);
 
-let oMvalue1 = one_maybes.getIn(["deep"]);
-expectType<DeepImmutable<{ values: { cake: string } } | undefined>>(oMvalue1);
+  let withMaybeValues1 = one_maybes.getIn(["deep"]);
+  expectType<DeepImmutable<{ values: { cake: string } } | undefined>>(
+    withMaybeValues1
+  );
 
-let oMvalue2 = one_maybes.getIn(["deep", "values"]);
-expectType<DeepImmutable<{ cake: string } | undefined>>(oMvalue2);
+  let withMaybeValues2 = one_maybes.getIn(["deep", "values"]);
+  expectType<DeepImmutable<{ cake: string } | undefined>>(withMaybeValues2);
 
-let oMvalue3 = one_maybes.getIn(["deep", "values", "cake"]);
-expectType<string | undefined>(oMvalue3);
+  let withMaybeValues3 = one_maybes.getIn(["deep", "values", "cake"]);
+  expectType<string | undefined>(withMaybeValues3);
+});
 
-const no_maybes = new Store<{ deep: { values: { cake: string } } }>(
-  "",
-  {} as any
-);
+test("Mapping with no maybes in State", () => {
+  interface State {
+    deep: { values: { cake: string } };
+  }
 
-let value1 = no_maybes.getIn(["deep"]);
-expectType<DeepImmutable<{ values: { cake: string } }>>(value1);
+  const redux = new AppRedux();
+  const no_maybes = new Store<State>("", redux);
 
-let value2 = no_maybes.getIn(["deep", "values"]);
-expectType<DeepImmutable<{ cake: string }>>(value2);
+  let value1 = no_maybes.getIn(["deep"]);
+  expectType<DeepImmutable<{ values: { cake: string } }>>(value1);
 
-let value3 = no_maybes.getIn(["deep", "values", "cake"]);
-expectType<string>(value3);
+  let value2 = no_maybes.getIn(["deep", "values"]);
+  expectType<DeepImmutable<{ cake: string }>>(value2);
 
+  let value3 = no_maybes.getIn(["deep", "values", "cake"]);
+  expectType<string>(value3);
+});

--- a/src/smc-webapp/app-framework/immutable-types.ts
+++ b/src/smc-webapp/app-framework/immutable-types.ts
@@ -15,6 +15,8 @@ export type DeepImmutable<T> = T extends Collection<any, any>
   ? T // Any immutable.js data structure
   : T extends (infer U)[]
   ? List<U>
+  : T extends TypedMap<infer U>
+  ? TypedMap<U>
   : T extends object // Filter out desired objects above this line
   ? MapToRecurse<T>
   : T; // Base case primatives

--- a/src/smc-webapp/app-framework/immutable-types.ts
+++ b/src/smc-webapp/app-framework/immutable-types.ts
@@ -1,0 +1,24 @@
+import { Collection, List } from "immutable";
+import { TypedMap } from "./TypedMap";
+
+
+export type Maybe<T> = T | undefined;
+// Return Maybe<U> iff T is a Maybe<?>
+export type CopyMaybe<T, U> = Maybe<T> extends T ? Maybe<U> : U;
+export type CopyAnyMaybe<T, U, V> = CopyMaybe<T, V> | CopyMaybe<U, V>;
+
+// Higher Kinded Types could make this generic.
+// ie. if we could pass in an additional generic type U, then
+// all objects could be U<T>
+// As it is, right now that U<T> = TypeMap<T>
+export type DeepImmutable<T> = T extends Collection<any, any>
+  ? T // Any immutable.js data structure
+  : T extends (infer U)[]
+  ? List<U>
+  : T extends object // Filter out desired objects above this line
+  ? MapToRecurse<T>
+  : T; // Base case primatives
+
+type MapToRecurse<T extends object> = TypedMap<
+  { [P in keyof T]: DeepImmutable<T[P]> }
+>;

--- a/src/smc-webapp/app-framework/immutable-types.ts
+++ b/src/smc-webapp/app-framework/immutable-types.ts
@@ -1,22 +1,31 @@
 import { Collection, List } from "immutable";
 import { TypedMap } from "./TypedMap";
 
-
 export type Maybe<T> = T | undefined;
 // Return Maybe<U> iff T is a Maybe<?>
 export type CopyMaybe<T, U> = Maybe<T> extends T ? Maybe<U> : U;
 export type CopyAnyMaybe<T, U, V> = CopyMaybe<T, V> | CopyMaybe<U, V>;
 
+type CoveredJSBuiltInTypes =
+  | Date
+  | Map<any, any>
+  | Set<any>
+  | WeakMap<any, any>
+  | WeakSet<any>
+  | Promise<any>
+  | ArrayBuffer;
+
 // Higher Kinded Types could make this generic.
 // ie. if we could pass in an additional generic type U, then
 // all objects could be U<T>
 // As it is, right now that U<T> = TypeMap<T>
-export type DeepImmutable<T> = T extends Collection<any, any>
-  ? T // Any immutable.js data structure
+export type DeepImmutable<T> = T extends  // TODO: Make any non-plain-object retain it's type
+  | Collection<any, any>
+  | TypedMap<any>
+  | CoveredJSBuiltInTypes
+  ? T // Any of the types above should not be TypedMap-ified
   : T extends (infer U)[]
   ? List<U>
-  : T extends TypedMap<infer U>
-  ? TypedMap<U>
   : T extends object // Filter out desired objects above this line
   ? MapToRecurse<T>
   : T; // Base case primatives

--- a/src/smc-webapp/billing/store.ts
+++ b/src/smc-webapp/billing/store.ts
@@ -1,7 +1,7 @@
 import { Map, Set } from "immutable";
 
 import { redux, Store } from "../app-framework";
-import { AppliedCoupons, CoursePay } from "./types";
+import { AppliedCoupons, CoursePay, Customer } from "./types";
 
 export interface BillingStoreState {
   stripe_publishable_key?: string;
@@ -10,7 +10,7 @@ export interface BillingStoreState {
   error?: string;
   action?: string;
   no_stripe?: boolean;
-  customer?: any;   // I tried and failed to declare these... It's Customer in types, but as immutable, so what do I do?
+  customer?: Customer;
   invoices?: any;
   loaded?: boolean;
   continue_first_purchase?: boolean;

--- a/src/smc-webapp/billing/store.ts
+++ b/src/smc-webapp/billing/store.ts
@@ -1,7 +1,7 @@
 import { Map, Set } from "immutable";
 
 import { redux, Store } from "../app-framework";
-import { AppliedCoupons, CoursePay, Customer } from "./types";
+import { AppliedCoupons, CoursePay, Customer, Invoices } from "./types";
 
 export interface BillingStoreState {
   stripe_publishable_key?: string;
@@ -11,7 +11,7 @@ export interface BillingStoreState {
   action?: string;
   no_stripe?: boolean;
   customer?: Customer;
-  invoices?: any;
+  invoices?: Invoices;
   loaded?: boolean;
   continue_first_purchase?: boolean;
   selected_plan?: string;

--- a/src/smc-webapp/billing/types.ts
+++ b/src/smc-webapp/billing/types.ts
@@ -62,8 +62,8 @@ export interface Invoices {
 }
 
 export interface Customer {
-  sources: { data: List<Source>; total_count: number };
-  subscriptions: { data: List<Subscription>; total_count: number };
+  sources: { data: Source[]; total_count: number };
+  subscriptions: { data: Subscription[]; total_count: number };
   default_source: string;
 }
 

--- a/src/smc-webapp/billing/types.ts
+++ b/src/smc-webapp/billing/types.ts
@@ -3,7 +3,7 @@ These interfaces are exactly what we **actually use** in our code, not
 what stripe actually provides!
 */
 
-import { Map, Set, List } from "immutable";
+import { Map, Set } from "immutable";
 
 export type AppliedCoupons = Map<string, any>;
 

--- a/src/smc-webapp/billing/types.ts
+++ b/src/smc-webapp/billing/types.ts
@@ -3,7 +3,7 @@ These interfaces are exactly what we **actually use** in our code, not
 what stripe actually provides!
 */
 
-import { Map, Set } from "immutable";
+import { Map, Set, List } from "immutable";
 
 export type AppliedCoupons = Map<string, any>;
 
@@ -62,8 +62,8 @@ export interface Invoices {
 }
 
 export interface Customer {
-  sources: { data: Source[]; total_count: number };
-  subscriptions: { data: Subscription[]; total_count: number };
+  sources: { data: List<Source>; total_count: number };
+  subscriptions: { data: List<Subscription>; total_count: number };
   default_source: string;
 }
 

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -82,11 +82,22 @@ interface gutterMarkerParams {
 const GutterMarker = createTypedMap<gutterMarkerParams>();
 type GutterMarkers = Map<string, TypedMap<gutterMarkerParams>>;
 
+interface LocalViewParams {
+  frame_tree?: Map<string, any>;// ImmutableFrameTree;
+  active_id: string;
+  full_id: string;
+  editor_state?: unknown;
+  version?: number;
+  font_size?: number
+}
+
+type LocalViewState = TypedMap<LocalViewParams>;
+
 export interface CodeEditorState {
   project_id: string;
   path: string;
   is_public: boolean;
-  local_view_state: any; // TypedMap({frame_tree?: ImmutableFrameTree, active_id: string, full_id: string, editor_state?: unknown, version?: number, font_size?: number})
+  local_view_state: any; // Generic use of Actions below makes this entirely befuddling...
   reload: Map<string, any>;
   resize: number;
   misspelled_words: Set<string>;
@@ -478,7 +489,7 @@ export class Actions<
     );
   }
 
-  _load_local_view_state(): Map<string, any> {
+  _load_local_view_state(): LocalViewState {
     let local_view_state;
     const x = localStorage[this.name];
     if (x != null) {
@@ -530,15 +541,16 @@ export class Actions<
     this.reset_frame_tree();
   }
 
-  set_local_view_state(obj): void {
+  set_local_view_state(obj: LocalViewParams): void {
     if (this._state === "closed") {
       return;
     }
     // Set local state related to what we see/search for/etc.
     let local = this.store.get("local_view_state");
     for (let key in obj) {
-      const value = obj[key];
-      local = local.set(key, fromJS(value));
+      const coerced_key = key as keyof LocalViewParams
+      const value = obj[coerced_key];
+      local = local.set(coerced_key, fromJS(value));
     }
     this.setState({
       local_view_state: local
@@ -548,7 +560,7 @@ export class Actions<
 
   _is_leaf_id(id: string): boolean {
     return tree_ops.is_leaf_id(
-      this.store.getIn(["local_view_state", "frame_tree"]),
+      this.store.getIn(["local_view_state", "frame_tree"]) as any,
       id
     );
   }
@@ -566,7 +578,7 @@ export class Actions<
   // If a different frame is maximized, switch out of maximized mode.
   public set_active_id(active_id: string, ignore_if_missing?: boolean): void {
     // Set the active_id, if necessary.
-    const local: Map<string, any> = this.store.get("local_view_state");
+    const local = this.store.get("local_view_state");
     if (local.get("active_id") === active_id) {
       // already set -- nothing more to do
       return;
@@ -1199,7 +1211,7 @@ export class Actions<
   }
 
   public _active_id(): string {
-    return this.store.getIn(["local_view_state", "active_id"]);
+    return this.store.getIn(["local_view_state", "active_id"]) as any;
   }
 
   _active_cm(): CodeMirror.Editor | undefined {
@@ -1576,10 +1588,7 @@ export class Actions<
     const proj_store = this.redux.getProjectStore(this.project_id);
     if (proj_store != null) {
       // TODO why is this an immutable map? it's project_configuration/Available
-      const available = proj_store.get("available_features") as Map<
-        string,
-        boolean
-      >;
+      const available = proj_store.get("available_features");
       if (available != null && !available.get("spellcheck", false)) {
         // console.log("Spellcheck not available");
         return;

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -130,7 +130,7 @@
     "react-addons-perf": "^15.4.2"
   },
   "scripts": {
-    "test": "cd .. && jest",
+    "test": "cd .. && npx jest",
     "testwapp": "echo 'TEST WEBAPP'; SMC_TEST=true node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/*.coffee",
     "testjcli": "echo 'TEST JUPYTER CLIENT'; cd jupyter && ../node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/*.coffee",
     "lint": "node_modules/.bin/coffeelint -f ../smc-util/coffeelint.json -c *.coffee *.cjsx",

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -50,7 +50,7 @@
     "history": "^1.17.0",
     "htmlparser": "^1.7.7",
     "humanize-list": "^1.0.1",
-    "immutable": "^4.0.0-rc.10",
+    "immutable": "^4.0.0-rc.12",
     "install": "^0.13.0",
     "jquery": "^3.4.0",
     "jquery-caret": "^1.3",

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -130,7 +130,7 @@
     "react-addons-perf": "^15.4.2"
   },
   "scripts": {
-    "test": "cd .. && npx jest",
+    "test": "cd .. && npx jest smc-webapp",
     "testwapp": "echo 'TEST WEBAPP'; SMC_TEST=true node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/*.coffee",
     "testjcli": "echo 'TEST JUPYTER CLIENT'; cd jupyter && ../node_modules/.bin/mocha ${BAIL} --reporter ${REPORTER:-progress} test/*.coffee",
     "lint": "node_modules/.bin/coffeelint -f ../smc-util/coffeelint.json -c *.coffee *.cjsx",


### PR DESCRIPTION
# Description
- Fix deep typing for `getIn` when the entire path was always defined
- Add deep typing for `getIn` when some part of the path MAY be defined
- Add type `DeepImmutable<T>` for converting from plain JS objects to our use of immutable js.
    - Does NOT support custom classes. So *the typing* (not runtime, so use `as any` if you must) will break if you stored a custom class inside a store. So far we don't do this it seems.

# Testing Steps
```
cd src/smc-webapp
npm test
```

- Spin up a dev server and open cocalc.
- Open account
- Go to billing
# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
