### PR TITLE
remove "mandatory" sentence & revise wording on pricing page

### DIFF
--- a/src/smc-webapp/billing/explain-plan.tsx
+++ b/src/smc-webapp/billing/explain-plan.tsx
@@ -67,21 +67,6 @@ export class ExplainPlan extends Component<Props> {
             {"'s"} real-time collaboration makes it easy to help students
             directly where they work.
           </p>
-          <p>
-            <b>Purchasing course packages is mandatory!</b> Either you buy
-            course packages <b>starting at $4 per student</b> to distribute
-            across your and your student's projects &mdash; or each of your
-            students pays ${STUDENT_COURSE_PRICE}. Any course package offering
-            starts right after the purchase, lasts for the indicated period, and
-            does <b>not auto-renew</b> when it ends.
-          </p>
-          <p>
-            <b>Start right now:</b>{" "}
-            <i>
-              you can fully set up your class and add students immediately
-              before you pay anything!
-            </i>
-          </p>
           <h4>Payment options</h4>
           <ul style={{ paddingLeft: "20px" }}>
             <li>
@@ -91,6 +76,8 @@ export class ExplainPlan extends Component<Props> {
               for one or more course plans. You distribute the quota upgrades to
               all projects of the course via the configuration frame of the
               course management file.
+              Course packages start immediately after purchase, last for the indicated
+              period, and do <b>not auto-renew</b> when they end.
             </li>
 
             <li>
@@ -110,12 +97,12 @@ export class ExplainPlan extends Component<Props> {
           </p>
           <p>
             However, we find that many data and computational science courses
-            run much smoother with the additional RAM and CPU found in the
+            run better with the additional RAM and CPU found in the
             standard or premium plans.
           </p>
           <h4>Custom Course Plans</h4>
           <p>
-            In addition to the plans listed on this page, we can offer the
+            In addition to the plans listed on this page, we offer the
             following on a custom basis:
           </p>
           <ul style={{ paddingLeft: "20px" }}>


### PR DESCRIPTION
# Description

The only changes are text in static page `src/smc-webapp/billing/explain-plan.tsx`.

- Remove "Purchasing course packages is mandatory!".
- Remove the following sentence because it is redundant with the "Payment options" section immediately below.
- Move last sentence of the "mandatory..." paragraph into "Payment options" section.
- Remove sentence suggesting starting a course before paying. Non-upgraded projects can't send emails to invite students who don't already have an account with that email.
- Other minor wording changes

Tested with cc-in-cc. No build errors. Here's the main part of the new text:

![draft-pricing-course-packages](https://user-images.githubusercontent.com/528072/70641752-b5df2080-1c03-11ea-95a5-21afe55fef99.png)


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
