### PR TITLE
removing wiki portal link and misc other usages of "wiki"

### DIFF
--- a/src/smc-hub/email.ts
+++ b/src/smc-hub/email.ts
@@ -473,10 +473,7 @@ You can share your thoughts in a <strong>side chat</strong> next to each documen
     <strong><a href="https://doc.cocalc.com/">${SITE_NAME} Manual:</a></strong> learn more about ${SITE_NAME}'s features.
 </li>
 <li style="margin-top:0;margin-bottom:10px;">
-    <a href="https://github.com/sagemathinc/cocalc/wiki">${SITE_NAME} Wiki:</a> the entry-point to learn more about all the details.
-</li>
-<li style="margin-top:0;margin-bottom:10px;">
-    <a href="https://github.com/sagemathinc/cocalc/wiki/sagews">Working with SageMath Worksheets</a>
+    <a href="https://doc.cocalc.com/sagews.html">Working with SageMath Worksheets</a>
 </li>
 <li style="margin-top:0;margin-bottom:10px;">
     <strong><a href="https://cocalc.com/policies/pricing.html">Subscriptions:</a></strong> make hosting more robust and increase project quotas

--- a/src/smc-util/theme.js
+++ b/src/smc-util/theme.js
@@ -19,7 +19,6 @@ exports.DNS                  = 'cocalc.com';
 exports.DOMAIN_NAME          = `https://${exports.DNS}`;
 exports.DISCUSSION_GROUP     = 'https://groups.google.com/forum/#!forum/cocalc';
 exports.DOC_URL              = 'https://doc.cocalc.com/';
-exports.WIKI_URL             = 'https://github.com/sagemathinc/cocalc/wiki/Portal';
 exports.BLOG_URL             = 'https://blog.sagemath.com/';
 exports.LIVE_DEMO_REQUEST    = 'https://docs.google.com/forms/d/e/1FAIpQLSesDZkGD2XVu8BHKd_sPwn5g7MrLAA8EYRTpB6daedGVMTpkA/viewform';
 exports.HELP_EMAIL           = 'help@cocalc.com';

--- a/src/smc-webapp/buttonbar.coffee
+++ b/src/smc-webapp/buttonbar.coffee
@@ -905,7 +905,7 @@ exports.commands =
         sagesyntaxerrors:
             url: 'https://github.com/sagemathinc/cocalc/wiki/MathematicalSyntaxErrors'
         cocalcwiki:
-            url: 'https://github.com/sagemathinc/cocalc/wiki/sagews'
+            url: 'https://doc.cocalc.com/sagews.html'
         sagequestion:
             url: 'https://github.com/sagemathinc/cocalc/wiki/SageQuestion'
         help:

