### PR TITLE
dev/npm build: stop all parallel jobs when the first one fails

### DIFF
--- a/src/scripts/smc-install-all
+++ b/src/scripts/smc-install-all
@@ -18,7 +18,7 @@ run_install() {
 if `hash parallel &> /dev/null`; then
 
     export -f run_install
-    parallel --will-cite --linebuffer --jobs 3 run_install ::: "${CODE_DIRS[@]}"
+    parallel --will-cite --halt now,fail=1 --linebuffer --jobs 3 run_install ::: "${CODE_DIRS[@]}"
 
 else
 


### PR DESCRIPTION
# Description
@williamstein  just when you merged it, I thought what happens if one of the jobs fails. well, there is a setting to abort everything, such that an error isn't getting lost. I'll merge this in.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
