### PR TITLE
hub: assume everywhere that createHmac can throw and take some action…

### DIFF
--- a/src/smc-hub/auth.coffee
+++ b/src/smc-hub/auth.coffee
@@ -98,6 +98,9 @@ HASH_SALT_LENGTH = 32
 # library.  To avoid having to fork/modify that library, we've just
 # copied it here.  We need it for remember_me cookies.
 exports.generate_hash = generate_hash = (algorithm, salt, iterations, password) ->
+    # there are cases where createHmac throws an error, because "salt" is undefined
+    if not algorithm? or not salt?
+        throw new Error("undefined arguments: algorithm='#{algorithm}' salt='#{salt}'")
     iterations = iterations || 1
     hash = password
     for i in [1..iterations]
@@ -183,7 +186,12 @@ passport_login = (opts) ->
                 dbg("badly formatted remember_me cookie")
                 cb()
                 return
-            hash = generate_hash(x[0], x[1], x[2], x[3])
+            try
+                hash = generate_hash(x[0], x[1], x[2], x[3])
+            catch err
+                dbg("unable to generate hash from remember_me cookie = '#{locals.remember_me_cookie}' -- #{err}")
+                cb()
+                return
             opts.database.get_remember_me
                 hash : hash
                 cb   : (err, signed_in_mesg) ->

--- a/src/smc-hub/client.coffee
+++ b/src/smc-hub/client.coffee
@@ -269,7 +269,13 @@ class exports.Client extends EventEmitter
         if x.length != 4
             @remember_me_failed("invalid remember_me cookie")
             return
-        hash = auth.generate_hash(x[0], x[1], x[2], x[3])
+        try
+            hash = auth.generate_hash(x[0], x[1], x[2], x[3])
+        catch err
+            dbg("unable to generate hash from '#{value}' -- #{err}")
+            @remember_me_failed("invalid remember_me cookie")
+            return
+
         dbg("checking for remember_me cookie with hash='#{hash.slice(0,15)}...'") # don't put all in log -- could be dangerous
         @database.get_remember_me
             hash : hash

--- a/src/smc-hub/proxy.coffee
+++ b/src/smc-hub/proxy.coffee
@@ -164,7 +164,13 @@ exports.init_http_proxy_server = (opts) ->
             (cb) ->
                 dbg("get remember_me message")
                 x    = opts.remember_me.split('$')
-                hash = auth.generate_hash(x[0], x[1], x[2], x[3])
+                try
+                    hash = auth.generate_hash(x[0], x[1], x[2], x[3])
+                catch err
+                    msg = "unable to generate hash from remember_me cookie = '#{opts.remember_me}' -- #{err}"
+                    dbg(msg)
+                    cb(msg)
+                    return
                 database.get_remember_me
                     hash : hash
                     cb   : (err, signed_in_mesg) =>


### PR DESCRIPTION
# Description

see  issue #4394

basically: this createHmac function can throw and additionally, it will if some args are undefined. The remainder of the code adds try/catches and well, I hope it does something useful.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
