### PR TITLE
ignore tsconfig.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ out
 
 src/cocalc-testcafe/package-lock.json
 
+src/tsconfig.tsbuildinfo
+
 src/static/
 src/static.git/
 src/webapp-lib/policies/_static_pricing_page.html


### PR DESCRIPTION
# Description

ignore `tsconfig.tsbuildinfo` which started to show up for me. maybe the speedier incremental builds are finally starting to work?

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
