### PR TITLE
hub: only shim the LTIService  in debug mode

### DIFF
--- a/src/smc-hub/hub.coffee
+++ b/src/smc-hub/hub.coffee
@@ -82,11 +82,14 @@ hub_http_server = require('./hub_http_server')
 
 try
     {LTIService} = require('./lti/lti')
-catch
-    # silly stub
-    class LTIService
-        start: =>
-            throw new Error('NO LTI MODULE')
+catch err
+    if DEBUG
+        throw err
+    else
+        # silly stub
+        class LTIService
+            start: =>
+                throw new Error('NO LTI MODULE')
 
 
 # registers the hub with the database periodically


### PR DESCRIPTION
# Description

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
