### PR TITLE
fix DNS for "normal" password reset emails

### DIFF
--- a/src/smc-hub/password.coffee
+++ b/src/smc-hub/password.coffee
@@ -117,7 +117,8 @@ exports.forgot_password = (opts) ->
             # send an email to opts.mesg.email_address that has a password reset link
             theme = require('smc-util/theme')
 
-            DOMAIN_NAME = theme.DOMAIN_NAME # actually a https url
+            dns         = locals.settings.dns or theme.DNS
+            DOMAIN_NAME = "https://#{dns}"
             HELP_EMAIL  = locals.settings.help_email ? theme.HELP_EMAIL
             SITE_NAME   = locals.settings.site_name  ? theme.SITE_NAME
 


### PR DESCRIPTION
# Description
a rather trivial case, where the hardcoded dns is used but it should be the one from the server config (if it is more than an empty string)

# Testing Steps
* I didn't test it yet

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
