### PR TITLE
webapp/rmd: increase timeout to 4 minutes

### DIFF
--- a/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
@@ -35,7 +35,7 @@ export async function convert(
 
   return await exec({
     allow_post: false, // definitely could take a long time to fully run all the R stuff...
-    timeout: 90,
+    timeout: 4 * 60,
     bash: true, // so timeout is enforced by ulimit
     command: "Rscript",
     args: ["-e", cmd],


### PR DESCRIPTION
# Description
This just changes the Rmd compile timeout to the same 4 minutes as we have for Latex.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
