### PR TITLE
move SignOut on top to be always accessible

### DIFF
--- a/src/smc-webapp/account_page.cjsx
+++ b/src/smc-webapp/account_page.cjsx
@@ -32,6 +32,7 @@ immutable = require('immutable')
 {SSHKeysPage}                            = require('./account_ssh_keys')
 {Icon, Loading}                          = require('./r_misc')
 {set_url}                                = require('./history')
+{SignOut}                                = require('./account/sign-out')
 
 ACCOUNT_SPEC =  # WARNING: these must ALL be comparable with == and != !!!!!
     account_id              : rtypes.string
@@ -191,6 +192,9 @@ exports.AccountPage = rclass
             return <div style={margin:'5% 10%'}>{@render_account_settings()}</div>
         <Row>
             <Col md={12}>
+                <div style={float:'right', marginTop:'1rem'}>
+                    <SignOut everywhere={false} danger={true}/>
+                </div>
                 <Tabs activeKey={@props.active_page} onSelect={@handle_select} animation={false} style={paddingTop: "1em"} id="account-page-tabs">
                     <Tab key='account' eventKey="account" title={<span><Icon name='wrench'/> Preferences</span>}>
                         {@render_account_settings()  if not @props.active_page? or @props.active_page == 'account'}

--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -684,8 +684,7 @@ AccountSettings = rclass
         if @props.is_anonymous
             return <h2><b>Thank you for using CoCalc!</b></h2>
         else
-            sign_out = <div style={{float:'right', marginTop:'-7.5px'}}><SignOut everywhere={false} danger={true}/></div>
-            return <h2> <Icon name='user' /> Account{sign_out}</h2>
+            return <h2> <Icon name='user' /> Account</h2>
 
     render: ->
         <Panel header={@render_header()}>


### PR DESCRIPTION
# Description
* problem:  select a tab != preferences in account and even when you tab back and forth to a project, you still have to know that in order to reach the sign out button you have to click on preferences first
* solution: move it up, to the row where the tabs are.

# Testing Steps
sign out works just like before, not much of a surprise 

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
