### PR TITLE
hub/email: update sendgrid api to v3 and stop using helpers

### DIFF
--- a/src/smc-hub/email.ts
+++ b/src/smc-hub/email.ts
@@ -30,8 +30,8 @@ const os_path = require("path");
 const async = require("async");
 const winston = require("./winston-metrics").get_logger("email");
 
-// sendgrid API: https://sendgrid.com/docs/API_Reference/Web_API/mail.html
-const sendgrid = require("sendgrid");
+// sendgrid API v3: https://sendgrid.com/docs/API_Reference/Web_API/mail.html
+const sendgrid = require("@sendgrid/mail");
 
 const misc = require("smc-util/misc");
 const { defaults, required } = misc;
@@ -215,7 +215,8 @@ exports.send_email = function(opts): void {
               email_server = { disabled: true };
               cb();
             } else {
-              email_server = sendgrid(api_key);
+              sendgrid.setApiKey(api_key);
+              email_server = sendgrid;
               dbg("started sendgrid client");
               cb();
             }
@@ -229,74 +230,77 @@ exports.send_email = function(opts): void {
         }
         dbg(`sending email to ${opts.to} starting...`);
         // Sendgrid V3 API -- https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html
-        const helper = sendgrid.mail;
-        const from_email = new helper.Email(opts.from, opts.fromname);
-        const to_email = new helper.Email(opts.to);
-        const content = new helper.Content("text/html", opts.body);
-        const mail = new helper.Mail(
-          from_email,
-          opts.subject,
-          to_email,
-          content
-        );
+
+        const msg: any = {
+          to: opts.to,
+          cc: "someone@example.org",
+          bcc: ["me@example.org", "you@example.org"],
+          from: { email: opts.from, name: opts.fromname },
+          subject: "Hello world",
+
+          content: {
+            type: "text/html",
+            value: opts.body
+          },
+          // plain template with a header (cocalc logo), a h1 title, and a footer
+          templateId: SENDGRID_TEMPLATE_ID,
+          substitutionWrappers: ["{{", "}}"],
+          substitutions: {
+            name: "Some One",
+            id: "123"
+          }
+        };
+
         if (opts.replyto) {
-          const replyto_name =
-            opts.replyto_name != null ? opts.replyto_name : opts.replyto;
-          mail.setReplyTo(new helper.Email(opts.replyto, replyto_name));
+          msg.reply_to = {
+            name: opts.replyto_name ?? opts.replyto,
+            email: opts.replyto
+          };
         }
 
-        const personalization = new helper.Personalization();
-        personalization.setSubject(opts.subject);
-        personalization.addTo(to_email);
+        //  const personalization = new helper.Personalization();
+        //  personalization.setSubject(opts.subject);
+        //  personalization.addTo(to_email);
+
         if ((opts.cc != null ? opts.cc.length : undefined) > 0) {
-          personalization.addCc(new helper.Email(opts.cc));
+          msg.cc = [{ email: opts.cc }];
         }
         if ((opts.bcc != null ? opts.bcc.length : undefined) > 0) {
-          personalization.addBcc(new helper.Email(opts.bcc));
+          msg.bcc = [{ email: opts.bcc }];
         }
 
         // one or more strings to categorize the sent emails on sendgrid
         if (opts.category != null) {
-          mail.addCategory(new helper.Category(opts.category));
+          if (typeof opts.category == "string") {
+            msg.categories = [opts.category];
+          } else if (Array.isArray(opts.category)) {
+            msg.categories = opts.category;
+          }
         }
 
         // to unsubscribe only from a specific type of email, not everything!
         // https://app.sendgrid.com/suppressions/advanced_suppression_manager
         if (opts.asm_group != null) {
-          mail.setAsm(new helper.Asm(opts.asm_group));
+          msg.asm = { group_id: opts.asm_group };
         }
 
-        // plain template with a header (cocalc logo), a h1 title, and a footer
-        mail.setTemplateId(SENDGRID_TEMPLATE_ID);
         // This #title# will end up below the header in an <h1> according to the template
-        personalization.addSubstitution(
-          new helper.Substitution("#title#", opts.subject)
-        );
+        msg.substitutions = {
+          "#title#": opts.subject
+        };
 
