### PR TITLE
formatting support for rust

### DIFF
--- a/src/smc-project/formatters/prettier.ts
+++ b/src/smc-project/formatters/prettier.ts
@@ -24,7 +24,7 @@ const { bib_format } = require("./bib-format");
 const { r_format } = require("./r-format");
 const { clang_format } = require("./clang-format");
 const { gofmt } = require("./gofmt");
-const { rust_format } = require("./rust_format");
+const { rust_format } = require("./rust-format");
 const misc = require("../smc-util/misc");
 const { remove_math, replace_math } = require("../smc-util/mathjax-utils"); // from project Jupyter
 

--- a/src/smc-project/formatters/prettier.ts
+++ b/src/smc-project/formatters/prettier.ts
@@ -24,6 +24,7 @@ const { bib_format } = require("./bib-format");
 const { r_format } = require("./r-format");
 const { clang_format } = require("./clang-format");
 const { gofmt } = require("./gofmt");
+const { rust_format } = require("./rust_format");
 const misc = require("../smc-util/misc");
 const { remove_math, replace_math } = require("../smc-util/mathjax-utils"); // from project Jupyter
 
@@ -109,6 +110,10 @@ export async function run_prettier_string(
       break;
     case "gofmt":
       pretty = await gofmt(str, options, logger);
+      break;
+    case "rust":
+    case "rustfmt":
+      pretty = await rust_format(str, options, logger);
       break;
     default:
       pretty = prettier.format(str, options);

--- a/src/smc-project/formatters/rust_format.ts
+++ b/src/smc-project/formatters/rust_format.ts
@@ -1,0 +1,78 @@
+const { writeFile, readFile, unlink } = require("fs");
+const tmp = require("tmp");
+const { callback } = require("awaiting");
+const { spawn } = require("child_process");
+
+interface ParserOptions {
+  parser: string;
+  tabWidth: number;
+}
+
+function close(proc, cb): void {
+  proc.on("close", code => cb(undefined, code));
+}
+
+// ref: https://github.com/rust-lang/rustfmt ... but the configuration comes with project specific toml files
+
+function run_rustfmt(input_path: string) {
+  return spawn("rustfmt", [input_path]);
+}
+
+function cleanup_error(err: string, tmpfn: string): string {
+  const ret: string[] = [];
+  for (let line of err.split("\n")) {
+    if (line.startsWith(tmpfn)) {
+      line = line.slice(tmpfn.length + 1);
+    }
+    ret.push(line);
+  }
+  return ret.join("\n");
+}
+
+export async function rust_format(
+  input: string,
+  options: ParserOptions,
+  logger: any
+): Promise<string> {
+  // create input temp file
+  const input_path: string = await callback(tmp.file);
+  try {
+    // logger.debug(`gofmt tmp file: ${input_path}`);
+    await callback(writeFile, input_path, input);
+
+    // spawn the html formatter
+    let formatter;
+
+    switch (options.parser) {
+      case "rustfmt":
+        formatter = run_rustfmt(input_path /*, logger*/);
+        break;
+      default:
+        throw Error(`Unknown Go code formatting utility '${options.parser}'`);
+    }
+    // stdout/err capture
+    let stdout: string = "";
+    let stderr: string = "";
+    // read data as it is produced.
+    formatter.stdout.on("data", data => (stdout += data.toString()));
+    formatter.stderr.on("data", data => (stderr += data.toString()));
+    // wait for subprocess to close.
+    const code = await callback(close, formatter);
+    if (code >= 1) {
+      stdout = cleanup_error(stdout, input_path);
+      stderr = cleanup_error(stderr, input_path);
+      const err_msg = `Gofmt code formatting utility "${options.parser}" exited with code ${code}\nOutput:\n${stdout}\n${stderr}`;
+      logger.debug(`gofmt error: ${err_msg}`);
+      throw Error(err_msg);
+    }
+
+    // all fine, we read from the temp file
+    const output: Buffer = await callback(readFile, input_path);
+    const s: string = output.toString("utf-8");
+    // logger.debug(`gofmt_format output s ${s}`);
+
+    return s;
+  } finally {
+    unlink(input_path, () => {});
+  }
+}

--- a/src/smc-util/code-formatter.ts
+++ b/src/smc-util/code-formatter.ts
@@ -1,6 +1,8 @@
 // common configuration for mapping programming languages (lower case) to formatters
 // this is used by webapp and the project
 
+import { tuple } from "smc-util/misc2";
+
 // ideally, this is the "syntax", but for historic reasons it's what is being "parsed"
 export type Parser =
   | "r"
@@ -50,10 +52,6 @@ export type Tool =
   | "biber"
   | "tidy"
   | "DOES_NOT_EXIST"; // use this for testing;
-
-function tuple<T extends string[]>(o: T) {
-  return o;
-}
 
 // the set of file extensions where we want to have formatting support
 export const file_extensions = tuple([

--- a/src/smc-util/code-formatter.ts
+++ b/src/smc-util/code-formatter.ts
@@ -1,7 +1,7 @@
 // common configuration for mapping programming languages (lower case) to formatters
 // this is used by webapp and the project
 
-import { tuple } from "smc-util/misc2";
+import { tuple } from "./misc2";
 
 // ideally, this is the "syntax", but for historic reasons it's what is being "parsed"
 export type Parser =

--- a/src/smc-util/code-formatter.ts
+++ b/src/smc-util/code-formatter.ts
@@ -11,6 +11,8 @@ export type Parser =
   | "latex"
   | "go"
   | "gofmt"
+  | "rust"
+  | "rustfmt"
   | "tidy"
   | "CSS"
   | "html"
@@ -44,36 +46,43 @@ export type Tool =
   | "clang-format"
   | "latexindent"
   | "gofmt"
+  | "rustfmt"
   | "biber"
   | "tidy"
   | "DOES_NOT_EXIST"; // use this for testing;
 
-// the list of file extensions where we want to have formatting support
-export type Exts =
-  | "js"
-  | "jsx"
-  | "md"
-  | "rmd"
-  | "css"
-  | "ts"
-  | "tsx"
-  | "json"
-  | "yaml"
-  | "yml"
-  | "py"
-  | "tex"
-  | "html"
-  | "r"
-  | "go"
-  | "c"
-  | "cc"
-  | "c++"
-  | "cpp"
-  | "h"
-  | "xml"
-  | "cml"
-  | "kml"
-  | "bib";
+function tuple<T extends string[]>(o: T) {
+  return o;
+}
+
+// the set of file extensions where we want to have formatting support
+export const file_extensions = tuple([
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "json",
+  "md",
+  "css",
+  "py",
+  "r",
+  "rs",
+  "go",
+  "yml",
+  "yaml",
+  "xml",
+  "cml" /* that's xml */,
+  "kml" /* geodata keyhole markup, also xml */,
+  "c",
+  "c++",
+  "cc",
+  "cpp",
+  "h",
+  "bib"
+]);
+
+// convert to type
+export type Exts = typeof file_extensions[number];
 
 // associating filename extensions with a specific type of syntax for a parser
 type Ext2Parser = { [s in Exts]: Parser };
@@ -92,6 +101,7 @@ export const ext2parser: Readonly<Ext2Parser> = Object.freeze({
   tex: "latex",
   html: "html",
   r: "R",
+  rs: "rust",
   go: "go",
   c: "clang",
   cc: "clang",
@@ -135,6 +145,8 @@ export const parser2tool: Readonly<Config> = Object.freeze({
   latex: "latexindent",
   go: "gofmt",
   gofmt: "gofmt",
+  rust: "rustfmt",
+  rustfmt: "rustfmt",
   bibtex: "biber",
   "bib-biber": "biber",
   tidy: "tidy",
@@ -159,6 +171,8 @@ export const parser2display: Readonly<Langs> = Object.freeze({
   yaml: "YAML",
   py: "Python",
   gofmt: "Go",
+  rust: "Rust",
+  rustfmt: "Rust",
   markdown: "Markdown",
   typescript: "TypeScript",
   html: "HTML",
@@ -220,6 +234,9 @@ export function format_parser_for_extension(ext: string): Parser {
       break;
     case "go":
       parser = "gofmt";
+      break;
+    case "rs":
+      parser = "rustfmt";
       break;
     case "html":
       parser = "html-tidy";

--- a/src/smc-util/misc2.ts
+++ b/src/smc-util/misc2.ts
@@ -612,3 +612,10 @@ export function hidden_meta_file(path: string, ext: string): string {
 export function history_path(path: string): string {
   return hidden_meta_file(path, "time-travel");
 }
+
+// helps with converting an array of strings to a union type of strings.
+// usage: 1. const foo : string[] = tuple(["bar", "baz"]);
+//        2. type Foo = typeof foo[number]; // bar | baz;
+export function tuple<T extends string[]>(o: T) {
+  return o;
+}

--- a/src/smc-webapp/frame-editors/code-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/code-editor/editor.ts
@@ -7,30 +7,7 @@ import { filename_extension, set } from "smc-util/misc2";
 import { createEditor } from "../frame-tree/editor";
 import { terminal } from "../terminal-editor/editor";
 import { time_travel } from "../time-travel-editor/editor";
-
-const FORMAT = set([
-  "js",
-  "jsx",
-  "ts",
-  "tsx",
-  "json",
-  "md",
-  "css",
-  "py",
-  "r",
-  "go",
-  "yml",
-  "yaml",
-  "xml",
-  "cml" /* that's xml */,
-  "kml" /* geodata keyhole markup, also xml */,
-  "c",
-  "c++",
-  "cc",
-  "cpp",
-  "h",
-  "bib"
-]);
+import { file_extensions as FORMAT } from "smc-util/code-formatter";
 
 export const SHELLS = {
   erl: "erl",
@@ -73,9 +50,7 @@ export const cm = {
       "shell"
     ]);
     const ext = filename_extension(path);
-    if (FORMAT[ext]) {
-      buttons.format = true;
-    }
+    buttons.format = FORMAT.includes(ext);
     return buttons;
   }
 };

--- a/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
@@ -305,7 +305,7 @@ class FrameTitleBar extends Component<Props & ReduxProps, State> {
     let title;
     if (selected_short) {
       title = (
-        <span cocalc-test={"short-"+selected_short} >
+        <span cocalc-test={"short-" + selected_short}>
           {title} {selected_short}
         </span>
       );
@@ -989,7 +989,7 @@ class FrameTitleBar extends Component<Props & ReduxProps, State> {
 
   render_format(): Rendered {
     if (!this.is_visible("format")) return;
-    let desc: any = this.props.editor_actions.has_format_support(
+    let desc = this.props.editor_actions.has_format_support(
       this.props.id,
       this.props.available_features
     );


### PR DESCRIPTION
# Description
This adds formatting support for `rs` Rust files.
It also refactors the formatting code a little bit.


# Testing Steps
I checked that formatting jupyter cells, html, tsx, py, r and of course, rs files work.

example rust code I used for testing is

```
fn main() {
    // `n` will take the values: 1, 2, ..., 100 in each iteration
    for n in 1..101 {
        if n % 15 == 0 {
            println!("fizzbuzz");
        } else if n % 3 == 0 {
            println!("fizz");
        } else if n % 5 == 0 {
            println!("buzz");
        } else {
            println!("{}", n);
        }
    }
}
```

If you also want to run it: `rustc [filename.rs]` and then run the compiled binary.


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
