### PR TITLE
webpack: undo change to ts-loader config

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -135,7 +135,7 @@ const CC_NOCLEAN = !!process.env.CC_NOCLEAN;
 // but obviously less safe.  This is designed for use, e.g.,
 // when trying to do a quick production build in an emergency,
 // when we already know the typescript all works.
-const TS_TRANSPILE_ONLY = process.env.TS_TRANSPILE_ONLY;
+const TS_TRANSPILE_ONLY = !!process.env.TS_TRANSPILE_ONLY;
 
 // When building the static page or if the user explicitly sets
 // an env variable, we do not want to use the forking typescript
@@ -518,11 +518,14 @@ module.exports = {
         test: /\.tsx?$/,
         use: {
           loader: "ts-loader",
-          options: {
-            // do not run typescript checker in same process...
-            transpileOnly: TS_TRANSPILE_ONLY,
-            experimentalWatchApi: !DISABLE_TS_LOADER_OPTIMIZATIONS,
-          },
+          options:
+            TS_TRANSPILE_ONLY || DISABLE_TS_LOADER_OPTIMIZATIONS
+              ? { transpileOnly: TS_TRANSPILE_ONLY } // run as normal or not at all
+              : {
+                  // do not run typescript checker in same process...
+                  transpileOnly: !TS_TRANSPILE_ONLY,
+                  experimentalWatchApi: true,
+                },
         },
       },
       {


### PR DESCRIPTION
# Description

I made this change, which undoes something with ts-loader config, but I don't really know what I should look for. Is it the turnaround time of making a change until webpack finished?

# Testing Steps


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
