### PR TITLE
Ts version of defaults

### DIFF
--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -24,6 +24,23 @@ module.exports = {
       // Setup Enzyme
       snapshotSerializers: ["enzyme-to-json/serializer"],
       setupFilesAfterEnv: ["<rootDir>/setupEnzyme.ts"]
+    },
+    {
+      displayName: "smc-util",
+      testMatch: [
+        "<rootDir>/smc-util/**/*test.ts"
+      ],
+      transform: {
+        ...tsjPreset.transform
+      },
+      testPathIgnorePatterns: ["/node_modules/", "/test-mocha/", "/data/"],
+      moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+      modulePaths: [
+        path.resolve(__dirname, "smc-util"),
+        path.resolve(__dirname, "smc-util/misc"),
+        path.resolve(__dirname, "smc-webapp"),
+        path.resolve(__dirname, "smc-webapp/node_modules")
+      ],
     }
   ]
 };

--- a/src/smc-util/fill/define.test.ts
+++ b/src/smc-util/fill/define.test.ts
@@ -1,0 +1,23 @@
+import { define, required } from "./define";
+import { expectType } from "tsd";
+
+
+
+test("Defaulted value should be defined", () => {
+  interface Input {
+    foo: number;
+    bar: string;
+    baz?: string;
+    biz?: string;
+  }
+  interface Defaults {
+    baz: string;
+  }
+  let A = define<Input, Defaults>({ foo: 0, bar: "" }, {
+    foo: required,
+    bar: required,
+    baz: "defaulted"
+  });
+
+  expectType<string>(A.baz);
+});

