### PR TITLE
jupyter/traceback: make traceback processing more robust 

### DIFF
--- a/src/smc-webapp/jupyter/output-messages/traceback.tsx
+++ b/src/smc-webapp/jupyter/output-messages/traceback.tsx
@@ -15,15 +15,23 @@ export class Traceback extends Component<TracebackProps> {
 
   render(): Rendered {
     const v: Rendered[] = [];
-    let n: number = 0;
 
-    this.props.message.get("traceback").forEach(function(x) {
-      if (!endswith(x, "\n")) {
-        x += "\n";
+    const tb = this.props.message.get("traceback");
+
+    if (typeof tb == "string") {
+      v.push(<Ansi>{tb}</Ansi>);
+    }
+    // forEach detects an immutable object
+    else if (typeof tb.forEach == "function" || Array.isArray(tb)) {
+      let n: number = 0;
+      for (let x of tb) {
+        if (!endswith(x, "\n")) {
+          x += "\n";
+        }
+        v.push(<Ansi key={n}>{x}</Ansi>);
+        n += 1;
       }
-      v.push(<Ansi key={n}>{x}</Ansi>);
-      n += 1;
-    });
+    }
 
     return <div style={TRACEBACK_STYLE}>{v}</div>;
   }


### PR DESCRIPTION
# Description

share server bug says: 

`TypeError: this.props.message.get(...).forEach is not a function at Traceback.render (/cocalc/src/smc-webapp/jupyter/output-messages/traceback.tsx:53:5) at ...`

`message.tsx` is already checking `message.get("traceback") != null`

I don't know what it got, but this change deals with a string and uses the iterator protocol for arrays and immutable js "forEach" objects. I think this should help. 



# Testing Steps
1. in a normal juypter notebook, I made `raise Exception("test")` and the traceback shows up. 
2. I shared that file in my cc-in-cc project and indeed, the stacktrace shows up.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
