### PR TITLE
Front end test 06

### DIFF
--- a/src/smc-webapp/project/settings/hide-delete-box.tsx
+++ b/src/smc-webapp/project/settings/hide-delete-box.tsx
@@ -108,6 +108,7 @@ export class HideDeleteBox extends React.Component<Props, State> {
         style={{ float: "right" }}
         onClick={onClick}
         disabled={disabled}
+        cocalc-test={is_deleted ? "undelete-project" : "delete-project"}
       >
         <Icon name="trash" /> {text}
       </Button>
@@ -138,7 +139,7 @@ export class HideDeleteBox extends React.Component<Props, State> {
           undefined
         )}
         <ButtonToolbar>
-          <Button bsStyle="danger" onClick={this.toggle_delete_project}>
+          <Button bsStyle="danger" onClick={this.toggle_delete_project} cocalc-test="please-delete-project">
             Yes, please delete this project
           </Button>
           <Button onClick={this.hide_delete_conf}>Cancel</Button>
@@ -162,6 +163,7 @@ export class HideDeleteBox extends React.Component<Props, State> {
               bsStyle="warning"
               onClick={this.toggle_hide_project}
               style={{ float: "right" }}
+              cocalc-test={hidden ? "unhide-project" : "hide-project"}
             >
               <Icon name="eye-slash" /> {hidden ? "Unhide" : "Hide"} Project
             </Button>

--- a/src/smc-webapp/projects/projects-filter-buttons.tsx
+++ b/src/smc-webapp/projects/projects-filter-buttons.tsx
@@ -30,6 +30,7 @@ export class ProjectsFilterButtons extends Component<Props> {
             analytics_event("projects_page", "clicked_deleted_filter");
           }}
           bsStyle={style}
+          cocalc-test={"deleted-filter"}
         >
           <Icon
             name={this.props.deleted ? "check-square-o" : "square-o"}
@@ -55,6 +56,7 @@ export class ProjectsFilterButtons extends Component<Props> {
             analytics_event("projects_page", "clicked_hidden_filter");
           }}
           bsStyle={style}
+          cocalc-test={"hidden-filter"}
         >
           <Icon
             name={this.props.hidden ? "check-square-o" : "square-o"}

--- a/src/test/puppeteer/src/api_create_project.ts
+++ b/src/test/puppeteer/src/api_create_project.ts
@@ -15,6 +15,7 @@ export const api_create_project = async function (creds: Creds, api_key: string)
     const url: string = creds.url.replace(/\/app.*/, "") + "/api/v1/create_project";
     debuglog('url', url);
 
+    const desc: string = new Date().toISOString();
     const response = await axios({
       method: 'post',
       url: url,
@@ -24,10 +25,12 @@ export const api_create_project = async function (creds: Creds, api_key: string)
       },
       data: {
         title: creds.project,
-        description: "front end testing",
+        description: desc,
         start: true
       }
     });
+    debuglog('title: ', creds.project);
+    debuglog('description: ', desc);
     expect(response.status).to.equal(200);
     const event: string = response.data.event;
     if (event === "error") console.log(chalk.red(`ERROR: ${response.data}`));

--- a/src/test/puppeteer/src/del_hide_project.ts
+++ b/src/test/puppeteer/src/del_hide_project.ts
@@ -1,0 +1,58 @@
+const path = require('path');
+const this_file:string = path.basename(__filename, '.js');
+const debuglog = require('util').debuglog('cc-' + this_file);
+
+import chalk from 'chalk';
+import { Opts, PassFail } from './types';
+import { time_log } from './time_log';
+import { Page } from 'puppeteer';
+
+import screenshot from './screenshot';
+
+export const del_hide_project = async function (opts: Opts, page: Page): Promise<PassFail> {
+  // assume puppeteer has opened the project specified in creds before this is called
+  let pfcounts: PassFail = new PassFail();
+  if (opts.skip && opts.skip.test(this_file)) {
+    debuglog('skipping test: ' + this_file);
+    pfcounts.skip += 1;
+    return pfcounts;
+  }
+  try {
+    const tm_del_hide = process.hrtime.bigint();
+
+    let sel;
+
+    // click the project Settings button
+    sel = '*[cocalc-test="Settings"]';
+    await page.click(sel);
+    debuglog('clicked Settings');
+
+    // click hide-project etc.
+    sel = `*[cocalc-test="${opts.xprj}-project"]`;
+    await page.click(sel);
+
+    debuglog(`clicked ${opts.xprj}-project`);
+    if (opts.xprj === 'delete') {
+      sel = '*[cocalc-test="please-delete-project"]';
+      await page.click(sel);
+      await screenshot(page, opts, 'cocalc-delete-project0.png');
+      debuglog(`confirmed delete project`);
+    }
+
+    // to exit Settings, click the Files button and wait for search box
+    sel = '*[cocalc-test="Files"]';
+    await page.click(sel);
+    debuglog('clicked Files');
+
+    sel = '*[cocalc-test="search-input"]';
+    await page.waitForSelector(sel);
+
+    time_log(`project ${opts.xprj}`, tm_del_hide);
+    pfcounts.pass += 1;
+
+  } catch (e) {
+    pfcounts.fail += 1;
+    console.log(chalk.red(`ERROR: ${e.message}`));
+  }
+  return pfcounts;
+}

