### PR TITLE
fix fullscreen=kiosk and a potential problem with history params

### DIFF
--- a/src/smc-webapp/history.coffee
+++ b/src/smc-webapp/history.coffee
@@ -91,8 +91,9 @@ params = ->
             val = page.get(param)
             if val?
                 current[param] = val
-            else
-                delete current[param]
+            # TODO either fix the comment above and uncomment the lines below, or delete these lines
+            #else
+            #    delete current[param]
 
     s = query_string.stringify(current)
     if s

--- a/src/smc-webapp/misc/query-params.ts
+++ b/src/smc-webapp/misc/query-params.ts
@@ -8,7 +8,16 @@ export namespace QueryParams {
   export type Params = query_string.ParsedQuery<string>;
 
   export function get_all(): Params {
-    return query_string.parse(location.search);
+    // fallback for situations where the url is temporarily like …/app#projects/…?…
+    if (location.hash?.length > 0 && location.search?.length == 0) {
+      const i = location.hash.indexOf("?");
+      if (i > 0) {
+        return query_string.parse(location.hash.slice(i));
+      }
+    } else {
+      return query_string.parse(location.search);
+    }
+    return {};
   }
 
   export function get(p: string) {


### PR DESCRIPTION
# Description

This fixes `fullscreen=kiosk` in a cc-in-cc dev project for me. I'm not sure about the other issue I found, where `params` in the history file would delete `fullscreen`. I think it is ok to delete params which aren't in the page store – but then the comment must be fixed. It's also a chicken-egg problem.

# Testing Steps
All I tested was a URL like `https://cocalc.com/xxxx/port/56754/projects/xxxxx/files/foo.md?fullscreen=kiosk&session=`

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
