### PR TITLE
course/handout: set overwrite to true when it should do so 

### DIFF
--- a/src/smc-webapp/course/handouts/handouts-panel.tsx
+++ b/src/smc-webapp/course/handouts/handouts-panel.tsx
@@ -525,7 +525,7 @@ class Handout extends Component<HandoutProps, HandoutState> {
       return;
     }
     const do_it = (): void => {
-      this.copy_handout(step, false);
+      this.copy_handout(step, false, true);
       this.setState({
         copy_handout_confirm_overwrite: false,
         copy_handout_confirm_overwrite_text: "",


### PR DESCRIPTION
# Description

this is a pretty straight forward fix for #4490

# Testing Steps
1. it issued `rsync --delete ...` in my cc-in-cc dev project: `2020-04-02T14:13:33.918Z - debug: stdout='{} ', stderr='Project(project_id=bc6f81b3-25ad-4d58-ae4a-65649fae4fa5).cmd(...): rsync --delete -zaxs  [...] `

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
