### PR TITLE
add Promise to return types for 2 functions in src/smc-webapp/launch/share.ts

### DIFF
--- a/src/smc-webapp/launch/share.ts
+++ b/src/smc-webapp/launch/share.ts
@@ -56,7 +56,7 @@ interface ShareInfo {
   license?: string;
 }
 
-export async function launch_share(launch: string): void {
+export async function launch_share(launch: string): Promise<void> {
   const v = launch.split("/");
   const share_id = v[1];
   const path = v.slice(2).join("/");
@@ -151,7 +151,7 @@ type Relationship =
   | "fork" // user is a normal user who needs to make a fork of the shared files in a new project (a fork)
   | "anonymous"; // user is anonymous, so make a copy of the shared files in their own project
 
-async function get_relationship_to_share(project_id: string): Relationship {
+async function get_relationship_to_share(project_id: string): Promise<Relationship> {
   const account_store = redux.getStore("account");
   if (account_store == null) {
     throw Error("acount_store MUST be defined");


### PR DESCRIPTION
# Description

Without this patch, the Docker image build fails with the following error while running src/package.json script `webpack-production`:
```
webpack error in docker build
[2869] multi ./webapp-lib/primus/primus-engine.min.js 28 bytes {0} [built]
    + 2856 hidden modules
ERROR in /cocalc/src/smc-webapp/launch/share.ts
./smc-webapp/launch/share.ts
[tsl] ERROR in /cocalc/src/smc-webapp/launch/share.ts(59,53)
      TS1055: Type 'void' is not a valid async function return type in ES5/ES3 because it does not refer to a Promise-compatible constructor value.
ERROR in /cocalc/src/smc-webapp/launch/share.ts
./smc-webapp/launch/share.ts
[tsl] ERROR in /cocalc/src/smc-webapp/launch/share.ts(154,63)
      TS1055: Type 'Relationship' is not a valid async function return type in ES5/ES3 because it does not refer to a Promise-compatible constructor value.
Child html-webpack-plugin for "app.html":
     6 assets
    Entrypoint undefined = app.html
```

# Testing Steps
1. Builds ok with cc-in-cc.
1. Cc-in-cc instance starts up and appears to run ok.
1. I did not test sharing from non-admin account in cc-in-cc because I didn't see a quick way to enable Internet Access. In this way, it's similar to trying to share from Docker, although that issue was resolved #4062.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
