### PR TITLE
html reload button

### DIFF
--- a/src/smc-webapp/frame-editors/html-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/html-editor/actions.ts
@@ -40,6 +40,19 @@ export class Actions extends CodeEditorActions {
     }
   }
 
+  // https://github.com/sagemathinc/cocalc/issues/3984
+  reload(id: string) {
+    const node = this._get_frame_node(id);
+    if (!node) return;
+
+    if (node.get("type") !== "iframe") {
+      super.reload(id);
+      return;
+    }
+
+    this.set_reload("iframe");
+  }
+
   print(id: string): void {
     const node = this._get_frame_node(id);
     if (!node) return;

--- a/src/smc-webapp/frame-editors/html-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/html-editor/actions.ts
@@ -50,7 +50,7 @@ export class Actions extends CodeEditorActions {
       return;
     }
 
-    this.set_reload("iframe");
+    this.set_reload("iframe", new Date().getTime());
   }
 
   print(id: string): void {

--- a/src/smc-webapp/frame-editors/html-editor/iframe-html.tsx
+++ b/src/smc-webapp/frame-editors/html-editor/iframe-html.tsx
@@ -120,9 +120,7 @@ export class IFrameHTML extends Component<PropTypes, {}> {
     }
 
     // param below is just to avoid caching.
-    const src_url = `${window.app_base_url}/${
-      this.props.project_id
-    }/raw/${path}?param=${this.props.reload}`;
+    const src_url = `${window.app_base_url}/${this.props.project_id}/raw/${path}?param=${this.props.reload}`;
 
     return (
       <iframe

--- a/src/smc-webapp/frame-editors/html-editor/options.ts
+++ b/src/smc-webapp/frame-editors/html-editor/options.ts
@@ -1,4 +1,4 @@
 // If the user makes the viewport really wide, it is very hard to read
 // the markdown, so we max the width out at 900px.  I have no idea if 900px
 // is a good choice...
-export const MAX_WIDTH : string = '900px';
+export const MAX_WIDTH: string = "900px";


### PR DESCRIPTION
# Description
This fixes #3984 -- or well, at least that button is actually doing something now. I hope this is not backwards…

# Testing Steps
* make a html file, open the iframe preview, and click the 3rd reload button. 
* this in the html shows a new random number each time

```
  <script>
  document.write(Math.random())
  </script>
```

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
