### PR TITLE
project settings: show when project was created

### DIFF
--- a/src/smc-webapp/project/settings/about-box.tsx
+++ b/src/smc-webapp/project/settings/about-box.tsx
@@ -1,17 +1,18 @@
 import * as React from "react";
-import { LabeledRow, TextInput, SettingBox } from "../../r_misc";
+import { LabeledRow, TextInput, SettingBox, TimeAgo } from "../../r_misc";
 import { ProjectsActions } from "../../todo-types";
 
 interface Props {
   project_title: string;
   project_id: string;
   description: string;
+  created?: Date;
   actions: ProjectsActions;
 }
 
-export function TitleDescriptionBox(props: Props) {
+export function AboutBox(props: Props) {
   return (
-    <SettingBox title="Title and description" icon="header">
+    <SettingBox title="About" icon="file-alt">
       <LabeledRow label="Title">
         <TextInput
           text={props.project_title}
@@ -30,6 +31,11 @@ export function TitleDescriptionBox(props: Props) {
           }
         />
       </LabeledRow>
+      {props.created && (
+        <LabeledRow label="Created">
+          <TimeAgo date={props.created} />
+        </LabeledRow>
+      )}
     </SettingBox>
   );
 }

--- a/src/smc-webapp/project/settings/body.tsx
+++ b/src/smc-webapp/project/settings/body.tsx
@@ -14,7 +14,7 @@ import {
   CurrentCollaboratorsPanel,
 } from "../../collaborators";
 
-import { TitleDescriptionBox } from "./title-description-box";
+import { AboutBox } from "./about-box";
 import { UpgradeUsage } from "./upgrade-usage";
 import { HideDeleteBox } from "./hide-delete-box";
 import { SagewsControl } from "./sagews-control";
@@ -168,10 +168,11 @@ export const Body = rclass<ReactProps>(
           </h1>
           <Row>
             <Col sm={6}>
-              <TitleDescriptionBox
+              <AboutBox
                 project_id={id}
                 project_title={this.props.project.get("title") || ""}
                 description={this.props.project.get("description") || ""}
+                created={this.props.project.get("created")}
                 actions={redux.getActions("projects")}
               />
               <UpgradeUsage


### PR DESCRIPTION
# Description
* project settings: rename title box to "about"
* show when the project was created

![Screenshot from 2020-04-30 12-19-11](https://user-images.githubusercontent.com/207405/80699758-d2a9c100-8adc-11ea-86a6-f626011b9434.png)


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