--- a/src/smc-util/fill/define.ts
+++ b/src/smc-util/fill/define.ts
@@ -14,13 +14,15 @@ type Definition<T> = {
  * Guarantees at runtime that `props` matches `definition`
  * `U` must only be the optional params on `T`
  *
- * A run time guarantee on obj definition
- *  Given interface T with some optional parameters
- *  and defaults of only the optional parameters,
+ * @return {object} T where provided defaults are guaranteed
  *
- *  returns an object U where provided defaults are guaranteed
+ * @example
  *
- *
+ *     define<{name: string, 
+ *              highlight?: boolean,
+ *              last?: string},
+ *           {highlight: boolean}>(unknown_prop, {highlight: false});
+ * 
  * Unfortunately you must use both type annotations until this goes through
  * https://github.com/microsoft/TypeScript/issues/26242
  *

--- a/src/smc-util/fill/define.ts
+++ b/src/smc-util/fill/define.ts
@@ -1,0 +1,98 @@
+import { Assign, RequiredKeys } from "utility-types";
+import { Optionals } from "./types";
+
+type Requireds<T> = Pick<T, RequiredKeys<T>>;
+
+export const required = "__!!!!!!this is a required property!!!!!!__";
+
+type Definition<T> = {
+  [K in keyof T]: {} extends Pick<T, K> ? T[K] : typeof required;
+};
+
+/**
+ * `define<T, U>(props: unknown, definition)`
+ * Guarantees at runtime that `props` matches `definition`
+ * `U` must only be the optional params on `T`
+ *
+ * A run time guarantee on obj definition
+ *  Given interface T with some optional parameters
+ *  and defaults of only the optional parameters,
+ *
+ *  returns an object U where provided defaults are guaranteed
+ *
+ *
+ * Unfortunately you must use both type annotations until this goes through
+ * https://github.com/microsoft/TypeScript/issues/26242
+ *
+ **/
+export function define<T extends object, U extends Optionals<T>>(
+  props: unknown,
+  definition: Assign<Definition<T>, U>,
+  allow_extra = false,
+  strict = false
+): Assign<U, Requireds<T>> {
+  // We put explicit traces before the errors in this function,
+  // since otherwise they can be very hard to debug.
+  function maybe_error(message: string): any {
+    const err = `${message} ${error_addendum(props, definition)}`;
+    if (strict) {
+      throw new Error(err);
+    } else {
+      console.log(err);
+      console.trace();
+      return definition as any;
+    }
+  }
+
+  if (props == undefined) {
+    props = {};
+  }
+  // Undefined was checked above but TS 3.6.3 is having none of it.
+  // Checking here makes TS work as expected below
+  if (typeof props !== "object" || props == undefined) {
+    return maybe_error(
+      `BUG -- Traceback -- misc.defaults -- TypeError: function takes inputs as an object`
+    );
+  }
+  const result: Assign<U, Requireds<T>> = {} as any;
+  for (let key in definition) {
+    if (props.hasOwnProperty(key) && props[key] != undefined) {
+      if (definition[key] === required && props[key] == undefined) {
+        return maybe_error(
+          `misc.defaults -- TypeError: property '${key}' must be specified on props:`
+        );
+      }
+      result[key] = props[key];
+    } else if (definition[key] != undefined) {
+      if (definition[key] == required) {
+        maybe_error(
+          `misc.defaults -- TypeError: property '${key}' must be specified:`
+        );
+      } else {
+        result[key] = definition[key];
+      }
+    }
+  }
+
+  if (!allow_extra) {
+    for (let key in props) {
+      if (!definition.hasOwnProperty(key)) {
+        return maybe_error(
+          `misc.defaults -- TypeError: got an unexpected argument '${key}'`
+        );
+      }
+    }
+  }
+  return result;
+}
+
+function error_addendum(props: unknown, definition: unknown) {
+  try {
+    return `(obj1=${exports.trunc(
+      exports.to_json(props),
+      1024
+    )}, obj2=${exports.trunc(exports.to_json(definition), 1024)})`;
+  } catch (err) {
+    return "";
+  }
+}

--- a/src/smc-util/fill/fill.test.ts
+++ b/src/smc-util/fill/fill.test.ts
@@ -1,10 +1,27 @@
 import { fill } from "./fill";
 import { expectType } from "tsd";
 
-test("Supplied default should be merged in to target", () => {
+test("Supplied default should be merged in to target even if marked undefined", () => {
   const opts: { name: string; height?: number } = {
     name: "jack",
     height: undefined
+  };
+  const actual = fill(opts, { height: 20 });
+  expect(actual).toStrictEqual({name: "jack", height: 20})
+});
+
+test("Defaults should not overwrite already defined optional params", () => {
+  const opts: { name: string; height?: number, weight?: number } = {
+    name: "jack",
+    height: 20
+  };
+  const actual = fill(opts, { height: 30 });
+  expect(actual).toStrictEqual({name: "jack", height: 20})
+});
+
+test("Missing optional params should not appear if not given defaults", () => {
+  const opts: { name: string; height?: number, weight?: number } = {
+    name: "jack"
   };
   const actual = fill(opts, { height: 20 });
   expect(actual).toStrictEqual({name: "jack", height: 20})

--- a/src/smc-util/fill/fill.test.ts
+++ b/src/smc-util/fill/fill.test.ts
@@ -1,0 +1,63 @@
+import { fill } from "./fill";
+import { expectType } from "tsd";
+
+test("Supplied default should be merged in to target", () => {
+  const opts: { name: string; height?: number } = {
+    name: "jack",
+    height: undefined
+  };
+  const actual = fill(opts, { height: 20 });
+  expect(actual).toStrictEqual({name: "jack", height: 20})
+});
+
+test("Supplied default should guarantee type existance", () => {
+  type Expected = {
+    name: string;
+    direction: "up" | "down" | "left" | "right";
+    highlight: boolean;
+    animate?: boolean;
+  };
+
+  const opts: {
+    name: string;
+    direction: "up" | "down" | "left" | "right";
+    highlight?: boolean;
+    animate?: boolean;
+  } = { name: "foo", direction: "up" };
+
+  const actual = fill(opts, { highlight: false });
+
+  expectType<Expected>(actual);
+});
+
+test("strings", () => {
+  function filled(props: {
+    name: string;
+    direction: "up" | "down" | "left" | "right";
+    highlight?: string;
+    animate?: boolean;
+  }) {
+    // This should not end up narrowing to the fixed value
+    return fill(props, { highlight: "fixed_string" });
+  }
+  let a = filled({ name: "foo", direction: "up" });
+  expectType<string>(a.name);
+  expectType<"up" | "down" | "left" | "right">(a.direction);
+  expectType<string>(a.highlight);
+  expectType<boolean | undefined>(a.animate);
+});
+
+// tsd expectError doesn't integrate into Jest
+test("Errors", () => {
+  /*
+  function prop_typed_errors(props: {
+    name: string;
+    direction: "up" | "down" | "left" | "right";
+    highlight?: boolean;
+    animate?: boolean;
+  }) {
+    // Don't allow requireds to even be listed
+    return fill(props, { name: "undefined", highlight: false });
+  }
+  */
+});

--- a/src/smc-util/fill/fill.ts
+++ b/src/smc-util/fill/fill.ts
@@ -2,15 +2,23 @@ import { Assign } from "utility-types";
 import { Restrict, Optionals } from "./types";
 
 /**
- * props: T
- *  Given interface T with some optional parameters
- *  and defaults of only the optional parameters,
+ * Given an object: T with some optional parameters  
+ * and defaults: a subset of optional parameters from T. 
+ *  
+ * Explicitly setting a default to `undefined`is not recommended
  *
- *  returns an object U where provided defaults are guaranteed
+ * @return T except provided defaults are guaranteed
  *
- * Examples:
- *  props: {foo: string; bar?: string}, defaults: {bar: "good stuff"} => {foo: string; bar: string}
- *
+ * @example
+ *     props: {foo: string; bar?: string}, 
+ *     defaults: {bar: "good stuff"}
+ *        => {foo: string; bar: string} // <- Note bar is defined
+ * 
+ * 
+ *     props: {foo: string; bar?: string; baz?: number}, 
+ *     defaults: {bar: "good stuff"}
+ *        => {foo: string; bar: string; baz?: number} // <- Note baz is optional
+ * .
  **/
 export function fill<T extends object, U extends Optionals<T>>(
   props: T,

--- a/src/smc-util/fill/fill.ts
+++ b/src/smc-util/fill/fill.ts
@@ -1,0 +1,30 @@
+import { Assign } from "utility-types";
+import { Restrict, Optionals } from "./types";
+
+/**
+ * props: T
+ *  Given interface T with some optional parameters
+ *  and defaults of only the optional parameters,
+ *
+ *  returns an object U where provided defaults are guaranteed
+ *
+ * Examples:
+ *  props: {foo: string; bar?: string}, defaults: {bar: "good stuff"} => {foo: string; bar: string}
+ *
+ **/
+export function fill<T extends object, U extends Optionals<T>>(
+  props: T,
+  defaults: Restrict<
+    U,
+    Optionals<T>,
+    "Defaults cannot contain required values"
+  >
+): Assign<T, U> {
+  const ret: U = {} as any;
+  for (let key in defaults) {
+    if (!props.hasOwnProperty(key) || props[key] == undefined) {
+      ret[key] = defaults[key];
+    }
+  }
+  return Object.assign({}, props, ret)
+}

--- a/src/smc-util/fill/index.ts
+++ b/src/smc-util/fill/index.ts
@@ -1,0 +1,2 @@
+export { fill } from "./fill";
+export { define, required } from "./define"

--- a/src/smc-util/fill/types.ts
+++ b/src/smc-util/fill/types.ts
@@ -1,0 +1,11 @@
+import { OptionalKeys } from "utility-types";
+
+export type Optionals<T> = Pick<T, OptionalKeys<T>>;
+
+/**
+ * Throws a type error if T has keys not preset in TExpected
+ *
+ * Errors: `[T] is not assignable to [TError]`
+ */
+export type Restrict<T, TExpected, TError> = T &
+  (Exclude<keyof T, keyof TExpected> extends never ? {} : TError);

--- a/src/smc-util/fill/types.ts
+++ b/src/smc-util/fill/types.ts
@@ -4,8 +4,10 @@ export type Optionals<T> = Pick<T, OptionalKeys<T>>;
 
 /**
  * Throws a type error if T has keys not preset in TExpected
- *
+ * 
  * Errors: `[T] is not assignable to [TError]`
+ * 
+ * @see https://stackoverflow.com/questions/54775790/forcing-excess-property-checking-on-variable-passed-to-typescript-function
  */
 export type Restrict<T, TExpected, TError> = T &
   (Exclude<keyof T, keyof TExpected> extends never ? {} : TError);

--- a/src/smc-util/package-lock.json
+++ b/src/smc-util/package-lock.json
@@ -6401,6 +6401,11 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
+    "utility-types": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.8.0.tgz",
+      "integrity": "sha512-UoKivAmVw5TL6AHuILieOJjIK9ajS0l5gyN5LbJglPuVwzfYBniDhe+3A5+ZBtS0TAHQs5qUxTwj9jXurINrcw=="
+    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",

--- a/src/smc-util/package.json
+++ b/src/smc-util/package.json
@@ -29,6 +29,7 @@
     "sha1": "^1.1.1",
     "ts-jest": "^24.1.0",
     "underscore": "^1.9.1",
+    "utility-types": "^3.8.0",
     "uuid": "^3.0.1"
   },
   "repository": {


### PR DESCRIPTION
# Description
Creates two functions to replace `defaults opts {}` when we used Coffeescript.

`fill(opts, defaults)` takes a known object ops and applies some defaults to its optional parts. 
```typescript
interface Props {
  name: string;
  show?: boolean; // Optional at call site
  highlight?: boolean;
}
function doSomething(props: Props) {
 props = fill(props, {show: true})
 // Now props.show is expected to be defined
 // { name: string; show: boolean; highlight?: boolean } 
 // ...
}
```

`define(props, definition, ...)` is directly converted from `defaults(obj1, obj2, ...)`.
It's typed such that props is unknown and like `fill`, knows when provided defaults change the result type to be defined.

# Testing Steps
1. In src, run `npx jest fill`
1. Open a course
1. Add some students
1. Make and distribute some assignments

# Todo
- [x] Function to fill defaults for known props
- [x] Function to define object for unknown props (user input or interfacing with non-ts code)
- [x] Finish writing jest tests
- [x] Finish documentation
  - [x] Add references to source URLs
  - [x] Add more examples

# Screenshots
<img width="634" alt="Screen Shot 2019-09-30 at 3 46 43 PM" src="https://user-images.githubusercontent.com/618575/65925757-f5d58c00-e3a6-11e9-8c86-38a6793f2afc.png">
<img width="931" alt="Screen Shot 2019-09-30 at 3 49 04 PM" src="https://user-images.githubusercontent.com/618575/65925756-f5d58c00-e3a6-11e9-81bf-a802a967b23c.png">

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [x] No debugging console.log messages.
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [x] Screenshots if relevant.
