### PR TITLE
webapp/rmd: do not mangle dirname of rmd preview file

### DIFF
--- a/src/smc-webapp/frame-editors/rmd-editor/utils.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/utils.ts
@@ -1,9 +1,14 @@
-import { change_filename_extension } from "smc-util/misc2";
+import { change_filename_extension, path_split } from "smc-util/misc2";
+import { join } from "path";
 
 // something in the rmarkdown source code replaces all spaces by dashes
 // [hsy] I think this is because of calling pandoc.
 // I'm not aware of any other replacements.
 // https://github.com/rstudio/rmarkdown
+// problem: do not do this for the directory name, only the filename -- issue #4405
 export function derive_rmd_output_filename(path, ext) {
-  return change_filename_extension(path, ext).replace(/ /g, "-");
+  const { head, tail } = path_split(path);
+  const fn = change_filename_extension(tail, ext).replace(/ /g, "-");
+  // avoid a leading / if it's just a filename (i.e. head = '')
+  return join(head, fn);
 }


### PR DESCRIPTION
# Description
simple fix to the preview of an rmd file

see https://github.com/sagemathinc/cocalc/issues/4405

# Testing Steps
edit `foo bar/foo baz.rmd` and also make sure the aux files are masked in the files listing

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
