### PR TITLE
webapp/breadcrumb nav: don't forget history when going back home

### DIFF
--- a/src/smc-webapp/project/explorer/path-navigator.tsx
+++ b/src/smc-webapp/project/explorer/path-navigator.tsx
@@ -36,13 +36,10 @@ export function PathNavigator({
     const is_root = current_path[0] === "/";
 
     const current_path_depth =
-      current_path == "" ? 0 : current_path.split("/").length - 1;
+      (current_path == "" ? 0 : current_path.split("/").length) - 1;
     const history_segments = history_path.split("/");
-    for (let i = 0; i < history_segments.length; i++) {
-      const segment = history_segments[i];
-      if (is_root && i === 0) {
-        continue;
-      }
+    history_segments.forEach((segment, i) => {
+      if (is_root && i === 0) return;
       const is_current = i === current_path_depth;
       const is_history = i > current_path_depth;
       v.push(
@@ -56,7 +53,7 @@ export function PathNavigator({
           history={is_history}
         />
       );
-    }
+    });
     return v;
   }
 

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -1457,7 +1457,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
       return;
     }
     let history_path = store.get("history_path") || "";
-    const is_adjacent = !`${history_path}/`.startsWith(`${path}/`);
+    const is_adjacent = path.length > 0 && !history_path.startsWith(path);
     // given is_adjacent is false, this tests if it is a subdirectory
     const is_nested = path.length > history_path.length;
     if (is_adjacent || is_nested) {


### PR DESCRIPTION
# Description
this is a simple fix to not forget the nav history when going back to "home" and well, the depth calculation must be tweaked a little bit to avoid an off-by-one error.

# Testing Steps
navigate 2 or 3 dirs deep, switch between files and check how the path looks, also switch between files in paths that are not in a parent/child relationship.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
