### PR TITLE
jupyter: fix cells undefined in uils/new_cell_pos

### DIFF
--- a/src/smc-webapp/jupyter/actions.ts
+++ b/src/smc-webapp/jupyter/actions.ts
@@ -865,7 +865,7 @@ export class JupyterActions extends Actions<JupyterStoreState> {
       id,
       delta
     );
-    return this.insert_cell_at(pos, save);
+    return this.insert_cell_at(pos != null ? pos : 0, save);
   }
 
   delete_selected_cells = (sync = true): void => {

--- a/src/smc-webapp/jupyter/cell-utils.ts
+++ b/src/smc-webapp/jupyter/cell-utils.ts
@@ -47,7 +47,9 @@ export function positions_between(
   return v;
 }
 
-export function sorted_cell_list(cells: Map<string, any>): List<string> {
+export function sorted_cell_list(
+  cells: Map<string, any> | undefined
+): List<string> {
   // Given an immutable Map from id's to cells, returns an immutable List whose
   // entries are the id's in the correct order, as defined by the pos field (a float).
   if (cells == null) {
@@ -91,11 +93,11 @@ export function ensure_positions_are_unique(cells?: Map<string, any>) {
 }
 
 export function new_cell_pos(
-  cells: Map<string, any>,
-  cell_list: List<string>,
-  cur_id: string,
+  cells: Map<string, any> | undefined,
+  cell_list: List<string> | undefined,
+  cur_id: string | undefined,
   delta: -1 | 1
-): number {
+): number | undefined {
   /*
     Returns pos for a new cell whose position
     is relative to the cell with cur_id.
@@ -109,8 +111,9 @@ export function new_cell_pos(
     just makes up a pos, and it'll get sorted out.
   */
   let cell_list_0: List<string>;
+  if (cells == null) return;
   if (cell_list == null) {
-    cell_list_0 = sorted_cell_list(cells)!;
+    cell_list_0 = sorted_cell_list(cells);
   } else {
     cell_list_0 = cell_list;
   }


### PR DESCRIPTION
# Description
well, this looks easy, but once I adhere to the text "Returned undefined whenever don't really know what to do" and encode that in typescript, I had to come up with a fallback. I don't know if that's reasonable or not. 

# Testing Steps
no idea how to reproduce, must be an odd corner-case.

# Relevant Issues
#4170

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
