### PR TITLE
webapp/admin/site settings: reveal stripe publishable key

### DIFF
--- a/src/smc-util/db-schema/site-settings-extras.ts
+++ b/src/smc-util/db-schema/site-settings-extras.ts
@@ -51,7 +51,7 @@ export const EXTRAS: SettingsExtras = {
     name: "Stripe Publishable",
     desc: "Stripe calls this key 'publishable'",
     default: "",
-    password: true,
+    password: false,
     show: only_commercial
   },
   stripe_secret_key: {


### PR DESCRIPTION
# Description
as requested, stripe publishable key not a password



# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