-        mail.addPersonalization(personalization);
+        dbg(`sending email to ${opts.to} data -- ${misc.to_json(msg)}`);
 
-        // dbg("sending email to #{opts.to} data -- #{misc.to_json(mail.toJSON())}")
-
-        // Sendgrid V3 API
-        const request = email_server.emptyRequest({
-          method: "POST",
-          path: "/v3/mail/send",
-          body: mail.toJSON()
-        });
-
-        email_server.API(request, function(err, res) {
-          dbg(
-            `sending email to ${opts.to} done...; got err=${misc.to_json(
-              err
-            )} and res=${misc.to_json(res)}`
-          );
-          if (err) {
-            dbg(`sending email -- error = ${misc.to_json(err)}`);
-          } else {
-            dbg(`sending email -- success = ${misc.to_json(res)}`);
-          }
-          cb(err);
-        });
+        email_server
+          .send(msg)
+          .then(() => {
+            dbg(`sending email to ${opts.to} -- success`);
+            cb();
+          })
+          .catch(err => {
+            dbg(`sending email to ${opts.to} -- error = ${misc.to_json(err)}`);
+            cb(err);
+          });
       }
     ],
     function(err, message) {

--- a/src/smc-hub/package-lock.json
+++ b/src/smc-hub/package-lock.json
@@ -1097,6 +1097,33 @@
       "resolved": "https://registry.npmjs.org/@passport-next/passport-strategy/-/passport-strategy-1.1.0.tgz",
       "integrity": "sha512-2KhFjtPueJG6xVj2HnqXt9BlANOfYCVLyu+pXYjPGBDT8yk+vQwc/6tsceIj+mayKcoxMau2JimggXRPHgoc8w=="
     },
+    "@sendgrid/client": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-6.5.1.tgz",
+      "integrity": "sha512-OooZXSy8wWcUI5ppz7ugddfNdZC66baTHYF1Yz57O64cTjpfhw60+mNmPB0ISKxBchqnHcMiVNZ1SL70eAItlg==",
+      "requires": {
+        "@sendgrid/helpers": "^6.5.1",
+        "request": "^2.88.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-6.5.1.tgz",
+      "integrity": "sha512-Bd05zxnKRAKtYCXMjDSlXKmlX/RceWMIHYVwU+auMFUk+C8Mx755hGhBl8IHLz0kYL03dF8cSQA0iXlnoMGIpQ==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "deepmerge": "^2.1.1"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-6.5.1.tgz",
+      "integrity": "sha512-OVHOrMykAy6Zt1xeOT//RhH6ThdPr6nhvkdzwXrKzSu3Ctr7OihIeWrWOGIh7CjGBOTiBWoMgFgVC6Twgr/jHw==",
+      "requires": {
+        "@sendgrid/client": "^6.5.1",
+        "@sendgrid/helpers": "^6.5.1"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -1218,11 +1245,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
-    },
-    "addressparser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
-      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
     },
     "after": {
       "version": "0.8.2",
@@ -1433,79 +1455,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-    },
-    "async.ensureasync": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.ensureasync/-/async.ensureasync-0.5.2.tgz",
-      "integrity": "sha1-w8fkpOmzHZaHXVa4UEWYRG4eMF0=",
-      "requires": {
-        "async.util.ensureasync": "0.5.2"
-      }
-    },
-    "async.queue": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.queue/-/async.queue-0.5.2.tgz",
-      "integrity": "sha1-jV2QgS4UgQZrwJBOjMFxKxfDvXw=",
-      "requires": {
-        "async.util.queue": "0.5.2"
-      }
-    },
-    "async.util.arrayeach": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.arrayeach/-/async.util.arrayeach-0.5.2.tgz",
-      "integrity": "sha1-WMTpgCjVXWm/sFrrOvROClVagpw="
-    },
-    "async.util.ensureasync": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.ensureasync/-/async.util.ensureasync-0.5.2.tgz",
-      "integrity": "sha1-EJB/LL0GegYfma5tIuCM7TDbDWg=",
-      "requires": {
-        "async.util.restparam": "0.5.2",
-        "async.util.setimmediate": "0.5.2"
-      }
-    },
-    "async.util.isarray": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.isarray/-/async.util.isarray-0.5.2.tgz",
-      "integrity": "sha1-5i2sjyY29lh13PdSHC0k0N+yu98="
-    },
-    "async.util.map": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.map/-/async.util.map-0.5.2.tgz",
-      "integrity": "sha1-5YjvhuCzq18CfZevTWg10FXKadY="
-    },
-    "async.util.noop": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.noop/-/async.util.noop-0.5.2.tgz",
-      "integrity": "sha1-vdYrl8sKo/YLWGrRSEaGmJdeWLk="
-    },
-    "async.util.onlyonce": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.onlyonce/-/async.util.onlyonce-0.5.2.tgz",
-      "integrity": "sha1-uOb8AErckjFk154y8oE+5GXCT/I="
-    },
-    "async.util.queue": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.queue/-/async.util.queue-0.5.2.tgz",
-      "integrity": "sha1-V/Zavho83yc9MavSirlUJfgiLuU=",
-      "requires": {
-        "async.util.arrayeach": "0.5.2",
-        "async.util.isarray": "0.5.2",
-        "async.util.map": "0.5.2",
-        "async.util.noop": "0.5.2",
-        "async.util.onlyonce": "0.5.2",
-        "async.util.setimmediate": "0.5.2"
-      }
-    },
-    "async.util.restparam": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.restparam/-/async.util.restparam-0.5.2.tgz",
-      "integrity": "sha1-A+/r88Ane5ciDlJaunUPXgT8gM0="
-    },
-    "async.util.setimmediate": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.setimmediate/-/async.util.setimmediate-0.5.2.tgz",
-      "integrity": "sha1-KBLrq/KlgCd1jUvHeT0cz68QJV8="
     },
     "asyncemit": {
       "version": "3.0.1",
@@ -2522,9 +2471,7 @@
     "deepmerge": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -2702,14 +2649,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -4933,11 +4872,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -5022,17 +4956,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.1.1.tgz",
       "integrity": "sha1-1vJPdcKMnsEjnKIGlSaJaW7BHmI="
     },
