### PR TITLE
webapp/landing page: connecting info + chrome browser issue warning

### DIFF
--- a/src/smc-webapp/account_page.cjsx
+++ b/src/smc-webapp/account_page.cjsx
@@ -1,4 +1,4 @@
-###############################################################################
+##############################################################################
 #
 #    CoCalc: Collaborative Calculation in the Cloud
 #
@@ -154,7 +154,8 @@ exports.AccountPage = rclass
             reset_password_error    = {@props.reset_password_error}
             remember_me             = {@props.remember_me}
             has_remember_me         = {@props.has_remember_me}
-            has_account             = {misc.local_storage_length() > 0} />
+            has_account             = {misc.local_storage_length() > 0}
+        />
 
     render_commercial_tabs: ->
         if not require('./customize').commercial

--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -36,6 +36,7 @@ misc = require('smc-util/misc')
 {show_announce_end} = require('./redux_account')
 {analytics_event} = require('./tracker')
 {user_tracking} = require('./user-tracking')
+{Connecting} = require('./landing_page')
 
 ACTIVE_BG_COLOR = COLORS.TOP_BAR.ACTIVE
 feature = require('./feature')
@@ -84,6 +85,11 @@ exports.ActiveAppContent = ({active_top_tab, render_small, open_projects}) ->
             v.push <AdminPage redux={redux} key={'admin'}/>
         when undefined
             v.push <div key={'broken'}>Broken... active_top_tab is undefined</div>
+
+    if v.length == 0
+        # this happens upon loading a URL for a project, but the project isn't open yet.
+        # implicitly, this waits for a websocket connection, hence show the same banner as for the landing page
+        v.push <Connecting />
     return v
 
 exports.NavTab = rclass

--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -228,7 +228,7 @@ SagePreview = rclass
             </Well>
         </div>
 
-Connecting = () ->
+exports.Connecting = Connecting = () ->
     <React.Fragment>
         <div style={fontSize : "25px", marginTop: "75px", textAlign: "center", color: COLORS.GRAY}>
             <Icon name="cc-icon-cocalc-ring" spin /> Connecting...

--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -26,6 +26,7 @@ The Landing Page
 {Alert, Button, ButtonToolbar, Col, Modal, Grid, Row, FormControl, FormGroup, Well, ClearFix, Checkbox} = require('react-bootstrap')
 {ErrorDisplay, Icon, Loading, ImmutablePureRenderMixin, Footer, UNIT, Markdown, COLORS, ExampleBox, Space, Tip} = require('./r_misc')
 {HelpEmailLink, SiteName, SiteDescription} = require('./customize')
+{get_browser} = require('./feature')
 {Passports} = require('./passports')
 {SignUp} = require('./landing-page/sign-up')
 {SignIn} = require('./landing-page/sign-in')
@@ -228,9 +229,15 @@ SagePreview = rclass
         </div>
 
 Connecting = () ->
-    <div style={fontSize : "35px", marginTop: "125px", textAlign: "center", color: "#888"}>
-        <Icon name="cc-icon-cocalc-ring" spin /> Connecting...
-    </div>
+    <React.Fragment>
+        <div style={fontSize : "25px", marginTop: "75px", textAlign: "center", color: COLORS.GRAY}>
+            <Icon name="cc-icon-cocalc-ring" spin /> Connecting...
+        </div>
+        {<div style={textAlign: "center", marginTop: "25px", color: COLORS.GRAY}>
+            If you have persistent problems connecting with <SiteName />,{' '}
+            please close and restart your browser or try using Firefox.
+        </div> if get_browser() == 'chrome'}
+    </React.Fragment>
 
 exports.LandingPage = rclass
     displayName: 'LandingPage'
@@ -318,8 +325,8 @@ exports.LandingPage = rclass
         if @props.remember_me and not @props.get_api_key
             # Just assume user will be signing in.
             # CSS of this looks like crap for a moment; worse than nothing. So disabling unless it can be fixed!!
-            #return <Connecting />
-            return <span/>
+            return <Connecting />
+            #return <span/>
 
         topbar =
             img_icon    : APP_ICON_WHITE


### PR DESCRIPTION
# Description

while connecting, this shows a spinner and a warning for chrome users that they might have to restart the browser.

without this, the users just sees the gray bar at the top and everything else is a white area without any info

# Testing Steps
I simulated a websocket issue by
1. being signed in as usual, and I'm in my settings/account page.
2. commenting out the line `init_primus_server(http_server)` in hub.coffee and restarting the hub
3. refreshing the page

additionally, the same as above but for a URL that tries to open a specific project! that's exactly where I was stuck last week. 

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
