### PR TITLE
webapp/proj navbar: fix low "hanging" tab descriptions

### DIFF
--- a/src/smc-webapp/_projects.sass
+++ b/src/smc-webapp/_projects.sass
@@ -7,7 +7,7 @@
   border-radius : 5px 5px 0px 0px
 
 .smc-file-tabs-fixed-desktop > li > a
-  padding       : 7px 5px
+  padding       : 5px
   +file-tabs-base
 
 .smc-file-tabs-files-desktop > li > a


### PR DESCRIPTION
# Description

I noticed today that the nav items for a project (files, log, ...) are slightly lower than the file tabs. This just tweaks some padding, that's all.

# Testing Steps
see screencast

# Screencast

This tabs between two tabs: prod and my dev project. In one of them the descriptions line up.

![Peek 2019-10-22 14-01](https://user-images.githubusercontent.com/207405/67283962-f3adab80-f4d4-11e9-9094-2ae9f475282c.gif)




### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
