### PR TITLE
listings: debonuce harder, but also fire a change when  it happens

### DIFF
--- a/src/smc-project/sync/listings.ts
+++ b/src/smc-project/sync/listings.ts
@@ -16,7 +16,7 @@ import { remove_jupyter_backend } from "../jupyter/jupyter";
 // Update directory listing only when file changes stop for at least this long.
 // This is important since we don't want to fire off dozens of changes per second,
 // e.g., if a logfile is being updated.
-const WATCH_DEBOUNCE_MS = 1000;
+const WATCH_DEBOUNCE_MS = 2000;
 
 // Watch directories for which some client has shown interest recently:
 const INTEREST_THRESH_SECONDS = WATCH_TIMEOUT_MS / 1000;

--- a/src/smc-project/sync/path-watcher.ts
+++ b/src/smc-project/sync/path-watcher.ts
@@ -54,7 +54,10 @@ export class Watcher extends EventEmitter {
   private init_watch_contents(): void {
     this.watch_contents = watch(
       this.path,
-      debounce(this.change.bind(this), this.debounce_ms)
+      debounce(this.change.bind(this), this.debounce_ms, {
+        leading: true,
+        trailing: true,
+      })
     );
   }
 


### PR DESCRIPTION
# Description

well, two motivations
1. see if this has an impact on overall load, when there are many projects running
2. the cool thing here is that you should try "touch x" in the mini console. after I hit return there is no longer a 1 sec delay refreshing the listing :running_man: 


# Testing Steps
project restarted, listings update, ... the change is really small

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
