### PR TITLE
new automatic filenames with dashes for year-month-day

### DIFF
--- a/src/smc-webapp/project/utils.ts
+++ b/src/smc-webapp/project/utils.ts
@@ -117,7 +117,7 @@ export class NewFilenames {
     }
     // in some cases, prefix with the current day
     if (this.type.startsWith("ymd_")) {
-      tokens.unshift(new Date().toISOString().slice(0, 10).split("-").join(""));
+      tokens.unshift(new Date().toISOString().slice(0, 10));
     }
     switch (this.effective_ext) {
       case "java": // CamelCase!


### PR DESCRIPTION
# Description
Instead of running year month and day together, this keeps the dashes. easier to read and sort-compatible with "current time"

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
