### PR TITLE
Fix pythontex errorpath

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -835,7 +835,7 @@ export class Actions extends BaseActions<LatexEditorState> {
     if (output != null) {
       // process any errors
       this.parsed_output_log = output.parse = sagetex_errors(
-        this.path,
+        path_split(this.path).tail,
         output
       ).toJS();
       this.set_build_logs({ sagetex: output });
@@ -873,7 +873,7 @@ export class Actions extends BaseActions<LatexEditorState> {
     }
     // this is similar to how knitr errors are processed
     this.parsed_output_log = output.parse = pythontex_errors(
-      this.path,
+      path_split(this.path).tail,
       output
     ).toJS();
     this.set_build_logs({ pythontex: output });

--- a/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -236,7 +236,7 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
     }
   }
 
-  render_group(tool: string, group: string): Rendered {
+  render_group(tool: string, group: string, num: number): Rendered {
     if (tool == "knitr" && !this.props.knitr) {
       return undefined;
     }
@@ -252,7 +252,7 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
       </>
     );
     return (
-      <div key={group}>
+      <div key={`${group}-${num}`}>
         {content.size == 0 ? <h5>{header}</h5> : <h3>{header}</h3>}
         {this.render_group_content(content)}
       </div>
@@ -284,11 +284,11 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
         {this.render_hint()}
         {this.render_status()}
         {["errors", "typesetting", "warnings"].map(group =>
-          this.render_group("latex", group)
+          this.render_group("latex", group, 0)
         )}
-        {this.render_group("sagetex", "errors")}
-        {["errors", "warnings"].map(group => this.render_group("knitr", group))}
-        {this.render_group("pythontex", "errors")}
+        {this.render_group("sagetex", "errors", 1)}
+        {["errors", "warnings"].map(group => this.render_group("knitr", group, 2))}
+        {this.render_group("pythontex", "errors", 3)}
       </div>
     );
   }

--- a/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
@@ -65,7 +65,7 @@ PythonTeX:  pytex-test - 1 error(s), 0 warning(s)
 */
 
 export function pythontex_errors(
-  path: string,
+  file: string,
   output: BuildLog
 ): ProcessedLatexLog {
   const pll = new ProcessedLatexLog();
@@ -81,7 +81,7 @@ export function pythontex_errors(
       }
       err = {
         line: line_no,
-        file: path,
+        file,
         level: "error",
         message: line,
         content: "",

--- a/src/smc-webapp/frame-editors/latex-editor/sagetex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/sagetex.ts
@@ -68,7 +68,7 @@ export async function sagetex(
  */
 
 export function sagetex_errors(
-  path: string,
+  file: string,
   output: BuildLog
 ): ProcessedLatexLog {
   const pll = new ProcessedLatexLog();
@@ -86,7 +86,7 @@ export function sagetex_errors(
       if (err == null) {
         err = {
           line: null,
-          file: path,
+          file,
           level: "error",
           message: line,
           content: "",


### PR DESCRIPTION
# Description

Fixes  #4443 and makes a key for react unique

# Testing Steps
1. I enabled pythontex and put e.g. `\py{ 2 3 }` in a line. That triggered an error to show up and clicking on the little link, it jumped to the correct line.

![screenshot-cocalc com-2020 03 17-15_31_22](https://user-images.githubusercontent.com/207405/76866435-70ff0180-6864-11ea-9fcd-ff247deec83f.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
