### PR TITLE
hub/stats: also stats about x11 files

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -2466,7 +2466,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
             )
             SELECT ext, cnt
             FROM ext_count
-            WHERE ext IN ('sagews', 'ipynb', 'tex', 'rtex', 'rnw',
+            WHERE ext IN ('sagews', 'ipynb', 'tex', 'rtex', 'rnw', 'x11',
                           'rmd', 'txt', 'py', 'md', 'sage', 'term', 'rst', 'lean',
                           'png', 'svg', 'jpeg', 'jpg', 'pdf',
                           'tasks', 'course', 'sage-chat', 'chat')


### PR DESCRIPTION
# Description
I just realized this is missing

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
