### PR TITLE
dropzone: reverting #4167 because it stalls when uploading larger files…

### DIFF
--- a/src/smc-webapp/package-lock.json
+++ b/src/smc-webapp/package-lock.json
@@ -3341,9 +3341,9 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "dropzone": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.5.1.tgz",
-      "integrity": "sha512-3VduRWLxx9hbVr42QieQN25mx/I61/mRdUSuxAmDGdDqZIN8qtP7tcKMa3KfpJjuGjOJGYYUzzeq6eGDnkzesA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-4.3.0.tgz",
+      "integrity": "sha1-SLC48q0JKHLktTW2cqfD8aHWfJE="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -9330,12 +9330,12 @@
       }
     },
     "react-dropzone-component": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone-component/-/react-dropzone-component-3.2.0.tgz",
-      "integrity": "sha512-QwopN2GgzHCKcMyJvBZuYCeqnU9F/Uiq1hD94/JmFdLmkzU1rw7SbNjLNUad864YoAEvcx93uHUItv0NUwlTxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone-component/-/react-dropzone-component-2.0.0.tgz",
+      "integrity": "sha1-Nc0BH1JcnKYg/LZH55cl7qobWlg=",
       "requires": {
-        "dropzone": "^5.4.0",
-        "extend": "^3.0.1"
+        "dropzone": "^4.3.0",
+        "extend": "^3.0.0"
       }
     },
     "react-image-crop": {

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -97,7 +97,7 @@
     "react-bootstrap": "^0.31.5",
     "react-dom": "^16.9.0",
     "react-draggable": "^3.0.0",
-    "react-dropzone-component": "^3.2.0",
+    "react-dropzone-component": "^2.0.0",
     "react-image-crop": "^8.3.1",
     "react-json-inspector": "^7.0.1",
     "react-mentions": "^2.4.2",


### PR DESCRIPTION
# Description

reverting #4167

I've tested that react dropzone version 2 or 3 two times back and forth. There is definitely a problem uploading larger files (~80mb in my case) with version 3. It always stalls at about 50%.

consequently, issue #4165 is still open

# Testing Steps


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
