### PR TITLE
Update Travis CI

### DIFF
--- a/.travis-install-services.sh
+++ b/.travis-install-services.sh
@@ -1,19 +1,25 @@
 # kucalc-style
 set -ex
 
-npm install coffeescript -g
+npm install -g coffeescript uglify-js
 
 cd $TRAVIS_BUILD_DIR/src
-npm install uglify-js
 
 # the first few are for the hub services, but we also build the project
-for path in smc-util smc-util-node smc-hub smc-webapp smc-webapp/jupyter smc-project smc-project/jupyter smc-webapp/jupyter; do
-    cd $TRAVIS_BUILD_DIR/src/$path
+export SMC_ROOT=$TRAVIS_BUILD_DIR/src/
+export SALVUS_ROOT=$SMC_ROOT
+
+. $TRAVIS_BUILD_DIR/src/scripts/cocalc-dirs.sh
+
+for path in "${CODE_DIRS[@]}"; do
+    cd $path
     npm ci
 done
 
+cd $TRAVIS_BUILD_DIR/src
+
 # hub: build primus
-env SALVUS_ROOT=$TRAVIS_BUILD_DIR/src PATH=$TRAVIS_BUILD_DIR/src/node_modules/.bin:$PATH $TRAVIS_BUILD_DIR/src/webapp-lib/primus/update_primus
+env PATH=$TRAVIS_BUILD_DIR/src/node_modules/.bin:$PATH $TRAVIS_BUILD_DIR/src/webapp-lib/primus/update_primus
 
 # coffee: # the first few are for the hub services, but we also build the project
 for path in smc-util smc-util-node smc-hub smc-webapp smc-project smc-project/jupyter smc-webapp/jupyter; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # CoCalc Travis-CI Configuration File
 sudo: required
-dist: xenial
+dist: bionic
 
 # no need to build all branches
 branches:
@@ -11,13 +11,14 @@ branches:
 language: "python"
 python: 3.6
 
-# travis supports 8 and 11 (as of winter 2018)
+# travis natively supports 8 and 11 (as of winter 2018)
+# version 10 should be installed via nvm
 node_js:
-  - "8"
+  - "10"
 
 cache:
   directories:
-  - "$HOME/.npm"
+    - "$HOME/.npm"
 
 git:
   depth: 3
@@ -38,6 +39,7 @@ addons:
       - "python3-pip"
       - "python3-pytest"
       - "python3-yaml"
+      - "postgresql-server-dev-10" # pg_config https://docs.travis-ci.com/user/database-setup/#using-pg_config
 
 # Travis supports "global" and "build matrix" variables
 # http://docs.travis-ci.com/user/environment-variables/
@@ -63,6 +65,7 @@ before_script:
   - "python -V"
   - "node --version"
   - "pytest --version"
+  - "pg_config --version"
   - 'export PGHOST="$TRAVIS_BUILD_DIR/src/dev/project/postgres_data/socket"'
   - "python2 $TRAVIS_BUILD_DIR/src/dev/project/start_postgres.py &"
   - "sleep 10" # for starting up postgres in the background (db init, etc.)


### PR DESCRIPTION
# Description

this updates the linux and nodejs version for travis, but well, it doesn't fix build errors. now it is

```
+/home/travis/build/sagemathinc/cocalc/src/dev/project/start_api.py test
service_hub.py --dev --foreground --hostname=0.0.0.0 --port=54147 --proxy_port=0 --gap=0 --test start
hub  --host=0.0.0.0 --port 54147 --proxy_port 0 --share_port 0  --share_path   --base_url= --dev  --test  --foreground  
node -r esm --max-old-space-size=8000 run/hub.js --host=0.0.0.0 --port 54147 --proxy_port 0 --share_port 0 --share_path --base_url= --dev --test --foreground
/home/travis/build/sagemathinc/cocalc/src/node_modules/ts-node/src/index.ts:261
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
postgres/changefeed.ts(49,111): error TS2322: Type '0' is not assignable to type '{ label: number; sent: () => any; trys: never[]; ops: never[]; }'.
postgres/changefeed.ts(52,75): error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
postgres/changefeed.ts(474,25): error TS2322: Type 'false' is not assignable to type 'undefined'.
postgres/changefeed.ts(478,47): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
postgres/changefeed.ts(481,37): error TS2322: Type 'true' is not assignable to type 'undefined'.
postgres/changefeed.ts(499,21): error TS2322: Type 'false' is not assignable to type 'undefined'.
postgres/changefeed.ts(503,45): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
postgres/changefeed.ts(505,95): error TS2532: Object is possibly 'undefined'.
postgres/changefeed.ts(506,33): error TS2322: Type 'true' is not assignable to type 'undefined'.
....
```

still merging it, since it improves what we had before

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
