### PR TITLE
webapp: fix xsl syntax highlighting -- fixes #4613

### DIFF
--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -93,7 +93,7 @@ const codemirror_associations: { [ext: string]: string } = {
   xml: "xml",
   cml: "xml", // http://www.xml-cml.org/, e.g. used by avogadro
   kml: "xml", // https://de.wikipedia.org/wiki/Keyhole_Markup_Language
-  xsl: "xsl",
+  xsl: "xml",
   v: "verilog",
   vh: "verilog",
   "": "text",


### PR DESCRIPTION
# Description
see #4613

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
