### PR TITLE
share/sagews: sanitize "value" in raw input

### DIFF
--- a/src/smc-webapp/sagews/output.tsx
+++ b/src/smc-webapp/sagews/output.tsx
@@ -131,17 +131,23 @@ export class CellOutput extends Component<Props> {
     );
   }
 
-  render_raw_input(val: { prompt: string; value: string }, key): Rendered {
+  render_raw_input(
+    val: { prompt: string; value: string | undefined },
+    key
+  ): Rendered {
     const { prompt, value } = val;
+    // sanitizing value, b/c we know the share server throws right here:
+    // TypeError: Cannot read property 'length' of undefined
+    const value_sani = value ?? "";
     return (
       <div key={key}>
         <b>{prompt}</b>
         <input
           style={{ padding: "0em 0.25em", margin: "0em 0.25em" }}
           type="text"
-          size={Math.max(47, value.length + 10)}
+          size={Math.max(47, value_sani.length + 10)}
           readOnly={true}
-          value={value}
+          value={value_sani}
         />
       </div>
     );


### PR DESCRIPTION
# Description

simple reason: we know this can happen:


```
TypeError: Cannot read property 'length' of undefined
 at CellOutput.render_raw_input (/cocalc/src/smc-webapp/sagews/output.tsx:136:1)
 at CellOutput.render_output_mesg (/cocalc/src/smc-webapp/sagews/output.tsx:156:8)
 at CellOutput.render_output (/cocalc/src/smc-webapp/sagews/output.tsx:163:20)
 at CellOutput.render (/cocalc/src/smc-webapp/sagews/output.tsx:177:11) ...
```

# Testing Steps
I don't know how to trigger it, but the hub starts...

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
