### PR TITLE
simplify default latex template and mention pythontex

### DIFF
--- a/src/smc_pyutil/smc_pyutil/templates/linux/default.tex
+++ b/src/smc_pyutil/smc_pyutil/templates/linux/default.tex
@@ -2,18 +2,7 @@
 
 % set font encoding for PDFLaTeX, XeLaTeX, or LuaTeX
 \usepackage{ifxetex,ifluatex}
-\newif\ifxetexorluatex
-\ifxetex
-  \xetexorluatextrue
-\else
-  \ifluatex
-    \xetexorluatextrue
-  \else
-    \xetexorluatexfalse
-  \fi
-\fi
-
-\ifxetexorluatex
+\if\ifxetex T\else\ifluatex T\else F\fi\fi T%
   \usepackage{fontspec}
 \else
   \usepackage[T1]{fontenc}
@@ -30,7 +19,14 @@
 % http://doc.sagemath.org/html/en/tutorial/sagetex.html
 % \usepackage{sagetex}
 
+% Enable PythonTeX to run Python – https://ctan.org/pkg/pythontex
+% \usepackage{pythontex}
+
 \begin{document}
 \maketitle
+
+
+
+
 
 \end{document}


### PR DESCRIPTION
# Description

this shrinks the default latex template and mentions pythontex

# Testing Steps
I texted that the engine selection still triggers the correct preamble.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] No debugging console.log messages.
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