-    "mailparser": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.6.2.tgz",
-      "integrity": "sha1-A8SGA5vfTfbNO2rcqqxBB9/bwGg=",
-      "requires": {
-        "encoding": "^0.1.12",
-        "mime": "^1.3.4",
-        "mimelib": "^0.3.0",
-        "uue": "^3.1.0"
-      }
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -5109,15 +5032,6 @@
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
         "mime-db": "~1.38.0"
-      }
-    },
-    "mimelib": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.3.1.tgz",
-      "integrity": "sha1-eHrdJBXYJ6yzr27EvKHqlZZBiFM=",
-      "requires": {
-        "addressparser": "~1.0.1",
-        "encoding": "~0.1.12"
       }
     },
     "mimic-response": {
@@ -6883,32 +6797,6 @@
         }
       }
     },
-    "sendgrid": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/sendgrid/-/sendgrid-4.10.0.tgz",
-      "integrity": "sha1-/WSuOz86lOFKoO5YfbKgEzOwf1M=",
-      "requires": {
-        "async.ensureasync": "^0.5.2",
-        "async.queue": "^0.5.2",
-        "bottleneck": "^1.12.0",
-        "debug": "^2.2.0",
-        "lodash.chunk": "^4.2.0",
-        "mailparser": "^0.6.1",
-        "sendgrid-rest": "^2.3.0"
-      },
-      "dependencies": {
-        "bottleneck": {
-          "version": "1.16.0",
-          "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-1.16.0.tgz",
-          "integrity": "sha1-1s4TgIUnr8gLaQkvFWBmVeWyHxo="
-        }
-      }
-    },
-    "sendgrid-rest": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/sendgrid-rest/-/sendgrid-rest-2.4.0.tgz",
-      "integrity": "sha512-3VRHhTnln17jPQNzBjEHO6u2Y7kLlhVnOvX0aGjr7yRVZpq5LXo0ilAFMsaHUfKVH+jFdCrHMAVLOAdtu6wLJA=="
-    },
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -7764,15 +7652,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uue": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/uue/-/uue-3.1.2.tgz",
-      "integrity": "sha512-axKLXVqwtdI/czrjG0X8hyV1KLgeWx8F4KvSbvVCnS+RUvsQMGRjx0kfuZDXXqj0LYvVJmx3B9kWlKtEdRrJLg==",
-      "requires": {
-        "escape-string-regexp": "~1.0.5",
-        "extend": "~3.0.0"
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/src/smc-hub/package-lock.json
+++ b/src/smc-hub/package-lock.json
@@ -1115,15 +1115,6 @@
         "deepmerge": "^2.1.1"
       }
     },
