### PR TITLE
share: render Rmd files like markdown 

### DIFF
--- a/src/smc-webapp/share/extensions.ts
+++ b/src/smc-webapp/share/extensions.ts
@@ -26,10 +26,11 @@ export const image = new Set([
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 export const video = new Set(VIDEO_EXTS);
 export const audio = new Set(AUDIO_EXTS);
-
 export const pdf = new Set(["pdf"]);
-
 export const html = new Set(["html", "htm"]);
+
+// what to render in markdown -- rmd is special, but it's ok to show it that way for now
+export const md = new Set(["md", "rmd"]);
 
 const cm = {};
 for (const ext in file_associations) {

--- a/src/smc-webapp/share/file-contents.tsx
+++ b/src/smc-webapp/share/file-contents.tsx
@@ -50,9 +50,9 @@ export function default_to_raw(ext: string): boolean {
 // just be embedded via html (e.g., NOT an image).
 export function has_special_viewer(ext: string): boolean {
   return (
-    ext === "md" ||
     ext === "ipynb" ||
     ext === "sagews" ||
+    extensions.md.has(ext) ||
     extensions.codemirror[ext] ||
     extensions.html.has(ext)
   );
@@ -103,7 +103,7 @@ export class FileContents extends Component<Props> {
       );
     } else if (extensions.audio.has(ext)) {
       elt = <audio src={src} autoPlay={true} controls={true} loop={false} />;
-    } else if (ext === "md" && this.props.highlight) {
+    } else if (extensions.md.has(ext) && this.props.highlight) {
       // WARNING: slow if big!
       elt = <Markdown value={this.props.content} />;
     } else if (extensions.html.has(ext)) {


### PR DESCRIPTION
# Description
* right now, shared Rmd files don't show up on the share server at all
* with that, they're treated like markdown. that's not ideal, but better than not at all.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