--- a/src/test/puppeteer/src/get_project_status.ts
+++ b/src/test/puppeteer/src/get_project_status.ts
@@ -37,7 +37,6 @@ export const get_project_status = async function (creds: Creds, api_key: string,
     expect(response.data.event).to.equal('query');
     const status: string = response.data.query.projects.status;
     debuglog('status', status);
-    //expect(status.length).to.equal(36);
     time_log(this_file, tm_start);
     ags.result = status;
     ags.pass += 1;

--- a/src/test/puppeteer/src/login_session.ts
+++ b/src/test/puppeteer/src/login_session.ts
@@ -9,6 +9,7 @@ import { time_log }  from './time_log';
 import test_tex from './test_tex';
 import test_widget from './test_widget';
 import test_sage_ker from './test_sage_ker';
+import { del_hide_project } from './del_hide_project';
 import { Page } from 'puppeteer';
 
 const LONG_TIMEOUT = 70000; // msec
@@ -85,9 +86,12 @@ export const login_tests = async function (creds: Creds, opts: Opts): Promise<Pa
     time_log("open project", tm_open_project);
     pfcounts.pass += 1;
 
-    pfcounts.add(await test_tex(opts, page));
-    pfcounts.add(await test_widget(opts, page));
-    pfcounts.add(await test_sage_ker(opts, page));
+    if (opts.xprj) pfcounts.add(await del_hide_project(opts, page));
+    if ((opts.xprj === undefined) || (opts.xprj !== "delete")) {
+      pfcounts.add(await test_tex(opts, page));
+      pfcounts.add(await test_widget(opts, page));
+      pfcounts.add(await test_sage_ker(opts, page));
+    }
 
     time_log("login session total", tm_launch_browser);
   } catch (e) {

--- a/src/test/puppeteer/src/test_sage_ker.ts
+++ b/src/test/puppeteer/src/test_sage_ker.ts
@@ -91,12 +91,6 @@ const test_sage_ker = async function (opts: Opts, page: Page): Promise<PassFail>
     debuglog('after ', step, 'tries, exec number starts with ', enpfx);
     expect(enpfx).to.equal(empty_exec_str);
 
-    // readout of slider should be zero
-    // WARNING: puppeteer waitForFunction does not work with async functions
-    // https://github.com/GoogleChrome/puppeteer/issues/4045
-
-    //await page.waitForFunction('document.querySelector("div.widget-readout").innerText==0');
-
     await page.$$('.myfrac');
     debuglog('got fraction in sage ipynb');
 
@@ -107,16 +101,6 @@ const test_sage_ker = async function (opts: Opts, page: Page): Promise<PassFail>
     sel = '*[cocalc-test="search-input"][placeholder="Search or create file"]';
     await page.waitForSelector(sel);
     debuglog('got file search');
-
-if(false) {
-    sel = "button[id='Cell']";
-    await page.click(sel);
-    debuglog('clicked Cell button');
-
-    linkHandlers = await page.$x("//a[contains(., 'Clear all output')]");
-    await linkHandlers[0].click();
-    debuglog("clicked Clear all output");
-}
 
     time_log("sage ipynb test", tm_sage_ker_test);
     await screenshot(page, opts, 'cocalc-sage-ipynb.png');

--- a/src/test/puppeteer/src/types.ts
+++ b/src/test/puppeteer/src/types.ts
@@ -14,6 +14,7 @@ export interface Opts {
   screenshot?: string;
   path?: string|boolean;
   skip?: RegExp;
+  xprj?: string;
 }
 
 export interface InstallOpts {


### PR DESCRIPTION
# Description

Start to add GUI tests for [un]deleting and [un]hiding projects. The tests don't fully work yet.

Only changes to production code are addition of `cocalc-test` attributes in 
* src/smc-webapp/project/settings/hide-delete-box.tsx
* src/smc-webapp/projects/projects-filter-buttons.tsx

Sample command to hide the project specified in the creds file:

```
cd ~/cocalc/src/test/puppeteer
# do setup as in README.md
npm run tdbg -- -c ~/CCTEST/staging-dev-p2.yaml -p -x hide
```

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
