### PR TITLE
Account Button drop down menu

### DIFF
--- a/src/smc-webapp/account/account-button.tsx
+++ b/src/smc-webapp/account/account-button.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { Popconfirm, Popover } from "antd";
+import { Popconfirm, Popover, Icon as Ant_icon } from "antd";
 const { NavItem } = require("react-bootstrap");
 import { AccountActions } from "../account";
+import { Icon } from "../r_misc";
 
 interface Props {
   icon: React.ReactNode; // When clicked, show popover
@@ -10,6 +11,8 @@ interface Props {
   show_label: boolean; // This tells button to show
   is_active: boolean; // if true set button background to ACTIVE_BG_COLOR
   user_label: string;
+  account_actions: AccountActions;
+  page_actions: any;
 }
 
 export const AccountTabDropdown: React.FC<Props> = ({
@@ -18,10 +21,10 @@ export const AccountTabDropdown: React.FC<Props> = ({
   label_class,
   show_label,
   is_active,
-  user_label
+  user_label,
+  account_actions,
+  page_actions
 }) => {
-  // If icon is a string then use the Icon component
-  // Else (it is a node already) just render icon
   return (
     <Popover
       placement="bottom"
@@ -37,14 +40,59 @@ export const AccountTabDropdown: React.FC<Props> = ({
           height: "30px"
         }}
       >
-        <div style={{ padding: "10px" }}>
+        <div
+          style={{ padding: "10px" }}
+          onClick={event => {
+            event.preventDefault();
+            page_actions.set_active_tab("account"); // Set to account page
+            account_actions.set_active_tab("account"); /// Set to the Preferences tab
+          }}
+        >
           {icon}
           <span style={{ marginLeft: 5 }} className={label_class}>
-            {show_label ? "Account" : undefined}
+            {show_label ? "Account" : ""}
           </span>
         </div>
       </NavItem>
     </Popover>
+  );
+};
+
+interface LinksProps {
+  name: string;
+  label: string;
+  icon: string;
+  account_actions: AccountActions;
+  page_actions: any;
+}
+
+const DropDownLinks: React.FC<LinksProps> = ({
+  name,
+  label,
+  icon,
+  account_actions,
+  page_actions
+}) => {
+  return (
+    <a
+      style={{
+        width: "100%",
+        padding: "4px 8px 4px 16px",
+        display: "block"
+      }}
+      className={"cocalc-account-button"}
+      onClick={event => {
+        event.preventDefault();
+        page_actions.set_active_tab("account"); // Set to account page
+        account_actions.set_active_tab(name); /// Set to the Preferences tab
+      }}
+      href=""
+    >
+      <span>
+        <Icon name={icon} />
+      </span>{" "}
+      {label}
+    </a>
   );
 };
 
@@ -60,99 +108,57 @@ export const DefaultAccountDropDownLinks: React.FC<LinksProps> = ({
   return (
     <>
       <div className="cocalc-account-button-dropdown-links">
-        <li>
+        <DropDownLinks
+          name="account"
+          label="Preferences"
+          icon="wrench"
+          account_actions={account_actions}
+          page_actions={page_actions}
+        />
+        <DropDownLinks
+          name="billing"
+          label="Billing"
+          icon="money"
+          account_actions={account_actions}
+          page_actions={page_actions}
+        />
+        <DropDownLinks
+          name="upgrades"
+          label="Upgrades"
+          icon="arrow-circle-up"
+          account_actions={account_actions}
+          page_actions={page_actions}
+        />
+        <DropDownLinks
+          name="support"
+          label="Support"
+          icon="medkit"
+          account_actions={account_actions}
+          page_actions={page_actions}
+        />
+        <Popconfirm
+          title={"Sign out of your account?"}
+          onConfirm={() => account_actions.sign_out(false, false)}
+          okText={"Yes, sign out"}
+          cancelText={"Cancel"}
+        >
           <a
             style={{
               width: "100%",
               padding: "4px 8px 4px 16px",
-              display: "inline-block"
+              display: "block",
+              background: "#fd4747",
+              color: "white"
             }}
             className={"cocalc-account-button"}
-            onClick={event => {
-              event.preventDefault();
-              page_actions.set_active_tab("account"); // Set to account page
-              account_actions.set_active_tab("account"); /// Set to the Subs and course packs tab
-            }}
             href=""
           >
-            Preferences
+            <span>
+              <Ant_icon type="logout" />
+            </span>{" "}
+            Sign out...
           </a>
-        </li>
-        <li>
-          <a
-            style={{
-              width: "100%",
-              padding: "4px 8px 4px 16px",
-              display: "inline-block"
-            }}
-            className={"cocalc-account-button"}
-            onClick={event => {
-              event.preventDefault();
-              page_actions.set_active_tab("account"); // Set to account page
-              account_actions.set_active_tab("billing"); /// Set to the Preferences tab
-            }}
-            href=""
-          >
-            Billing
-          </a>
-        </li>
-        <li>
-          <a
-            style={{
-              width: "100%",
-              padding: "4px 8px 4px 16px",
-              display: "inline-block"
-            }}
-            className={"cocalc-account-button"}
-            onClick={event => {
-              event.preventDefault();
-              page_actions.set_active_tab("account"); // Set to account page
-              account_actions.set_active_tab("upgrades"); /// Set to the Preferences tab
-            }}
-            href=""
-          >
-            Upgrades
-          </a>
-        </li>
-        <li>
-          <a
-            style={{
-              width: "100%",
-              padding: "4px 8px 4px 16px",
-              display: "inline-block"
-            }}
-            className={"cocalc-account-button"}
-            onClick={event => {
-              event.preventDefault();
-              page_actions.set_active_tab("account"); // Set to account page
-              account_actions.set_active_tab("support"); /// Set to the Preferences tab
-            }}
-            href=""
-          >
-            Support
-          </a>
-        </li>
-        <li>
-          <Popconfirm
-            title={"Sign out of your account?"}
-            onConfirm={() => account_actions.sign_out(false, false)}
-            okText={"Yes, sign out"}
-            cancelText={"Cancel"}
-          >
-            <a
-              style={{
-                width: "100%",
-                padding: "4px 8px 4px 16px",
-                display: "inline-block"
-              }}
-              className={"cocalc-account-button"}
-              href=""
-            >
-              Sign out...
-            </a>
-          </Popconfirm>
-          ;
-        </li>
+        </Popconfirm>
       </div>
     </>
   );

--- a/src/smc-webapp/account/account-button.tsx
+++ b/src/smc-webapp/account/account-button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Popconfirm, Popover, Icon as Ant_icon } from "antd";
-const { NavItem } = require("react-bootstrap");
+//const { NavItem } = require("react-bootstrap");
+import { NavItem } from "react-bootstrap";
 import { AccountActions } from "../account";
 import { Icon } from "../r_misc";
 
@@ -11,7 +12,7 @@ interface Props {
   show_label: boolean; // This tells button to show
   is_active: boolean; // if true set button background to ACTIVE_BG_COLOR
   user_label: string;
-  account_actions: AccountActions;
+  account_actions: AccountActions;   // Type AccountActions
   page_actions: any;
 }
 
@@ -42,10 +43,10 @@ export const AccountTabDropdown: React.FC<Props> = ({
       >
         <div
           style={{ padding: "10px" }}
-          onClick={event => {
+          onClick={(event): void => {    //Sets Active page to account page on click
             event.preventDefault();
-            page_actions.set_active_tab("account"); // Set to account page
-            account_actions.set_active_tab("account"); /// Set to the Preferences tab
+            page_actions.set_active_tab("account"); 
+            account_actions.set_active_tab("account");
           }}
         >
           {icon}
@@ -59,13 +60,15 @@ export const AccountTabDropdown: React.FC<Props> = ({
 };
 
 interface LinksProps {
-  name: string;
-  label: string;
-  icon: string;
-  account_actions: AccountActions;
+  name: string;     // Name of tab link. Passed into accout_actions.set_active_tab(name)
+  label: string;    // String to appear on menu
+  icon: string;     // Icon to appear on menu
+  account_actions: AccountActions;  // Type AccountActions
   page_actions: any;
 }
 
+
+//Returns a single dropdown link
 const DropDownLinks: React.FC<LinksProps> = ({
   name,
   label,
@@ -81,10 +84,10 @@ const DropDownLinks: React.FC<LinksProps> = ({
         display: "block"
       }}
       className={"cocalc-account-button"}
-      onClick={event => {
+      onClick={(event): void => {
         event.preventDefault();
-        page_actions.set_active_tab("account"); // Set to account page
-        account_actions.set_active_tab(name); /// Set to the Preferences tab
+        page_actions.set_active_tab("account");
+        account_actions.set_active_tab(name);
       }}
       href=""
     >
@@ -138,7 +141,9 @@ export const DefaultAccountDropDownLinks: React.FC<LinksProps> = ({
         />
         <Popconfirm
           title={"Sign out of your account?"}
-          onConfirm={() => account_actions.sign_out(false, false)}
+          onConfirm={(): void => {
+            return account_actions.sign_out(false, false);
+          }}
           okText={"Yes, sign out"}
           cancelText={"Cancel"}
         >

--- a/src/smc-webapp/account/index.ts
+++ b/src/smc-webapp/account/index.ts
@@ -2,6 +2,7 @@ export { AccountStore } from "./store";
 export { AccountActions } from "./actions";
 export { AccountTable } from "./table";
 export { init } from "./init";
+export { AccountTabDropdown, DefaultAccountDropDownLinks} from "./account-button";
 
 export { show_announce_start, show_announce_end } from "./dates";
 

--- a/src/smc-webapp/account/index.ts
+++ b/src/smc-webapp/account/index.ts
@@ -2,7 +2,10 @@ export { AccountStore } from "./store";
 export { AccountActions } from "./actions";
 export { AccountTable } from "./table";
 export { init } from "./init";
-export { AccountTabDropdown, DefaultAccountDropDownLinks} from "./account-button";
+export {
+  AccountTabDropdown,
+  DefaultAccountDropDownLinks
+} from "./account-button";
 
 export { show_announce_start, show_announce_end } from "./dates";
 

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -19,6 +19,7 @@
 #
 ###############################################################################
 
+
 {isMobile} = require('./feature')
 
 {React, ReactDOM, rclass, redux, rtypes, Redux, redux_fields} = require('./app-framework')
@@ -41,6 +42,8 @@ misc_page = require('./misc_page')
 
 # CoCalc Libraries
 misc = require('smc-util/misc')
+
+{AccountTabDropdown, DefaultAccountDropDownLinks} = require('./account')
 
 {ProjectsNav} = require('./projects_nav')
 {ActiveAppContent, CookieWarning, GlobalInformationMessage, LocalStorageWarning, ConnectionIndicator, ConnectionInfo, FullscreenButton, NavTab, NotificationBell, AppLogo, VersionWarning, announce_bar_offset} = require('./app_shared')
@@ -126,7 +129,7 @@ Page = rclass
     componentWillUnmount: ->
         @actions('page').clear_all_handlers()
 
-    render_account_tab: ->
+    xxx_render_account_tab: ->
         if @props.is_anonymous
             a = undefined
         else if @props.account_id
@@ -158,7 +161,7 @@ Page = rclass
         />
 
     # This is the new version with a dropdown menu.
-    xxx_render_account_tab: ->
+    render_account_tab: ->
         if @props.is_anonymous
             return <NavTab
                         name           = 'account'
@@ -188,9 +191,10 @@ Page = rclass
                 label_class = {nav_class}
                 show_label = {@state.show_label}
                 is_active = {@props.active_top_tab == 'account'}
+                account_actions={@actions("account")}
+                page_actions={@actions("page")}
             />
-
-
+    
     render_admin_tab: ->
         <NavTab
             name           = 'admin'

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -43,6 +43,7 @@ misc_page = require('./misc_page')
 # CoCalc Libraries
 misc = require('smc-util/misc')
 
+
 {AccountTabDropdown, DefaultAccountDropDownLinks} = require('./account')
 
 {ProjectsNav} = require('./projects_nav')


### PR DESCRIPTION
# Description
Account button drop down menu like in github.
Clicking the Account button still jumps you to Preferences. Could be changed later.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
