### PR TITLE
inconsistent use of "instead_of_change"

### DIFF
--- a/src/smc-util/db-schema/db-schema.ts
+++ b/src/smc-util/db-schema/db-schema.ts
@@ -174,7 +174,7 @@ schema.blobs = {
   },
   user_query: {
     get: {
-      instead_of_query(database, obj, _account_id, cb) {
+      async instead_of_query(database, obj, cb): Promise<void> {
         if (obj.id == null) {
           cb("id must be specified");
           return;
@@ -207,7 +207,13 @@ schema.blobs = {
         blob: true,
         project_id: true
       },
-      instead_of_change(database, _old_value, new_val, _account_id, cb) {
+      async instead_of_change(
+        database,
+        _old_value,
+        new_val,
+        _account_id,
+        cb
+      ): Promise<void> {
         database.save_blob({
           uuid: new_val.id,
           blob: new_val.blob,
@@ -885,7 +891,7 @@ schema.projects = {
     "USING GIN (users)", // so get_collaborator_ids is fast
     "USING GIN (host jsonb_path_ops)", // so get_projects_on_compute_server is fast
     "lti_id",
-    "USING GIN (state)",  // so getting all running projects is fast (e.g. for site_license_usage_log... but also manage-state)
+    "USING GIN (state)" // so getting all running projects is fast (e.g. for site_license_usage_log... but also manage-state)
   ],
 
   user_query: {

--- a/src/smc-util/db-schema/types.ts
+++ b/src/smc-util/db-schema/types.ts
@@ -49,15 +49,14 @@ interface TableSchema<F extends Fields> {
       instead_of_query?: (
         database,
         obj,
-        instead_of_query,
-        cb: Function
+        cb: (err?: string | Error, result?: any) => void
       ) => void;
       check_hook?: (
         database,
         query,
         account_id: string,
         project_id: string,
-        cb: Function
+        cb: (err?: string | Error) => void
       ) => void;
     };
     set?: {
@@ -81,7 +80,7 @@ interface TableSchema<F extends Fields> {
         query,
         account_id: string,
         project_id: string,
-        cb: Function
+        cb: (err?: string | Error) => void
       ) => void;
 
       /**
@@ -94,7 +93,7 @@ interface TableSchema<F extends Fields> {
         old_val,
         query,
         account_id: string,
-        cb: Function
+        cb: (err?: string | Error) => void
       ) => void;
 
       // hook to note that project is being used (CRITICAL: do not pass path
@@ -113,7 +112,7 @@ interface TableSchema<F extends Fields> {
         old_val,
         query,
         account_id: string,
-        cb: Function
+        cb: (err?: string | Error, result?: any) => void
       ) => void;
 
       /**
@@ -126,7 +125,7 @@ interface TableSchema<F extends Fields> {
         old_val,
         query,
         account_id: string,
-        cb: Function
+        cb: (err?: string | Error) => void
       ) => void;
     };
   };


### PR DESCRIPTION
# Description

As described internally, there are crashes like

```
TypeError: cb is not a function
    at Object.instead_of_query (/cocalc/src/smc-util/db-schema/db-schema.ts:179:11)
    at async.series (/cocalc/src/smc-hub/postgres-user-queries.js:2347:32)
    at /cocalc/src/smc-hub/node_modules/async/lib/async.js:718:13
    at Immediate.iterate (/cocalc/src/smc-hub/node_modules/async/lib/async.js:262:13)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```

which I can trace back to `f3bb7ab2f9` which seems to trigger this as a side effect of that change. I don't know the overall reasoning behind this, needs a check. 

I also added more typing info for the callbacks, which seems to be a good idea.

# Testing Steps
* hub and static compiles and runs without errors … that's all I tested, though

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
