### PR TITLE
filter disabled jupyter kernels

### DIFF
--- a/src/smc-webapp/jupyter/actions.ts
+++ b/src/smc-webapp/jupyter/actions.ts
@@ -268,7 +268,10 @@ export class JupyterActions extends Actions<JupyterStoreState> {
       this.set_error(err);
       return;
     }
-    const kernels = immutable.fromJS(data);
+    // we filter kernels that are disabled for the cocalc notebook – motivated by a broken GAP kernel
+    const kernels = immutable
+      .fromJS(data)
+      .filter(k => !k.getIn(["metadata", "cocalc", "disabled"], false));
     const key = this.store.jupyter_kernel_key();
     jupyter_kernels = jupyter_kernels.set(key, kernels); // global
     this.setState({ kernels });

--- a/src/smc-webapp/jupyter/store.ts
+++ b/src/smc-webapp/jupyter/store.ts
@@ -321,8 +321,7 @@ export class JupyterStore extends Store<JupyterStoreState> {
   };
 
   /*
-   * select all kernels, which are ranked highest for a specific language
-   * and do have a priority weight > 0.
+   * select all kernels, which are ranked highest for a specific language.
    *
    * kernel metadata looks like that
    *
@@ -333,7 +332,8 @@ export class JupyterStore extends Store<JupyterStoreState> {
    *    "cocalc": {
    *      "priority": 10,
    *      "description": "Open-source mathematical software system",
-   *      "url": "https://www.sagemath.org/"
+   *      "url": "https://www.sagemath.org/",
+   *      "disabled": true
    *    }
    *  }
    *


### PR DESCRIPTION
# Description
this in combination with a change for the next software update will hide the gap kernel in the cocalc notebook. which means you have to use the classical one to use it.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
