### PR TITLE
project: support custom environment vars

### DIFF
--- a/src/smc-hub/compute-client.coffee
+++ b/src/smc-hub/compute-client.coffee
@@ -1333,6 +1333,8 @@ class ProjectClient extends EventEmitter
                     else
                         opts.cb()
             return
+        locals =
+            env: {}
         async.series([
             (cb) =>
                 if opts.set_quotas
@@ -1344,10 +1346,19 @@ class ProjectClient extends EventEmitter
             (cb) =>
                 @open(cb : cb)
             (cb) =>
+                @compute_server.database.get_project_extra_env
+                    project_id : @project_id
+                    cb         : (err, env) =>
+                        if err
+                            cb(err)
+                        else
+                            locals.env = Buffer.from(JSON.stringify(env)).toString('base64')
+                            cb()
+            (cb) =>
                 dbg("issuing the start command")
                 @_action
                     action : "start"
-                    args   : ['--base_url', @compute_server._base_url]
+                    args   : ['--base_url', @compute_server._base_url, '--extra_env', locals.env]
                     cb     : cb
             (cb) =>
                 dbg("waiting until running")

--- a/src/smc-hub/compute-server.coffee
+++ b/src/smc-hub/compute-server.coffee
@@ -239,7 +239,6 @@ class Project
                     opts.cb?(err, {})
             return
 
-
         if opts.at_most_one
             if @_command_cbs[opts.action]?
                 @_command_cbs[opts.action].push(opts.cb)
@@ -264,11 +263,6 @@ class Project
             # information about that here.
             args.push('--network')
             args.push(1)
-
-        if @_env
-            args.push('--env')
-            env64 = Buffer.from(JSON.stringify(@_env)).toString('base64')
-            args.push(env64)
 
         args.push(@project_id)
         dbg("args=#{misc.to_safe_str(args)}")

--- a/src/smc-hub/compute-server.coffee
+++ b/src/smc-hub/compute-server.coffee
@@ -265,6 +265,11 @@ class Project
             args.push('--network')
             args.push(1)
 
+        if @_env
+            args.push('--env')
+            env64 = Buffer.from(JSON.stringify(@_env)).toString('base64')
+            args.push(env64)
+
         args.push(@project_id)
         dbg("args=#{misc.to_safe_str(args)}")
         smc_compute

--- a/src/smc-hub/postgres-base.coffee
+++ b/src/smc-hub/postgres-base.coffee
@@ -44,7 +44,7 @@ required = defaults.required
 
 {SCHEMA, client_db} = require('smc-util/schema')
 
-exports.PUBLIC_PROJECT_COLUMNS = ['project_id',  'last_edited', 'title', 'description', 'deleted',  'created']
+exports.PUBLIC_PROJECT_COLUMNS = ['project_id',  'last_edited', 'title', 'description', 'deleted',  'created', 'env']
 exports.PROJECT_COLUMNS = ['users'].concat(exports.PUBLIC_PROJECT_COLUMNS)
 
 {read_db_password_from_disk} = require('./utils')

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -2601,6 +2601,18 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
             jsonb_merge : {settings: opts.settings}
             cb          : opts.cb
 
+    get_project_extra_env: (opts) =>
+        opts = defaults opts,
+            project_id : required
+            cb         : required
+        @_query
+            query : "SELECT env FROM projects"
+            where : 'project_id = $::UUID' : opts.project_id
+            cb    : one_result 'env', (err, env) =>
+                if err
+                    opts.cb(err)
+                else
+                    opts.cb(undefined, env ? {})
 
     ###
     Stats

--- a/src/smc-util/db-schema/projects.ts
+++ b/src/smc-util/db-schema/projects.ts
@@ -53,6 +53,7 @@ Table({
           compute_image: DEFAULT_COMPUTE_IMAGE,
           addons: null,
           created: null,
+          env: null,
         },
       },
       set: {
@@ -69,6 +70,7 @@ Table({
           compute_image: true,
           course: true,
           site_license: true,
+          env: true,
         },
 
         before_change(database, old_val, new_val, account_id, cb) {
@@ -272,6 +274,10 @@ Table({
     lti_data: {
       type: "map",
       desc: "extra information related to LTI",
+    },
+    env: {
+      type: "map",
+      desc: "Additional environment variables (TS: {[key:string]:string})",
     },
   },
 });


### PR DESCRIPTION
# Description
This is pure backend behind-the-scenes code. All it does is to inject a `{string:string}` map from the database for a specific project into the local hub. It's done in a way that the project itself is not affected (will always start, nothing funny will happen) while all spawned processes will have these env vars. What's obviously missing is some UI to set that field in the DB…

# Testing Steps
1. base case is clear: if nothing is set, projects still behave as usual
2. the fun starts once something like that is in the database:
```
update projects set env = '{"FOO": "THIS IS A TEST", "BAR": "123"}'::JSONB where project_id ='[project id]';
```

for my `cc-in-cc` project it works:
```
~$ echo $FOO 
THIS IS A TEST
```
because there is a special function `dev_env` in `smc_compute.py` passing it on. A similar line is there for the usual usage (docker?) and I also prepared the template file for cocalc kubernetes. All other code is just to tie everything together.

Regarding kubernetes, there is a branch `project-env-4523` in kucalc, which I've tested as well. `manage` must be rebuilt with `--no-cache`. Changes to our other kubernetes setups are very similar (I didn't do them):
1. pass on the env variable in the project `Dockerfile`, at the bottom where project init.sh is called.
2. the project's `init.sh` file must set `export COCALC_EXTRA_ENV="$2"`

![Screenshot from 2020-06-10 19-32-43](https://user-images.githubusercontent.com/207405/84299597-482f9500-ab51-11ea-9f1f-97e5de2c264c.png)

# Deployment

Hub first (!) to update the database. Then manage and project.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
