### PR TITLE
idle banner: show customized logos or the default

### DIFF
--- a/src/smc-webapp/_misc_page.sass
+++ b/src/smc-webapp/_misc_page.sass
@@ -71,9 +71,22 @@
     left             : 0
     right            : 0
     cursor           : pointer
-    h1
-      font-size : 22px
+    h1, h2, h3, h4
       color     : white
-    img
+    h1, h2
+      font-size : 22px
+    h3
+      font-size : 20px
+    h4
+      font-size : 16px
+    img.logo-square,
+    img.logo-rectangular
+      display: block
+      margin : 0 auto 10px auto
+      padding: 0
+    img.logo-square
+      width  : 200px
+      height : 200px
+    img.logo-rectangular
       width  : 150px
-      height : 150px
+      height : auto

--- a/src/smc-webapp/client/idle.ts
+++ b/src/smc-webapp/client/idle.ts
@@ -6,7 +6,6 @@ import { delay } from "awaiting";
 
 import { redux } from "../app-framework";
 const { APP_LOGO_WHITE } = require("../art");
-import { SITE_NAME } from "smc-util/theme";
 import { IS_TOUCH } from "../feature";
 import { WebappClient } from "./client";
 
@@ -109,14 +108,25 @@ export class IdleClient {
 
   private notification_html(): string {
     const customize = redux.getStore("customize");
-    const site_name = customize.get("site_name") || SITE_NAME;
-    const logo_url = customize.get("logo_square") || APP_LOGO_WHITE;
-    return `
-<div>
-<img src="${logo_url}">
-<h1>${site_name}</h1>
-&mdash; click to reconnect &mdash;
-</div>`;
+    const site_name = customize.get("site_name");
+    const description = customize.get("site_description");
+    const logo_rect = customize.get("logo_rectangular");
+    const logo_square = customize.get("logo_square");
+
+    // we either have just a customized square logo or square + rectangular -- or just the baked in default
+    let html: string = "<div>";
+    if (logo_square != "") {
+      if (logo_rect != "") {
+        html += `<img class="logo-square" src="${logo_square}"><img  class="logo-rectangular" src="${logo_rect}">`;
+      } else {
+        html += `<img class="logo-square" src="${logo_square}"><h3>${site_name}</h3>`;
+      }
+      html += `<h4>${description}</h4>`;
+    } else {
+      html += `<img class="logo-square" src="${APP_LOGO_WHITE}"><h3>${description}</h3>`;
+    }
+
+    return html + "&mdash; click to reconnect &mdash;</div>";
   }
 
   public show_notification(): void {


### PR DESCRIPTION
# Description
either show the white default logo, or the square or square+rectangular one

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
