### PR TITLE
typescript 3.6.4

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -15620,9 +15620,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/src/package.json
+++ b/src/package.json
@@ -65,7 +65,7 @@
     "ts-loader": "^4.4.1",
     "ts-node": "^7.0.0",
     "tsd": "^0.7.4",
-    "typescript": "^3.6.2",
+    "typescript": "^3.6.4",
     "uglify-js": "^2.6.2",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "url-loader": "^0.6",

--- a/src/smc-hub/package-lock.json
+++ b/src/smc-hub/package-lock.json
@@ -7623,9 +7623,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -70,7 +70,7 @@
     "start-stop-daemon": "^0.1.1",
     "stripe": "^6.19.0",
     "temp": "^0.8.3",
-    "typescript": "^3.6.3",
+    "typescript": "^3.6.4",
     "uglify-js": "^3.5.15",
     "underscore": "^1.9.1",
     "winston": "^2.4"

--- a/src/smc-project/package-lock.json
+++ b/src/smc-project/package-lock.json
@@ -5120,9 +5120,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
     },
     "ultron": {
       "version": "1.1.1",

--- a/src/smc-project/package.json
+++ b/src/smc-project/package.json
@@ -48,7 +48,7 @@
     "temp": "^0.8.3",
     "tmp": "0.0.33",
     "ts-node": "^8.4.1",
-    "typescript": "^3.6.3",
+    "typescript": "^3.6.4",
     "underscore": "^1.9.1",
     "uuid": "^3.0.1",
     "which": "^1.3.1",

--- a/src/test/puppeteer/package-lock.json
+++ b/src/test/puppeteer/package-lock.json
@@ -1700,9 +1700,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/src/test/puppeteer/package.json
+++ b/src/test/puppeteer/package.json
@@ -33,6 +33,6 @@
     "puppeteer": "^1.20.0",
     "sprintf-js": "^1.1.2",
     "type-of-is": "^3.5.1",
-    "typescript": "^3.6.3"
+    "typescript": "^3.6.4"
   }
 }


### PR DESCRIPTION
# Description
this updates typescript to 3.6.4 (previously, we had a mix of slightly different versions)

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
