### PR TITLE
site-settings: add GA token for cocalc.com only

### DIFF
--- a/src/smc-util/db-schema/site-defaults.ts
+++ b/src/smc-util/db-schema/site-defaults.ts
@@ -13,6 +13,7 @@ type SiteSettingsKeys =
   | "account_creation_email_instructions"
   | "help_email"
   | "commercial"
+  | "google_analytics"
   | "kucalc"
   | "ssh_gateway"
   | "version_min_project"
@@ -53,6 +54,7 @@ export const only_for_sendgrid = conf =>
 export const only_for_password_reset_smtp = conf =>
   to_bool(conf.email_enabled) && conf.password_reset_override === "smtp";
 export const only_onprem = conf => conf.kucalc === KUCALC_ON_PREMISES;
+export const only_cocalc_com = conf => conf.kucalc === KUCALC_COCALC_COM;
 export const only_commercial = conf => to_bool(conf.commercial);
 export const to_bool = val => val === "true" || val === "yes";
 export const only_booleans = ["yes", "no"]; // we also understand true and false
@@ -121,6 +123,12 @@ export const site_settings_conf: SiteSettings = {
     desc: `Configure which UI elements to show in order to match the Kubernetes backend. '${KUCALC_COCALC_COM}' for cocalc.com production site, '${KUCALC_ON_PREMISES}' for on-premises k8s, or '${KUCALC_DISABLED}'`,
     default: KUCALC_DISABLED,
     valid: KUCALC_VALID_VALS
+  },
+  google_analytics: {
+    name: "Google Analytics",
+    desc: `The GA tag, only for the cocalc.com production site`,
+    default: "",
+    show: only_cocalc_com
   },
   ssh_gateway: {
     name: "SSH Gateway",


### PR DESCRIPTION
# Description

this is a tiny amendment for the landing pages: for the commercial cocalc.com setup, it allows to set the google analytics token. that's all. it's already used (I set it directly in the DB) in production. (if you wonder about other usages to set the token, there could be some but that's part of this)

![Screenshot from 2020-03-13 18-24-28](https://user-images.githubusercontent.com/207405/76644901-317ca080-6558-11ea-9b96-c709a76bdaa6.png)


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
