### PR TITLE
fix ToS url as a fallback to the ToS phrase

### DIFF
--- a/src/smc-util/db-schema/site-defaults.ts
+++ b/src/smc-util/db-schema/site-defaults.ts
@@ -131,16 +131,17 @@ export const site_settings_conf: SiteSettings = {
     show: show_theming_vars,
   },
   terms_of_service_url: {
-    name: "Terms of Service",
-    desc: "URL to a page describing ToS, Policies, etc.",
+    name: "Terms of Service URL",
+    desc:
+      "URL to the page describing ToS, Policies, etc. (leave empty to not require)",
     default: "",
     clearable: true,
-    show: (conf) => show_theming_vars(conf) && conf.terms_of_service == "",
+    show: show_theming_vars,
   },
   terms_of_service: {
     name: "ToS information",
     desc:
-      "The text displayed for the terms of service link (make empty to not require).",
+      "The text displayed for the terms of service link (empty falls back a boilerplate using the URL).",
     default:
       "By creating an account you agree to the <em>Terms of Service</em>.",
     clearable: true,

--- a/src/smc-webapp/landing-page/sign-up.tsx
+++ b/src/smc-webapp/landing-page/sign-up.tsx
@@ -40,6 +40,7 @@ interface Props {
   has_remember_me: boolean;
   help_email: string;
   terms_of_service: string;
+  terms_of_service_url: string;
 }
 
 interface State {
@@ -51,7 +52,9 @@ interface State {
 export class SignUp extends React.Component<Props, State> {
   constructor(props) {
     super(props);
-    const show_terms = props.terms_of_service?.length > 0;
+    const show_terms =
+      props.terms_of_service?.length > 0 ||
+      props.terms_of_service_url?.length > 0;
     this.state = {
       show_terms,
       terms_checkbox: !show_terms,

--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -271,12 +271,13 @@ exports.LandingPage = rclass
         page:
             get_api_key   : rtypes.string
         customize:
-            is_commercial    : rtypes.bool
-            _is_configured   : rtypes.bool
-            logo_square      : rtypes.string
-            logo_rectangular : rtypes.string
-            help_email       : rtypes.string
-            terms_of_service : rtypes.string
+            is_commercial        : rtypes.bool
+            _is_configured       : rtypes.bool
+            logo_square          : rtypes.string
+            logo_rectangular     : rtypes.string
+            help_email           : rtypes.string
+            terms_of_service     : rtypes.string
+            terms_of_service_url : rtypes.string
         account:
             sign_in_email_address : rtypes.string
         "#{LA_NAME}":
@@ -468,6 +469,7 @@ exports.LandingPage = rclass
                         has_account     = {@props.has_account}
                         help_email      = {@props.help_email}
                         terms_of_service= {@props.terms_of_service}
+                        terms_of_service_url = {@props.terms_of_service_url}
                     />
                 </Col>
                 <Col sm={6}>


### PR DESCRIPTION
# Description

There was an inconsistency between the sign-on logic and the theming variables – basically a missing "or"-clause. This changes it so, that if there is a ToS url, it is used primarily and a boilerplate text is show in the sign up dialog. As currently used, it is possible to replace that text with a customized version.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
