### PR TITLE
highlight fixed formatted cobol files

### DIFF
--- a/src/smc-webapp/codemirror/modes.coffee
+++ b/src/smc-webapp/codemirror/modes.coffee
@@ -7,6 +7,7 @@ that shouldn't also be used on the backend.
 
 require('codemirror/mode/clike/clike.js')
 require('codemirror/mode/clojure/clojure.js')
+require('codemirror/mode/cobol/cobol.js')
 require('codemirror/mode/coffeescript/coffeescript.js')
 require('codemirror/mode/commonlisp/commonlisp.js')
 require('codemirror/mode/css/css.js')

--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -11,6 +11,7 @@ const codemirror_associations: { [ext: string]: string } = {
   adb: "ada",
   c: "text/x-c",
   "c++": "text/x-c++src",
+  cob: "text/x-cobol",
   cql: "text/x-sql",
   cpp: "text/x-c++src",
   cc: "text/x-c++src",


### PR DESCRIPTION
# Description

saturday fun (cblc will be in the next software update)

![Screenshot from 2020-04-11 12-19-01](https://user-images.githubusercontent.com/207405/79041276-cc67a980-7bee-11ea-9500-6e45d86c6596.png)



# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
