### PR TITLE
app page: tweak error message and fix some CSS

### DIFF
--- a/src/webapp-lib/app-startup-style.css
+++ b/src/webapp-lib/app-startup-style.css
@@ -47,6 +47,7 @@
     float: left;
 }
 #smc-startup-banner .banner-error .message {
+    width: auto;
     background-color: #bf1919;
 }
 #smc-startup-banner .banner-blink {

--- a/src/webapp-lib/app.pug
+++ b/src/webapp-lib/app.pug
@@ -19,8 +19,9 @@ html(lang="en")
         div.message
           | Timeout while loading CoCalc.
           br/
-          | If the problem persists, try hitting shift and refreshing the page,
-          | <a target="_blank" rel="noopener" href="https://github.com/sagemathinc/cocalc/wiki/Connection-Timeout">these steps</a> or email <a href="mailto:help@cocalc.com" target="_blank" rel="noopener">help@cocalc.com</a>.
+          | Try hitting shift and reload the page, restart your browser, or
+          | <a target="_blank" rel="noopener" href="https://doc.cocalc.com/howto/connectivity-issues.html">follow these steps</a>.
+          | If the problem persists, email <a href="mailto:help@cocalc.com" target="_blank" rel="noopener">help@cocalc.com</a>.
 
     div#smc-startup-banner-status
       | Initializing ...


### PR DESCRIPTION
# Description
Currently, the red error message doesn't suggest refreshing the browser strongly enough. This tweaks this a little bit. Also, it fixes the link to point to the actual doc page and some CSS.

With that, it looks like this

![Screenshot from 2020-02-17 16-01-22](https://user-images.githubusercontent.com/207405/74664965-0abc8b80-519f-11ea-9658-e9c69c2fe354.png)


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
