### PR TITLE
 make the discord link configurable and let it to point to the main room

### DIFF
--- a/src/smc-util/theme.js
+++ b/src/smc-util/theme.js
@@ -51,6 +51,7 @@ exports.SENDGRID_TEMPLATE_ID = "0375d02c-945f-4415-a611-7dc3411e2a78";
 // asm_group: 699 is for invites https://app.sendgrid.com/suppressions/advanced_suppression_manager
 exports.SENDGRID_ASM_INVITES = 699;
 exports.SENDGRID_ASM_NEWSLETTER = 698;
+exports.DISCORD_INVITE = "https://discord.gg/nEHs2GK";
 
 // This is the applications color scheme
 const COLORS = {

--- a/src/smc-webapp/info/links.tsx
+++ b/src/smc-webapp/info/links.tsx
@@ -15,7 +15,8 @@ import {
   HELP_EMAIL,
   DOC_URL,
   TWITTER_HANDLE,
-  LIVE_DEMO_REQUEST
+  LIVE_DEMO_REQUEST,
+  DISCORD_INVITE
 } from "smc-util/theme";
 
 interface LinkInfo {
@@ -108,8 +109,12 @@ export const CONNECT_LINKS = {
   discord: {
     bold: true,
     icon: "fab fa-discord",
-    href: "https://discord.gg/Pz3h5bH",
-    link: "Discord - chat about CoCalc"
+    href: DISCORD_INVITE,
+    link: (
+      <span>
+        Discord - chat about <SiteName />
+      </span>
+    )
   },
   share: {
     icon: "bullhorn",

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1,4 +1,4 @@
-###############################################################################
+##############################################################################
 #
 #    CoCalc: Collaborative Calculation in the Cloud
 #
@@ -40,7 +40,7 @@ misc = require('smc-util/misc')
 markdown = require('./markdown')
 
 {Row, Col, Well, Button, ButtonGroup, ButtonToolbar, Grid, FormControl, FormGroup, InputGroup, Alert, Checkbox, Label} = require('react-bootstrap')
-{VisibleMDLG, ErrorDisplay, Icon, Loading, LoginLink, Saving, SearchInput, Space , TimeAgo, Tip, UPGRADE_ERROR_STYLE, UpgradeAdjustor} = require('./r_misc')
+{VisibleMDLG, ErrorDisplay, Icon, Loading, LoginLink, Saving, SearchInput, Space , TimeAgo, Tip, UPGRADE_ERROR_STYLE, UpgradeAdjustor, A} = require('./r_misc')
 {WindowedList} = require("./r_misc/windowed-list")
 {React, ReactDOM, Actions, Store, Table, redux, rtypes, rclass, Redux}  = require('./app-framework')
 {UsersViewing} = require('./other-users')
@@ -48,6 +48,7 @@ markdown = require('./markdown')
 {PROJECT_UPGRADES} = require('smc-util/schema')
 {fromPairs} = require('lodash')
 ZERO_QUOTAS = fromPairs(Object.keys(PROJECT_UPGRADES.params).map(((x) -> [x, 0])))
+{DISCORD_INVITE} = require('smc-util/theme')
 
 { reuseInFlight } = require("async-await-utils/hof")
 
@@ -1692,7 +1693,7 @@ exports.ProjectsPage = ProjectsPage = rclass
             <Row>
                 <VisibleMDLG>
                     <div style={{float:'right'}}>
-                        <a href="https://discord.gg/Pz3h5bH" target="_blank" rel="nofollow"><Icon name="fab fa-discord"/> Chat about CoCalc on Discord...</a>
+                        <A href={DISCORD_INVITE}><Icon name="fab fa-discord"/> Chat about <SiteName/> on Discord...</A>
                     </div>
                 </VisibleMDLG>
                 <Col sm={4}>

--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -29,13 +29,13 @@ misc = require('smc-util/misc')
 misc_page = require('./misc_page')
 {defaults, required} = misc
 {webapp_client} = require('./webapp_client')
-
+{DISCORD_INVITE} = require('smc-util/theme')
 {alert_message} = require('./alerts')
 {analytics_event} = require('./tracker')
 
 # React libraries
 {React, ReactDOM, rclass, rtypes, Actions, Store, Redux}  = require('./app-framework')
-{Icon, Loading, Markdown, SearchInput, Space, TimeAgo, Tip} = require('./r_misc')
+{Icon, Loading, Markdown, SearchInput, Space, TimeAgo, Tip, A} = require('./r_misc')
 {Button, Col, Grid, FormGroup, FormControl, ListGroup, ListGroupItem, Panel, Row, ButtonGroup, Well} = require('react-bootstrap')
 
 {User} = require('./users')
@@ -149,7 +149,7 @@ ChatRoom = rclass ({name}) ->
         if not project?
             return
         <div>
-            Stream your screen or chat <a href="https://discord.gg/Pz3h5bH" target="_blank" rel="nofollow">using Discord.</a>
+            Stream your screen or chat <A href={DISCORD_INVITE}>using Discord</A>.
             <div>
                 Add people to this project below:
             </div>

--- a/src/smc-webapp/smc_chat.tsx
+++ b/src/smc-webapp/smc_chat.tsx
@@ -29,6 +29,8 @@ const { Avatar } = require("./other-users");
 const misc = require("smc-util/misc");
 const misc_page = require("./misc_page");
 
+const { DISCORD_INVITE } = require("smc-util/theme");
+
 import { SaveButton } from "./frame-editors/frame-tree/save-button";
 
 import { ChatInput } from "./chat/input";
@@ -40,7 +42,7 @@ import { MentionList } from "./chat/store";
 // React libraries
 import { React, ReactDOM, Component, rclass, rtypes } from "./app-framework";
 
-import { Icon, Loading, Tip, SearchInput, TimeAgo } from "./r_misc";
+import { Icon, Loading, Tip, SearchInput, TimeAgo, A } from "./r_misc";
 
 import {
   Button,
@@ -773,8 +775,8 @@ class ChatRoom0 extends Component<ChatRoomProps, ChatRoomState> {
           >
             LaTeX
           </a>
-          . Emoticons: {misc.emoticons}.
-          Chat outside CoCalc <a href="https://discord.gg/Pz3h5bH" target="_blank" rel="nofollow">on Discord</a>.
+          . Emoticons: {misc.emoticons}. Chat outside CoCalc{" "}
+          <A href={DISCORD_INVITE}>on Discord</A>.
         </div>
       </Tip>
     );

--- a/src/smc-webapp/support.cjsx
+++ b/src/smc-webapp/support.cjsx
@@ -23,12 +23,13 @@ $          = window.$
 underscore = _ = require('underscore')
 {React, ReactDOM, Actions, Store, rtypes, rclass, redux, COLOR}  = require('./app-framework')
 {Button, FormControl, FormGroup, Well, Alert, Modal, Table} = require('react-bootstrap')
-{Icon, Markdown, Loading, Space, ImmutablePureRenderMixin, Footer} = require('./r_misc')
+{Icon, Markdown, Loading, Space, ImmutablePureRenderMixin, Footer, A} = require('./r_misc')
 misc            = require('smc-util/misc')
 misc_page       = require('./misc_page')
 {webapp_client} = require('./webapp_client')
 feature         = require('./feature')
 {HelpEmailLink, SiteName} = require('./customize')
+{DISCORD_INVITE} = require('smc-util/theme')
 
 STATE =
     NEW        : 'new'      # new/default/resetted/no problem
@@ -413,7 +414,7 @@ SupportInfo = rclass
                     <b>Hit a bug, just need to talk with us, or request that we install software:</b> Fill out the form below...
                 </li>
                 <li>
-                    Just <b>want to chat</b> with somebody?  Visit <a href="https://discord.gg/Pz3h5bH" target="_blank" rel="nofollow">our Discord server</a>.
+                    Just <b>want to chat</b> with somebody?  Visit <A href={DISCORD_INVITE}>our Discord server</A>.
                 </li>
             </ul>
 


### PR DESCRIPTION
# Description

# Testing Steps
tested to work on: help dialog, about page, files listing and side chat. any misses?

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
