### PR TITLE
webapp/x11: add grass launch button

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/apps.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/apps.ts
@@ -201,6 +201,11 @@ export const APPS: Readonly<APPS_Interface> = Object.freeze({
     icon: "globe",
     desc: "A user friendly Open Source Geographic Information System."
   },
+  grass: {
+    label: "GRASS",
+    icon: "globe",
+    desc: "Geographic Resources Analysis Support System"
+  },
   ds9: {
     icon: "star",
     label: "SAOImage DS9",


### PR DESCRIPTION
# Description

this just adds a button if `grass` is available. 

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
