### PR TITLE
webapp/sagews: show 2nd button row on even narrower screens

### DIFF
--- a/src/smc-webapp/buttonbar.coffee
+++ b/src/smc-webapp/buttonbar.coffee
@@ -1719,7 +1719,10 @@ initialize_sage_python_r_toolbar = () ->
     cythonbar.append(cythonbar)
 
     # -- sage specific --
-    sagebar  = make_bar("webapp-editor-codeedit-buttonbar-sage")
+    # we hide this bar on smaller screens to avoid the linebreak but still show the assistant
+    # https://github.com/sagemathinc/cocalc/issues/4068
+    # don't worry about xs, because then the whole bar is not visible (and replaced by one for mobile)
+    sagebar  = make_bar("webapp-editor-codeedit-buttonbar-sage hidden-md hidden-sm")
 
     sage_calculus = ["Calculus", "Calculus",
                      [["&part; Differentiate", "#differentiate", "Differentiate a function"],

--- a/src/smc-webapp/editor.html
+++ b/src/smc-webapp/editor.html
@@ -171,12 +171,11 @@ Editor for files in a project
 
                     <span class="webapp-editor-codemirror-message"></span>
                     <span class="webapp-editor-codemirror-filename pull-right"></span>
-
                 </div>
 
                 <div class="webapp-editor-buttonbars webapp-editor-write-only">
                     <div class="webapp-editor-latex-buttonbar hide"></div>
-                    <div class="webapp-editor-codemirror-textedit-buttons hide visible-md-block visible-lg-block">
+                    <div class="webapp-editor-codemirror-textedit-buttons hide visible-sm-block visible-md-block visible-lg-block">
                         <code class="webapp-editor-codeedit-buttonbar-mode pull-right hide"></code>
                         <span class="react-target"></span>
                         <span class="webapp-editor-codeedit-buttonbar-assistant pull-right hide">


### PR DESCRIPTION
# Description
this makes the 2nd button row (without sage buttons, but with the assistant) still show up on narrower screens

# Testing Steps
I made before/after screencasts

![4068-before](https://user-images.githubusercontent.com/207405/64796487-0e107300-d580-11e9-8c26-2fc5e5848e7e.gif)

![4068-after](https://user-images.githubusercontent.com/207405/64796492-110b6380-d580-11e9-8a18-800176b95d17.gif)


# Relevant Issues

 #4068

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
