### PR TITLE
project/git: ignore aux files by default

### DIFF
--- a/src/smc-project/gitconfig.ts
+++ b/src/smc-project/gitconfig.ts
@@ -1,0 +1,121 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { promisify } from "util";
+import {
+  writeFile as writeFileCB,
+  access as accessCB,
+  constants as fs_constants,
+} from "fs";
+const writeFile = promisify(writeFileCB);
+const access = promisify(accessCB);
+import { homedir } from "os";
+import { join } from "path";
+const { execute_code } = require("smc-util-node/misc_node");
+const { callback2: cb2 } = require("smc-util/async-utils");
+
+const EXCLUDES_FN = join(homedir(), ".gitexcludes");
+
+const EXCLUDES = `\
+# Global .gitignore file
+# configured via ~/.gitconfig: core/excludesfile
+
+### CoCalc Platform ###
+.snapshots/
+.*.sage-chat
+.*.sage-history
+.*.sage-jupyter
+.*.sage-jupyter2
+.*.syncdb
+.*.syncdoc
+.*.syncdoc[34]
+
+### Python ###
+__pycache__/
+*.py[cod]
+
+# SageMath parsed files
+*.sage.py
+
+# mypy typechecker
+.mypy_cache/
+
+### JupyterNotebooks ###
+.ipynb_checkpoints/
+
+### LaTeX ###
+# Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+# Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+# Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+# knitr
+*-concordance.tex
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+`;
+
+// initialize files in a project to help working with git
+export async function init_gitconfig(winston: {
+  debug: Function;
+}): Promise<void> {
+  const conf = await cb2(execute_code, {
+    command: "git",
+    args: ["config", "--global", "--get", "core.excludesfile"],
+    bash: false,
+    err_on_exit: false,
+  });
+  // exit_code == 1 if key isn't set. only then we check if there is no file and do the setup
+  if (conf.exit_code != 0) {
+    winston.debug("git: core.excludesfile key not set");
+    try {
+      // throws if files doesn't exist
+      await access(EXCLUDES_FN, fs_constants.F_OK);
+      winston.debug(`git: excludes file '${EXCLUDES_FN}' exists -> abort`);
+      return;
+    } catch {}
+    winston.debug(
+      `git: writing '${EXCLUDES_FN}' file and setting global git config`
+    );
+    await writeFile(EXCLUDES_FN, EXCLUDES, "utf8");
+    await cb2(execute_code, {
+      command: "git",
+      args: ["config", "--global", "--add", "core.excludesfile", EXCLUDES_FN],
+      bash: false,
+    });
+  }
+}

--- a/src/smc-project/local_hub.coffee
+++ b/src/smc-project/local_hub.coffee
@@ -4,10 +4,6 @@
 #########################################################################
 
 ###
-
-CoCalc: Collaborative web-based SageMath, Jupyter, LaTeX and Terminals.
-Copyright 2015, SageMath, Inc., GPL v3.
-
 local_hub -- a node.js program that runs as a regular user, and
              coordinates and maintains the connections between
              the global hubs and *all* projects running as
@@ -29,6 +25,8 @@ uuid    = require('uuid')
 winston = require('winston')
 request = require('request')
 program = require('commander')          # command line arguments -- https://github.com/visionmedia/commander.js/
+
+init_gitconfig = require('./gitconfig').init_gitconfig
 
 BUG_COUNTER = 0
 
@@ -309,9 +307,14 @@ start_server = (tcp_port, raw_port, cb) ->
     the_secret_token = undefined
     if program.console_port
         console_sessions.set_port(program.console_port)
+
     # We run init_info_json to determine the INFO variable.
     # However, we do NOT wait for the cb of init_info_json to be called, since we don't care in this process that the file info.json was written.
     init_info_json()
+
+    # setup some files to help users working with Git
+    # this is an async function, but we don't wait for it -- no need
+    init_gitconfig(winston)
 
     async.series([
         (cb) ->


### PR DESCRIPTION
# Description
This is pure convenience. With this, temporary cocalc, latex and python files are ignored in Git. No existing config will be harmed nor will user changes be overwritten.


# Testing Steps
* in cc-in-cc, the home directory is your actual project. should be ok for production
* what's probably nice to test is editing a jupyter file in a fresh git dir and then no aux files show up in the status

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
