### PR TITLE
webapp: fix Rmd rendering; slightly type directory listing fetch

### DIFF
--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -229,7 +229,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
     if (this.props.errorstyle === "monospace") {
       style.fontFamily = "monospace";
       style.fontSize = "85%";
-      style.whiteSpace = "pre";
+      style.whiteSpace = "pre-wrap";
     }
     return (
       <ErrorDisplay

--- a/src/smc-webapp/frame-editors/rmd-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/actions.ts
@@ -3,8 +3,8 @@ R Markdown Editor Actions
 */
 
 import { Set } from "immutable";
-import { callback } from "awaiting";
 import { debounce } from "lodash";
+import { callback2 } from "smc-util/async-utils";
 import { Actions } from "../markdown-editor/actions";
 import { convert } from "./rmd-converter";
 import { markdown_to_html_frontmatter } from "../../markdown";
@@ -42,10 +42,7 @@ export class RmdActions extends Actions {
       return;
     }
     const path = path_split(this.path).head;
-    const update_dir = (path, cb) => {
-      project_actions.fetch_directory_listing({ finish_cb: cb, path: path });
-    };
-    await callback(update_dir, path);
+    await callback2(project_actions.fetch_directory_listing, { path });
 
     const project_store = project_actions.get_store();
     if (project_store == undefined) {
@@ -110,7 +107,7 @@ export class RmdActions extends Actions {
       this.set_reload("pdfjs_canvas");
       await this._check_produced_files();
     } catch (err) {
-      this.set_error(err);
+      this.set_error(err, "monospace");
       return;
     } finally {
       this.set_status("");

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -101,6 +101,11 @@ export const QUERIES = {
   }
 };
 
+interface FetchDirectoryListingOpts {
+  path: string;
+  cb?: () => void;
+}
+
 // src: where the library files are
 // start: open this file after copying the directory
 const LIBRARY = {
@@ -812,9 +817,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     // sagenb worksheet (or backup of it created during unzip of multiple worksheets with same name)
     alert_message({
       type: "info",
-      message: `Opening converted CoCalc worksheet file instead of '${
-        opts.path
-      }...`
+      message: `Opening converted CoCalc worksheet file instead of '${opts.path}...`
     });
     try {
       const path: string = await callback(
@@ -946,9 +949,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     ) {
       alert_message({
         type: "error",
-        message: `CoCalc is in Kiosk mode, so you may not open new files.  Please try visiting ${
-          document.location.origin
-        } directly.`,
+        message: `CoCalc is in Kiosk mode, so you may not open new files.  Please try visiting ${document.location.origin} directly.`,
         timeout: 15
       });
       return;
@@ -994,9 +995,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     } catch (err) {
       this.set_activity({
         id: misc.uuid(),
-        error: `Error opening file '${
-          opts.path
-        }' (error ensuring project is open) -- ${err}`
+        error: `Error opening file '${opts.path}' (error ensuring project is open) -- ${err}`
       });
       return;
     }
@@ -1524,13 +1523,13 @@ export class ProjectActions extends Actions<ProjectStoreState> {
 
   // Update the directory listing cache for the given path
   // Uses current path if path not provided
-  fetch_directory_listing(opts?): void {
+  fetch_directory_listing(opts_args?: FetchDirectoryListingOpts): void {
     let status;
     let store = this.get_store();
     if (store == undefined) {
       return;
     }
-    opts = defaults(opts, {
+    const opts: FetchDirectoryListingOpts = defaults(opts_args, {
       path: store.get("current_path"),
       cb: undefined
     }); // WARNING: THINK VERY HARD BEFORE YOU USE THIS
@@ -1645,7 +1644,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
           }
         }
         //if DEBUG then console.log('ProjectStore::fetch_directory_listing cb', opts, opts.cb)
-        if (opts.cb !== undefined) {
+        if (typeof opts.cb === "function") {
           opts.cb();
         }
       }


### PR DESCRIPTION
# Description
* fixes a stacktrace introduced by changes in 894ced87d3
* adds some type info to directory fetching
* monospace formatted error messages for rmd

# Testing Steps
* well, make an rmd file, no stacktrace appears. e.g.

        ---
        title: "The Title"
        author: John Doe
        date: March 22, 2019
        ---
        
        # Testing a simple plot
        
        ```{r}
        plot(rnorm(10))
        ```


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
