### PR TITLE
webapp/frame-editor: wrap touch_project call, fails in case of being disconnected

### DIFF
--- a/src/smc-webapp/frame-editors/generic/client.ts
+++ b/src/smc-webapp/frame-editors/generic/client.ts
@@ -59,7 +59,11 @@ export async function touch(project_id: string, path: string): Promise<void> {
 
 // Resets the idle timeout timer and makes it known we are using the project.
 export async function touch_project(project_id: string): Promise<void> {
-  return await callback2(webapp_client.touch_project, { project_id });
+  try {
+    return await callback2(webapp_client.touch_project, { project_id });
+  } catch (err) {
+    console.warn(`unable to touch '${project_id}' -- ${err}`);
+  }
 }
 
 export async function start_project(


### PR DESCRIPTION
# Description
i saw an uncaught exception while being disconnected. I guess it's that call.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
