### PR TITLE
webapp/latex/pythontex: tell matplotlib what to use

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
@@ -39,6 +39,7 @@ export async function pythontex(
     bash: true, // timeout is enforced by ulimit
     command: "pythontex3",
     args: args.concat(base),
+    env: { MPLBACKEND: "Agg" }, // for python plots -- https://github.com/sagemathinc/cocalc/issues/4203
     project_id: project_id,
     path: output_directory || directory,
     err_on_exit: false,


### PR DESCRIPTION
# Description
This is analogous to https://github.com/sagemathinc/cocalc/pull/4204

Fixes  #4203

# Testing Steps

```
\documentclass{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{lmodern}
\usepackage[parfill]{parskip}
\usepackage{amsmath,amssymb}
\usepackage{fullpage}
\usepackage{graphicx}
\usepackage{pythontex}

\title{Title of Document}
\author{Name of Author}

\begin{document}


\begin{pyconsole}
var = 1 + 1
import os
print(os.environ.get("MPLBACKEND"))
\end{pyconsole}

1+1 = \pycon{2}!

\begin{pylabcode}
x = linspace(0, pi, 1000)
plt.plot(x, 2*sin(x**2), label='$2 sin(x^2)$')
plt.plot(x, cos(x), label='cos(x)')
savefig("plot.pdf")
\end{pylabcode}

\begin{center}
\includegraphics[width=0.85\textwidth]{plot.pdf}
\end{center}

\end{document}
```

![Screenshot from 2019-11-01 18-24-43](https://user-images.githubusercontent.com/207405/68043151-ee224380-fcd4-11e9-9d50-b2b9c54aacb8.png)



# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
