### PR TITLE
Popconfirm project restart

### DIFF
--- a/src/cocalc-ui/index.ts
+++ b/src/cocalc-ui/index.ts
@@ -30,4 +30,8 @@ import "antd/es/popconfirm/style/css";
 import Popconfirm from "antd/es/popconfirm";
 export { Popconfirm };
 
+import "antd/es/icon/style/css";
+import Icon from "antd/es/icon";
+export { Icon };
+
 import "./fix.css";

--- a/src/cocalc-ui/index.ts
+++ b/src/cocalc-ui/index.ts
@@ -26,4 +26,8 @@ import "antd/es/col/style/css";
 import Col from "antd/es/col";
 export { Col };
 
+import "antd/es/popconfirm/style/css";
+import Popconfirm from "antd/es/popconfirm";
+export { Popconfirm };
+
 import "./fix.css";

--- a/src/smc-webapp/project/settings/project-control.tsx
+++ b/src/smc-webapp/project/settings/project-control.tsx
@@ -30,7 +30,7 @@ import {
 import { alert_message } from "../../alerts";
 import { Project } from "./types";
 import { Map, fromJS } from "immutable";
-import { Popconfirm } from "cocalc-ui";
+import { Popconfirm, Icon as AntIcon } from "cocalc-ui";
 
 let {
   COMPUTE_IMAGES,
@@ -231,7 +231,6 @@ export const ProjectControl = rclass<ReactProps>(
     }
 
     render_restart_button(commands): Rendered {
-      const icon = <Icon name="refresh" />;
       const text = (
         <div style={{ maxWidth: "300px" }}>
           Restarting the project server will terminate all processes, update the
@@ -247,7 +246,7 @@ export const ProjectControl = rclass<ReactProps>(
           placement={"bottom"}
           arrowPointAtCenter={true}
           title={text}
-          icon={icon}
+          icon={<AntIcon type={"sync"} theme="outlined" />}
           onConfirm={e => {
             if (e != null) e.preventDefault();
             this.setState({ show_stop_confirmation: false });

--- a/src/smc-webapp/project/settings/project-control.tsx
+++ b/src/smc-webapp/project/settings/project-control.tsx
@@ -20,7 +20,6 @@ import {
 import { async } from "async";
 import { analytics_event } from "../../tracker";
 import {
-  Well,
   ButtonToolbar,
   Button,
   MenuItem,
@@ -52,12 +51,10 @@ interface ReduxProps {
 }
 
 interface State {
-  restart: boolean;
   show_ssh: boolean;
   compute_image: string;
   compute_image_changing: boolean;
   compute_image_focused: boolean;
-  show_stop_confirmation?: boolean;
 }
 
 export const ProjectControl = rclass<ReactProps>(
@@ -76,7 +73,6 @@ export const ProjectControl = rclass<ReactProps>(
     constructor(props) {
       super(props);
       this.state = {
-        restart: false,
         show_ssh: false,
         compute_image: this.props.project.get("compute_image"),
         compute_image_changing: false,
@@ -162,72 +158,30 @@ export const ProjectControl = rclass<ReactProps>(
       analytics_event("project_settings", "stop project");
     };
 
-    //render_confirm_restart() {
-    //  if (this.state.restart) {
-    //    return (
-    //      <LabeledRow key="restart" label="">
-    //        <Well>
-    //
-    //          <hr />
-    //          <ButtonToolbar>
-    //            <Button
-    //              bsStyle="warning"
-    //              onClick={e => {
-    //                e.preventDefault();
-    //                this.setState({ restart: false });
-    //                this.restart_project();
-    //              }}
-    //            >
-    //              <Icon name="refresh" /> Restart Project Server
-    //            </Button>
-    //            <Button
-    //              onClick={e => {
-    //                e.preventDefault();
-    //                this.setState({ restart: false });
-    //              }}
-    //            >
-    //              Cancel
-    //            </Button>
-    //          </ButtonToolbar>
-    //        </Well>
-    //      </LabeledRow>
-    //    );
-    //  }
-    //}
+    render_stop_button(commands): Rendered {
+      const text = (
+        <div style={{ maxWidth: "300px" }}>
+          Stopping the project server will kill all processes. After stopping a
+          project, it will not start until you or a collaborator restarts the
+          project.
+        </div>
+      );
 
-    render_confirm_stop() {
-      if (this.state.show_stop_confirmation) {
-        return (
-          <LabeledRow key="stop" label="">
-            <Well>
-              Stopping the project server will kill all processes. After
-              stopping a project, it will not start until a collaborator
-              restarts the project.
-              <hr />
-              <ButtonToolbar>
-                <Button
-                  bsStyle="warning"
-                  onClick={e => {
-                    e.preventDefault();
-                    this.setState({ show_stop_confirmation: false });
-                    this.stop_project();
-                  }}
-                >
-                  <Icon name="stop" /> Stop Project Server
-                </Button>
-                <Button
-                  onClick={e => {
-                    e.preventDefault();
-                    this.setState({ show_stop_confirmation: false });
-                  }}
-                >
-                  Cancel
-                </Button>
-              </ButtonToolbar>
-            </Well>
-          </LabeledRow>
-        );
-      }
+      return (
+        <Popconfirm
+          placement={"bottom"}
+          arrowPointAtCenter={true}
+          title={text}
+          icon={<AntIcon type={"stop"} theme="outlined" />}
+          onConfirm={() => this.stop_project()}
+          okText="Yes, stop project"
+          cancelText="No"
+        >
+          <Button bsStyle="warning" disabled={!commands.includes("stop")}>
+            <Icon name="stop" /> Stop Project...
+          </Button>
+        </Popconfirm>
+      );
     }
 
     render_restart_button(commands): Rendered {
@@ -247,12 +201,8 @@ export const ProjectControl = rclass<ReactProps>(
           arrowPointAtCenter={true}
           title={text}
           icon={<AntIcon type={"sync"} theme="outlined" />}
-          onConfirm={e => {
-            if (e != null) e.preventDefault();
-            this.setState({ show_stop_confirmation: false });
-            this.restart_project();
-          }}
-          okText="Yes, restart project server"
+          onConfirm={() => this.restart_project()}
+          okText="Yes, restart project"
           cancelText="No"
         >
           <Button
@@ -273,19 +223,7 @@ export const ProjectControl = rclass<ReactProps>(
       return (
         <ButtonToolbar style={{ marginTop: "10px", marginBottom: "10px" }}>
           {this.render_restart_button(commands)}
-          <Button
-            bsStyle="warning"
-            disabled={!commands.includes("stop")}
-            onClick={e => {
-              e.preventDefault();
-              this.setState({
-                show_stop_confirmation: true,
-                restart: false
-              });
-            }}
-          >
-            <Icon name="stop" /> Stop Project...
-          </Button>
+          {this.render_stop_button(commands)}
         </ButtonToolbar>
       );
     }
@@ -574,7 +512,6 @@ export const ProjectControl = rclass<ReactProps>(
           <LabeledRow key="action" label="Actions">
             {this.render_action_buttons()}
           </LabeledRow>
-          {this.render_confirm_stop()}
           <LabeledRow key="project_id" label="Project id">
             <pre>{this.props.project.get("project_id")}</pre>
           </LabeledRow>


### PR DESCRIPTION
# Description
Antd's Popconfirm for restarting/stopping a project.

I imported the icons to match the ones we have. Not sure if that's a good idea.

The text itself has a few little changes as well...

# Testing Steps
stop/restart a project

# Screenshots

![Screenshot from 2019-10-07 14-24-37](https://user-images.githubusercontent.com/207405/66311211-42244d00-e90e-11e9-9391-8af9f10eec07.png)

![Screenshot from 2019-10-07 14-24-31](https://user-images.githubusercontent.com/207405/66311213-42bce380-e90e-11e9-8508-d0ccd7cd3d77.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
