### PR TITLE
additional site settings

### DIFF
--- a/src/smc-util/db-schema/site-defaults.ts
+++ b/src/smc-util/db-schema/site-defaults.ts
@@ -14,6 +14,7 @@ export interface SiteSettings {
   help_email: Config;
   commercial: Config;
   kucalc: Config;
+  ssh_gateway: Config;
   version_min_project: Config;
   version_min_browser: Config;
   version_recommended_browser: Config;
@@ -56,11 +57,16 @@ export const site_settings_conf: SiteSettings = {
     default: "no"
   },
   kucalc: {
-    name: "KuCalc UI ('yes' or 'no')",
+    name: "KuCalc UI",
     desc:
-      "Whether to show UI elements adapted to what the KuCalc backend provides",
+      "Configure which UI elements to show in order to match the Kubernetes backend. 'yes' or 'cocalc.com' for production, 'cloudcalc' for on-prem k8s, or 'no'",
     default: "no"
   }, // TODO -- this will *default* to yes when run from kucalc; but site admin can set it either way anywhere for testing.
+  ssh_gateway: {
+    name: "SSH Gateway",
+    desc: "'yes' if an ssh gateway exists to show UI elements; or 'no'",
+    default: "no"
+  },
   version_min_project: {
     name: "Required project version",
     desc:

--- a/src/smc-webapp/project/settings/body.tsx
+++ b/src/smc-webapp/project/settings/body.tsx
@@ -23,6 +23,7 @@ import { ProjectControl } from "./project-control";
 import { Customer, ProjectMap, UserMap } from "smc-webapp/todo-types";
 import { Project } from "./types";
 import { SSHPanel } from "./ssh";
+import { KUCALC_COCALC_COM } from "../../customize";
 
 const { webapp_client } = require("../../webapp_client");
 const { Col, Row } = require("react-bootstrap");
@@ -198,7 +199,7 @@ export const Body = rclass<ReactProps>(
                 project={this.props.project}
                 actions={redux.getActions("projects")}
               />
-              {this.props.kucalc === "yes" ? (
+              {this.props.kucalc === KUCALC_COCALC_COM ? (
                 <SSHPanel
                   key="ssh-keys"
                   project={this.props.project}
@@ -231,7 +232,6 @@ export const Body = rclass<ReactProps>(
               <ProjectControl
                 key="control"
                 project={this.props.project}
-                allow_ssh={this.props.kucalc !== "yes"}
               />
               <SagewsControl key="worksheet" project={this.props.project} />
               {have_jupyter_notebook ? (

--- a/src/smc-webapp/project/settings/project-control.tsx
+++ b/src/smc-webapp/project/settings/project-control.tsx
@@ -30,7 +30,7 @@ import { alert_message } from "../../alerts";
 import { Project } from "./types";
 import { Map, fromJS } from "immutable";
 import { Popconfirm, Icon as AntIcon } from "antd";
-
+import { KUCALC_COCALC_COM } from "../../customize";
 let {
   COMPUTE_IMAGES,
   DEFAULT_COMPUTE_IMAGE
@@ -42,7 +42,6 @@ const misc = require("smc-util/misc");
 
 interface ReactProps {
   project: Project;
-  allow_ssh: boolean;
 }
 
 interface ReduxProps {
@@ -340,19 +339,22 @@ export const ProjectControl = rclass<ReactProps>(
     }
 
     render_select_compute_image_row() {
-      if (this.props.kucalc !== "yes") {
+      if (this.props.kucalc !== KUCALC_COCALC_COM) {
         return;
       }
       return (
-        <div>
-          <LabeledRow
-            key="cpu-usage"
-            label="Software Environment"
-            style={this.rowstyle(true)}
-          >
-            {this.render_select_compute_image()}
-          </LabeledRow>
-        </div>
+        <>
+          <hr />
+          <div>
+            <LabeledRow
+              key="cpu-usage"
+              label="Software Environment"
+              style={this.rowstyle(true)}
+            >
+              {this.render_select_compute_image()}
+            </LabeledRow>
+          </div>
+        </>
       );
     }
 
@@ -516,7 +518,6 @@ export const ProjectControl = rclass<ReactProps>(
           <LabeledRow key="project_id" label="Project id">
             <pre>{this.props.project.get("project_id")}</pre>
           </LabeledRow>
-          {this.props.kucalc !== "yes" ? <hr /> : undefined}
           {this.render_select_compute_image_row()}
         </SettingBox>
       );


### PR DESCRIPTION

# Description
* diversify kucalc setting to include an on-prem kubernetes mode
*  add an ssh gateway setting (not used yet )

# Testing Steps
well, there is no actual change and hence there is no visible impact. kucalc ui set to 'yes' or 'no' shows/hides the quota upgrades

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