-    "@sendgrid/mail": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-6.5.1.tgz",
-      "integrity": "sha512-OVHOrMykAy6Zt1xeOT//RhH6ThdPr6nhvkdzwXrKzSu3Ctr7OihIeWrWOGIh7CjGBOTiBWoMgFgVC6Twgr/jHw==",
-      "requires": {
-        "@sendgrid/client": "^6.5.1",
-        "@sendgrid/helpers": "^6.5.1"
-      }
-    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -6,7 +6,7 @@
   "directories": {},
   "dependencies": {
     "@passport-next/passport-google-oauth2": "^1.0.0",
-    "@sendgrid/mail": "^6.5.1",
+    "@sendgrid/client": "^6.5.1",
     "@types/http-proxy": "^1.17.0",
     "@types/node": "^12.12.7",
     "async": "^1.5.2",

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -6,6 +6,7 @@
   "directories": {},
   "dependencies": {
     "@passport-next/passport-google-oauth2": "^1.0.0",
+    "@sendgrid/mail": "^6.5.1",
     "@types/http-proxy": "^1.17.0",
     "@types/node": "^12.12.7",
     "async": "^1.5.2",
@@ -63,7 +64,6 @@
     "require-reload": "^0.2.2",
     "rimraf": "^2.4.4",
     "sanitize-html": "^1.20.1",
-    "sendgrid": "^4.7.1",
     "serve-index": "^1.9.1",
     "sharp": "^0.20.8",
     "snappy": "^6.0.1",

--- a/src/smc-hub/test/email.js
+++ b/src/smc-hub/test/email.js
@@ -1,0 +1,24 @@
+// this is purely for manual testing: in ./src/smc-hub$ nodejs test/email.js
+
+require("ts-node").register();
+require("coffeescript/register");
+
+const { send_email } = require("../email");
+
+function cb(err) {
+  console.log(`cb done: err=${err}`);
+}
+
+const ts = new Date().toISOString();
+
+const body = `<p>Hello!</p><p>TS = ${ts}</p>\n<p>We will use CoCalc for the course <em>small</em>.</p>\n<p>Please sign up!</p>\n<p>--</p>\n<p>Harald Schilly</p>\n\n<br/><br/>\n<b>To accept the invitation:\n<ol>\n<li>Open <a href=\"https://cocalc.com/app\">CoCalc</a></li>\n<li>Sign up/in using <i>exactly</i> your email address <code>harald.schilly+student9191919@gmail.com</code></li>\n<li>Open <a href='https://cocalc.com/projects/35e03677-1408-4776-9eba-0423cc6d7c1e/'>the project 'small'</a>.</li>\n</ol></b>\n<br/><br />\n(If you're already signed in via <i>another</i> email address,\n you have to sign out and sign up/in using the mentioned email address.)\n`;
+
+send_email({
+  subject: `Test Subject ${ts}`,
+  body: body,
+  to: "harald.schilly+student9191919@gmail.com",
+  asm_group: 147985,
+  cb: cb
+});
+
+


### PR DESCRIPTION
# Description
this is a modernization of sending emails and fixing #4345. the main difference is that this is more "low level" and therefore we can do everything the V3 api is talking about. the callback has a more rich response, which is discarded. in the future, it might be a good extension to check what's actually coming back from the service. I also added a silly small test file, which helped me with development.

# Testing Steps
in my cc-in-cc project, I created an account for an invite email, invited myself, added a new student, and did a fake password reset. in all cases I got one email.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
