### PR TITLE
only query analytics.js in a commerical setup

### DIFF
--- a/src/smc-hub/open-cocalc-server.ts
+++ b/src/smc-hub/open-cocalc-server.ts
@@ -62,6 +62,7 @@ async function get_params(opts: GetData) {
   const ORGANIZATION_NAME = settings.organization_name;
   const ORGANIZATION_URL = settings.organization_url;
   const HELP_EMAIL = settings.help_email;
+  const COMMERCIAL = settings.commercial;
 
   const data = {
     // to be compatible with webpack
@@ -69,6 +70,7 @@ async function get_params(opts: GetData) {
       options: {
         BASE_URL,
         PREFIX,
+        COMMERCIAL,
       },
     },
     PREFIX,

--- a/src/smc-util/db-schema/site-defaults.ts
+++ b/src/smc-util/db-schema/site-defaults.ts
@@ -224,7 +224,7 @@ export const site_settings_conf: SiteSettings = {
   commercial: {
     name: "Commercial",
     desc:
-      "Whether or not to include user interface elements related to for-pay upgrades and features.  Set to 'yes' to include these elements.",
+      "Whether or not to include user interface elements related to for-pay upgrades and other features.  Set to 'yes' to include these elements.",
     default: "no",
     valid: only_booleans,
     to_val: to_bool,

--- a/src/webapp-lib/_inc_analytics.pug
+++ b/src/webapp-lib/_inc_analytics.pug
@@ -24,4 +24,5 @@ if typeof GOOGLE_ANALYTICS == "string" && GOOGLE_ANALYTICS.length > 0
     //--- End Google Analytics ---
 
 //- cocalc analytics
-script(async defer type="text/javascript" src=htmlWebpackPlugin.options.BASE_URL + '/analytics.js?fqd=false')
+if htmlWebpackPlugin.options.COMMERCIAL
+  script(async defer type="text/javascript" src=htmlWebpackPlugin.options.BASE_URL + '/analytics.js?fqd=false')

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -126,6 +126,7 @@ const PRODMODE = NODE_ENV !== DEVEL;
 const COMP_ENV =
   (process.env.CC_COMP_ENV || PRODMODE) &&
   fs.existsSync("webapp-lib/compute-components.json");
+const COMMERCIAL = !!COMP_ENV; // assume to be in the commercial setup, if we show the compute environment
 let { CDN_BASE_URL } = process.env; // CDN_BASE_URL must have a trailing slash
 const DEVMODE = !PRODMODE;
 const MINIFY = !!process.env.WP_MINIFY;
@@ -322,6 +323,7 @@ const pug2app = new HtmlWebpackPlugin({
   template: path.join(INPUT, "app.pug"),
   minify: htmlMinifyOpts,
   GOOGLE_ANALYTICS,
+  COMMERCIAL,
 });
 
 // global css loader configuration


### PR DESCRIPTION


# Description
addresses #4584 

add a "commercial" env variable for the templates and introduce it in webpack and the open cocalc server

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
