### PR TITLE
webapp: remove google+

### DIFF
--- a/src/smc-webapp/r_help.cjsx
+++ b/src/smc-webapp/r_help.cjsx
@@ -263,10 +263,6 @@ CONNECT_LINKS =
         icon : 'facebook-square'
         href : 'https://www.facebook.com/CoCalcOnline/'
         link : 'Like our facebook page'
-    google_plus :
-        icon : 'google-plus-square'
-        href : 'https://plus.google.com/117696122667171964473/posts'
-        link : <span>+1 our Google+ page</span>
     github :
         icon : 'github-square'
         href : 'https://github.com/sagemathinc/cocalc'


### PR DESCRIPTION
# Description
 remove google+ link

# Testing Steps
it not longer shows up

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
