### PR TITLE
webapp/project log: fix impendance between recording and showing downloaded files

### DIFF
--- a/src/smc-webapp/project/explorer/action-box.tsx
+++ b/src/smc-webapp/project/explorer/action-box.tsx
@@ -735,8 +735,9 @@ export const ActionBox = rclass<ReactProps>(
         this.refs.download_archive
       ) as any).value;
       const dest = misc.path_to_file(this.props.current_path, destination);
+      const files = this.props.checked_files.toArray();
       this.props.actions.zip_files({
-        src: this.props.checked_files.toArray(),
+        src: files,
         dest,
         cb: err => {
           if (err) {
@@ -745,7 +746,7 @@ export const ActionBox = rclass<ReactProps>(
           }
           this.props.actions.download_file({
             path: dest,
-            log: true
+            log: files
           });
           this.props.actions.fetch_directory_listing();
         }

--- a/src/smc-webapp/project/history/log-entry.tsx
+++ b/src/smc-webapp/project/history/log-entry.tsx
@@ -97,8 +97,8 @@ export class LogEntry extends React.Component<Props> {
           style={this.props.cursor ? selected_item : undefined}
           trunc={TRUNC}
           project_id={this.props.project_id}
-        />
-        {" "}<TookTime ms={event.time} />
+        />{" "}
+        <TookTime ms={event.time} />
       </span>
     );
   }
@@ -172,9 +172,16 @@ export class LogEntry extends React.Component<Props> {
     );
   }
 
-  multi_file_links(event: { files: string[] }, link?: boolean): Rendered[] {
+  multi_file_links(
+    event: { files: string | string[] },
+    link?: boolean
+  ): Rendered[] {
     if (link == null) {
       link = true;
+    }
+    // due to a bug, "files" could just be a string
+    if (typeof event.files === "string") {
+      event.files = [event.files];
     }
     const links: Rendered[] = [];
     for (let i = 0; i < event.files.length; i++) {
@@ -206,8 +213,7 @@ export class LogEntry extends React.Component<Props> {
       case "downloaded":
         return (
           <span>
-            downloaded{" "}
-            {this.file_link(e.path != null ? e.path : e.files[0], true, 0)}{" "}
+            downloaded {this.multi_file_links(e, true)}{" "}
             {e.count != null ? `(${e.count} total)` : ""}
           </span>
         );

--- a/src/smc-webapp/project/history/types.ts
+++ b/src/smc-webapp/project/history/types.ts
@@ -92,7 +92,7 @@ export type ProjectControlEvent = {
 
 export type FileActionEvent = (
   | { action: "deleted" }
-  | { action: "downloaded"; path?: string }
+  | { action: "downloaded"; files?: string[] }
   | { action: "moved" }
   | { action: "copied" }
   | { action: "shared" }

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -2627,13 +2627,15 @@ export class ProjectActions extends Actions<ProjectStoreState> {
       auto: true,
       print: false,
       timeout: 45
-    });
+    } as { path: string; log: boolean | string[]; auto: boolean; print: boolean; timeout: number });
 
+    // log could also be an array of strings to record all the files that were downloaded in a zip file
     if (opts.log) {
+      const files = Array.isArray(opts.log) ? opts.log : [opts.path];
       this.log({
         event: "file_action",
         action: "downloaded",
-        files: opts.path
+        files
       });
     }
 


### PR DESCRIPTION
# Description
the core bug is showing `event.files[0]` where files is actually a string. 

# Testing Steps
1. download one or more files, before testing this
2. switch to this, the entries should show up
3. do a single/multiple file download and this time, instead of the zip file name for multiple files, the files itself show up.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
