### PR TITLE
hub/server queries: process all default values as well

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -272,7 +272,11 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     for config in [SERVER_SETTINGS_EXTRAS, SITE_SETTINGS_CONF]
                         for ckey in Object.keys(config)
                             if (not x[ckey]?) or x[ckey] == ''
-                                x[ckey] = config[ckey].default
+                                conf = config[ckey]
+                                if conf?.to_val?
+                                    x[ckey] = conf.to_val(conf.default)
+                                else
+                                    x[ckey] = conf.default
                     SERVER_SETTINGS_CACHE.set('server_settings', x)
                     #dbg("server_settings = #{JSON.stringify(x, null, 2)}")
                     opts.cb(undefined, x)

--- a/src/smc-hub/utils.ts
+++ b/src/smc-hub/utils.ts
@@ -7,7 +7,6 @@ import * as fs from "fs";
 const winston = require("./winston-metrics").get_logger("utils");
 import { PostgreSQL } from "./postgres/types";
 import { AllSiteSettings } from "../smc-util/db-schema/types";
-import { pii_retention_parse } from "../smc-util/db-schema/site-settings-extras";
 import { expire_time } from "smc-util/misc";
 
 export function get_smc_root(): string {
@@ -50,7 +49,7 @@ export async function pii_expire<T extends object>(
   data?: T & { expire?: Date }
 ): Promise<Date | undefined> {
   const settings = await get_server_settings(db);
-  const secs : number | false = pii_retention_parse(settings.pii_retention);
+  const secs: number | false = settings.pii_retention;
   if (!secs) return;
   const future: Date = expire_time(secs);
   if (data != null) {


### PR DESCRIPTION
# Description

so, with that, if `pii_retention` isn't set, it results in `false` as a boolean. :champagne: 

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
