### PR TITLE
Ptx xml 4632

### DIFF
--- a/src/smc-util/code-formatter.ts
+++ b/src/smc-util/code-formatter.ts
@@ -100,6 +100,8 @@ export const file_extensions = tuple([
   "xml",
   "cml" /* that's xml */,
   "kml" /* geodata keyhole markup, also xml */,
+  "xsl",
+  "ptx",
   "c",
   "c++",
   "cc",
@@ -138,6 +140,8 @@ export const ext2syntax: Readonly<Ext2Syntax> = Object.freeze({
   xml: "xml",
   cml: "xml",
   kml: "xml",
+  xsl: "xml",
+  ptx: "xml",
   bib: "bibtex", // via biber --tool
 } as Ext2Syntax);
 

--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -94,6 +94,7 @@ const codemirror_associations: { [ext: string]: string } = {
   cml: "xml", // http://www.xml-cml.org/, e.g. used by avogadro
   kml: "xml", // https://de.wikipedia.org/wiki/Keyhole_Markup_Language
   xsl: "xml",
+  ptx: "xml", // https://pretextbook.org/
   v: "verilog",
   vh: "verilog",
   "": "text",


### PR DESCRIPTION
# Description
add support for `.ptx` files as xml and fix detecting tidy for xml and html syntax

# Testing Steps
1. xml, html, ptx, ... the format button shows up and calls tidy accordingly

# Relevant Issues
#4632


### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
