### PR TITLE
hub: add "expire" cols to tables collecting errors

### DIFF
--- a/src/smc-util/db-schema/central-log.ts
+++ b/src/smc-util/db-schema/central-log.ts
@@ -8,7 +8,8 @@ export const central_log = create({
     },
     event: {
       type: "string",
-      desc: "Event name which must start with 'webapp-' to not conflict with other names that might be used already (e.g., by the backend)."
+      desc:
+        "Event name which must start with 'webapp-' to not conflict with other names that might be used already (e.g., by the backend)."
     },
     value: {
       type: "map",
@@ -17,6 +18,10 @@ export const central_log = create({
     time: {
       type: "timestamp",
       desc: "When the event took place"
+    },
+    expire: {
+      type: "timestamp",
+      desc: "future date, when the entry will be deleted"
     }
   },
   rules: {

--- a/src/smc-util/db-schema/db-schema.ts
+++ b/src/smc-util/db-schema/db-schema.ts
@@ -233,21 +233,12 @@ schema.client_error_log = {
   primary_key: "id",
   durability: "soft", // loss of some log data not serious, since used only for analytics
   fields: {
-    id: {
-      type: "uuid"
-    },
-    event: {
-      type: "string"
-    },
-    error: {
-      type: "string"
-    },
-    account_id: {
-      type: "uuid"
-    },
-    time: {
-      type: "timestamp"
-    }
+    id: { type: "uuid" },
+    event: { type: "string" },
+    error: { type: "string" },
+    account_id: { type: "uuid" },
+    time: { type: "timestamp" },
+    expire: { type: "timestamp" }
   },
   pg_indexes: ["time", "event"]
 };
@@ -276,7 +267,8 @@ schema.webapp_errors = {
     smc_git_rev: { type: "string" },
     uptime: { type: "string" },
     start_time: { type: "timestamp" },
-    time: { type: "timestamp" }
+    time: { type: "timestamp" },
+    expire: { type: "timestamp" }
   },
   pg_indexes: [
     "time",


### PR DESCRIPTION
# Description

this is quite straight forward. I didn't test it, though. 

# Testing Steps
I'm guessing the only real way to test this is to deploy it in "test" and keep it running for a while. then check the DB.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
