### PR TITLE
hub/email: users might sign up but still have no email address

### DIFF
--- a/src/smc-hub/email.ts
+++ b/src/smc-hub/email.ts
@@ -525,6 +525,11 @@ exports.welcome_email = function(opts): void {
     cb: undefined
   });
 
+  if (opts.to == null) {
+    // users can sign up without an email address. ignore this.
+    typeof opts.cb === "function" ? opts.cb(undefined) : undefined;
+  }
+
   const base_url = require("./base-url").base_url();
   const token_query = encodeURI(
     `email=${encodeURIComponent(opts.to)}&token=${opts.token}`


### PR DESCRIPTION
# Description

below a reported stacktrace from a  hub, which can happen if we want to welcome someone but there is no email address

```
TypeError: Cannot read property 'indexOf' of undefined at exports.is_banned (/cocalc/src/smc-hub/email.ts:147:21) 
at Object.exports.send_email (/cocalc/src/smc-hub/email.ts:185:7) 
at Object.exports.welcome_email (/cocalc/src/smc-hub/email.ts:546:11) 
at async.waterfall (/cocalc/src/smc-hub/auth.js:961:22) 
[...]
```

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
