### PR TITLE
minor pricing page changes

### DIFF
--- a/src/smc-webapp/billing/billing-page.tsx
+++ b/src/smc-webapp/billing/billing-page.tsx
@@ -12,10 +12,7 @@ import {
 import { AppliedCoupons, Customer, Invoices } from "./types";
 import { Map } from "immutable";
 import { ErrorDisplay } from "../r_misc/error-display";
-import { Space } from "../r_misc/space";
-import { Icon } from "../r_misc/icon";
-import { Loading } from "../r_misc/loading";
-const { ActivityDisplay, Footer } = require("../r_misc");
+import { Loading, Space, Icon, A, ActivityDisplay, Footer } from "../r_misc";
 const { HelpEmailLink, PolicyPricingPageUrl } = require("../customize");
 import { SubscriptionList } from "./subscription-list";
 import { PaymentMethods } from "./payment-methods";
@@ -95,24 +92,23 @@ export const BillingPage = rclass<ReactProps>(
       return (
         <span>
           <Space /> If you have any questions at all, read the{" "}
-          <a
-            href={"https://doc.cocalc.com/billing.html"}
-            target={"_blank"}
-            rel={"noopener"}
-          >
+          <A href={"https://doc.cocalc.com/billing.html"}>
             Billing{"/"}Upgrades FAQ
-          </a>{" "}
+          </A>{" "}
           or email <HelpEmailLink /> immediately.
           <b>
             <Space />
             <HelpEmailLink text={<span>Contact&nbsp;us</span>} /> if you are
-            considering purchasing a course subscription and need a short evaluation trial.
+            considering purchasing a course subscription and need a short
+            evaluation trial.
             <Space />
           </b>
-          <br/><br/>
-          <b>Enterprise Support:</b> Contact us at <HelpEmailLink /> for <i>enterprise
-          support</i>, including customized course packages, modified terms of service,
-          additional legal agreements, purchase orders, insurance and priority technical support.
+          <br />
+          <br />
+          <b>Enterprise Support:</b> Contact us at <HelpEmailLink /> for{" "}
+          <i>enterprise support</i>, including customized course packages,
+          modified terms of service, additional legal agreements, purchase
+          orders, insurance and priority technical support.
         </span>
       );
     }
@@ -141,14 +137,10 @@ export const BillingPage = rclass<ReactProps>(
           return (
             <span>
               If you are{" "}
-              <a
-                href={"https://doc.cocalc.com/teaching-instructors.html"}
-                target={"_blank"}
-                rel={"noopener"}
-              >
-                teaching a course,
-              </a>
-              choose one of the course packages. If you need to upgrade your
+              <A href={"https://doc.cocalc.com/teaching-instructors.html"}>
+                teaching a course
+              </A>
+              , choose one of the course packages. If you need to upgrade your
               personal projects, choose a recurring subscription. You will{" "}
               <b>not be charged</b> until you explicitly click "Add Subscription
               or Course Package".
@@ -174,13 +166,9 @@ export const BillingPage = rclass<ReactProps>(
         return (
           <span>
             Click "Add Subscription or Course Package...". If you are{" "}
-            <a
-              href={"https://doc.cocalc.com/teaching-instructors.html"}
-              target={"_blank"}
-              rel={"noopener"}
-            >
+            <A href={"https://doc.cocalc.com/teaching-instructors.html"}>
               teaching a course,
-            </a>
+            </A>
             choose one of the course packages. If you need to upgrade your
             personal projects, choose a recurring subscription. You will be
             charged only after you select a specific subscription and click "Add
@@ -214,10 +202,7 @@ export const BillingPage = rclass<ReactProps>(
       return (
         <div style={{ marginTop: "1em", marginBottom: "1em", color: "#666" }}>
           We offer many{" "}
-          <a href={PolicyPricingPageUrl} target="_blank" rel="noopener">
-            {" "}
-            pricing and subscription options
-          </a>
+          <A href={PolicyPricingPageUrl}>pricing and subscription options</A>
           .
           <Space />
           {this.render_suggested_next_step()}

--- a/src/smc-webapp/billing/billing-page.tsx
+++ b/src/smc-webapp/billing/billing-page.tsx
@@ -88,6 +88,18 @@ export const BillingPage = rclass<ReactProps>(
       }
     }
 
+    private render_enterprise_support(): Rendered {
+      return (
+        <p>
+          <br />
+          <b>Enterprise Support:</b> Contact us at <HelpEmailLink /> for{" "}
+          <i>enterprise support</i>, including customized course packages,
+          modified terms of service, additional legal agreements, purchase
+          orders, insurance and priority technical support.
+        </p>
+      );
+    }
+
     private render_help_suggestion(): Rendered {
       return (
         <span>
@@ -103,12 +115,7 @@ export const BillingPage = rclass<ReactProps>(
             evaluation trial.
             <Space />
           </b>
-          <br />
-          <br />
-          <b>Enterprise Support:</b> Contact us at <HelpEmailLink /> for{" "}
-          <i>enterprise support</i>, including customized course packages,
-          modified terms of service, additional legal agreements, purchase
-          orders, insurance and priority technical support.
+          {this.render_enterprise_support()}
         </span>
       );
     }
@@ -158,6 +165,7 @@ export const BillingPage = rclass<ReactProps>(
               about purchase orders, using PayPal or wire transfers for
               non-recurring subscriptions above $50) please email{" "}
               <HelpEmailLink /> immediately.
+              {this.render_enterprise_support()}
             </span>
           );
         }

--- a/src/smc-webapp/billing/explain-resources.tsx
+++ b/src/smc-webapp/billing/explain-resources.tsx
@@ -24,7 +24,7 @@ export class ExplainResources extends Component<Props> {
     }
     return (
       <>
-        <h4>Table of content</h4>
+        <h4>Table of contents</h4>
         <ul style={{ paddingLeft: "20px" }}>
           <li>
             <b>
@@ -73,15 +73,14 @@ export class ExplainResources extends Component<Props> {
               ) : (
                 undefined
               )}
-              if anything is unclear to you, you just have a quick question
-              and do not want to wade through all the text below.  Also, contact
-              us if you need <b>enterprise support</b>, which includes customized
+              if anything is unclear to you, you just have a quick question and
+              do not want to wade through all the text below. Also, contact us
+              if you need <b>enterprise support</b>, which includes customized
               course packages, modified terms of service, additional legal
-              agreements, purchase orders, insurance and priority technical support.
+              agreements, purchase orders, insurance and priority technical
+              support.
             </div>
             <Space />
-
-            {this.render_toc()}
 
             <a id="projects" />
             <h4>Projects</h4>
@@ -108,7 +107,7 @@ export class ExplainResources extends Component<Props> {
             </div>
             <Space />
 
-            <h4>Shared Resources</h4>
+            <h4>Shared resources</h4>
             <div>
               Each project runs on a server, where it shares disk space, CPU,
               and RAM with other projects. Initially, you work in a{" "}
@@ -153,6 +152,9 @@ export class ExplainResources extends Component<Props> {
                 order to increase the total amount of upgrades available to you.
               </li>
             </ul>
+            <Space />
+
+            {this.render_toc()}
 
             <Space />
             <h4>More information</h4>

--- a/src/smc-webapp/billing/faq.tsx
+++ b/src/smc-webapp/billing/faq.tsx
@@ -6,7 +6,7 @@ export class FAQ extends Component {
     return (
       <div>
         <a id="faq" />
-        <ul>
+        <ul style={{ paddingLeft: "20px" }}>
           <li>
             <A href={"https://doc.cocalc.com/billing.html"}>
               Billing, quotas, and upgrades FAQ

--- a/src/smc-webapp/r_misc/A.tsx
+++ b/src/smc-webapp/r_misc/A.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 interface AProps {
   href: string;
-  children: string;
+  children: React.ReactNode;
 }
 
 export function A({ href, children }: AProps) {


### PR DESCRIPTION
# Description
1. taking care of #4182
2. some r_misc related cleanup and using `A` for external links
3. showing enterprise info even in the case of no card with at least one subscription

# Testing Steps
This is easy to test ... just check if the page shows up, and the enterprise info is there in that special case.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
