### PR TITLE
terminal: set MPLBACKEND to tell matplotlib how to draw 

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1983,8 +1983,10 @@ export class Actions<
 
   // Override in derived class to set a special env for
   // any launched terminals.
-  get_term_env(): any {
-    return undefined;
+  get_term_env(): { [envvar: string]: string } {
+    // https://github.com/sagemathinc/cocalc/issues/4120
+    const MPLBACKEND = "Agg";
+    return { MPLBACKEND };
   }
 
   // If you override show, make sure to still call this

--- a/src/smc-webapp/frame-editors/x11-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/actions.ts
@@ -142,11 +142,14 @@ export class Actions extends BaseActions<X11EditorState> {
     });
   }
 
-  get_term_env(): any {
+  // overrides parent class method
+  get_term_env() {
     const DISPLAY = `:${this.client.get_display()}`;
     // This supports url forwarding via xdg-open wrapper:
     const XPRA_XDG_OPEN_SERVER_SOCKET = this.client.get_socket_path();
-    return { DISPLAY, XPRA_XDG_OPEN_SERVER_SOCKET };
+    // https://github.com/sagemathinc/cocalc/issues/4120
+    const MPLBACKEND = "WxAgg"; // a more conservative (b/c old) choice is TkAgg
+    return { DISPLAY, XPRA_XDG_OPEN_SERVER_SOCKET, MPLBACKEND };
   }
 
   close(): void {


### PR DESCRIPTION
# Description

# Testing Steps
* run this in a terminal
```
>>> import matplotlib.pyplot as plt
>>> plt.plot([2,3,4,3,32,2,3,2,1])
>>> plt.savefig('x.png')
```
* and the above in an X11 terminal, plus
```
plt.show()
```
which should open a window.

# Relevant Issues
#4120

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