--- a/src/smc-webapp/course/upgrades.tsx
+++ b/src/smc-webapp/course/upgrades.tsx
@@ -48,6 +48,7 @@ import { CourseStore } from "./store";
 import { Map } from "immutable";
 
 const {
+  A,
   Icon,
   Loading,
   NoUpgrades,
@@ -613,12 +614,9 @@ class StudentProjectUpgrades extends Component<
             Add or remove upgrades to student projects associated to this
             course, adding to what is provided for free and what students may
             have purchased.{" "}
-            <a
-              href="https://github.com/sagemathinc/cocalc/wiki/prof-pay"
-              target="_blank"
-            >
+            <A href="https://doc.cocalc.com/teaching-create-course.html#option-2-teacher-or-institution-pays-for-upgradespay">
               Help...
-            </a>
+            </A>
           </p>
         </div>
       </div>

--- a/src/smc-webapp/customize.tsx
+++ b/src/smc-webapp/customize.tsx
@@ -291,4 +291,3 @@ export const PolicyPricingPageUrl = app_base_url + "/policies/pricing.html";
 export const PolicyPrivacyPageUrl = app_base_url + "/policies/privacy.html";
 export const PolicyCopyrightPageUrl = app_base_url + "/policies/copyright.html";
 export const PolicyTOSPageUrl = app_base_url + "/policies/terms.html";
-export const SmcWikiUrl = theme.WIKI_URL;

--- a/src/smc-webapp/r_help.cjsx
+++ b/src/smc-webapp/r_help.cjsx
@@ -36,7 +36,7 @@ misc = require('smc-util/misc')
 {Icon, Loading, Space, TimeAgo, UNIT, Footer} = require('./r_misc')
 {HelpEmailLink, SiteName, SiteDescription, PolicyPricingPageUrl} = require('./customize')
 {RECENT_TIMES, RECENT_TIMES_KEY} = require('smc-util/schema')
-{COLORS, HELP_EMAIL, WIKI_URL, DOC_URL, TWITTER_HANDLE, LIVE_DEMO_REQUEST, SITE_NAME} = require('smc-util/theme')
+{COLORS, HELP_EMAIL, DOC_URL, TWITTER_HANDLE, LIVE_DEMO_REQUEST, SITE_NAME} = require('smc-util/theme')
 {ComputeEnvironment} = require('./compute_environment')
 
 # List item style
@@ -215,11 +215,6 @@ SUPPORT_LINKS =
         bold : true
         href : DOC_URL
         link : <span><SiteName/> manual</span>
-    wiki :
-        icon : 'question-circle'
-        bold : true
-        href : WIKI_URL
-        link : <span><SiteName/> WIKI portal</span>
     teaching :
         icon : 'graduation-cap'
         href : 'https://doc.cocalc.com/teaching-instructors.html'
@@ -425,7 +420,6 @@ exports.HelpPage = HelpPage = rclass
             textAlign       : 'center'
             marginBottom    : '30px'
 
-        {SmcWikiUrl}      = require('./customize')
         {ShowSupportLink} = require('./support')
         {APP_LOGO}        = require('./art')
 

--- a/src/smc-webapp/share/config/config.tsx
+++ b/src/smc-webapp/share/config/config.tsx
@@ -14,7 +14,7 @@ simultaneously edit this and have it be synced properly
 between them.
 */
 
-const WIKI_SHARE_HELP_URL = "https://doc.cocalc.com/share.html";
+const SHARE_HELP_URL = "https://doc.cocalc.com/share.html";
 
 import {
   Alert,
@@ -359,7 +359,7 @@ class Configure extends Component<Props, State> {
     const server = share_server_url();
     return (
       <div style={{ color: "#555", fontSize: "12pt" }}>
-        <a href={WIKI_SHARE_HELP_URL} target="_blank" rel="noopener">
+        <a href={SHARE_HELP_URL} target="_blank" rel="noopener">
           You share
         </a>{" "}
         files or directories{" "}

--- a/src/smc-webapp/support.cjsx
+++ b/src/smc-webapp/support.cjsx
@@ -1,5 +1,5 @@
 
-###############################################################################
+##############################################################################
 #
 #    CoCalc: Collaborative Calculation in the Cloud
 #
@@ -28,7 +28,7 @@ misc            = require('smc-util/misc')
 misc_page       = require('./misc_page')
 {webapp_client} = require('./webapp_client')
 feature         = require('./feature')
-{HelpEmailLink, SiteName, SmcWikiUrl} = require('./customize')
+{HelpEmailLink, SiteName} = require('./customize')
 
 STATE =
     NEW        : 'new'      # new/default/resetted/no problem

--- a/src/smc-webapp/tasks/actions.coffee
+++ b/src/smc-webapp/tasks/actions.coffee
@@ -4,7 +4,7 @@ Task Actions
 
 LAST_EDITED_THRESH_S = 30
 
-WIKI_HELP_URL = "https://doc.cocalc.com/tasks.html"
+TASKS_HELP_URL = "https://doc.cocalc.com/tasks.html"
 
 immutable  = require('immutable')
 underscore = require('underscore')
@@ -334,7 +334,7 @@ class exports.TaskActions extends Actions
             foreground : true
 
     help: =>
-        window.open(WIKI_HELP_URL, "_blank").focus()
+        window.open(TASKS_HELP_URL, "_blank").focus()
 
     set_current_task: (task_id) =>
         @setState(current_task_id : task_id)


### PR DESCRIPTION
# Description

this removes the link to the wiki portal and also gets rid of other miscellaneous usages of "wiki"

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
