### PR TITLE
webapp/latex: make detecting of multifiles more robust 

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -669,8 +669,8 @@ export class Actions extends BaseActions<LatexEditorState> {
     this.set_build_logs({ latex: output });
     // TODO: knitr complicates multifile a lot, so we do
     // not support it yet.
-    if (!this.knitr && this.parsed_output_log.files != null) {
-      this.set_switch_to_files(this.parsed_output_log.files);
+    if (!this.knitr && this.parsed_output_log.deps != null) {
+      this.set_switch_to_files(this.parsed_output_log.deps);
     }
     this.check_for_fatal_error();
     this.update_gutters();

--- a/src/smc-webapp/frame-editors/latex-editor/latexmk.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latexmk.ts
@@ -142,6 +142,7 @@ export function build_command(
     "-f",
     "-g",
     "-bibtex",
+    "-deps",
     "-synctex=1",
     "-interaction=nonstopmode",
   ];


### PR DESCRIPTION
# Description
this uses latexmk to detect all the files making up the project. this is more robust than reading the log. e.g. there is a large example (internally only) which breaks somewhere and only some files show up. this is negative side effects regarding saving and building the project.

# Testing Steps
* for multifile documents, all filename show up in the dropdown list.
* an important case are existing documents. for that,
  *  I did first go back to `master` → reload page → select build command → no `-deps` → closed tex file
  *  then I checked the `.*.syncdb` file that it is saved (as an array)
  * checked out this branch  → build → reload page
  *  opened the tex file and then it inserted `-deps`. saving the file, I confirmed it also changed the syncdb file. (this didn't work the first time around, not sure why)
  * then I manually edited the build command and removed `-deps` (saved as a string in syncdb file)
  * reload page → reopen tex file  → and `-deps` is there again.

for the second case I added an additional sanitization function.


# Relevant Issues
#4618

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
