### PR TITLE
respect orga name + email when sending welcome/verify emails

### DIFF
--- a/src/smc-hub/email.ts
+++ b/src/smc-hub/email.ts
@@ -778,8 +778,8 @@ export function welcome_email(opts): void {
   send_email({
     subject,
     body,
-    fromname: COMPANY_NAME,
-    from: COMPANY_EMAIL,
+    fromname: fallback(settings.organization_name, COMPANY_NAME),
+    from: fallback(settings.organization_email, COMPANY_EMAIL),
     to: opts.to,
     cb: opts.cb,
     category,


### PR DESCRIPTION
# Description

this should fix issue #4486

if the organization name + organization email address is set, this makes the hub use it

# Testing Steps
* set these settings to a recognizable value, then send an email verification to youself.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
