### PR TITLE
verilog file support

### DIFF
--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -88,6 +88,8 @@ const codemirror_associations: { [ext: string]: string } = {
   cml: "xml", // http://www.xml-cml.org/, e.g. used by avogadro
   kml: "xml", // https://de.wikipedia.org/wiki/Keyhole_Markup_Language
   xsl: "xsl",
+  v: "verilog",
+  vh: "verilog",
   "": "text"
 };
 
@@ -274,6 +276,14 @@ file_associations["ipynb"] = {
   icon: "cc-icon-ipynb",
   opts: {},
   name: "Jupyter Notebook"
+};
+
+// verilog files
+file_associations["v"] = file_associations["vh"] = {
+  editor: "codemirror",
+  icon: "fa-microchip",
+  opts: { mode: "verilog", indent_unit: 2, tab_size: 2 },
+  name: "Verilog"
 };
 
 for (let ext of ["png", "jpg", "jpeg", "gif", "svg", "bmp"]) {


### PR DESCRIPTION
# Description
Support for verilog, `.v` and `.vh` files.

# Testing Steps
* copy/paste https://codemirror.net/mode/verilog/ into these files

# Screenshot

![Screenshot from 2019-10-23 15-43-31](https://user-images.githubusercontent.com/207405/67399140-0e068880-f5ac-11e9-8da1-cdfb2076a3f1.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
