### PR TITLE
dev: consistency checker for npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ src/smc-webapp/_colors.sass
 
 # pytest cache
 src/smc_sagews/.pytest_cache/
+.mypy_cache/

--- a/src/package.json
+++ b/src/package.json
@@ -92,7 +92,7 @@
     "lint": "node_modules/.bin/coffeelint -f smc-util/coffeelint.json -c *.coffee && cd smc-hub && npm run lint && cd ../smc-webapp && npm run lint && cd ../smc-util && npm run lint && cd ../smc-util-node && npm run lint",
     "test": "export SMC_TEST=true&& cd smc-util && npm test && cd ../smc-util-node && npm test && cd ../smc-hub && npm test && cd ../smc-webapp && npm test && cd ../smc-project && npm test",
     "coverage": "cd smc-util && npm run coverage && cd ../smc-util-node && npm run coverage && cd ../smc-hub && npm run coverage && cd ../smc-webapp && npm run coverage",
-    "webpack-watch": "cd $SALVUS_ROOT; scripts/update_color_scheme.coffee; webapp-lib/primus/update_primus; unset CC_STATICPAGES; CC_NOCLEAN=true SOURCE_MAP=true NODE_ENV=development node --max_old_space_size=8192 node_modules/webpack/bin/webpack.js --debug --output-pathinfo --progress --colors --watch --watch-poll=1000",
+    "webpack-watch": "cd $SALVUS_ROOT; scripts/check_npm_packages.py; scripts/update_color_scheme.coffee; webapp-lib/primus/update_primus; unset CC_STATICPAGES; CC_NOCLEAN=true SOURCE_MAP=true NODE_ENV=development node --max_old_space_size=8192 node_modules/webpack/bin/webpack.js --debug --output-pathinfo --progress --colors --watch --watch-poll=1000",
     "webpack-debug": "cd $SALVUS_ROOT; scripts/update_color_scheme.coffee; webapp-lib/primus/update_primus; SOURCE_MAP=true NODE_ENV=development webpack --debug --progress --colors",
     "webpack-production": "cd $SALVUS_ROOT; scripts/update_color_scheme.coffee; webapp-lib/primus/update_primus; NODE_ENV=production node --max_old_space_size=8192 node_modules/webpack/bin/webpack.js --progress --colors",
     "webpack-clean": "rm -rvf $SALVUS_ROOT/static/",

--- a/src/scripts/check_npm_packages.py
+++ b/src/scripts/check_npm_packages.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
 Consistency check for npm packages across node modules
