### PR TITLE
hub/auth: wrapping twitter, email for facebook and twitter

### DIFF
--- a/src/smc-hub/package-lock.json
+++ b/src/smc-hub/package-lock.json
@@ -1288,16 +1288,6 @@
         }
       }
     },
-    "@passport-next/passport-oauth1": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@passport-next/passport-oauth1/-/passport-oauth1-1.2.0.tgz",
-      "integrity": "sha512-pZV36AHsaKiZSMsUNItMLJe5rBfk/JICWEjFyhNrlj+37w81sYeAbXFWhvfZhYZDrPAS/em/PhNnJVyWf0EAeg==",
-      "requires": {
-        "@passport-next/passport-strategy": "1.x.x",
-        "lodash": "4.17.x",
-        "oauth": "0.9.x"
-      }
-    },
     "@passport-next/passport-oauth2": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@passport-next/passport-oauth2/-/passport-oauth2-2.1.0.tgz",
@@ -1312,15 +1302,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@passport-next/passport-strategy/-/passport-strategy-1.1.0.tgz",
       "integrity": "sha512-2KhFjtPueJG6xVj2HnqXt9BlANOfYCVLyu+pXYjPGBDT8yk+vQwc/6tsceIj+mayKcoxMau2JimggXRPHgoc8w=="
-    },
-    "@passport-next/passport-twitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@passport-next/passport-twitter/-/passport-twitter-1.1.0.tgz",
-      "integrity": "sha512-bGj/UrP6drdXFiQ8TrDMPZcltoo0y89GOhrgIoZYm1OSja52bTbgSm02bWBD1DsO1gK28IGpSXvMdABPq206HQ==",
-      "requires": {
-        "@passport-next/passport-oauth1": "1.2.x",
-        "xtraverse": "^0.1.0"
-      }
     },
     "@sendgrid/client": {
       "version": "6.5.1",
@@ -8478,6 +8459,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
+    "passport-twitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/passport-twitter/-/passport-twitter-1.0.4.tgz",
+      "integrity": "sha1-AaeZ4fdgvy3knyul+6MigvGJMtc=",
+      "requires": {
+        "passport-oauth1": "1.x.x",
+        "xtraverse": "0.1.x"
+      }
     },
     "password-hash": {
       "version": "1.2.2",

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@passport-next/passport-google-oauth2": "^1.0.0",
     "@passport-next/passport-oauth2": "^2.1.0",
-    "@passport-next/passport-twitter": "^1.1.0",
     "@sendgrid/client": "^6.5.1",
     "@types/http-proxy": "^1.17.3",
     "@types/node": "^12.12.28",
@@ -59,6 +58,7 @@
     "passport-oauth2": "^1.5.0",
     "passport-orcid": "0.0.4",
     "passport-saml": "^1.3.3",
+    "passport-twitter": "^1.0.4",
     "password-hash": "^1.2.2",
     "pdfkit": "^0.7.1",
     "pg": "^6.1.0",


### PR DESCRIPTION
# Description
so ,this fixes twitter, and it also sets up everything to get the email address out of facebook and twitter. twitter doesn't work, though, because we need new credentials. I didn't want to mess around with this.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
