### PR TITLE
license headers: remove a silly end-of-line space

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/c.js
+++ b/src/c.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/postcss.config.js
+++ b/src/postcss.config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/scripts/export-api-doc.ts
+++ b/src/scripts/export-api-doc.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/setupEnzyme.ts
+++ b/src/setupEnzyme.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/analytics-script.ts
+++ b/src/smc-hub/analytics-script.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/analytics.ts
+++ b/src/smc-hub/analytics.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/client/create-account.ts
+++ b/src/smc-hub/client/create-account.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/coffee-coverage-loader.js
+++ b/src/smc-hub/coffee-coverage-loader.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/copy-path.ts
+++ b/src/smc-hub/copy-path.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/dev/hub-http-server.ts
+++ b/src/smc-hub/dev/hub-http-server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/email.ts
+++ b/src/smc-hub/email.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/index.js
+++ b/src/smc-hub/index.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/kucalc/quota.ts
+++ b/src/smc-hub/kucalc/quota.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/mentions/handle.ts
+++ b/src/smc-hub/mentions/handle.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/open-cocalc-server.ts
+++ b/src/smc-hub/open-cocalc-server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/account-queries.ts
+++ b/src/smc-hub/postgres/account-queries.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/changefeed-query.ts
+++ b/src/smc-hub/postgres/changefeed-query.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/changefeed.ts
+++ b/src/smc-hub/postgres/changefeed.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/collab.ts
+++ b/src/smc-hub/postgres/collab.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/delete-projects.ts
+++ b/src/smc-hub/postgres/delete-projects.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/file-use-times.ts
+++ b/src/smc-hub/postgres/file-use-times.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/project-action-hooks.ts
+++ b/src/smc-hub/postgres/project-action-hooks.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/project-and-user-tracker.ts
+++ b/src/smc-hub/postgres/project-and-user-tracker.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/project-queries.ts
+++ b/src/smc-hub/postgres/project-queries.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/public-paths.ts
+++ b/src/smc-hub/postgres/public-paths.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/query.ts
+++ b/src/smc-hub/postgres/query.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/remember-me.ts
+++ b/src/smc-hub/postgres/remember-me.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/site-license/analytics.ts
+++ b/src/smc-hub/postgres/site-license/analytics.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/site-license/hook.ts
+++ b/src/smc-hub/postgres/site-license/hook.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/site-license/public.ts
+++ b/src/smc-hub/postgres/site-license/public.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/site-license/search.ts
+++ b/src/smc-hub/postgres/site-license/search.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/site-license/usage-log.ts
+++ b/src/smc-hub/postgres/site-license/usage-log.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/syncdoc-history.ts
+++ b/src/smc-hub/postgres/syncdoc-history.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/test-postgres-import.js
+++ b/src/smc-hub/postgres/test-postgres-import.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/types.ts
+++ b/src/smc-hub/postgres/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/postgres/user-tracking.ts
+++ b/src/smc-hub/postgres/user-tracking.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/run/compute.js
+++ b/src/smc-hub/run/compute.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/run/hub.js
+++ b/src/smc-hub/run/hub.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/run/smc-vm-manager.js
+++ b/src/smc-hub/run/smc-vm-manager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/run/storage.js
+++ b/src/smc-hub/run/storage.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/server-settings.ts
+++ b/src/smc-hub/server-settings.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/access.ts
+++ b/src/smc-hub/share/access.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/authenticate.ts
+++ b/src/smc-hub/share/authenticate.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/dev/t.js
+++ b/src/smc-hub/share/dev/t.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/handle-path-request.ts
+++ b/src/smc-hub/share/handle-path-request.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/handle-share-css.ts
+++ b/src/smc-hub/share/handle-share-css.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/handle-share-listing.ts
+++ b/src/smc-hub/share/handle-share-listing.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/handle-user-request.ts
+++ b/src/smc-hub/share/handle-user-request.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/http-server.ts
+++ b/src/smc-hub/share/http-server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/jsdom-support.ts
+++ b/src/smc-hub/share/jsdom-support.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/listing.ts
+++ b/src/smc-hub/share/listing.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/public-paths.ts
+++ b/src/smc-hub/share/public-paths.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/react-viewer.ts
+++ b/src/smc-hub/share/react-viewer.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/render-public-path.ts
+++ b/src/smc-hub/share/render-public-path.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/render-static-path.ts
+++ b/src/smc-hub/share/render-static-path.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/render-user.ts
+++ b/src/smc-hub/share/render-user.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/router.ts
+++ b/src/smc-hub/share/router.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/server.ts
+++ b/src/smc-hub/share/server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/share.ts
+++ b/src/smc-hub/share/share.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/test-import.js
+++ b/src/smc-hub/share/test-import.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/util.ts
+++ b/src/smc-hub/share/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/share/virtual-hosts.ts
+++ b/src/smc-hub/share/virtual-hosts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/stripe/client.ts
+++ b/src/smc-hub/stripe/client.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/test-hub-import.js
+++ b/src/smc-hub/test-hub-import.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/test/email.js
+++ b/src/smc-hub/test/email.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-hub/utils.ts
+++ b/src/smc-hub/utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/api.ts
+++ b/src/smc-project/browser-websocket/api.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/browser-client.ts
+++ b/src/smc-project/browser-websocket/browser-client.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/canonical-path.ts
+++ b/src/smc-project/browser-websocket/canonical-path.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/delete-files.ts
+++ b/src/smc-project/browser-websocket/delete-files.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/eval-code.ts
+++ b/src/smc-project/browser-websocket/eval-code.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/move-files.ts
+++ b/src/smc-project/browser-websocket/move-files.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/server.ts
+++ b/src/smc-project/browser-websocket/server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/browser-websocket/symmetric_channel.ts
+++ b/src/smc-project/browser-websocket/symmetric_channel.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/configuration.ts
+++ b/src/smc-project/configuration.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/directory-listing.ts
+++ b/src/smc-project/directory-listing.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/bib-format.ts
+++ b/src/smc-project/formatters/bib-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/clang-format.ts
+++ b/src/smc-project/formatters/clang-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/gofmt.ts
+++ b/src/smc-project/formatters/gofmt.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/html-format.ts
+++ b/src/smc-project/formatters/html-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/latex-format.ts
+++ b/src/smc-project/formatters/latex-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/prettier.ts
+++ b/src/smc-project/formatters/prettier.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/python-format.ts
+++ b/src/smc-project/formatters/python-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/r-format.ts
+++ b/src/smc-project/formatters/r-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/rust-format.ts
+++ b/src/smc-project/formatters/rust-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/formatters/xml-format.ts
+++ b/src/smc-project/formatters/xml-format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/globals.d.ts
+++ b/src/smc-project/globals.d.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/http-api/server.ts
+++ b/src/smc-project/http-api/server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/http-api/test.js
+++ b/src/smc-project/http-api/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/index.js
+++ b/src/smc-project/index.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/async-utils-node.ts
+++ b/src/smc-project/jupyter/async-utils-node.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/execute-code.ts
+++ b/src/smc-project/jupyter/execute-code.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/http-server.ts
+++ b/src/smc-project/jupyter/http-server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/jupyter-blobs-sqlite.ts
+++ b/src/smc-project/jupyter/jupyter-blobs-sqlite.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/jupyter.ts
+++ b/src/smc-project/jupyter/jupyter.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/kernel-data.ts
+++ b/src/smc-project/jupyter/kernel-data.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/launch_jupyter_kernel.ts
+++ b/src/smc-project/jupyter/launch_jupyter_kernel.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/nbconvert.ts
+++ b/src/smc-project/jupyter/nbconvert.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/basic.ts
+++ b/src/smc-project/jupyter/test/basic.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/blobs.ts
+++ b/src/smc-project/jupyter/test/blobs.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/common.ts
+++ b/src/smc-project/jupyter/test/common.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/completion.ts
+++ b/src/smc-project/jupyter/test/completion.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/kernel.ts
+++ b/src/smc-project/jupyter/test/kernel.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/payload.ts
+++ b/src/smc-project/jupyter/test/payload.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/stdin.ts
+++ b/src/smc-project/jupyter/test/stdin.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/test/supported-kernels.ts
+++ b/src/smc-project/jupyter/test/supported-kernels.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/jupyter/websocket-api.ts
+++ b/src/smc-project/jupyter/websocket-api.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/lean/global-packages.ts
+++ b/src/smc-project/lean/global-packages.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/lean/lean.ts
+++ b/src/smc-project/lean/lean.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/lean/server.ts
+++ b/src/smc-project/lean/server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/nbgrader/api.ts
+++ b/src/smc-project/nbgrader/api.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/nbgrader/jupyter-parse.ts
+++ b/src/smc-project/nbgrader/jupyter-parse.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/nbgrader/jupyter-run.ts
+++ b/src/smc-project/nbgrader/jupyter-run.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/public-paths.ts
+++ b/src/smc-project/public-paths.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/sync/listings.ts
+++ b/src/smc-project/sync/listings.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/sync/open-synctables.ts
+++ b/src/smc-project/sync/open-synctables.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/sync/path-watcher.ts
+++ b/src/smc-project/sync/path-watcher.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/sync/server.ts
+++ b/src/smc-project/sync/server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/sync/sync-doc.ts
+++ b/src/smc-project/sync/sync-doc.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/terminal/server.ts
+++ b/src/smc-project/terminal/server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-project/x11/server.ts
+++ b/src/smc-project/x11/server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util-node/coffee-coverage-loader.js
+++ b/src/smc-util-node/coffee-coverage-loader.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util-node/index.js
+++ b/src/smc-util-node/index.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util-node/misc2_node.ts
+++ b/src/smc-util-node/misc2_node.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/aggregate.js
+++ b/src/smc-util/aggregate.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/async-utils.ts
+++ b/src/smc-util/async-utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/async-wait.ts
+++ b/src/smc-util/async-wait.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/code-formatter.ts
+++ b/src/smc-util/code-formatter.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/coffee-coverage-loader.js
+++ b/src/smc-util/coffee-coverage-loader.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/compute-images.js
+++ b/src/smc-util/compute-images.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/compute-states.js
+++ b/src/smc-util/compute-states.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/consts.ts
+++ b/src/smc-util/consts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/account-creation-actions.ts
+++ b/src/smc-util/db-schema/account-creation-actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/account-profiles.ts
+++ b/src/smc-util/db-schema/account-profiles.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/accounts.ts
+++ b/src/smc-util/db-schema/accounts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/auth.ts
+++ b/src/smc-util/db-schema/auth.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/blobs.ts
+++ b/src/smc-util/db-schema/blobs.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/central-log.ts
+++ b/src/smc-util/db-schema/central-log.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/client-db.ts
+++ b/src/smc-util/db-schema/client-db.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/client-error-log.ts
+++ b/src/smc-util/db-schema/client-error-log.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/collaborators.ts
+++ b/src/smc-util/db-schema/collaborators.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/compute-images.ts
+++ b/src/smc-util/db-schema/compute-images.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/compute-servers.ts
+++ b/src/smc-util/db-schema/compute-servers.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/copy-paths.ts
+++ b/src/smc-util/db-schema/copy-paths.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/defaults.ts
+++ b/src/smc-util/db-schema/defaults.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/file-access-log.ts
+++ b/src/smc-util/db-schema/file-access-log.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/file-use-times.ts
+++ b/src/smc-util/db-schema/file-use-times.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/file-use.ts
+++ b/src/smc-util/db-schema/file-use.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/hub-servers.ts
+++ b/src/smc-util/db-schema/hub-servers.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/index.ts
+++ b/src/smc-util/db-schema/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/instances.ts
+++ b/src/smc-util/db-schema/instances.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/listings.ts
+++ b/src/smc-util/db-schema/listings.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/lti.ts
+++ b/src/smc-util/db-schema/lti.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/mentions.ts
+++ b/src/smc-util/db-schema/mentions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/password-reset.ts
+++ b/src/smc-util/db-schema/password-reset.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/project-log.ts
+++ b/src/smc-util/db-schema/project-log.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/projects.ts
+++ b/src/smc-util/db-schema/projects.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/public-paths.ts
+++ b/src/smc-util/db-schema/public-paths.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/server-settings.ts
+++ b/src/smc-util/db-schema/server-settings.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/site-defaults.ts
+++ b/src/smc-util/db-schema/site-defaults.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/site-licenses.ts
+++ b/src/smc-util/db-schema/site-licenses.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/site-settings-extras.ts
+++ b/src/smc-util/db-schema/site-settings-extras.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/site-settings.ts
+++ b/src/smc-util/db-schema/site-settings.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/stats.ts
+++ b/src/smc-util/db-schema/stats.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/storage-servers.ts
+++ b/src/smc-util/db-schema/storage-servers.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/system-notifications.ts
+++ b/src/smc-util/db-schema/system-notifications.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/tracking.ts
+++ b/src/smc-util/db-schema/tracking.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/types.ts
+++ b/src/smc-util/db-schema/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/db-schema/webapp-errors.ts
+++ b/src/smc-util/db-schema/webapp-errors.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/delete-files.ts
+++ b/src/smc-util/delete-files.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/dmp.js
+++ b/src/smc-util/dmp.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/failing-to-save.ts
+++ b/src/smc-util/failing-to-save.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/fill/define.test.ts
+++ b/src/smc-util/fill/define.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/fill/define.ts
+++ b/src/smc-util/fill/define.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/fill/fill.test.ts
+++ b/src/smc-util/fill/fill.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/fill/fill.ts
+++ b/src/smc-util/fill/fill.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/fill/index.ts
+++ b/src/smc-util/fill/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/fill/types.ts
+++ b/src/smc-util/fill/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/heartbeat.js
+++ b/src/smc-util/heartbeat.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/immutable-types.js
+++ b/src/smc-util/immutable-types.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/index.js
+++ b/src/smc-util/index.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/key-value-store.js
+++ b/src/smc-util/key-value-store.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/markdown-utils.ts
+++ b/src/smc-util/markdown-utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/mathjax-config.js
+++ b/src/smc-util/mathjax-config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/mathjax-utils-2.js
+++ b/src/smc-util/mathjax-utils-2.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/mathjax-utils.js
+++ b/src/smc-util/mathjax-utils.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/message-types.ts
+++ b/src/smc-util/message-types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/message.js
+++ b/src/smc-util/message.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/misc.js
+++ b/src/smc-util/misc.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/misc2.ts
+++ b/src/smc-util/misc2.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/opts.js
+++ b/src/smc-util/opts.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/regex-split.js
+++ b/src/smc-util/regex-split.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sagews.ts
+++ b/src/smc-util/sagews.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/schema-static.ts
+++ b/src/smc-util/schema-static.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/schema-validate.js
+++ b/src/smc-util/schema-validate.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/schema.js
+++ b/src/smc-util/schema.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/smc-version.js
+++ b/src/smc-util/smc-version.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/db/doc.ts
+++ b/src/smc-util/sync/editor/db/doc.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/db/index.ts
+++ b/src/smc-util/sync/editor/db/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/db/sync.ts
+++ b/src/smc-util/sync/editor/db/sync.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/db/test/doc.test.ts
+++ b/src/smc-util/sync/editor/db/test/doc.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/db/util.ts
+++ b/src/smc-util/sync/editor/db/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/evaluator.ts
+++ b/src/smc-util/sync/editor/generic/evaluator.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/export.ts
+++ b/src/smc-util/sync/editor/generic/export.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/index.js
+++ b/src/smc-util/sync/editor/generic/index.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/ipywidgets-state.ts
+++ b/src/smc-util/sync/editor/generic/ipywidgets-state.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/patch-value-cache.ts
+++ b/src/smc-util/sync/editor/generic/patch-value-cache.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/sorted-patch-list.ts
+++ b/src/smc-util/sync/editor/generic/sorted-patch-list.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/sync-doc.ts
+++ b/src/smc-util/sync/editor/generic/sync-doc.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/test/patch-value-cache.test.ts
+++ b/src/smc-util/sync/editor/generic/test/patch-value-cache.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/test/sorted-patch-list.test.ts
+++ b/src/smc-util/sync/editor/generic/test/sorted-patch-list.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/test/util.test.ts
+++ b/src/smc-util/sync/editor/generic/test/util.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/types.ts
+++ b/src/smc-util/sync/editor/generic/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/generic/util.ts
+++ b/src/smc-util/sync/editor/generic/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/doc.ts
+++ b/src/smc-util/sync/editor/string/doc.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/index.js
+++ b/src/smc-util/sync/editor/string/index.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/sync.ts
+++ b/src/smc-util/sync/editor/string/sync.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/test/client-test.ts
+++ b/src/smc-util/sync/editor/string/test/client-test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/test/data.ts
+++ b/src/smc-util/sync/editor/string/test/data.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/test/doc.test.ts
+++ b/src/smc-util/sync/editor/string/test/doc.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/test/sync.0.test.ts
+++ b/src/smc-util/sync/editor/string/test/sync.0.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/test/sync.1.test.ts
+++ b/src/smc-util/sync/editor/string/test/sync.1.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/editor/string/test/sync.offline.test.ts
+++ b/src/smc-util/sync/editor/string/test/sync.offline.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/jest.config.js
+++ b/src/smc-util/sync/jest.config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/changefeed.ts
+++ b/src/smc-util/sync/table/changefeed.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/global-cache.ts
+++ b/src/smc-util/sync/table/global-cache.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/index.ts
+++ b/src/smc-util/sync/table/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/query-function.ts
+++ b/src/smc-util/sync/table/query-function.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/synctable-no-changefeed.ts
+++ b/src/smc-util/sync/table/synctable-no-changefeed.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/synctable-no-database.ts
+++ b/src/smc-util/sync/table/synctable-no-database.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/synctable.ts
+++ b/src/smc-util/sync/table/synctable.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/test/changefeed.test.ts
+++ b/src/smc-util/sync/table/test/changefeed.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/test/client-test.ts
+++ b/src/smc-util/sync/table/test/client-test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/test/synctable.0.test.ts
+++ b/src/smc-util/sync/table/test/synctable.0.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/test/util.test.ts
+++ b/src/smc-util/sync/table/test/util.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/sync/table/util.ts
+++ b/src/smc-util/sync/table/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/syncstring_schema.js
+++ b/src/smc-util/syncstring_schema.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/test/jest.config.js
+++ b/src/smc-util/test/jest.config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/test/misc2.test.ts
+++ b/src/smc-util/test/misc2.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/theme.js
+++ b/src/smc-util/theme.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/upgrade-spec.js
+++ b/src/smc-util/upgrade-spec.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-util/upgrades.js
+++ b/src/smc-util/upgrades.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_3d.sass
+++ b/src/smc-webapp/_3d.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_account-button.sass
+++ b/src/smc-webapp/_account-button.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_activity.sass
+++ b/src/smc-webapp/_activity.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_antd_fix.sass
+++ b/src/smc-webapp/_antd_fix.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_console.sass
+++ b/src/smc-webapp/_console.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_d3.sass
+++ b/src/smc-webapp/_d3.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_editor.sass
+++ b/src/smc-webapp/_editor.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_examples.sass
+++ b/src/smc-webapp/_examples.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_help.sass
+++ b/src/smc-webapp/_help.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_interact.sass
+++ b/src/smc-webapp/_interact.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_jsoninspector.sass
+++ b/src/smc-webapp/_jsoninspector.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_jupyter.sass
+++ b/src/smc-webapp/_jupyter.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_misc_page.sass
+++ b/src/smc-webapp/_misc_page.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_profile.sass
+++ b/src/smc-webapp/_profile.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_project_page.sass
+++ b/src/smc-webapp/_project_page.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_projects.sass
+++ b/src/smc-webapp/_projects.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/_projects_nav.sass
+++ b/src/smc-webapp/_projects_nav.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/actions.ts
+++ b/src/smc-webapp/account/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/dark-mode.ts
+++ b/src/smc-webapp/account/dark-mode.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/dates.ts
+++ b/src/smc-webapp/account/dates.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/default-file-name-generator.ts
+++ b/src/smc-webapp/account/default-file-name-generator.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/index.ts
+++ b/src/smc-webapp/account/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/init.ts
+++ b/src/smc-webapp/account/init.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/settings/strategies.ts
+++ b/src/smc-webapp/account/settings/strategies.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/store.ts
+++ b/src/smc-webapp/account/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/table.ts
+++ b/src/smc-webapp/account/table.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/test/preferences.ts
+++ b/src/smc-webapp/account/test/preferences.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/types.ts
+++ b/src/smc-webapp/account/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/account/util.ts
+++ b/src/smc-webapp/account/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/admin/index.ts
+++ b/src/smc-webapp/admin/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/admin/users/actions.ts
+++ b/src/smc-webapp/admin/users/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/admin/users/store.ts
+++ b/src/smc-webapp/admin/users/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/alerts.ts
+++ b/src/smc-webapp/alerts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework.ts
+++ b/src/smc-webapp/app-framework.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/Actions.ts
+++ b/src/smc-webapp/app-framework/Actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/ShallowTypedMap.ts
+++ b/src/smc-webapp/app-framework/ShallowTypedMap.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/Store.ts
+++ b/src/smc-webapp/app-framework/Store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/Table.ts
+++ b/src/smc-webapp/app-framework/Table.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/TypedMap.ts
+++ b/src/smc-webapp/app-framework/TypedMap.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/__tests__/deep-immutable.type.test.ts
+++ b/src/smc-webapp/app-framework/__tests__/deep-immutable.type.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/__tests__/getIn.test.ts
+++ b/src/smc-webapp/app-framework/__tests__/getIn.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/__tests__/store-get-in.type.test.ts
+++ b/src/smc-webapp/app-framework/__tests__/store-get-in.type.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/immutable-types.ts
+++ b/src/smc-webapp/app-framework/immutable-types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/app-framework/react-rendering-debug.ts
+++ b/src/smc-webapp/app-framework/react-rendering-debug.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/art.ts
+++ b/src/smc-webapp/art.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/billing/actions.ts
+++ b/src/smc-webapp/billing/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/billing/data.ts
+++ b/src/smc-webapp/billing/data.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/billing/store.ts
+++ b/src/smc-webapp/billing/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/billing/stripe.ts
+++ b/src/smc-webapp/billing/stripe.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/billing/types.ts
+++ b/src/smc-webapp/billing/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/chat/store.ts
+++ b/src/smc-webapp/chat/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/chat/utils.ts
+++ b/src/smc-webapp/chat/utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/account.ts
+++ b/src/smc-webapp/client/account.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/admin.ts
+++ b/src/smc-webapp/client/admin.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/anonymous-setup.ts
+++ b/src/smc-webapp/client/anonymous-setup.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/client.ts
+++ b/src/smc-webapp/client/client.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/console.ts
+++ b/src/smc-webapp/client/console.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/file.ts
+++ b/src/smc-webapp/client/file.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/handle-hash-url.ts
+++ b/src/smc-webapp/client/handle-hash-url.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/hub.ts
+++ b/src/smc-webapp/client/hub.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/idle.ts
+++ b/src/smc-webapp/client/idle.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/password-reset.ts
+++ b/src/smc-webapp/client/password-reset.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/project-collaborators.ts
+++ b/src/smc-webapp/client/project-collaborators.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/project.ts
+++ b/src/smc-webapp/client/project.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/query.ts
+++ b/src/smc-webapp/client/query.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/stripe.ts
+++ b/src/smc-webapp/client/stripe.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/support.ts
+++ b/src/smc-webapp/client/support.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/sync.ts
+++ b/src/smc-webapp/client/sync.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/time.ts
+++ b/src/smc-webapp/client/time.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/tracking.ts
+++ b/src/smc-webapp/client/tracking.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/users.ts
+++ b/src/smc-webapp/client/users.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/client/welcome-file.ts
+++ b/src/smc-webapp/client/welcome-file.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/addon/hint/python-hint.js
+++ b/src/smc-webapp/codemirror/addon/hint/python-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/addon/show-hint.css
+++ b/src/smc-webapp/codemirror/addon/show-hint.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/addon/smc-search.js
+++ b/src/smc-webapp/codemirror/addon/smc-search.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/ada.ts
+++ b/src/smc-webapp/codemirror/mode/ada.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/coffeescript2.js
+++ b/src/smc-webapp/codemirror/mode/coffeescript2.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/lean.ts
+++ b/src/smc-webapp/codemirror/mode/lean.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/less.js
+++ b/src/smc-webapp/codemirror/mode/less.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/makefile.js
+++ b/src/smc-webapp/codemirror/mode/makefile.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/mediawiki/mediawiki.css
+++ b/src/smc-webapp/codemirror/mode/mediawiki/mediawiki.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/mediawiki/mediawiki.js
+++ b/src/smc-webapp/codemirror/mode/mediawiki/mediawiki.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/ocaml.js
+++ b/src/smc-webapp/codemirror/mode/ocaml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/pari.js
+++ b/src/smc-webapp/codemirror/mode/pari.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/python.js
+++ b/src/smc-webapp/codemirror/mode/python.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/codemirror/mode/rst.js
+++ b/src/smc-webapp/codemirror/mode/rst.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/coffee-coverage-loader.js
+++ b/src/smc-webapp/coffee-coverage-loader.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/collaborators/style.scss
+++ b/src/smc-webapp/collaborators/style.scss
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/actions.ts
+++ b/src/smc-webapp/course/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/activity/actions.ts
+++ b/src/smc-webapp/course/activity/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/assignments/actions.ts
+++ b/src/smc-webapp/course/assignments/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/configuration/actions.ts
+++ b/src/smc-webapp/course/configuration/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/configuration/state-helpers.ts
+++ b/src/smc-webapp/course/configuration/state-helpers.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/export/actions.ts
+++ b/src/smc-webapp/course/export/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/export/export-assignment.ts
+++ b/src/smc-webapp/course/export/export-assignment.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/export/file-use-times.ts
+++ b/src/smc-webapp/course/export/file-use-times.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/handouts/actions.ts
+++ b/src/smc-webapp/course/handouts/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/project-upgrades.ts
+++ b/src/smc-webapp/course/project-upgrades.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/redux.ts
+++ b/src/smc-webapp/course/redux.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/shared-project/actions.ts
+++ b/src/smc-webapp/course/shared-project/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/store.ts
+++ b/src/smc-webapp/course/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/student-projects/actions.ts
+++ b/src/smc-webapp/course/student-projects/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/student-projects/run-in-all-projects.ts
+++ b/src/smc-webapp/course/student-projects/run-in-all-projects.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/students/actions.ts
+++ b/src/smc-webapp/course/students/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/styles.ts
+++ b/src/smc-webapp/course/styles.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/sync.ts
+++ b/src/smc-webapp/course/sync.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/types.ts
+++ b/src/smc-webapp/course/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/course/util.ts
+++ b/src/smc-webapp/course/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/custom-software/init.ts
+++ b/src/smc-webapp/custom-software/init.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/custom-software/util.ts
+++ b/src/smc-webapp/custom-software/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/editor-tmp.ts
+++ b/src/smc-webapp/editor-tmp.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/feature.ts
+++ b/src/smc-webapp/feature.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/file-editors.ts
+++ b/src/smc-webapp/file-editors.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/file-use/actions.ts
+++ b/src/smc-webapp/file-use/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/file-use/init.ts
+++ b/src/smc-webapp/file-use/init.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/file-use/store.ts
+++ b/src/smc-webapp/file-use/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/file-use/table.ts
+++ b/src/smc-webapp/file-use/table.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/file-use/util.ts
+++ b/src/smc-webapp/file-use/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/_style.sass
+++ b/src/smc-webapp/frame-editors/_style.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/code-editor-manager.ts
+++ b/src/smc-webapp/frame-editors/code-editor/code-editor-manager.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/doc.ts
+++ b/src/smc-webapp/frame-editors/code-editor/doc.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/code-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/keyboard.ts
+++ b/src/smc-webapp/frame-editors/code-editor/keyboard.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/register.ts
+++ b/src/smc-webapp/frame-editors/code-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/simulate_typing.ts
+++ b/src/smc-webapp/frame-editors/code-editor/simulate_typing.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/spell-check.ts
+++ b/src/smc-webapp/frame-editors/code-editor/spell-check.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/test/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/test/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/test/basic.ts
+++ b/src/smc-webapp/frame-editors/code-editor/test/basic.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/test/format.ts
+++ b/src/smc-webapp/frame-editors/code-editor/test/format.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/code-editor/test/frame.ts
+++ b/src/smc-webapp/frame-editors/code-editor/test/frame.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/codemirror/cm-options.ts
+++ b/src/smc-webapp/frame-editors/codemirror/cm-options.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/codemirror/codemirror-state.ts
+++ b/src/smc-webapp/frame-editors/codemirror/codemirror-state.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/codemirror/mobile.ts
+++ b/src/smc-webapp/frame-editors/codemirror/mobile.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/codemirror/util.ts
+++ b/src/smc-webapp/frame-editors/codemirror/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/course-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/course-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/course-editor/course-actions.ts
+++ b/src/smc-webapp/frame-editors/course-editor/course-actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/course-editor/course-panels.ts
+++ b/src/smc-webapp/frame-editors/course-editor/course-panels.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/course-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/course-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/course-editor/overview/index.ts
+++ b/src/smc-webapp/frame-editors/course-editor/overview/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/course-editor/register.ts
+++ b/src/smc-webapp/frame-editors/course-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/frame-tree/config.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/config.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/frame-tree/print-code.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/print-code.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/frame-tree/print.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/print.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/frame-tree/register.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/frame-tree/tree-ops.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/tree-ops.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/frame-tree/types.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/frame-tree/util.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/browser.ts
+++ b/src/smc-webapp/frame-editors/generic/browser.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/client.ts
+++ b/src/smc-webapp/frame-editors/generic/client.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/codemirror-plugins.ts
+++ b/src/smc-webapp/frame-editors/generic/codemirror-plugins.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/jquery-plugins.ts
+++ b/src/smc-webapp/frame-editors/generic/jquery-plugins.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/misc-page.ts
+++ b/src/smc-webapp/frame-editors/generic/misc-page.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/mocha-tests/misc.ts
+++ b/src/smc-webapp/frame-editors/generic/mocha-tests/misc.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/syncstring-fake.ts
+++ b/src/smc-webapp/frame-editors/generic/syncstring-fake.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/test/init.ts
+++ b/src/smc-webapp/frame-editors/generic/test/init.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/generic/test/util.ts
+++ b/src/smc-webapp/frame-editors/generic/test/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/html-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/html-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/html-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/html-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/html-editor/options.ts
+++ b/src/smc-webapp/frame-editors/html-editor/options.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/html-editor/register.ts
+++ b/src/smc-webapp/frame-editors/html-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/jupyter-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/jupyter-editor/cell-notebook/actions.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/cell-notebook/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/jupyter-editor/cell-notebook/store.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/cell-notebook/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/jupyter-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/jupyter-editor/jupyter-actions.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/jupyter-actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/jupyter-editor/register.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/jupyter-editor/slideshow-revealjs/nbconvert.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/slideshow-revealjs/nbconvert.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/bibtex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/bibtex.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/clean.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/clean.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/codemirror-autoclose-latex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/codemirror-autoclose-latex.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/constants.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/constants.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/count_words.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/count_words.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/experimental/latexjs.jsx
+++ b/src/smc-webapp/frame-editors/latex-editor/experimental/latexjs.jsx
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/experimental/peg.jsx
+++ b/src/smc-webapp/frame-editors/latex-editor/experimental/peg.jsx
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/knitr.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/knitr.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/latexmk.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latexmk.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/mouse-click.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/mouse-click.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/mouse-draggable.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/mouse-draggable.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/pdfjs-doc-cache.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/pdfjs-doc-cache.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/pythontex.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/register.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/sagetex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/sagetex.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/synctex.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/synctex.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/latex-editor/util.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/_lean.sass
+++ b/src/smc-webapp/frame-editors/lean-editor/_lean.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/codemirror-lean-symbols.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/codemirror-lean-symbols.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/register.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/symbols.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/symbols.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/tab-completion.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/tab-completion.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/lean-editor/types.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/markdown-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/markdown-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/markdown-editor/options.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/options.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/markdown-editor/register.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/markdown-editor/test/basic.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/test/basic.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/markdown-editor/test/math.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/test/math.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/pdf-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/pdf-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/pdf-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/pdf-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/pdf-editor/register.ts
+++ b/src/smc-webapp/frame-editors/pdf-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/register.ts
+++ b/src/smc-webapp/frame-editors/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rmd-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rmd-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rmd-editor/register.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rmd-editor/utils.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rst-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rst-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rst-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/rst-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rst-editor/register.ts
+++ b/src/smc-webapp/frame-editors/rst-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/rst-editor/rst2html.ts
+++ b/src/smc-webapp/frame-editors/rst-editor/rst2html.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/sagews-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/sagews-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/sagews-editor/code-executor.ts
+++ b/src/smc-webapp/frame-editors/sagews-editor/code-executor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/sagews-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/sagews-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/sagews-editor/flags.ts
+++ b/src/smc-webapp/frame-editors/sagews-editor/flags.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/sagews-editor/register.ts
+++ b/src/smc-webapp/frame-editors/sagews-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/sagews-editor/types.ts
+++ b/src/smc-webapp/frame-editors/sagews-editor/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/settings/aspell-dicts.ts
+++ b/src/smc-webapp/frame-editors/settings/aspell-dicts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/settings/types.ts
+++ b/src/smc-webapp/frame-editors/settings/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/terminal-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/terminal-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/terminal-editor/init-file.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/init-file.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/terminal-editor/register.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/terminal-editor/terminal-manager.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/terminal-manager.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/terminal-editor/themes.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/themes.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/time-travel-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/time-travel-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/time-travel-editor/diff-util.ts
+++ b/src/smc-webapp/frame-editors/time-travel-editor/diff-util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/time-travel-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/time-travel-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/time-travel-editor/export-to-json.ts
+++ b/src/smc-webapp/frame-editors/time-travel-editor/export-to-json.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/time-travel-editor/register.ts
+++ b/src/smc-webapp/frame-editors/time-travel-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/time-travel-editor/style.sass
+++ b/src/smc-webapp/frame-editors/time-travel-editor/style.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/time-travel-editor/util.ts
+++ b/src/smc-webapp/frame-editors/time-travel-editor/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/wiki-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/wiki-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/wiki-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/wiki-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/wiki-editor/register.ts
+++ b/src/smc-webapp/frame-editors/wiki-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/wiki-editor/wiki2html.ts
+++ b/src/smc-webapp/frame-editors/wiki-editor/wiki2html.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/apps.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/apps.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/editor.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/register.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/theme.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/theme.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra-client.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra-client.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/bencode.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/bencode.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/capabilities.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/capabilities.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/client.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/client.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/connection.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/connection.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/constants.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/constants.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/keyboard.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/keyboard.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/keyboards.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/keyboards.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/lz4.js
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/lz4.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/mouse.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/mouse.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/protocol.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/protocol.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/renderer.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/renderer.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/surface.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/surface.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/frame-editors/x11-editor/xpra/util.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/fullscreen.ts
+++ b/src/smc-webapp/fullscreen.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/history2.ts
+++ b/src/smc-webapp/history2.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/hooks.ts
+++ b/src/smc-webapp/hooks.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/iframe-communication.ts
+++ b/src/smc-webapp/iframe-communication.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/index.sass
+++ b/src/smc-webapp/index.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/info/style.ts
+++ b/src/smc-webapp/info/style.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jquery-plugins/katex.ts
+++ b/src/smc-webapp/jquery-plugins/katex.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jquery-plugins/tex2jax.ts
+++ b/src/smc-webapp/jquery-plugins/tex2jax.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/_jupyter.sass
+++ b/src/smc-webapp/jupyter/_jupyter.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/actions.ts
+++ b/src/smc-webapp/jupyter/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/browser-actions.ts
+++ b/src/smc-webapp/jupyter/browser-actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/cell-utils.ts
+++ b/src/smc-webapp/jupyter/cell-utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/cm_options.ts
+++ b/src/smc-webapp/jupyter/cm_options.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/commands.ts
+++ b/src/smc-webapp/jupyter/commands.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/contents.ts
+++ b/src/smc-webapp/jupyter/contents.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/cursor-manager.ts
+++ b/src/smc-webapp/jupyter/cursor-manager.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/export-to-ipynb.ts
+++ b/src/smc-webapp/jupyter/export-to-ipynb.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/find.ts
+++ b/src/smc-webapp/jupyter/find.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/help-links.ts
+++ b/src/smc-webapp/jupyter/help-links.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/history-actions.ts
+++ b/src/smc-webapp/jupyter/history-actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/iframe.ts
+++ b/src/smc-webapp/jupyter/iframe.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/import-from-ipynb.ts
+++ b/src/smc-webapp/jupyter/import-from-ipynb.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/jupyter-classic-support.ts
+++ b/src/smc-webapp/jupyter/jupyter-classic-support.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/keyboard.ts
+++ b/src/smc-webapp/jupyter/keyboard.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/actions.ts
+++ b/src/smc-webapp/jupyter/nbgrader/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/api.ts
+++ b/src/smc-webapp/jupyter/nbgrader/api.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/autograde.ts
+++ b/src/smc-webapp/jupyter/nbgrader/autograde.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/cell-types.ts
+++ b/src/smc-webapp/jupyter/nbgrader/cell-types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/clear-hidden-tests.ts
+++ b/src/smc-webapp/jupyter/nbgrader/clear-hidden-tests.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/clear-mark-regions.ts
+++ b/src/smc-webapp/jupyter/nbgrader/clear-mark-regions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/clear-solutions.ts
+++ b/src/smc-webapp/jupyter/nbgrader/clear-solutions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/compute-checksums.ts
+++ b/src/smc-webapp/jupyter/nbgrader/compute-checksums.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/store.ts
+++ b/src/smc-webapp/jupyter/nbgrader/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbgrader/types.ts
+++ b/src/smc-webapp/jupyter/nbgrader/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbviewer/actions.ts
+++ b/src/smc-webapp/jupyter/nbviewer/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbviewer/register.ts
+++ b/src/smc-webapp/jupyter/nbviewer/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/nbviewer/store.ts
+++ b/src/smc-webapp/jupyter/nbviewer/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/output-handler.ts
+++ b/src/smc-webapp/jupyter/output-handler.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/output-messages/ansi.ts
+++ b/src/smc-webapp/jupyter/output-messages/ansi.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/output-messages/javascript-eval.ts
+++ b/src/smc-webapp/jupyter/output-messages/javascript-eval.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/output-messages/style.ts
+++ b/src/smc-webapp/jupyter/output-messages/style.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/parsing.ts
+++ b/src/smc-webapp/jupyter/parsing.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/project-actions.ts
+++ b/src/smc-webapp/jupyter/project-actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/project-interface.ts
+++ b/src/smc-webapp/jupyter/project-interface.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/server-urls.ts
+++ b/src/smc-webapp/jupyter/server-urls.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/store.ts
+++ b/src/smc-webapp/jupyter/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/basic-tests-ts.ts
+++ b/src/smc-webapp/jupyter/test/basic-tests-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/cell-menu-ts.ts
+++ b/src/smc-webapp/jupyter/test/cell-menu-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/cell-utils-ts.ts
+++ b/src/smc-webapp/jupyter/test/cell-utils-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/complete-ts.ts
+++ b/src/smc-webapp/jupyter/test/complete-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/edit-menu-ts.ts
+++ b/src/smc-webapp/jupyter/test/edit-menu-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/export-to-ipynb-ts.ts
+++ b/src/smc-webapp/jupyter/test/export-to-ipynb-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/file-menu-ts.ts
+++ b/src/smc-webapp/jupyter/test/file-menu-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/find-ts.ts
+++ b/src/smc-webapp/jupyter/test/find-ts.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/test/travis.ts
+++ b/src/smc-webapp/jupyter/test/travis.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/types.ts
+++ b/src/smc-webapp/jupyter/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/util.ts
+++ b/src/smc-webapp/jupyter/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/widgets/comm.ts
+++ b/src/smc-webapp/jupyter/widgets/comm.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/widgets/controls.ts
+++ b/src/smc-webapp/jupyter/widgets/controls.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/widgets/manager.ts
+++ b/src/smc-webapp/jupyter/widgets/manager.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/jupyter/widgets/output.ts
+++ b/src/smc-webapp/jupyter/widgets/output.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/landing-page/hub-landing.ts
+++ b/src/smc-webapp/landing-page/hub-landing.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/landing-page/sign-in-hooks.ts
+++ b/src/smc-webapp/landing-page/sign-in-hooks.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/landing-page/util.ts
+++ b/src/smc-webapp/landing-page/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/launch/actions.ts
+++ b/src/smc-webapp/launch/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/launch/binder.ts
+++ b/src/smc-webapp/launch/binder.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/launch/custom-image.ts
+++ b/src/smc-webapp/launch/custom-image.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/launch/share.ts
+++ b/src/smc-webapp/launch/share.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/markdown.ts
+++ b/src/smc-webapp/markdown.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/misc-page/index.ts
+++ b/src/smc-webapp/misc-page/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/misc/browser.ts
+++ b/src/smc-webapp/misc/browser.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/misc/local-storage.ts
+++ b/src/smc-webapp/misc/local-storage.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/misc/query-params.ts
+++ b/src/smc-webapp/misc/query-params.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/misc/window-globals.ts
+++ b/src/smc-webapp/misc/window-globals.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/_style.sass
+++ b/src/smc-webapp/notifications/_style.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/index.ts
+++ b/src/smc-webapp/notifications/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/init.ts
+++ b/src/smc-webapp/notifications/init.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/mentions/actions.ts
+++ b/src/smc-webapp/notifications/mentions/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/mentions/index.ts
+++ b/src/smc-webapp/notifications/mentions/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/mentions/init.ts
+++ b/src/smc-webapp/notifications/mentions/init.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/mentions/store.ts
+++ b/src/smc-webapp/notifications/mentions/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/mentions/table.ts
+++ b/src/smc-webapp/notifications/mentions/table.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/mentions/types.ts
+++ b/src/smc-webapp/notifications/mentions/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notifications/mentions/util.ts
+++ b/src/smc-webapp/notifications/mentions/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/notify-resize/index.js
+++ b/src/smc-webapp/notify-resize/index.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/password-reset.ts
+++ b/src/smc-webapp/password-reset.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/process-links.ts
+++ b/src/smc-webapp/process-links.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/delete-files.ts
+++ b/src/smc-webapp/project/delete-files.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/directory-listing.ts
+++ b/src/smc-webapp/project/directory-listing.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/explorer/file-listing/index.ts
+++ b/src/smc-webapp/project/explorer/file-listing/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/explorer/file-listing/utils.ts
+++ b/src/smc-webapp/project/explorer/file-listing/utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/explorer/index.ts
+++ b/src/smc-webapp/project/explorer/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/explorer/types.ts
+++ b/src/smc-webapp/project/explorer/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/file-tab-labels.ts
+++ b/src/smc-webapp/project/file-tab-labels.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/history/index.ts
+++ b/src/smc-webapp/project/history/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/history/types.ts
+++ b/src/smc-webapp/project/history/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/new/index.ts
+++ b/src/smc-webapp/project/new/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/new/types.ts
+++ b/src/smc-webapp/project/new/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/open-files.ts
+++ b/src/smc-webapp/project/open-files.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/settings/index.ts
+++ b/src/smc-webapp/project/settings/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/settings/types.ts
+++ b/src/smc-webapp/project/settings/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/transform-get-url.ts
+++ b/src/smc-webapp/project/transform-get-url.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/utils.ts
+++ b/src/smc-webapp/project/utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/websocket/api.ts
+++ b/src/smc-webapp/project/websocket/api.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/websocket/connect.ts
+++ b/src/smc-webapp/project/websocket/connect.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/websocket/listings.ts
+++ b/src/smc-webapp/project/websocket/listings.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/websocket/synctable.ts
+++ b/src/smc-webapp/project/websocket/synctable.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/websocket/types.ts
+++ b/src/smc-webapp/project/websocket/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project/websocket/websocket-state.ts
+++ b/src/smc-webapp/project/websocket/websocket-state.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project_configuration.ts
+++ b/src/smc-webapp/project_configuration.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/project_store.ts
+++ b/src/smc-webapp/project_store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/r_misc/share-server.ts
+++ b/src/smc-webapp/r_misc/share-server.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/render.js
+++ b/src/smc-webapp/render.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/sagews/parse-sagews.ts
+++ b/src/smc-webapp/sagews/parse-sagews.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/session.ts
+++ b/src/smc-webapp/session.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/set-version-cookie.js
+++ b/src/smc-webapp/set-version-cookie.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/share/config/licenses.ts
+++ b/src/smc-webapp/share/config/licenses.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/share/config/util.ts
+++ b/src/smc-webapp/share/config/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/share/extensions.ts
+++ b/src/smc-webapp/share/extensions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/share/server-render.ts
+++ b/src/smc-webapp/share/server-render.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/share/types.ts
+++ b/src/smc-webapp/share/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/site-licenses/admin/actions.ts
+++ b/src/smc-webapp/site-licenses/admin/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/site-licenses/admin/store.ts
+++ b/src/smc-webapp/site-licenses/admin/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/site-licenses/admin/types.ts
+++ b/src/smc-webapp/site-licenses/admin/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/site-licenses/admin/upgrade-presets.ts
+++ b/src/smc-webapp/site-licenses/admin/upgrade-presets.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/site-licenses/types.ts
+++ b/src/smc-webapp/site-licenses/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/site-licenses/util.ts
+++ b/src/smc-webapp/site-licenses/util.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/stopwatch/actions.ts
+++ b/src/smc-webapp/stopwatch/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/stopwatch/register.ts
+++ b/src/smc-webapp/stopwatch/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/tasks/_tasks.sass
+++ b/src/smc-webapp/tasks/_tasks.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/tasks/register.ts
+++ b/src/smc-webapp/tasks/register.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/test-mocha/setup.ts
+++ b/src/smc-webapp/test-mocha/setup.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/test-mocha/test.ts
+++ b/src/smc-webapp/test-mocha/test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/test/history2.test.ts
+++ b/src/smc-webapp/test/history2.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/test/iframe-comm.test.ts
+++ b/src/smc-webapp/test/iframe-comm.test.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/todo-types.ts
+++ b/src/smc-webapp/todo-types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/tracker/index.ts
+++ b/src/smc-webapp/tracker/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/upgrades/upgrade-utils.ts
+++ b/src/smc-webapp/upgrades/upgrade-utils.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/user-tracking.ts
+++ b/src/smc-webapp/user-tracking.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/users/actions.ts
+++ b/src/smc-webapp/users/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/users/index.ts
+++ b/src/smc-webapp/users/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/users/store.ts
+++ b/src/smc-webapp/users/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/users/table.ts
+++ b/src/smc-webapp/users/table.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/users/types.ts
+++ b/src/smc-webapp/users/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/webapp-client.ts
+++ b/src/smc-webapp/webapp-client.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/webapp-hooks.ts
+++ b/src/smc-webapp/webapp-hooks.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/widget-markdown-input/actions.ts
+++ b/src/smc-webapp/widget-markdown-input/actions.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/widget-markdown-input/info.ts
+++ b/src/smc-webapp/widget-markdown-input/info.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/smc-webapp/widget-markdown-input/store.ts
+++ b/src/smc-webapp/widget-markdown-input/store.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/.eslintrc.js
+++ b/src/test/puppeteer/.eslintrc.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/.prettierrc.js
+++ b/src/test/puppeteer/.prettierrc.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/api_create_file.ts
+++ b/src/test/puppeteer/src/api_create_file.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/api_create_project.ts
+++ b/src/test/puppeteer/src/api_create_project.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/api_project_exec.ts
+++ b/src/test/puppeteer/src/api_project_exec.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/api_session.ts
+++ b/src/test/puppeteer/src/api_session.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/create_account.ts
+++ b/src/test/puppeteer/src/create_account.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/del_hide_project.ts
+++ b/src/test/puppeteer/src/del_hide_project.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/get_account_id.ts
+++ b/src/test/puppeteer/src/get_account_id.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/get_api_key.ts
+++ b/src/test/puppeteer/src/get_api_key.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/get_auth_token.ts
+++ b/src/test/puppeteer/src/get_auth_token.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/get_project_id.ts
+++ b/src/test/puppeteer/src/get_project_id.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/get_project_status.ts
+++ b/src/test/puppeteer/src/get_project_status.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/gui_is_admin.ts
+++ b/src/test/puppeteer/src/gui_is_admin.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/install_files.ts
+++ b/src/test/puppeteer/src/install_files.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/login_session.ts
+++ b/src/test/puppeteer/src/login_session.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/screenshot.ts
+++ b/src/test/puppeteer/src/screenshot.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/sign_up.ts
+++ b/src/test/puppeteer/src/sign_up.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/test_driver.ts
+++ b/src/test/puppeteer/src/test_driver.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/test_ir.ts
+++ b/src/test/puppeteer/src/test_ir.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/test_sage_ker.ts
+++ b/src/test/puppeteer/src/test_sage_ker.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/test_sagews.ts
+++ b/src/test/puppeteer/src/test_sagews.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/test_shared_file.ts
+++ b/src/test/puppeteer/src/test_shared_file.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/test_tex.ts
+++ b/src/test/puppeteer/src/test_tex.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/test_widget.ts
+++ b/src/test/puppeteer/src/test_widget.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/time_log.ts
+++ b/src/test/puppeteer/src/time_log.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/test/puppeteer/src/types.ts
+++ b/src/test/puppeteer/src/types.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-cocalc.js
+++ b/src/webapp-cocalc.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-css.js
+++ b/src/webapp-css.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/_base.sass
+++ b/src/webapp-lib/_base.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/_vars.sass
+++ b/src/webapp-lib/_vars.sass
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/app-startup-style.css
+++ b/src/webapp-lib/app-startup-style.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/bootstrap-3.3.0/css/bootstrap-theme.css
+++ b/src/webapp-lib/bootstrap-3.3.0/css/bootstrap-theme.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/bootstrap-3.3.0/css/bootstrap-theme.min.css
+++ b/src/webapp-lib/bootstrap-3.3.0/css/bootstrap-theme.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/bootstrap-3.3.0/css/bootstrap.css
+++ b/src/webapp-lib/bootstrap-3.3.0/css/bootstrap.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/bootstrap-3.3.0/css/bootstrap.min.css
+++ b/src/webapp-lib/bootstrap-3.3.0/css/bootstrap.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/bootstrap-3.3.0/js/bootstrap.js
+++ b/src/webapp-lib/bootstrap-3.3.0/js/bootstrap.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/bootstrap-3.3.0/js/bootstrap.min.js
+++ b/src/webapp-lib/bootstrap-3.3.0/js/bootstrap.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/bootstrap-3.3.0/js/npm.js
+++ b/src/webapp-lib/bootstrap-3.3.0/js/npm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/cocalc-icons-font/style.css
+++ b/src/webapp-lib/cocalc-icons-font/style.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/coffeescript/coffee-script.js
+++ b/src/webapp-lib/coffeescript/coffee-script.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/datetimepicker/bootstrap-datetimepicker.min.css
+++ b/src/webapp-lib/datetimepicker/bootstrap-datetimepicker.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/datetimepicker/bootstrap-datetimepicker.min.js
+++ b/src/webapp-lib/datetimepicker/bootstrap-datetimepicker.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/dropzone/css/basic.css
+++ b/src/webapp-lib/dropzone/css/basic.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/dropzone/css/dropzone.css
+++ b/src/webapp-lib/dropzone/css/dropzone.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/auth/css/override.css
+++ b/src/webapp-lib/ipython/auth/css/override.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/auth/js/loginmain.js
+++ b/src/webapp-lib/ipython/auth/js/loginmain.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/auth/js/loginwidget.js
+++ b/src/webapp-lib/ipython/auth/js/loginwidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/auth/js/logoutmain.js
+++ b/src/webapp-lib/ipython/auth/js/logoutmain.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/dialog.js
+++ b/src/webapp-lib/ipython/base/js/dialog.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/events.js
+++ b/src/webapp-lib/ipython/base/js/events.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/keyboard.js
+++ b/src/webapp-lib/ipython/base/js/keyboard.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/namespace.js
+++ b/src/webapp-lib/ipython/base/js/namespace.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/page.js
+++ b/src/webapp-lib/ipython/base/js/page.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/pagemain.js
+++ b/src/webapp-lib/ipython/base/js/pagemain.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/security.js
+++ b/src/webapp-lib/ipython/base/js/security.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/base/js/utils.js
+++ b/src/webapp-lib/ipython/base/js/utils.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/backbone/backbone-min.js
+++ b/src/webapp-lib/ipython/components/backbone/backbone-min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/bootstrap-tour/build/css/bootstrap-tour.min.css
+++ b/src/webapp-lib/ipython/components/bootstrap-tour/build/css/bootstrap-tour.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/bootstrap-tour/build/js/bootstrap-tour.min.js
+++ b/src/webapp-lib/ipython/components/bootstrap-tour/build/js/bootstrap-tour.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/bootstrap/bootstrap/js/bootstrap.min.js
+++ b/src/webapp-lib/ipython/components/bootstrap/bootstrap/js/bootstrap.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/comment/comment.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/comment/comment.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/comment/continuecomment.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/comment/continuecomment.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/dialog/dialog.css
+++ b/src/webapp-lib/ipython/components/codemirror/addon/dialog/dialog.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/dialog/dialog.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/dialog/dialog.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/display/fullscreen.css
+++ b/src/webapp-lib/ipython/components/codemirror/addon/display/fullscreen.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/display/fullscreen.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/display/fullscreen.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/display/placeholder.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/display/placeholder.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/display/rulers.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/display/rulers.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/edit/closebrackets.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/edit/closebrackets.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/edit/closetag.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/edit/closetag.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/edit/continuelist.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/edit/continuelist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/edit/matchbrackets.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/edit/matchbrackets.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/edit/matchtags.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/edit/matchtags.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/edit/trailingspace.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/edit/trailingspace.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/brace-fold.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/brace-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/comment-fold.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/comment-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/foldcode.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/foldcode.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/foldgutter.css
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/foldgutter.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/foldgutter.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/foldgutter.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/indent-fold.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/indent-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/markdown-fold.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/markdown-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/fold/xml-fold.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/fold/xml-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/anyword-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/anyword-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/css-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/css-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/html-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/html-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/javascript-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/javascript-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/pig-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/pig-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/python-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/python-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/show-hint.css
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/show-hint.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/show-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/show-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/sql-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/sql-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/hint/xml-hint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/hint/xml-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/lint/coffeescript-lint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/lint/coffeescript-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/lint/css-lint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/lint/css-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/lint/javascript-lint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/lint/javascript-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/lint/json-lint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/lint/json-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/lint/lint.css
+++ b/src/webapp-lib/ipython/components/codemirror/addon/lint/lint.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/lint/lint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/lint/lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/lint/yaml-lint.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/lint/yaml-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/merge/dep/diff_match_patch.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/merge/dep/diff_match_patch.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/merge/merge.css
+++ b/src/webapp-lib/ipython/components/codemirror/addon/merge/merge.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/merge/merge.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/merge/merge.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/mode/loadmode.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/mode/loadmode.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/mode/multiplex.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/mode/multiplex.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/mode/multiplex_test.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/mode/multiplex_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/mode/overlay.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/mode/overlay.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/runmode/colorize.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/runmode/colorize.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/runmode/runmode-standalone.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/runmode/runmode-standalone.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/runmode/runmode.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/runmode/runmode.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/runmode/runmode.node.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/runmode/runmode.node.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/scroll/scrollpastend.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/scroll/scrollpastend.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/search/match-highlighter.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/search/match-highlighter.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/search/search.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/search/search.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/search/searchcursor.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/search/searchcursor.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/selection/active-line.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/selection/active-line.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/selection/mark-selection.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/selection/mark-selection.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/tern/tern.css
+++ b/src/webapp-lib/ipython/components/codemirror/addon/tern/tern.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/tern/tern.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/tern/tern.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/tern/worker.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/tern/worker.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/addon/wrap/hardwrap.js
+++ b/src/webapp-lib/ipython/components/codemirror/addon/wrap/hardwrap.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/keymap/emacs.js
+++ b/src/webapp-lib/ipython/components/codemirror/keymap/emacs.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/keymap/extra.js
+++ b/src/webapp-lib/ipython/components/codemirror/keymap/extra.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/keymap/vim.js
+++ b/src/webapp-lib/ipython/components/codemirror/keymap/vim.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/lib/codemirror.css
+++ b/src/webapp-lib/ipython/components/codemirror/lib/codemirror.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/lib/codemirror.js
+++ b/src/webapp-lib/ipython/components/codemirror/lib/codemirror.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/apl/apl.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/apl/apl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/asterisk/asterisk.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/asterisk/asterisk.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/clike/clike.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/clike/clike.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/clojure/clojure.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/clojure/clojure.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/cobol/cobol.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/cobol/cobol.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/coffeescript/coffeescript.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/coffeescript/coffeescript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/commonlisp/commonlisp.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/commonlisp/commonlisp.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/css/css.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/css/css.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/css/less_test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/css/less_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/css/scss_test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/css/scss_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/css/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/css/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/d/d.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/d/d.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/diff/diff.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/diff/diff.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/dtd/dtd.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/dtd/dtd.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/ecl/ecl.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/ecl/ecl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/eiffel/eiffel.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/eiffel/eiffel.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/erlang/erlang.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/erlang/erlang.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/fortran/fortran.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/fortran/fortran.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/gas/gas.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/gas/gas.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/gfm/gfm.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/gfm/gfm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/gfm/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/gfm/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/gherkin/gherkin.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/gherkin/gherkin.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/go/go.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/go/go.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/groovy/groovy.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/groovy/groovy.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/haml/haml.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/haml/haml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/haml/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/haml/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/haskell/haskell.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/haskell/haskell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/haxe/haxe.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/haxe/haxe.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/htmlembedded/htmlembedded.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/htmlembedded/htmlembedded.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/htmlmixed/htmlmixed.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/htmlmixed/htmlmixed.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/http/http.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/http/http.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/jade/jade.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/jade/jade.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/javascript/javascript.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/javascript/javascript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/javascript/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/javascript/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/jinja2/jinja2.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/jinja2/jinja2.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/julia/julia.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/julia/julia.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/less/less.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/less/less.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/livescript/livescript.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/livescript/livescript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/lua/lua.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/lua/lua.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/markdown/markdown.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/markdown/markdown.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/markdown/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/markdown/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/meta.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/meta.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/mirc/mirc.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/mirc/mirc.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/mllike/mllike.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/mllike/mllike.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/nginx/nginx.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/nginx/nginx.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/ntriples/ntriples.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/ntriples/ntriples.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/octave/octave.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/octave/octave.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/pascal/pascal.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/pascal/pascal.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/pegjs/pegjs.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/pegjs/pegjs.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/perl/perl.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/perl/perl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/php/php.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/php/php.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/pig/pig.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/pig/pig.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/properties/properties.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/properties/properties.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/puppet/puppet.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/puppet/puppet.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/python/python.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/python/python.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/q/q.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/q/q.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/r/r.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/r/r.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/rpm/changes/changes.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/rpm/changes/changes.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/rpm/spec/spec.css
+++ b/src/webapp-lib/ipython/components/codemirror/mode/rpm/spec/spec.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/rpm/spec/spec.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/rpm/spec/spec.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/rst/rst.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/rst/rst.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/ruby/ruby.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/ruby/ruby.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/ruby/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/ruby/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/rust/rust.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/rust/rust.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/sass/sass.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/sass/sass.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/scheme/scheme.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/scheme/scheme.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/shell/shell.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/shell/shell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/sieve/sieve.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/sieve/sieve.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/smalltalk/smalltalk.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/smalltalk/smalltalk.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/smarty/smarty.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/smarty/smarty.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/smartymixed/smartymixed.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/smartymixed/smartymixed.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/solr/solr.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/solr/solr.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/sparql/sparql.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/sparql/sparql.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/sql/sql.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/sql/sql.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/stex/stex.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/stex/stex.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/stex/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/stex/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/tcl/tcl.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/tcl/tcl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/tiddlywiki/tiddlywiki.css
+++ b/src/webapp-lib/ipython/components/codemirror/mode/tiddlywiki/tiddlywiki.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/tiddlywiki/tiddlywiki.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/tiddlywiki/tiddlywiki.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/tiki/tiki.css
+++ b/src/webapp-lib/ipython/components/codemirror/mode/tiki/tiki.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/tiki/tiki.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/tiki/tiki.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/toml/toml.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/toml/toml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/turtle/turtle.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/turtle/turtle.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/vb/vb.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/vb/vb.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/vbscript/vbscript.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/vbscript/vbscript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/velocity/velocity.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/velocity/velocity.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/verilog/verilog.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/verilog/verilog.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/xml/xml.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/xml/xml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/xquery/test.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/xquery/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/xquery/xquery.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/xquery/xquery.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/yaml/yaml.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/yaml/yaml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/mode/z80/z80.js
+++ b/src/webapp-lib/ipython/components/codemirror/mode/z80/z80.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/3024-day.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/3024-day.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/3024-night.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/3024-night.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/ambiance-mobile.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/ambiance-mobile.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/ambiance.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/ambiance.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/base16-dark.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/base16-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/base16-light.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/base16-light.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/blackboard.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/blackboard.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/cobalt.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/cobalt.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/eclipse.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/eclipse.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/elegant.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/elegant.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/erlang-dark.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/erlang-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/lesser-dark.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/lesser-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/mbo.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/mbo.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/mdn-like.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/mdn-like.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/midnight.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/midnight.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/monokai.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/monokai.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/neat.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/neat.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/night.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/night.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/paraiso-dark.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/paraiso-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/paraiso-light.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/paraiso-light.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/pastel-on-dark.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/pastel-on-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/rubyblue.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/rubyblue.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/solarized.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/solarized.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/the-matrix.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/the-matrix.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/tomorrow-night-eighties.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/tomorrow-night-eighties.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/twilight.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/twilight.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/vibrant-ink.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/vibrant-ink.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/xq-dark.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/xq-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/codemirror/theme/xq-light.css
+++ b/src/webapp-lib/ipython/components/codemirror/theme/xq-light.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/google-caja/html-css-sanitizer-minified.js
+++ b/src/webapp-lib/ipython/components/google-caja/html-css-sanitizer-minified.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/highlight.js/build/highlight.pack.js
+++ b/src/webapp-lib/ipython/components/highlight.js/build/highlight.pack.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/jquery-ui/themes/smoothness/jquery-ui.min.css
+++ b/src/webapp-lib/ipython/components/jquery-ui/themes/smoothness/jquery-ui.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/jquery-ui/ui/minified/jquery-ui.min.js
+++ b/src/webapp-lib/ipython/components/jquery-ui/ui/minified/jquery-ui.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/jquery/jquery.min.js
+++ b/src/webapp-lib/ipython/components/jquery/jquery.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/marked/lib/marked.js
+++ b/src/webapp-lib/ipython/components/marked/lib/marked.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/requirejs/require.js
+++ b/src/webapp-lib/ipython/components/requirejs/require.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/components/underscore/underscore-min.js
+++ b/src/webapp-lib/ipython/components/underscore/underscore-min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/custom/custom.css
+++ b/src/webapp-lib/ipython/custom/custom.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/custom/custom.js
+++ b/src/webapp-lib/ipython/custom/custom.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/dateformat/date.format.js
+++ b/src/webapp-lib/ipython/dateformat/date.format.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/css/override.css
+++ b/src/webapp-lib/ipython/notebook/css/override.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/cell.js
+++ b/src/webapp-lib/ipython/notebook/js/cell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/celltoolbar.js
+++ b/src/webapp-lib/ipython/notebook/js/celltoolbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/default.js
+++ b/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/default.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/example.js
+++ b/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/example.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/rawcell.js
+++ b/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/rawcell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/slideshow.js
+++ b/src/webapp-lib/ipython/notebook/js/celltoolbarpresets/slideshow.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/codecell.js
+++ b/src/webapp-lib/ipython/notebook/js/codecell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/codemirror-ipython.js
+++ b/src/webapp-lib/ipython/notebook/js/codemirror-ipython.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/completer.js
+++ b/src/webapp-lib/ipython/notebook/js/completer.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/config.js
+++ b/src/webapp-lib/ipython/notebook/js/config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/contexthint.js
+++ b/src/webapp-lib/ipython/notebook/js/contexthint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/keyboardmanager.js
+++ b/src/webapp-lib/ipython/notebook/js/keyboardmanager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/layoutmanager.js
+++ b/src/webapp-lib/ipython/notebook/js/layoutmanager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/main.js
+++ b/src/webapp-lib/ipython/notebook/js/main.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/maintoolbar.js
+++ b/src/webapp-lib/ipython/notebook/js/maintoolbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/mathjaxutils.js
+++ b/src/webapp-lib/ipython/notebook/js/mathjaxutils.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/menubar.js
+++ b/src/webapp-lib/ipython/notebook/js/menubar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/notebook.js
+++ b/src/webapp-lib/ipython/notebook/js/notebook.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/notificationarea.js
+++ b/src/webapp-lib/ipython/notebook/js/notificationarea.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/notificationwidget.js
+++ b/src/webapp-lib/ipython/notebook/js/notificationwidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/outputarea.js
+++ b/src/webapp-lib/ipython/notebook/js/outputarea.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/pager.js
+++ b/src/webapp-lib/ipython/notebook/js/pager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/quickhelp.js
+++ b/src/webapp-lib/ipython/notebook/js/quickhelp.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/savewidget.js
+++ b/src/webapp-lib/ipython/notebook/js/savewidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/textcell.js
+++ b/src/webapp-lib/ipython/notebook/js/textcell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/toolbar.js
+++ b/src/webapp-lib/ipython/notebook/js/toolbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/tooltip.js
+++ b/src/webapp-lib/ipython/notebook/js/tooltip.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/notebook/js/tour.js
+++ b/src/webapp-lib/ipython/notebook/js/tour.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/services/kernels/js/comm.js
+++ b/src/webapp-lib/ipython/services/kernels/js/comm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/services/kernels/js/kernel.js
+++ b/src/webapp-lib/ipython/services/kernels/js/kernel.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/services/sessions/js/session.js
+++ b/src/webapp-lib/ipython/services/sessions/js/session.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/style/ipython.min.css
+++ b/src/webapp-lib/ipython/style/ipython.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/style/style.min.css
+++ b/src/webapp-lib/ipython/style/style.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/tree/css/override.css
+++ b/src/webapp-lib/ipython/tree/css/override.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/tree/js/clusterlist.js
+++ b/src/webapp-lib/ipython/tree/js/clusterlist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/tree/js/kernellist.js
+++ b/src/webapp-lib/ipython/tree/js/kernellist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/tree/js/main.js
+++ b/src/webapp-lib/ipython/tree/js/main.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/tree/js/notebooklist.js
+++ b/src/webapp-lib/ipython/tree/js/notebooklist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/tree/js/sessionlist.js
+++ b/src/webapp-lib/ipython/tree/js/sessionlist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/init.js
+++ b/src/webapp-lib/ipython/widgets/js/init.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/manager.js
+++ b/src/webapp-lib/ipython/widgets/js/manager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget.js
+++ b/src/webapp-lib/ipython/widgets/js/widget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_bool.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_bool.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_button.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_button.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_container.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_container.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_float.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_float.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_image.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_image.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_int.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_int.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_selection.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_selection.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_selectioncontainer.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_selectioncontainer.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/ipython/widgets/js/widget_string.js
+++ b/src/webapp-lib/ipython/widgets/js/widget_string.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/jquery-ui/css/humanity/jquery-ui.css
+++ b/src/webapp-lib/jquery/jquery-ui/css/humanity/jquery-ui.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/jquery-ui/js/jquery-ui.min.js
+++ b/src/webapp-lib/jquery/jquery-ui/js/jquery-ui.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/jquery.min.js
+++ b/src/webapp-lib/jquery/jquery.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/bootstrap-colorpicker/css/bootstrap-colorpicker.css
+++ b/src/webapp-lib/jquery/plugins/bootstrap-colorpicker/css/bootstrap-colorpicker.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/bootstrap-colorpicker/js/bootstrap-colorpicker.js
+++ b/src/webapp-lib/jquery/plugins/bootstrap-colorpicker/js/bootstrap-colorpicker.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/bootstrap_hide_show.js
+++ b/src/webapp-lib/jquery/plugins/bootstrap_hide_show.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/caret/jquery.caret.js
+++ b/src/webapp-lib/jquery/plugins/caret/jquery.caret.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/jquery.highlight.js
+++ b/src/webapp-lib/jquery/plugins/jquery.highlight.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/jquery.highlight.min.js
+++ b/src/webapp-lib/jquery/plugins/jquery.highlight.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/jquery.scrollintoview.min.js
+++ b/src/webapp-lib/jquery/plugins/jquery.scrollintoview.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/jquery.timeago.js
+++ b/src/webapp-lib/jquery/plugins/jquery.timeago.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/jquery.timeago.min.js
+++ b/src/webapp-lib/jquery/plugins/jquery.timeago.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/jquery.ui.touch-punch.min.js
+++ b/src/webapp-lib/jquery/plugins/jquery.ui.touch-punch.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jquery/plugins/themeswitchertool.js
+++ b/src/webapp-lib/jquery/plugins/themeswitchertool.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jsbeautify/beautify-html.js
+++ b/src/webapp-lib/jsbeautify/beautify-html.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jsbeautify/beautify-html.min.js
+++ b/src/webapp-lib/jsbeautify/beautify-html.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jsxgraph/geonext.min.js
+++ b/src/webapp-lib/jsxgraph/geonext.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jsxgraph/jsxgraph.css
+++ b/src/webapp-lib/jsxgraph/jsxgraph.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jsxgraph/jsxgraphcore.js
+++ b/src/webapp-lib/jsxgraph/jsxgraphcore.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/auth/css/override.css
+++ b/src/webapp-lib/jupyter/auth/css/override.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/auth/js/loginmain.js
+++ b/src/webapp-lib/jupyter/auth/js/loginmain.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/auth/js/loginwidget.js
+++ b/src/webapp-lib/jupyter/auth/js/loginwidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/auth/js/logoutmain.js
+++ b/src/webapp-lib/jupyter/auth/js/logoutmain.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/dialog.js
+++ b/src/webapp-lib/jupyter/base/js/dialog.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/events.js
+++ b/src/webapp-lib/jupyter/base/js/events.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/keyboard.js
+++ b/src/webapp-lib/jupyter/base/js/keyboard.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/namespace.js
+++ b/src/webapp-lib/jupyter/base/js/namespace.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/notificationarea.js
+++ b/src/webapp-lib/jupyter/base/js/notificationarea.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/notificationwidget.js
+++ b/src/webapp-lib/jupyter/base/js/notificationwidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/page.js
+++ b/src/webapp-lib/jupyter/base/js/page.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/pagemain.js
+++ b/src/webapp-lib/jupyter/base/js/pagemain.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/security.js
+++ b/src/webapp-lib/jupyter/base/js/security.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/base/js/utils.js
+++ b/src/webapp-lib/jupyter/base/js/utils.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/backbone/backbone-min.js
+++ b/src/webapp-lib/jupyter/components/backbone/backbone-min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/bootstrap-tour/build/css/bootstrap-tour.min.css
+++ b/src/webapp-lib/jupyter/components/bootstrap-tour/build/css/bootstrap-tour.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/bootstrap-tour/build/js/bootstrap-tour.min.js
+++ b/src/webapp-lib/jupyter/components/bootstrap-tour/build/js/bootstrap-tour.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/bootstrap/bootstrap/js/bootstrap.min.js
+++ b/src/webapp-lib/jupyter/components/bootstrap/bootstrap/js/bootstrap.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/bootstrap/js/bootstrap.min.js
+++ b/src/webapp-lib/jupyter/components/bootstrap/js/bootstrap.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/comment/comment.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/comment/comment.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/comment/continuecomment.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/comment/continuecomment.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/dialog/dialog.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/dialog/dialog.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/dialog/dialog.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/dialog/dialog.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/display/fullscreen.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/display/fullscreen.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/display/fullscreen.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/display/fullscreen.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/display/panel.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/display/panel.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/display/placeholder.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/display/placeholder.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/display/rulers.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/display/rulers.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/edit/closebrackets.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/edit/closebrackets.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/edit/closetag.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/edit/closetag.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/edit/continuelist.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/edit/continuelist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/edit/matchbrackets.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/edit/matchbrackets.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/edit/matchtags.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/edit/matchtags.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/edit/trailingspace.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/edit/trailingspace.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/brace-fold.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/brace-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/comment-fold.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/comment-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/foldcode.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/foldcode.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/foldgutter.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/foldgutter.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/foldgutter.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/foldgutter.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/indent-fold.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/indent-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/markdown-fold.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/markdown-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/fold/xml-fold.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/fold/xml-fold.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/anyword-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/anyword-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/css-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/css-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/html-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/html-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/javascript-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/javascript-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/pig-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/pig-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/python-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/python-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/show-hint.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/show-hint.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/show-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/show-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/sql-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/sql-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/hint/xml-hint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/hint/xml-hint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/lint/coffeescript-lint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/lint/coffeescript-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/lint/css-lint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/lint/css-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/lint/javascript-lint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/lint/javascript-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/lint/json-lint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/lint/json-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/lint/lint.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/lint/lint.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/lint/lint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/lint/lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/lint/yaml-lint.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/lint/yaml-lint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/merge/dep/diff_match_patch.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/merge/dep/diff_match_patch.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/merge/merge.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/merge/merge.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/merge/merge.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/merge/merge.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/mode/loadmode.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/mode/loadmode.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/mode/multiplex.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/mode/multiplex.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/mode/multiplex_test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/mode/multiplex_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/mode/overlay.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/mode/overlay.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/mode/simple.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/mode/simple.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/runmode/colorize.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/runmode/colorize.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/runmode/runmode-standalone.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/runmode/runmode-standalone.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/runmode/runmode.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/runmode/runmode.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/runmode/runmode.node.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/runmode/runmode.node.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/scroll/annotatescrollbar.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/scroll/annotatescrollbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/scroll/scrollpastend.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/scroll/scrollpastend.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/scroll/simplescrollbars.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/scroll/simplescrollbars.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/scroll/simplescrollbars.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/scroll/simplescrollbars.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/search/match-highlighter.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/search/match-highlighter.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/search/matchesonscrollbar.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/search/matchesonscrollbar.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/search/matchesonscrollbar.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/search/matchesonscrollbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/search/search.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/search/search.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/search/searchcursor.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/search/searchcursor.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/selection/active-line.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/selection/active-line.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/selection/mark-selection.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/selection/mark-selection.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/tern/tern.css
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/tern/tern.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/tern/tern.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/tern/tern.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/tern/worker.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/tern/worker.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/addon/wrap/hardwrap.js
+++ b/src/webapp-lib/jupyter/components/codemirror/addon/wrap/hardwrap.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/keymap/emacs.js
+++ b/src/webapp-lib/jupyter/components/codemirror/keymap/emacs.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/keymap/extra.js
+++ b/src/webapp-lib/jupyter/components/codemirror/keymap/extra.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/keymap/sublime.js
+++ b/src/webapp-lib/jupyter/components/codemirror/keymap/sublime.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/keymap/vim.js
+++ b/src/webapp-lib/jupyter/components/codemirror/keymap/vim.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/lib/codemirror.css
+++ b/src/webapp-lib/jupyter/components/codemirror/lib/codemirror.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/lib/codemirror.js
+++ b/src/webapp-lib/jupyter/components/codemirror/lib/codemirror.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/apl/apl.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/apl/apl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/asterisk/asterisk.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/asterisk/asterisk.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/clike/clike.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/clike/clike.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/clojure/clojure.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/clojure/clojure.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/cobol/cobol.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/cobol/cobol.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/coffeescript/coffeescript.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/coffeescript/coffeescript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/commonlisp/commonlisp.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/commonlisp/commonlisp.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/css/css.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/css/css.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/css/less_test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/css/less_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/css/scss_test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/css/scss_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/css/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/css/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/cypher/cypher.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/cypher/cypher.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/d/d.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/d/d.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/dart/dart.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/dart/dart.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/diff/diff.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/diff/diff.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/django/django.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/django/django.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/dockerfile/dockerfile.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/dockerfile/dockerfile.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/dtd/dtd.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/dtd/dtd.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/dylan/dylan.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/dylan/dylan.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/ebnf/ebnf.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/ebnf/ebnf.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/ecl/ecl.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/ecl/ecl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/eiffel/eiffel.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/eiffel/eiffel.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/erlang/erlang.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/erlang/erlang.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/fortran/fortran.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/fortran/fortran.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/gas/gas.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/gas/gas.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/gfm/gfm.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/gfm/gfm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/gfm/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/gfm/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/gherkin/gherkin.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/gherkin/gherkin.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/go/go.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/go/go.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/groovy/groovy.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/groovy/groovy.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/haml/haml.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/haml/haml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/haml/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/haml/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/haskell/haskell.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/haskell/haskell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/haxe/haxe.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/haxe/haxe.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/htmlembedded/htmlembedded.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/htmlembedded/htmlembedded.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/htmlmixed/htmlmixed.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/htmlmixed/htmlmixed.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/http/http.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/http/http.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/idl/idl.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/idl/idl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/jade/jade.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/jade/jade.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/javascript/javascript.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/javascript/javascript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/javascript/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/javascript/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/jinja2/jinja2.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/jinja2/jinja2.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/julia/julia.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/julia/julia.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/kotlin/kotlin.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/kotlin/kotlin.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/less/less.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/less/less.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/livescript/livescript.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/livescript/livescript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/lua/lua.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/lua/lua.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/markdown/markdown.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/markdown/markdown.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/markdown/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/markdown/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/meta.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/meta.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/mirc/mirc.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/mirc/mirc.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/mllike/mllike.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/mllike/mllike.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/modelica/modelica.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/modelica/modelica.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/nginx/nginx.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/nginx/nginx.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/ntriples/ntriples.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/ntriples/ntriples.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/octave/octave.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/octave/octave.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/pascal/pascal.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/pascal/pascal.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/pegjs/pegjs.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/pegjs/pegjs.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/perl/perl.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/perl/perl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/php/php.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/php/php.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/php/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/php/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/pig/pig.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/pig/pig.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/properties/properties.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/properties/properties.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/puppet/puppet.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/puppet/puppet.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/python/python.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/python/python.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/q/q.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/q/q.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/r/r.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/r/r.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/rpm/changes/changes.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/rpm/changes/changes.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/rpm/rpm.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/rpm/rpm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/rpm/spec/spec.css
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/rpm/spec/spec.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/rpm/spec/spec.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/rpm/spec/spec.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/rst/rst.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/rst/rst.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/ruby/ruby.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/ruby/ruby.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/ruby/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/ruby/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/rust/rust.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/rust/rust.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/sass/sass.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/sass/sass.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/scheme/scheme.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/scheme/scheme.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/shell/shell.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/shell/shell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/shell/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/shell/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/sieve/sieve.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/sieve/sieve.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/slim/slim.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/slim/slim.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/slim/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/slim/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/smalltalk/smalltalk.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/smalltalk/smalltalk.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/smarty/smarty.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/smarty/smarty.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/smartymixed/smartymixed.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/smartymixed/smartymixed.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/solr/solr.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/solr/solr.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/soy/soy.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/soy/soy.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/sparql/sparql.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/sparql/sparql.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/spreadsheet/spreadsheet.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/spreadsheet/spreadsheet.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/sql/sql.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/sql/sql.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/stex/stex.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/stex/stex.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/stex/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/stex/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/tcl/tcl.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/tcl/tcl.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/textile/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/textile/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/textile/textile.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/textile/textile.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/tiddlywiki/tiddlywiki.css
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/tiddlywiki/tiddlywiki.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/tiddlywiki/tiddlywiki.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/tiddlywiki/tiddlywiki.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/tiki/tiki.css
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/tiki/tiki.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/tiki/tiki.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/tiki/tiki.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/toml/toml.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/toml/toml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/tornado/tornado.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/tornado/tornado.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/turtle/turtle.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/turtle/turtle.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/vb/vb.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/vb/vb.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/vbscript/vbscript.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/vbscript/vbscript.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/velocity/velocity.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/velocity/velocity.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/verilog/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/verilog/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/verilog/verilog.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/verilog/verilog.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/xml/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/xml/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/xml/xml.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/xml/xml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/xquery/test.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/xquery/test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/xquery/xquery.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/xquery/xquery.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/yaml/yaml.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/yaml/yaml.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/mode/z80/z80.js
+++ b/src/webapp-lib/jupyter/components/codemirror/mode/z80/z80.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/3024-day.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/3024-day.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/3024-night.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/3024-night.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/ambiance-mobile.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/ambiance-mobile.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/ambiance.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/ambiance.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/base16-dark.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/base16-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/base16-light.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/base16-light.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/blackboard.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/blackboard.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/cobalt.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/cobalt.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/eclipse.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/eclipse.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/elegant.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/elegant.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/erlang-dark.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/erlang-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/lesser-dark.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/lesser-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/mbo.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/mbo.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/mdn-like.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/mdn-like.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/midnight.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/midnight.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/monokai.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/monokai.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/neat.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/neat.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/neo.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/neo.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/night.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/night.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/paraiso-dark.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/paraiso-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/paraiso-light.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/paraiso-light.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/pastel-on-dark.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/pastel-on-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/rubyblue.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/rubyblue.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/solarized.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/solarized.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/the-matrix.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/the-matrix.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/tomorrow-night-bright.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/tomorrow-night-bright.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/tomorrow-night-eighties.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/tomorrow-night-eighties.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/twilight.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/twilight.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/vibrant-ink.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/vibrant-ink.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/xq-dark.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/xq-dark.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/xq-light.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/xq-light.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/codemirror/theme/zenburn.css
+++ b/src/webapp-lib/jupyter/components/codemirror/theme/zenburn.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/es6-promise/promise.js
+++ b/src/webapp-lib/jupyter/components/es6-promise/promise.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/es6-promise/promise.min.js
+++ b/src/webapp-lib/jupyter/components/es6-promise/promise.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/google-caja/html-css-sanitizer-minified.js
+++ b/src/webapp-lib/jupyter/components/google-caja/html-css-sanitizer-minified.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/highlight.js/build/highlight.pack.js
+++ b/src/webapp-lib/jupyter/components/highlight.js/build/highlight.pack.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/jquery-ui/themes/smoothness/jquery-ui.min.css
+++ b/src/webapp-lib/jupyter/components/jquery-ui/themes/smoothness/jquery-ui.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/jquery-ui/ui/minified/jquery-ui.min.js
+++ b/src/webapp-lib/jupyter/components/jquery-ui/ui/minified/jquery-ui.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/jquery/jquery.min.js
+++ b/src/webapp-lib/jupyter/components/jquery/jquery.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/marked/lib/marked.js
+++ b/src/webapp-lib/jupyter/components/marked/lib/marked.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/moment/min/moment.min.js
+++ b/src/webapp-lib/jupyter/components/moment/min/moment.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/moment/moment.js
+++ b/src/webapp-lib/jupyter/components/moment/moment.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/requirejs/require.js
+++ b/src/webapp-lib/jupyter/components/requirejs/require.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/term.js/src/term.js
+++ b/src/webapp-lib/jupyter/components/term.js/src/term.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/text-encoding/lib/encoding.js
+++ b/src/webapp-lib/jupyter/components/text-encoding/lib/encoding.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/components/underscore/underscore-min.js
+++ b/src/webapp-lib/jupyter/components/underscore/underscore-min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/custom/custom.css
+++ b/src/webapp-lib/jupyter/custom/custom.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/custom/custom.js
+++ b/src/webapp-lib/jupyter/custom/custom.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/dateformat/date.format.js
+++ b/src/webapp-lib/jupyter/dateformat/date.format.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/edit/js/editor.js
+++ b/src/webapp-lib/jupyter/edit/js/editor.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/edit/js/main.js
+++ b/src/webapp-lib/jupyter/edit/js/main.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/edit/js/menubar.js
+++ b/src/webapp-lib/jupyter/edit/js/menubar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/edit/js/notificationarea.js
+++ b/src/webapp-lib/jupyter/edit/js/notificationarea.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/edit/js/savewidget.js
+++ b/src/webapp-lib/jupyter/edit/js/savewidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/css/override.css
+++ b/src/webapp-lib/jupyter/notebook/css/override.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/about.js
+++ b/src/webapp-lib/jupyter/notebook/js/about.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/actions.js
+++ b/src/webapp-lib/jupyter/notebook/js/actions.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/cell.js
+++ b/src/webapp-lib/jupyter/notebook/js/cell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/celltoolbar.js
+++ b/src/webapp-lib/jupyter/notebook/js/celltoolbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/default.js
+++ b/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/default.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/example.js
+++ b/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/example.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/rawcell.js
+++ b/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/rawcell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/slideshow.js
+++ b/src/webapp-lib/jupyter/notebook/js/celltoolbarpresets/slideshow.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/codecell.js
+++ b/src/webapp-lib/jupyter/notebook/js/codecell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/codemirror-ipython.js
+++ b/src/webapp-lib/jupyter/notebook/js/codemirror-ipython.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/codemirror-ipythongfm.js
+++ b/src/webapp-lib/jupyter/notebook/js/codemirror-ipythongfm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/completer.js
+++ b/src/webapp-lib/jupyter/notebook/js/completer.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/config.js
+++ b/src/webapp-lib/jupyter/notebook/js/config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/contexthint.js
+++ b/src/webapp-lib/jupyter/notebook/js/contexthint.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/kernelselector.js
+++ b/src/webapp-lib/jupyter/notebook/js/kernelselector.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/keyboardmanager.js
+++ b/src/webapp-lib/jupyter/notebook/js/keyboardmanager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/layoutmanager.js
+++ b/src/webapp-lib/jupyter/notebook/js/layoutmanager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/main.js
+++ b/src/webapp-lib/jupyter/notebook/js/main.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/maintoolbar.js
+++ b/src/webapp-lib/jupyter/notebook/js/maintoolbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/mathjaxutils.js
+++ b/src/webapp-lib/jupyter/notebook/js/mathjaxutils.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/menubar.js
+++ b/src/webapp-lib/jupyter/notebook/js/menubar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/notebook.js
+++ b/src/webapp-lib/jupyter/notebook/js/notebook.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/notificationarea.js
+++ b/src/webapp-lib/jupyter/notebook/js/notificationarea.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/notificationwidget.js
+++ b/src/webapp-lib/jupyter/notebook/js/notificationwidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/outputarea.js
+++ b/src/webapp-lib/jupyter/notebook/js/outputarea.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/pager.js
+++ b/src/webapp-lib/jupyter/notebook/js/pager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/quickhelp.js
+++ b/src/webapp-lib/jupyter/notebook/js/quickhelp.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/savewidget.js
+++ b/src/webapp-lib/jupyter/notebook/js/savewidget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/scrollmanager.js
+++ b/src/webapp-lib/jupyter/notebook/js/scrollmanager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/textcell.js
+++ b/src/webapp-lib/jupyter/notebook/js/textcell.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/toolbar.js
+++ b/src/webapp-lib/jupyter/notebook/js/toolbar.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/tooltip.js
+++ b/src/webapp-lib/jupyter/notebook/js/tooltip.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/notebook/js/tour.js
+++ b/src/webapp-lib/jupyter/notebook/js/tour.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/config.js
+++ b/src/webapp-lib/jupyter/services/config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/contents.js
+++ b/src/webapp-lib/jupyter/services/contents.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/kernels/comm.js
+++ b/src/webapp-lib/jupyter/services/kernels/comm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/kernels/js/comm.js
+++ b/src/webapp-lib/jupyter/services/kernels/js/comm.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/kernels/js/kernel.js
+++ b/src/webapp-lib/jupyter/services/kernels/js/kernel.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/kernels/kernel.js
+++ b/src/webapp-lib/jupyter/services/kernels/kernel.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/kernels/serialize.js
+++ b/src/webapp-lib/jupyter/services/kernels/serialize.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/sessions/js/session.js
+++ b/src/webapp-lib/jupyter/services/sessions/js/session.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/services/sessions/session.js
+++ b/src/webapp-lib/jupyter/services/sessions/session.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/style/ipython.min.css
+++ b/src/webapp-lib/jupyter/style/ipython.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/style/style.min.css
+++ b/src/webapp-lib/jupyter/style/style.min.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/terminal/css/override.css
+++ b/src/webapp-lib/jupyter/terminal/css/override.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/terminal/js/main.js
+++ b/src/webapp-lib/jupyter/terminal/js/main.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/terminal/js/terminado.js
+++ b/src/webapp-lib/jupyter/terminal/js/terminado.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/css/override.css
+++ b/src/webapp-lib/jupyter/tree/css/override.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/js/clusterlist.js
+++ b/src/webapp-lib/jupyter/tree/js/clusterlist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/js/kernellist.js
+++ b/src/webapp-lib/jupyter/tree/js/kernellist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/js/main.js
+++ b/src/webapp-lib/jupyter/tree/js/main.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/js/newnotebook.js
+++ b/src/webapp-lib/jupyter/tree/js/newnotebook.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/js/notebooklist.js
+++ b/src/webapp-lib/jupyter/tree/js/notebooklist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/js/sessionlist.js
+++ b/src/webapp-lib/jupyter/tree/js/sessionlist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/tree/js/terminallist.js
+++ b/src/webapp-lib/jupyter/tree/js/terminallist.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/init.js
+++ b/src/webapp-lib/jupyter/widgets/js/init.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/manager.js
+++ b/src/webapp-lib/jupyter/widgets/js/manager.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_bool.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_bool.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_box.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_box.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_button.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_button.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_container.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_container.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_float.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_float.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_image.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_image.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_int.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_int.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_link.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_link.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_output.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_output.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_selection.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_selection.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_selectioncontainer.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_selectioncontainer.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/jupyter/widgets/js/widget_string.js
+++ b/src/webapp-lib/jupyter/widgets/js/widget_string.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/framing.css
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/framing.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/opera.css
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/opera.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/outline.css
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/outline.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/pretty.css
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/pretty.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/print.css
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/print.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/s5-core.css
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/s5-core.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/slides.css
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/slides.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/misc/talk-20121004/ui/default/slides.js
+++ b/src/webapp-lib/misc/talk-20121004/ui/default/slides.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/preflight-checks.ts
+++ b/src/webapp-lib/preflight-checks.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/primus/update-primus.js
+++ b/src/webapp-lib/primus/update-primus.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/rainbow/generic.js
+++ b/src/webapp-lib/rainbow/generic.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/rainbow/python.js
+++ b/src/webapp-lib/rainbow/python.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/rainbow/rainbow.min.js
+++ b/src/webapp-lib/rainbow/rainbow.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/rainbow/salvus.css
+++ b/src/webapp-lib/rainbow/salvus.css
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/sockjs/sockjs.min.js
+++ b/src/webapp-lib/sockjs/sockjs.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/spin/spin.min.js
+++ b/src/webapp-lib/spin/spin.min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/term/color_themes.js
+++ b/src/webapp-lib/term/color_themes.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/term/term.js
+++ b/src/webapp-lib/term/term.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/threejs/r73/CanvasRenderer.js
+++ b/src/webapp-lib/threejs/r73/CanvasRenderer.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/threejs/r73/Detector.js
+++ b/src/webapp-lib/threejs/r73/Detector.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/threejs/r73/OrbitControls.js
+++ b/src/webapp-lib/threejs/r73/OrbitControls.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/threejs/r73/Projector.js
+++ b/src/webapp-lib/threejs/r73/Projector.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/xyjax/fp.js
+++ b/src/webapp-lib/xyjax/fp.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webapp-lib/xyjax/xypic-min.js
+++ b/src/webapp-lib/xyjax/xypic-min.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */


### PR DESCRIPTION
# Description
this is just to get rid of one end-of-line space char, that's all

# Testing Steps
* `git diff --numstat master...` only shows "1   1 ...", hence no unexpected changes.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
