### PR TITLE
build docker: just unblocking it to build

### DIFF
--- a/src/install.py
+++ b/src/install.py
@@ -65,9 +65,9 @@ def install_project():
         './smc-util',
     ]
 
-    # npm ci for using pkg lock file
+    # TODO switch to use npm ci to install these (which doesn't exist for global installs, AFAIU)
     def build_op(pkg):
-        c = f"npm --loglevel=warn --unsafe-perm=true --progress=false ci {pkg} -g"
+        c = f"npm --loglevel=warn --unsafe-perm=true --progress=false install {pkg} -g"
         return cmd(SUDO + c)
 
     with ThreadPoolExecutor(max_workers=WORKERS) as executor:


### PR DESCRIPTION
npm ci does not work with global, AFAIU. instead, we should probably build it locally and then symlink to the module from /usr/lib/node_modules



# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
