### PR TITLE
webapp/copy files: prefix all names with ./

### DIFF
--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -2346,16 +2346,13 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     }
 
     // If files start with a -, make them interpretable by rsync (see https://github.com/sagemathinc/cocalc/issues/516)
-    const deal_with_leading_dash = function(src_path: string) {
-      if (src_path[0] === "-") {
-        return `./${src_path}`;
-      } else {
-        return src_path;
-      }
+    // Just prefix all of them, due to https://github.com/sagemathinc/cocalc/issues/4428 brining up yet another issue
+    const add_leading_dash = function(src_path: string) {
+      return `./${src_path}`;
     };
 
     // Ensure that src files are not interpreted as an option to rsync
-    opts.src = opts.src.map(deal_with_leading_dash);
+    opts.src = opts.src.map(add_leading_dash);
 
     const id = opts.id != null ? opts.id : misc.uuid();
     this.set_activity({
@@ -2379,7 +2376,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     }
 
     args = args.concat(opts.src);
-    args = args.concat([opts.dest]);
+    args = args.concat([add_leading_dash(opts.dest)]);
 
     webapp_client.exec({
       project_id: this.project_id,


### PR DESCRIPTION
# Description

see #4428

instead of adding a second case (searching for ":"), I added the prefix for all paths. That shouldn't hurt.

# Testing Steps
1. tried it in my dev project server, ok
1. that's  the message being sent via the websocket: `... "data":{"cmd":"exec","opts":{"path":".","command":"rsync","args":["-rltgoDxH","./colon: path/file name.md","./colon: path/file name-3.md"],"timeout":120,"bash":false,"err_on_exit":true}}}`
1. the project log entries are also ok

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
