### PR TITLE
webapp: fixing firefox display of uncommitted saving warning

### DIFF
--- a/src/smc-webapp/r_misc/uncommited-changes.tsx
+++ b/src/smc-webapp/r_misc/uncommited-changes.tsx
@@ -16,15 +16,16 @@ const STYLE: React.CSSProperties = {
   fontWeight: "bold",
   marginLeft: "5px",
   marginRight: "-5px",
-  borderRadius: "3px"
+  borderRadius: "3px",
+  whiteSpace: "nowrap"
 };
 
 /**
-* Shows `NOT saved!` if `has_uncommitted_changes` is true for ~delay_ms time.
-* Shows nothing if `has_uncommitted_changes` is false
-*
-* Does not work with changes to `delay_ms`
-*/
+ * Shows `NOT saved!` if `has_uncommitted_changes` is true for ~delay_ms time.
+ * Shows nothing if `has_uncommitted_changes` is false
+ *
+ * Does not work with changes to `delay_ms`
+ */
 export function UncommittedChanges({
   has_uncommitted_changes,
   delay_ms = 5000


### PR DESCRIPTION
# Description

see #4434

my firefox before

![Screenshot from 2020-03-17 11-14-26](https://user-images.githubusercontent.com/207405/76846666-26b85900-6841-11ea-8287-b3f04d9d550e.png)

my firefox after

![Screenshot from 2020-03-17 11-16-23](https://user-images.githubusercontent.com/207405/76846677-2b7d0d00-6841-11ea-9459-b48e27235af7.png)

chrome, with this patch, as a reference

![Screenshot from 2020-03-17 11-16-58](https://user-images.githubusercontent.com/207405/76846691-333cb180-6841-11ea-8809-b3e56e908c11.png)


# Testing Steps
for testing, I flipped this `show_error` boolean around to let it always show

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
