### PR TITLE
do not hardcode DB credentials

### DIFF
--- a/src/smc-hub/postgres-base.coffee
+++ b/src/smc-hub/postgres-base.coffee
@@ -269,7 +269,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                 # issues with scope of "client" below.
                 init_client = (host) =>
                     client = new pg.Client
-                        user     : 'smc'
+                        user     : @_user
                         host     : host
                         port     : @_port
                         password : @_password

--- a/src/smc-hub/postgres-ops.coffee
+++ b/src/smc-hub/postgres-ops.coffee
@@ -155,7 +155,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     home    : '.'
                     env     :
                         PGPASSWORD : @_password
-                        PGUSER     : 'smc'
+                        PGUSER     : @_user
                         PGHOST     : @_host
                     err_on_exit : true
                     cb      : cb

--- a/src/smc-hub/test/get_stats.coffee
+++ b/src/smc-hub/test/get_stats.coffee
@@ -3,7 +3,8 @@
 postgres = require('../postgres')
 misc = require('../../smc-util/misc')
 
-db = postgres.db(database:'smc', debug:true, connect:false)
+db_name = process.env['SMC_DB'] ? 'smc'
+db = postgres.db(database:db_name, debug:true, connect:false)
 
 db.connect cb: ->
     db.get_stats


### PR DESCRIPTION
# Description

There are several places where the connection to the database is established. The first one is ok, but another one hardcodes `'smc'`.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
