### PR TITLE
webapp/jupyter2: resize too large images to container width

### DIFF
--- a/src/smc-webapp/jupyter/output-messages/data.tsx
+++ b/src/smc-webapp/jupyter/output-messages/data.tsx
@@ -121,9 +121,9 @@ export class Data extends Component<DataProps> {
                 if (value && value.forEach) {
                   value.forEach((value: any, key: any) => {
                     if (key === "width") {
-                      return (width = value);
+                      width = value;
                     } else if (key === "height") {
-                      return (height = value);
+                      height = value;
                     }
                   });
                 }

--- a/src/smc-webapp/jupyter/output-messages/image.tsx
+++ b/src/smc-webapp/jupyter/output-messages/image.tsx
@@ -13,6 +13,7 @@ interface ImageProps {
 
 interface ImageState {
   attempts: number;
+  zoomed: boolean;
 }
 
 export class Image extends Component<ImageProps, ImageState> {
@@ -20,7 +21,8 @@ export class Image extends Component<ImageProps, ImageState> {
 
   constructor(props: ImageProps, context: any) {
     super(props, context);
-    this.state = { attempts: 0 };
+    this.img_click = this.img_click.bind(this);
+    this.state = { attempts: 0, zoomed: false };
   }
 
   load_error = async (): Promise<void> => {
@@ -43,18 +45,37 @@ export class Image extends Component<ImageProps, ImageState> {
     return this.props.type.split("/")[1].split("+")[0];
   };
 
+  img_click(): void {
+    this.setState(state => {
+      return { zoomed: !state.zoomed };
+    });
+  }
+
+  render_image(src, on_error?): Rendered {
+    const props = {
+      src,
+      width: this.props.width,
+      height: this.props.height,
+      onClick: this.img_click
+    };
+    if (this.props.width == null && this.props.height == null) {
+      const cursor = this.state.zoomed ? "zoom-out" : "zoom-in";
+      props["style"] = { cursor } as React.CSSProperties;
+      if (!this.state.zoomed) {
+        const limit: React.CSSProperties = { maxWidth: "100%", height: "auto" };
+        Object.assign(props["style"], limit);
+      }
+    }
+    if (on_error != null) {
+      props["onError"] = on_error;
+    }
+    return <img {...props} />;
+  }
+
   render_using_server(project_id: string, sha1: string): Rendered {
-    const src =
-      get_blob_url(project_id, this.extension(), sha1) +
-      `&attempts=${this.state.attempts}`;
-    return (
-      <img
-        src={src}
-        onError={this.load_error}
-        width={this.props.width}
-        height={this.props.height}
-      />
-    );
+    const blob_url = get_blob_url(project_id, this.extension(), sha1);
+    const src = `${blob_url}&attempts=${this.state.attempts}`;
+    return this.render_image(src, this.load_error);
   }
 
   encoding = (): string => {
@@ -70,12 +91,9 @@ export class Image extends Component<ImageProps, ImageState> {
     // The encodeURIComponent is definitely necessary these days.
     // See https://github.com/sagemathinc/cocalc/issues/3197 and the comments at
     // https://css-tricks.com/probably-dont-base64-svg/
-    const src = `data:${
-      this.props.type
-    };${this.encoding()},${encodeURIComponent(value)}`;
-    return (
-      <img src={src} width={this.props.width} height={this.props.height} />
-    );
+    const prefix = `data:${this.props.type};${this.encoding()}`;
+    const src = `${prefix},${encodeURIComponent(value)}`;
+    return this.render_image(src);
   }
 
   render(): Rendered {


### PR DESCRIPTION
# Description
this is something that bugs me and I today just saw it in a notebook again. if an image has no height/width, it's show as it is. for large ones, they're off screen and it's hard to scroll around, etc. this here limits the width to 100% and if you need to see it full size, you can click. this doesn't impact any of the other plots, because they all have height and width set.

# Testing Steps
I used dask to plot a graph, which is in this case larger than my screen and hence hard to understand.

```
import dask.array as da
x = da.random.random((1000, 1000), chunks=(300, 300))
y = x + x.T
z = y[::75, 100:].mean(axis=1)
rz = (z[:100].sum() / z[:100].shape[0])
rz.visualize()
```


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