+
+Hint: to get a "real time" info while working on resolving this, run
+      $ /usr/bin/watch -n1 check_npm_packages.py
+      in the SMC_ROOT dir in a separate terminal.
 """
 
 import os
@@ -12,32 +16,70 @@ from subprocess import run, PIPE
 from typing import List, Set, Dict, Tuple, Optional
 from typing_extensions import Final
 
-root: Final[str] = os.environ.get('SMC_ROOT', os.curdir)
-search = run(['git', 'ls-files', '--', '../**/package.json'], stdout=PIPE)
-data = search.stdout.decode('utf8')
-packages: Final[List[str]] = [abspath(_) for _ in data.splitlines()]
+T_installs = Dict[str, Dict[str, str]]
 
-installs: Dict[str, Dict[str, str]] = defaultdict(dict)
-modules: Set[str] = set()
+root: Final[str] = os.environ.get('SMC_ROOT', abspath(os.curdir))
 
-for pkg in packages:
-    pkgs = json.load(open(pkg))
-    module = basename(dirname(pkg))
-    modules.add(module)
-    for name, vers in pkgs.get('dependencies', {}).items():
-        installs[name][module] = vers
 
-smodules: Final = sorted(modules)
+def pkg_dirs() -> List[str]:
+    search = run(['git', 'ls-files', '--', '../**/package.json'], stdout=PIPE)
+    data = search.stdout.decode('utf8')
+    packages = [abspath(_) for _ in data.splitlines()]
+    return packages
 
-print(f"{'':<30s}", end="")
-for mod in smodules:
-    print(f"{mod:<15s}", end="")
-print()
 
-for pkg, inst in sorted(installs.items()):
-    if len(set(inst.values())) == 1: continue
-    print(f"{pkg:<30s}", end="")
-    for mod in smodules:
-        vers = inst.get(mod, '')
-        print(f"{vers:<15s}", end="")
-    print()
+def get_versions(packages, dep_type) -> Tuple[T_installs, Set[str]]:
+    installs: T_installs = defaultdict(dict)
+    modules: Set[str] = set()
+
+    for pkg in packages:
+        pkgs = json.load(open(pkg))
+        module = basename(dirname(pkg))
+        modules.add(module)
+        for name, vers in pkgs.get(dep_type, {}).items():
+            installs[name][module] = vers
+    return installs, modules
+
+
+def print_table(installs: T_installs, modules) -> Tuple[str, int]:
+    cnt = 0
+    table = ""
+
+    table += f"{'':<30s}"
+    for mod in sorted(modules):
+        table += f"{mod:<15s}"
+    table += "\n"
+
+    for pkg, inst in sorted(installs.items()):
+        if len(set(inst.values())) == 1: continue
+        cnt += 1
+        table += f"{pkg:<30s}"
+        for mod in sorted(modules):
+            vers = inst.get(mod, '')
+            table += f"{vers:<15s}"
+        table += "\n"
+    return table, cnt
+
+
+def main() -> None:
+    packages: Final = pkg_dirs()
+
+    main_pkgs, main_mods = get_versions(packages, 'dependencies')
+    dev_pkgs, dev_mods = get_versions(packages, 'devDependencies')
+
+    dev_table, dev_incon = print_table(dev_pkgs, dev_mods)
+    if dev_incon > 0:
+        print("Development Modules")
+        print(dev_table)
+        print("\nRegular Code Modules")
+
+    table, incons = print_table(main_pkgs, main_mods)
+
+    if incons > 0:
+        print(table)
+        print(f"\nThere are {incons} inconsistencies")
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/check_npm_packages.py
+++ b/src/scripts/check_npm_packages.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Consistency check for npm packages across node modules
+"""
+
+import os
+from os.path import abspath, dirname, basename
+import json
+from collections import defaultdict
+from pprint import pprint
+from subprocess import run, PIPE
+from typing import List, Set, Dict, Tuple, Optional
+from typing_extensions import Final
+
+root: Final[str] = os.environ.get('SMC_ROOT', os.curdir)
+search = run(['git', 'ls-files', '--', '../**/package.json'], stdout=PIPE)
+data = search.stdout.decode('utf8')
+packages: Final[List[str]] = [abspath(_) for _ in data.splitlines()]
+
+installs: Dict[str, Dict[str, str]] = defaultdict(dict)
+modules: Set[str] = set()
+
+for pkg in packages:
+    pkgs = json.load(open(pkg))
+    module = basename(dirname(pkg))
+    modules.add(module)
+    for name, vers in pkgs.get('dependencies', {}).items():
+        installs[name][module] = vers
+
+smodules: Final = sorted(modules)
+
+print(f"{'':<30s}", end="")
+for mod in smodules:
+    print(f"{mod:<15s}", end="")
+print()
+
+for pkg, inst in sorted(installs.items()):
+    if len(set(inst.values())) == 1: continue
+    print(f"{pkg:<30s}", end="")
+    for mod in smodules:
+        vers = inst.get(mod, '')
+        print(f"{vers:<15s}", end="")
+    print()


### PR DESCRIPTION
# Description
just an idea, this could help us getting insight/warnings about version inconsistencies (e.g. as part of CI testing)

the only change that touches anything is calling this at the start of `webpack-watch`, to give us some feedback. Later, once this is down to zero inconsistencies, we can add it to travis CI to inform us about introducing new ones.

# Testing Steps

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
