### PR TITLE
npm install: delete old node_modules by moving them out of the way

### DIFF
--- a/src/scripts/cocalc-dirs.sh
+++ b/src/scripts/cocalc-dirs.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-CODE_DIRS=($SMC_ROOT $SMC_ROOT/smc-webapp $SMC_ROOT/smc-webapp/jupyter $SMC_ROOT/smc-hub $SMC_ROOT/smc-project $SMC_ROOT/smc-project/jupyter $SMC_ROOT/smc-util-node $SMC_ROOT/smc-util $SMC_ROOT/cocalc-ui)
+CODE_DIRS=($SMC_ROOT  $SMC_ROOT/smc-project $SMC_ROOT/smc-project/jupyter $SMC_ROOT/smc-webapp $SMC_ROOT/smc-webapp/jupyter $SMC_ROOT/smc-hub $SMC_ROOT/smc-util-node $SMC_ROOT/smc-util $SMC_ROOT/cocalc-ui)

--- a/src/scripts/smc-install-all
+++ b/src/scripts/smc-install-all
@@ -6,16 +6,35 @@ set -v
 cd `dirname $0`/..
 . smc-env
 
-# npm ci install function, will run in parallel if gnu parallel is installed
-run_install() {
-    cd "$1"
-    npm ci
-}
-
 # all module directories
 . cocalc-dirs.sh
 
-if `hash parallel &> /dev/null`; then
+# we move and delete node_modules in parallel of npm ci to speed up install
+for dir in "${CODE_DIRS[@]}"; do
+    cd "$dir"
+    echo "cleanup $(basename $dir)"
+    # get rid of leftovers in case this got interrupted
+    rm -rf node_modules.delme/
+    if [[ -d node_modules/ ]]; then
+        mv -v node_modules node_modules.delme
+    fi
+done
+
+cd $SMC_ROOT
+find -type d -name node_modules.delme | xargs rm -rf &
+
+# npm ci install function, will run in parallel if gnu parallel is installed
+run_install() {
+    cd "$1"
+    # ts is part of moreutils
+    if `hash ts 2> /dev/null`; then
+        npm ci | ts "[%Y-%m-%d %H:%M:%S|$(basename $1)]"
+    else
+        npm ci
+    fi
+}
+
+if `hash parallel 2> /dev/null`; then
 
     export -f run_install
     parallel --will-cite --halt now,fail=1 --linebuffer --jobs 3 run_install ::: "${CODE_DIRS[@]}"


### PR DESCRIPTION
# Description
this is just for speeding up `npm run make`. deletes old node modules in parallel of npm ci. also,  building project first, because there is more C++ code being built.

# Testing Steps
well ... if it causes issues, it should be easy to fix. I've not noticed any problems.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
