### PR TITLE
webapp/pdf viewer:  fix upperase extensions 

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/pdfjs-doc-cache.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/pdfjs-doc-cache.ts
@@ -47,7 +47,8 @@ export function url_to_pdf(
   path: string,
   reload: number
 ): string {
-  return `${raw_url(project_id, encode_path(pdf_path(path)))}?param=${reload}`;
+  const url = raw_url(project_id, encode_path(pdf_path(path)))
+  return `${url}?param=${reload}`;
 }
 
 const doc_cache = new LRU(options);

--- a/src/smc-webapp/frame-editors/latex-editor/util.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/util.ts
@@ -3,12 +3,13 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-/*
-data and functions specific to the latex editor.
-*/
+// data and functions specific to the latex editor.
 
-import { change_filename_extension } from "smc-util/misc2";
+import { separate_file_extension } from "smc-util/misc2";
 
 export function pdf_path(path: string): string {
-  return change_filename_extension(path, "pdf");
+  // if it is already a pdf, don't change the upper/lower casing -- #4562
+  const { name, ext } = separate_file_extension(path);
+  if (ext.toLowerCase() == "pdf") return path;
+  return `${name}.pdf`;
 }


### PR DESCRIPTION
# Description
simple fix for #4562

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
