### PR TITLE
add to project_exec doc

### DIFF
--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -1033,7 +1033,9 @@ Notes:
   a path and command line arguments.
 - If option \`args\` is provided, options must be sent as a JSON object.
 - Argument \`path\` is optional. When provided, \`path\` is relative to home directory in target project
-  and specifies the working directory in which the command will be run.\
+  and specifies the working directory in which the command will be run.
+- If the project is stopped or archived, this API call will cause it to be started. Starting the project can take
+  several seconds. In this case, the call may return a timeout error and will need to be repeated. \
 `
   })
 );


### PR DESCRIPTION
# Description

Add item to API docs about starting projects when `project_exec` is called.

- tested build of cc-in-cc to make sure it starts up
- committed the generated "api.json" file to cocalc-doc

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
