### PR TITLE
software table: fix excessive width and closing of info box

### DIFF
--- a/src/smc-webapp/info/info.tsx
+++ b/src/smc-webapp/info/info.tsx
@@ -155,10 +155,10 @@ const InfoPageElement = rclass<{}>(
               ) : undefined}
             </Row>
             <Row>
-              <ComputeEnvironment />
+              <hr />
             </Row>
+            <ComputeEnvironment />
           </Col>
-          <Col sm={1} md={2}></Col>
           <Col xs={12} sm={12} md={12}>
             <Footer />
           </Col>


### PR DESCRIPTION
# Description
This fixes the width of the executables table, uses Row/Col of that antd wrapper, and somehow closing the info box was broken.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
