### PR TITLE
webapp/rmd: make sure mpl backend is set correctly when plotting via matplotlib

### DIFF
--- a/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
@@ -39,6 +39,7 @@ export async function convert(
     bash: true, // so timeout is enforced by ulimit
     command: "Rscript",
     args: ["-e", cmd],
+    env: { MPLBACKEND: "Agg" }, // for python plots -- https://github.com/sagemathinc/cocalc/issues/4202
     project_id: project_id,
     path: x.head,
     err_on_exit: true,


### PR DESCRIPTION

# Description

see  #4202 .. this is trivial

# Testing Steps
incidentally, this is hard to test. the hub in a cc-in-cc project starts in a terminal, which has this env var set. that propagates down to the project and so on. you have to unset it, then start the hub, then experience the difference between setting this or not.

content

<pre>
---
title: python3 test
---

```{r setup, include=FALSE}
# this setup code is important, otherwise it won't run!
library(reticulate)
use_python('/usr/bin/python3')
```

```{python}
import numpy as np
import matplotlib.pyplot as plt
xx = np.linspace(0, 20, 100)
yy = np.sin(xx) + np.cos(xx)
plt.plot(xx, yy)
plt.show()
```
</pre>

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
