### PR TITLE
webapp/rmd: fix file mangling

### DIFF
--- a/src/smc-webapp/frame-editors/rmd-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/actions.ts
@@ -10,7 +10,8 @@ import { convert } from "./rmd-converter";
 import { markdown_to_html_frontmatter } from "../../markdown";
 import { FrameTree } from "../frame-tree/types";
 import { redux } from "../../app-framework";
-import { change_filename_extension, path_split } from "smc-util/misc2";
+import { path_split } from "smc-util/misc2";
+import { derive_rmd_output_filename } from "./utils";
 
 const custom_pdf_error_message: string = `
 To create a PDF document from R Markdown, you specify the \`pdf_document\` output format in the
@@ -82,8 +83,8 @@ export class RmdActions extends Actions {
 
     let existing = Set();
     for (const ext of ["pdf", "html", "nb.html"]) {
-      // full path
-      const expected_fn = change_filename_extension(this.path, ext);
+      // full path – basename might change
+      const expected_fn = derive_rmd_output_filename(this.path, ext);
       const fn_exists = listing.some(entry => {
         const name = entry.get("name");
         return name === path_split(expected_fn).tail;

--- a/src/smc-webapp/frame-editors/rmd-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/editor.ts
@@ -3,7 +3,8 @@ Top-level react component for editing R markdown documents
 */
 
 import { RenderedMarkdown } from "../markdown-editor/rendered-markdown";
-import { set, change_filename_extension } from "smc-util/misc2";
+import { set } from "smc-util/misc2";
+import { derive_rmd_output_filename } from "./utils";
 import { createEditor } from "../frame-tree/editor";
 import { CodemirrorEditor } from "../code-editor/codemirror-editor";
 import { SETTINGS_SPEC } from "../settings/editor";
@@ -44,7 +45,7 @@ const EDITOR_SPEC = {
     component: IFrameHTML,
     mode: "rmd",
     path(path) {
-      return change_filename_extension(path, "html");
+      return derive_rmd_output_filename(path, "html");
     },
     buttons: set([
       "print",
@@ -68,7 +69,7 @@ const EDITOR_SPEC = {
     style: { background: "#525659" },
     renderer: "canvas",
     path(path) {
-      return change_filename_extension(path, "pdf");
+      return derive_rmd_output_filename(path, "pdf");
     }
   },
 

--- a/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
@@ -3,7 +3,7 @@ Convert R Markdown file to hidden Markdown file, then read.
 */
 
 // import { aux_file } from "../frame-tree/util";
-import { path_split /* change_filename_extension */ } from "smc-util/misc2";
+import { path_split } from "smc-util/misc2";
 import {
   exec,
   ExecOutput /* read_text_file_from_project */
@@ -17,7 +17,6 @@ export async function convert(
 ): Promise<ExecOutput> {
   const x = path_split(path);
   const infile = x.tail;
-
   // console.log("frontmatter", frontmatter);
   let cmd: string;
   // https://www.rdocumentation.org/packages/rmarkdown/versions/1.10/topics/render
@@ -27,9 +26,10 @@ export async function convert(
     frontmatter.indexOf("self_contained") >= 0 ||
     frontmatter.indexOf("output:") >= 0
   ) {
+    // , output_file = '${outfile}'
     cmd = `rmarkdown::render('${infile}', output_format = NULL, run_pandoc = TRUE)`;
   } else {
-    cmd = `rmarkdown::render('${infile}', output_format = NULL, output_options = list(self_contained = FALSE) , run_pandoc = TRUE)`;
+    cmd = `rmarkdown::render('${infile}', output_format = NULL, run_pandoc = TRUE, output_options = list(self_contained = FALSE))`;
   }
   // console.log("rmd cmd", cmd);
 

--- a/src/smc-webapp/frame-editors/rmd-editor/utils.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/utils.ts
@@ -1,0 +1,9 @@
+import { change_filename_extension } from "smc-util/misc2";
+
+// something in the rmarkdown source code replaces all spaces by dashes
+// [hsy] I think this is because of calling pandoc.
+// I'm not aware of any other replacements.
+// https://github.com/rstudio/rmarkdown
+export function derive_rmd_output_filename(path, ext) {
+  return change_filename_extension(path, ext).replace(/ /g, "-");
+}


### PR DESCRIPTION
# Description
* rmd processing replaces spaces with dashes in the filename (I think this is for pandoc) --  see #4351
* I also took the opportunity to clean up `project_store::_compute_file_masks` because I was very confused about what's going on there


# Testing Steps
* filemasks should still work, obviously
* an rmd file with a crazy name like `x   Y Ö_-{[]}.rmd` has a visible html or pdf preview
   * well, for that name, PDF fails due to an latex error ... a less crazy one like `x   Y x.rmd` does work, though


![Screenshot from 2020-01-30 12-32-18](https://user-images.githubusercontent.com/207405/73446746-9e97f600-435d-11ea-8063-e43d154be123.png)


# Relevant Issues
#4351 



### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
