### PR TITLE
Fix active file sort and `displayed_listing`

### DIFF
--- a/src/smc-webapp/app-framework/TypedMap.ts
+++ b/src/smc-webapp/app-framework/TypedMap.ts
@@ -119,7 +119,7 @@ interface TypedMapFactory<TProps extends Record<string, any>> {
   new (values: TProps): TypedMap<TProps>;
 }
 
-export function typedMap<TProps extends object>(
+export function TypedMap<TProps extends object>(
   defaults: Partial<TProps> = {}
 ): TypedMap<TProps> {
   // Add `& readonly TProps` to enable property access?

--- a/src/smc-webapp/project/explorer/explorer.tsx
+++ b/src/smc-webapp/project/explorer/explorer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as immutable from "immutable";
 import * as underscore from "underscore";
-import { rtypes, rclass, redux } from "../../app-framework";
+import { rtypes, rclass, redux, TypedMap } from "../../app-framework";
 import {
   ActivityDisplay,
   Icon,
@@ -77,7 +77,7 @@ interface ReduxProps {
   kucalc?: string;
   site_name?: string;
   images: ComputeImages;
-  active_file_sort?: object;
+  active_file_sort: TypedMap<{ column_name: string; is_descending: boolean }>;
   current_path: string;
   history_path: string;
   activity?: object;
@@ -153,7 +153,7 @@ export const Explorer = rclass<ReactProps>(
         },
 
         [name]: {
-          active_file_sort: rtypes.object,
+          active_file_sort: rtypes.immutable.Map,
           current_path: rtypes.string,
           history_path: rtypes.string,
           activity: rtypes.object,

--- a/src/smc-webapp/project/explorer/file-listing/file-listing.tsx
+++ b/src/smc-webapp/project/explorer/file-listing/file-listing.tsx
@@ -22,6 +22,7 @@ import { DirectoryRow } from "./directory-row";
 import { FileRow } from "./file-row";
 import { TERM_MODE_CHAR } from "./utils";
 import { MainConfiguration } from "../../../project_configuration";
+import { TypedMap } from "../../../app-framework";
 
 const misc = require("smc-util/misc");
 const { Col, Row } = require("react-bootstrap");
@@ -32,7 +33,7 @@ interface Props {
   redux: AppRedux;
 
   name: string;
-  active_file_sort?: any;
+  active_file_sort: TypedMap<{ column_name: string; is_descending: boolean }>;
   listing: any[];
   file_map: object;
   file_search: string;

--- a/src/smc-webapp/project/explorer/file-listing/listing-header.tsx
+++ b/src/smc-webapp/project/explorer/file-listing/listing-header.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
+import { TypedMap } from "../../../app-framework";
 
 import { Icon, Space } from "../../../r_misc";
 const { Row, Col } = require("react-bootstrap");
 
 // TODO: Flatten active_file_sort for easy PureComponent use
 interface Props {
-  active_file_sort: { column_name: string; is_descending: boolean };
+  active_file_sort: TypedMap<{ column_name: string; is_descending: boolean }>;
   sort_by: (heading: string) => void;
 }
 
@@ -33,11 +34,11 @@ export class ListingHeader extends React.Component<Props> {
       >
         {display_name}
         <Space />
-        {this.props.active_file_sort.column_name === column_name ? (
+        {this.props.active_file_sort.get("column_name") === column_name ? (
           <Icon
             style={inner_icon_style}
             name={
-              this.props.active_file_sort.is_descending
+              this.props.active_file_sort.get("is_descending")
                 ? "caret-up"
                 : "caret-down"
             }

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -1657,12 +1657,14 @@ export class ProjectActions extends Actions<ProjectStoreState> {
       return;
     }
     const current = store.get("active_file_sort");
-    if ((current != null ? current.column_name : undefined) === column_name) {
-      is_descending = !current.is_descending;
+    if (current.get("column_name") === column_name) {
+      is_descending = !current.get("is_descending");
     } else {
       is_descending = false;
     }
-    const next_file_sort = { is_descending, column_name };
+    const next_file_sort = current
+      .set("is_descending", is_descending)
+      .set("column_name", column_name);
     this.setState({ active_file_sort: next_file_sort });
   }
 


### PR DESCRIPTION
# Description
Fixes #4326

Also makes it so that `displayed_listing` is correctly recomputed only when its args are changed.

# Testing Steps
1. Change the file sort in a project
1. Change the default file sort in account settings
1. Open a new project, the sort should be that default
1. The project from step 1 should have the same sorting
1. In the browser console, run `smc.redux.getProjectStore(project_id).selectors.stripped_public_paths.fn.recomputations();` with `project_id` appropriately filled in.
1. Select some files
1. Run the same code above. The result should not have increased.
1. Toggle displaying masked files, that should work
1. Filter by searching. That should work too.
1. Recomputations should have increased.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [x] All new code is actually used.
- [x] Non-obvious code has some sort of comments.

Front end:
- [x] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [x] Completely restart Webpack with `./w` in `/src`
- [x] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
