### PR TITLE
mostly get rid of  analytics_event 

### DIFF
--- a/src/smc-webapp/account/actions.ts
+++ b/src/smc-webapp/account/actions.ts
@@ -169,8 +169,7 @@ If that doesn't work after a few minutes, try these ${doc_conn} or email ${this.
         return;
       case "signed_in":
         this.redux.getActions("page").set_active_tab("projects");
-        const { analytics_event, track_conversion } = require("../misc_page");
-        analytics_event("account", "create_account"); // user created an account
+        const { track_conversion } = require("../misc_page");
         track_conversion("create_account");
         return;
       default:
@@ -252,18 +251,9 @@ If that doesn't work after a few minutes, try these ${doc_conn} or email ${this.
     // disable redirection from main index page to landing page
     // (existence of cookie signals this is a known client)
     // note: similar code is in account.coffee → signed_in
-    let { APP_BASE_URL, analytics_event } = require("../misc_page");
+    let { APP_BASE_URL } = require("../misc_page");
     const exp = server_days_ago(-30).toGMTString();
     document.cookie = `${APP_BASE_URL}has_remember_me=false; expires=${exp} ;path=/`;
-
-    // record this event
-    let evt = "sign_out";
-    if (everywhere) {
-      evt += "_everywhere";
-    }
-
-    analytics_event("account", evt); // user explicitly signed out.
-
     // Send a message to the server that the user explicitly
     // requested to sign out.  The server must clean up resources
     // and *invalidate* the remember_me cookie for this client.

--- a/src/smc-webapp/app_shared.cjsx
+++ b/src/smc-webapp/app_shared.cjsx
@@ -18,7 +18,6 @@ misc = require('smc-util/misc')
 {NotificationPage} = require('./notifications')
 {AdminPage} = require('./admin')
 {show_announce_end} = require('./account')
-{analytics_event} = require('./tracker')
 {user_tracking} = require('./user-tracking')
 {KioskModeBanner} = require('./app/kiosk-mode-banner')
 {Connecting} = require('./landing-page/connecting')
@@ -132,12 +131,6 @@ exports.NavTab = rclass
 
         if @props.name?
             @actions('page').set_active_tab(@props.name)
-            if @props.is_project
-                analytics_event('top_nav', 'opened_a_project');
-            else
-                analytics_event('top_nav', @props.name)
-        else if @props.label?
-            analytics_event('top_nav', @props.label)
 
     render: ->
         is_active = @props.active_top_tab == @props.name

--- a/src/smc-webapp/chat/chat-indicator.tsx
+++ b/src/smc-webapp/chat/chat-indicator.tsx
@@ -5,7 +5,6 @@
 
 import { debounce } from "lodash";
 import { filename_extension } from "smc-util/misc2";
-import { analytics_event } from "../tracker";
 import { React, redux, useRedux, useMemo } from "../app-framework";
 import { COLORS } from "smc-util/theme";
 import { Icon, Tip, Space } from "../r_misc";
@@ -59,10 +58,8 @@ export const ChatIndicator: React.FC<Props> = ({
       const a = redux.getProjectActions(project_id);
       if (is_chat_open) {
         a.close_chat({ path });
-        analytics_event("side_chat", "close");
       } else {
         a.open_chat({ path });
-        analytics_event("side_chat", "open");
       }
     },
     1000,

--- a/src/smc-webapp/chat/side-chat.tsx
+++ b/src/smc-webapp/chat/side-chat.tsx
@@ -9,7 +9,7 @@ import {
   useRedux,
   useRef,
 } from "../app-framework";
-import { analytics_event } from "../tracker";
+import { user_activity } from "../tracker";
 import { A, Icon, Loading, SearchInput } from "../r_misc";
 import { Button } from "../antd-bootstrap";
 import { ProjectUsers } from "../projects/project-users";
@@ -209,7 +209,7 @@ export const SideChat: React.FC<Props> = ({ project_id, path }: Props) => {
             input={input}
             on_send={() => {
               send_chat();
-              analytics_event("side_chat", "send_chat", "keyboard");
+              user_activity("side_chat", "send_chat", "keyboard");
             }}
             height={INPUT_HEIGHT}
             onChange={(value) => actions.set_input(value)}
@@ -227,7 +227,7 @@ export const SideChat: React.FC<Props> = ({ project_id, path }: Props) => {
               style={{ height: INPUT_HEIGHT }}
               onClick={() => {
                 send_chat();
-                analytics_event("side_chat", "send_chat", "click");
+                user_activity("side_chat", "send_chat", "click");
               }}
               disabled={input.trim() === "" || is_uploading}
               bsStyle="success"

--- a/src/smc-webapp/chat/video/launch-button.tsx
+++ b/src/smc-webapp/chat/video/launch-button.tsx
@@ -4,7 +4,7 @@ import { debounce } from "lodash";
 import { React, useState, useRedux, useRef } from "../../app-framework";
 
 import { Icon, Tip } from "../../r_misc";
-import { analytics_event } from "../../tracker";
+import { user_activity } from "../../tracker";
 import { VideoChat } from "./video-chat";
 
 //import { Button } from "../../antd-bootstrap";
@@ -44,10 +44,10 @@ export const VideoChatButton: React.FC<Props> = ({
       if (video_chat.current.we_are_chatting()) {
         // we are chatting, so stop chatting
         video_chat.current.stop_chatting();
-        analytics_event("side_chat", "stop_video");
+        user_activity("side_chat", "stop_video");
       } else {
         video_chat.current.start_chatting(); // not chatting, so start
-        analytics_event("side_chat", "start_video");
+        user_activity("side_chat", "start_video");
       }
     },
     750,
@@ -137,10 +137,7 @@ export const VideoChatButton: React.FC<Props> = ({
     );
   } else {
     return (
-      <span
-        style={{ ...style, height: "30px" }}
-        onClick={click_video_button}
-      >
+      <span style={{ ...style, height: "30px" }} onClick={click_video_button}>
         {icon}
       </span>
     );

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -34,7 +34,6 @@ IS_MOBILE = feature.IS_MOBILE
 
 misc = require('smc-util/misc')
 misc_page = require('./misc_page')
-{analytics_event} = require('./tracker')
 
 # Ensure CodeMirror is available and configured
 require('./codemirror/codemirror')
@@ -1440,7 +1439,6 @@ class CodeMirrorEditor extends FileEditor
         else
             @snippets_dialog.show(lang)
         @snippets_dialog.set_handler(@example_insert_handler)
-        analytics_event('editor_assistant', @ext, lang)
 
     example_insert_handler: (insert) =>
         # insert : {lang: string, descr: string, code: string[]}

--- a/src/smc-webapp/file-use/info.tsx
+++ b/src/smc-webapp/file-use/info.tsx
@@ -4,20 +4,12 @@
  */
 
 import { Component, React, Rendered } from "../app-framework";
-
-import { analytics_event } from "../tracker";
-
 const { User } = require("../users");
 import { Icon, TimeAgo, r_join } from "../r_misc";
-
 import { FileUseIcon } from "./icon";
-
 import { Map as iMap } from "immutable";
-
 const { Col, Grid, Row } = require("react-bootstrap");
-
 const misc = require("smc-util/misc");
-
 import { open_file_use_entry } from "./util";
 
 // Arbitrary constants:
@@ -97,11 +89,6 @@ export class FileUseInfo extends Component<Props, {}> {
       x.get("path"),
       x.get("show_chat", false),
       this.props.redux
-    );
-    analytics_event(
-      "file_notifications",
-      "open from click",
-      misc.filename_extension(x.get("path"))
     );
   }
 

--- a/src/smc-webapp/file-use/viewer.tsx
+++ b/src/smc-webapp/file-use/viewer.tsx
@@ -7,13 +7,11 @@ import { Map as iMap, List as iList } from "immutable";
 import { FileUseInfo } from "./info";
 import { Alert, Button, Col, Row } from "react-bootstrap";
 import { Component, React, Rendered } from "../app-framework";
-import { analytics_event } from "../tracker";
 import { SearchInput, WindowedList, Icon } from "../r_misc";
 import { FileUseActions } from "./actions";
 import { open_file_use_entry } from "./util";
 
 const {
-  filename_extension,
   search_match,
   search_split,
 } = require("smc-util/misc");
@@ -145,11 +143,6 @@ export class FileUseViewer extends Component<Props, State> {
       x.get("path"),
       x.get("show_chat", false),
       this.props.redux
-    );
-    analytics_event(
-      "file_notifications",
-      "open from search",
-      filename_extension(x.get("path"))
     );
   }
 

--- a/src/smc-webapp/jupyter/top-menubar.tsx
+++ b/src/smc-webapp/jupyter/top-menubar.tsx
@@ -8,7 +8,7 @@
 // File, Edit, etc....
 
 import { React, Component, rclass, rtypes, Rendered } from "../app-framework";
-import { analytics_event } from "../tracker";
+import { user_activity } from "../tracker";
 import * as immutable from "immutable";
 import { ButtonGroup, SelectCallback } from "react-bootstrap";
 import { Icon, r_join, DropdownMenu, MenuItem, MenuDivider } from "../r_misc";
@@ -333,7 +333,7 @@ export class TopMenubar0 extends Component<TopMenubarProps> {
     this.props.actions.set_kernel(kernel_name);
     this.focus();
     this.props.actions.set_default_kernel(kernel_name);
-    analytics_event("cocal_jupyter", "change kernel", kernel_name);
+    user_activity("cocal_jupyter", "change kernel", kernel_name);
   }
 
   private render_kernel_item(kernel: any): Rendered {

--- a/src/smc-webapp/launch/custom-image.ts
+++ b/src/smc-webapp/launch/custom-image.ts
@@ -9,7 +9,6 @@
 // testing: app?launch=csi/course-calculate-20
 
 import { redux } from "../app-framework";
-import { analytics_event } from "../tracker";
 import { retry_until_success } from "smc-util/async-utils";
 import {
   custom_image_name,
@@ -124,7 +123,6 @@ export class CSILauncher {
     }
     this.actions.apply_default_upgrades({ project_id });
     this.actions.open_project({ project_id, switch_to: true });
-    analytics_event("create_project", "launch_csi");
     return project_id;
   }
 }

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1826,27 +1826,6 @@ return _sanitize_html_lib html,
         allowedAttributes: _sanitize_html_allowedAttributes
 ###
 
-# `analytics` is a generalized wrapper for reporting data to google analytics, pwiki, parsley, ...
-# for now, it either does nothing or works with GA
-# this API basically allows to send off events by name and category
-
-exports.analytics = (type, args...) ->
-    # GoogleAnalyticsObject contains the possibly customized function name of GA.
-    # It's a good idea to call it differently from the default 'ga' to avoid name clashes...
-    if window.GoogleAnalyticsObject?
-        ga = window[window.GoogleAnalyticsObject]
-        if ga?
-            switch type
-                when 'event', 'pageview'
-                    ga('send', type, args...)
-                else
-                    console.warn("unknown analytics event '#{type}'")
-
-exports.analytics_pageview = (args...) ->
-    exports.analytics('pageview', args...)
-
-exports.analytics_event = (args...) ->
-    exports.analytics('event', args...)
 
 # conversion tracking (commercial only)
 exports.track_conversion = (type, amount) ->

--- a/src/smc-webapp/project/explorer/action-bar.tsx
+++ b/src/smc-webapp/project/explorer/action-bar.tsx
@@ -6,7 +6,6 @@
 import * as React from "react";
 import * as immutable from "immutable";
 import { COLORS, HiddenSM, Icon, Space } from "../../r_misc";
-import { analytics_event } from "../../tracker";
 import { ComputeImages } from "smc-webapp/custom-software/init";
 import { ProjectActions } from "smc-webapp/project_store";
 
@@ -189,7 +188,6 @@ export class ActionBar extends React.Component<Props, State> {
     };
     const handle_click = (_e: React.MouseEvent) => {
       this.props.actions.set_file_action(name, get_basename);
-      analytics_event("project_file_listing", "open " + name + " menu");
     };
 
     return (

--- a/src/smc-webapp/project/explorer/action-box.tsx
+++ b/src/smc-webapp/project/explorer/action-box.tsx
@@ -10,7 +10,6 @@ import * as immutable from "immutable";
 import { rtypes, rclass } from "../../app-framework";
 import { Icon, Loading, LoginLink } from "../../r_misc";
 import { DirectorySelector } from "../directory-selector";
-import { analytics_event } from "../../tracker";
 import { file_actions, ProjectActions } from "../../project_store";
 const misc = require("smc-util/misc");
 const {
@@ -158,7 +157,6 @@ export const ActionBox = rclass<ReactProps>(
       });
       this.props.actions.set_all_files_unchecked();
       this.props.actions.set_file_action();
-      analytics_event("project_file_listing", "compress item");
     };
 
     render_compress = (): JSX.Element => {
@@ -211,7 +209,6 @@ export const ActionBox = rclass<ReactProps>(
       this.props.actions.set_file_action();
       this.props.actions.set_all_files_unchecked();
       this.props.actions.fetch_directory_listing();
-      analytics_event("project_file_listing", "delete item");
     };
 
     render_delete_warning(): JSX.Element | undefined {
@@ -293,7 +290,6 @@ export const ActionBox = rclass<ReactProps>(
             src: checked[0],
             dest: misc.path_to_file(rename_dir, destination),
           });
-          analytics_event("project_file_listing", "rename item");
           break;
         case "duplicate":
           this.props.actions.copy_paths({
@@ -301,7 +297,6 @@ export const ActionBox = rclass<ReactProps>(
             dest: misc.path_to_file(rename_dir, destination),
             only_contents: true,
           });
-          analytics_event("project_file_listing", "duplicate item");
           break;
       }
       this.props.actions.set_file_action();
@@ -423,7 +418,6 @@ export const ActionBox = rclass<ReactProps>(
       });
       this.props.actions.set_file_action();
       this.props.actions.set_all_files_unchecked();
-      analytics_event("project_file_listing", "move item");
     };
 
     valid_move_input = (): boolean => {
@@ -576,13 +570,11 @@ export const ActionBox = rclass<ReactProps>(
           overwrite_newer,
           delete_missing: delete_extra_files,
         });
-        analytics_event("project_file_listing", "copy between projects");
       } else {
         this.props.actions.copy_paths({
           src: paths,
           dest: destination_directory,
         });
-        analytics_event("project_file_listing", "copy within a project");
       }
 
       this.props.actions.set_file_action();
@@ -738,7 +730,6 @@ export const ActionBox = rclass<ReactProps>(
         log: true,
       });
       this.props.actions.set_file_action();
-      analytics_event("project_file_listing", "download item");
     };
 
     download_multiple_click = (): void => {
@@ -764,7 +755,6 @@ export const ActionBox = rclass<ReactProps>(
       });
       this.props.actions.set_all_files_unchecked();
       this.props.actions.set_file_action();
-      analytics_event("project_file_listing", "download item");
     };
 
     render_download_single(single_item: string): JSX.Element {

--- a/src/smc-webapp/project/explorer/file-listing/file-row.tsx
+++ b/src/smc-webapp/project/explorer/file-listing/file-row.tsx
@@ -7,15 +7,11 @@ import * as React from "react";
 import memoizeOne from "memoize-one";
 
 import { ProjectActions } from "../../../project_actions";
-import { analytics_event } from "../../../tracker";
-
 import { CopyButton } from "./copy-button";
 import { PublicButton } from "./public-button";
 import { FileCheckbox } from "./file-checkbox";
 import { generate_click_for } from "./utils";
-
 import { COLORS, TimeAgo, Tip, Icon } from "../../../r_misc";
-
 const { Button, Row, Col } = require("react-bootstrap");
 const misc = require("smc-util/misc");
 const { project_tasks } = require("../../../project_tasks");
@@ -185,11 +181,6 @@ export class FileRow extends React.Component<Props, State> {
     if (foreground) {
       this.props.actions.set_file_search("");
     }
-    analytics_event(
-      "project_file_listing",
-      "clicked_file_row",
-      misc.filename_extension(this.full_path())
-    );
   };
 
   handle_download_click = (e) => {

--- a/src/smc-webapp/project/explorer/file-listing/no-files.tsx
+++ b/src/smc-webapp/project/explorer/file-listing/no-files.tsx
@@ -5,7 +5,6 @@
 
 import * as React from "react";
 import { Rendered } from "../../../app-framework";
-import { analytics_event } from "../../../tracker";
 import { Icon } from "../../../r_misc/icon";
 import { ProjectActions } from "../../../project_actions";
 
@@ -48,19 +47,12 @@ export class NoFiles extends React.PureComponent<Props> {
   handle_click = () => {
     if (this.props.file_search.length === 0) {
       this.props.actions.toggle_new(true);
-      analytics_event("project_file_listing", "listing_create_button", "empty");
     } else if (
       this.props.file_search[this.props.file_search.length - 1] === "/"
     ) {
       this.props.create_folder();
-      analytics_event(
-        "project_file_listing",
-        "listing_create_button",
-        "folder"
-      );
     } else {
       this.props.create_file();
-      analytics_event("project_file_listing", "listing_create_button", "file");
     }
   };
 

--- a/src/smc-webapp/project/explorer/mini-terminal.tsx
+++ b/src/smc-webapp/project/explorer/mini-terminal.tsx
@@ -16,7 +16,7 @@ IDEAS FOR LATER:
 */
 
 import { React, ReactDOM } from "../../app-framework";
-import { analytics_event } from "../../tracker";
+import { user_activity } from "../../tracker";
 import { ProjectActions } from "../../project_actions";
 const {
   Button,
@@ -117,7 +117,7 @@ export class MiniTerminal extends React.Component<Props, State> {
     this._id = this._id + 1;
     const id = this._id;
     const start_time = new Date().getTime();
-    analytics_event("mini_terminal", "exec", input);
+    user_activity("mini_terminal", "exec", input);
     webapp_client.exec({
       project_id: this.props.project_id,
       command: input0,

--- a/src/smc-webapp/project/explorer/misc-side-buttons.tsx
+++ b/src/smc-webapp/project/explorer/misc-side-buttons.tsx
@@ -5,7 +5,6 @@
 
 import * as React from "react";
 import { HiddenSM, Icon, Tip } from "../../r_misc";
-import { analytics_event } from "../../tracker";
 import { ProjectActions } from "smc-webapp/project_store";
 const { Button, ButtonGroup, ButtonToolbar } = require("react-bootstrap");
 
@@ -88,7 +87,6 @@ export class MiscSideButtons extends React.Component<Props> {
 
   handle_library_click = (_e: React.MouseEvent): void => {
     this.props.actions.toggle_library();
-    analytics_event("project_file_listing", "toggle library");
   };
 
   render_library_button(): JSX.Element | undefined {
@@ -103,16 +101,11 @@ export class MiscSideButtons extends React.Component<Props> {
     );
   }
 
-  handle_upload_click = (_e: React.MouseEvent): void => {
-    analytics_event("project_file_listing", "clicked upload");
-  };
-
   render_upload_button(): JSX.Element {
     return (
       <Button
         bsSize="small"
         className="upload-button"
-        onClick={this.handle_upload_click}
       >
         <Icon name="upload" /> <HiddenSM>Upload</HiddenSM>
       </Button>

--- a/src/smc-webapp/project/explorer/new-button.tsx
+++ b/src/smc-webapp/project/explorer/new-button.tsx
@@ -7,7 +7,6 @@ import * as React from "react";
 import { Configuration } from "./explorer";
 import { EXTs as ALL_FILE_BUTTON_TYPES } from "./file-listing/utils";
 import { Icon } from "../../r_misc";
-import { analytics_event } from "../../tracker";
 import { ProjectActions } from "smc-webapp/project_store";
 
 const { MenuItem, SplitButton } = require("react-bootstrap");
@@ -79,15 +78,12 @@ export class NewButton extends React.Component<Props> {
   on_create_button_clicked = (): void => {
     if (this.props.file_search.length === 0) {
       this.props.actions.toggle_new();
-      analytics_event("project_file_listing", "search_create_button", "empty");
     } else if (
       this.props.file_search[this.props.file_search.length - 1] === "/"
     ) {
       this.props.create_folder();
-      analytics_event("project_file_listing", "search_create_button", "folder");
     } else {
       this.props.create_file();
-      analytics_event("project_file_listing", "search_create_button", "file");
     }
   };
 

--- a/src/smc-webapp/project/explorer/search-bar.tsx
+++ b/src/smc-webapp/project/explorer/search-bar.tsx
@@ -4,7 +4,6 @@
  */
 
 import * as React from "react";
-import { analytics_event } from "../../tracker";
 import { TERM_MODE_CHAR } from "./file-listing";
 import { Icon, SearchInput } from "../../r_misc";
 import { ProjectActions } from "smc-webapp/project_store";
@@ -75,7 +74,6 @@ export class SearchBar extends React.Component<Props, State> {
 
     this._id = (this._id != undefined ? this._id : 0) + 1;
     const id = this._id;
-    analytics_event("project_file_listing", "exec file search miniterm", input);
     webapp_client.exec({
       project_id: this.props.project_id,
       command: input0,

--- a/src/smc-webapp/project/file-tab.cjsx
+++ b/src/smc-webapp/project/file-tab.cjsx
@@ -17,8 +17,6 @@ misc = require('smc-util/misc')
 
 {COLORS, HiddenXS, Icon, Tip} = require('../r_misc')
 
-{analytics_event} = require("../tracker")
-
 exports.DEFAULT_FILE_TAB_STYLES =
     width        : 250
     borderRadius : "5px 5px 0px 0px"
@@ -73,11 +71,6 @@ exports.FileTab = rclass
                 new_browser_window : true
         else
             actions.set_active_tab(@props.name)
-
-        if @props.file_tab
-            analytics_event('project_navigation', 'opened_a_file', misc.filename_extension(@props.name))
-        else
-            analytics_event('project_navigation', 'opened_project_' + @props.name)
 
     # middle mouse click closes
     onMouseDown: (e) ->

--- a/src/smc-webapp/project/settings/body.tsx
+++ b/src/smc-webapp/project/settings/body.tsx
@@ -4,7 +4,6 @@
  */
 
 import * as React from "react";
-import { analytics_event } from "../../tracker";
 const misc = require("smc-util/misc");
 import {
   Icon,
@@ -236,9 +235,6 @@ export const Body = rclass<ReactProps>(
               <AddCollaboratorsPanel
                 key="new-collabs"
                 project={this.props.project}
-                on_invite={() =>
-                  analytics_event("project_settings", "add collaborator")
-                }
                 allow_urls={allow_urls}
               />
               <ProjectControl key="control" project={this.props.project} />

--- a/src/smc-webapp/project/settings/hide-delete-box.tsx
+++ b/src/smc-webapp/project/settings/hide-delete-box.tsx
@@ -5,7 +5,6 @@
 
 import * as React from "react";
 import { Project } from "./types";
-import { analytics_event } from "smc-webapp/tracker";
 import { Icon, SettingBox, DeletedProjectWarning } from "smc-webapp/r_misc";
 import { Button, Well, Alert, ButtonToolbar, Row, Col } from "react-bootstrap";
 import { ProjectsActions } from "smc-webapp/todo-types";
@@ -40,23 +39,12 @@ export class HideDeleteBox extends React.Component<Props, State> {
       this.props.project.get("project_id")
     );
     this.hide_delete_conf();
-    if (this.props.project.get("deleted")) {
-      analytics_event("project_settings", "undelete project");
-    } else {
-      analytics_event("project_settings", "delete project");
-    }
   };
 
   toggle_hide_project = (): void => {
     this.props.actions.toggle_hide_project(
       this.props.project.get("project_id")
     );
-    const user = this.props.project.getIn(["users", webapp_client.account_id]);
-    if (user && user.get("hide")) {
-      analytics_event("project_settings", "unhide project");
-    } else {
-      analytics_event("project_settings", "hide project");
-    }
   };
 
   user_has_applied_upgrades(account_id: string, project: Project) {

--- a/src/smc-webapp/project/settings/project-control.tsx
+++ b/src/smc-webapp/project/settings/project-control.tsx
@@ -23,7 +23,6 @@ import {
   CUSTOM_IMG_PREFIX,
 } from "../../custom-software/util";
 import { async } from "async";
-import { analytics_event } from "../../tracker";
 import {
   ButtonToolbar,
   Button,
@@ -153,14 +152,12 @@ export const ProjectControl = rclass<ReactProps>(
       redux
         .getActions("projects")
         .restart_project(this.props.project.get("project_id"));
-      analytics_event("project_settings", "restart project");
     };
 
     stop_project = () => {
       redux
         .getActions("projects")
         .stop_project(this.props.project.get("project_id"));
-      analytics_event("project_settings", "stop project");
     };
 
     render_stop_button(commands): Rendered {
@@ -311,7 +308,6 @@ export const ProjectControl = rclass<ReactProps>(
       const actions = redux.getProjectActions(
         this.props.project.get("project_id")
       );
-      analytics_event("project_settings", "change compute image");
       try {
         await actions.set_compute_image(new_image);
         this.restart_project();

--- a/src/smc-webapp/project/settings/ssh.tsx
+++ b/src/smc-webapp/project/settings/ssh.tsx
@@ -4,7 +4,6 @@
  */
 
 import * as React from "react";
-import { analytics_event } from "../../tracker";
 import * as misc from "smc-util/misc";
 import { Icon } from "../../r_misc";
 import { redux } from "../../app-framework";
@@ -26,7 +25,6 @@ export class SSHPanel extends React.Component<Props> {
   add_ssh_key = (opts) => {
     opts.project_id = this.props.project.get("project_id");
     redux.getActions("projects").add_ssh_key_to_project(opts);
-    analytics_event("project_settings", "add project ssh key");
   };
 
   delete_ssh_key = (fingerprint) => {
@@ -34,7 +32,6 @@ export class SSHPanel extends React.Component<Props> {
       fingerprint,
       project_id: this.props.project.get("project_id"),
     });
-    analytics_event("project_settings", "remove project ssh key");
   };
 
   render_ssh_notice() {

--- a/src/smc-webapp/projects/create-project.tsx
+++ b/src/smc-webapp/projects/create-project.tsx
@@ -6,7 +6,6 @@
 /*
 Create a new project
 */
-import { analytics_event } from "../tracker";
 
 import {
   React,
@@ -145,7 +144,6 @@ export const NewProjectCreator: React.FC<Props> = ({
     // switch_to=true is perhaps suggested by #4088
     actions.open_project({ project_id, switch_to: true });
     cancel_editing();
-    analytics_event("create_project", "created_new_project");
   }
 
   function render_info_alert(): JSX.Element | undefined {

--- a/src/smc-webapp/projects/hashtags.tsx
+++ b/src/smc-webapp/projects/hashtags.tsx
@@ -8,7 +8,6 @@ import { Set } from "immutable";
 import { trunc } from "smc-util/misc";
 
 import { React } from "../app-framework";
-import { analytics_event } from "../tracker";
 const { CheckableTag } = Tag;
 
 const STYLE: React.CSSProperties = {
@@ -40,7 +39,6 @@ export const Hashtags: React.FC<Props> = ({
         checked={checked}
         onChange={() => {
           toggle_hashtag(tag);
-          analytics_event("projects_page", "clicked_hashtag", tag);
         }}
       >
         {trunc(tag, 40)}

--- a/src/smc-webapp/projects/project-row.tsx
+++ b/src/smc-webapp/projects/project-row.tsx
@@ -15,10 +15,7 @@ import {
   useRedux,
 } from "../app-framework";
 import { ProjectUsers } from "./project-users";
-import { analytics_event } from "../tracker";
-
 const { AddCollaborators } = require("../collaborators/add-to-project");
-
 import { Row, Col, Well } from "../antd-bootstrap";
 import { Icon, Markdown, ProjectState, Space, TimeAgo } from "../r_misc";
 import { id2name } from "../custom-software/init";
@@ -157,7 +154,6 @@ export const ProjectRow: React.FC<Props> = ({ project_id, index }: Props) => {
       switch_to: !(e.which === 2 || e.ctrlKey || e.metaKey),
     });
     e.preventDefault();
-    analytics_event("projects_page", "opened_a_project");
     user_tracking("open_project", { how: "projects_page", project_id });
   }
 

--- a/src/smc-webapp/projects/projects-filter-buttons.tsx
+++ b/src/smc-webapp/projects/projects-filter-buttons.tsx
@@ -4,7 +4,7 @@
  */
 
 import { React, useRedux, useActions } from "../app-framework";
-import { analytics_event } from "../tracker";
+import { user_activity } from "../tracker";
 import { Button, ButtonGroup } from "../antd-bootstrap";
 import { Icon } from "../r_misc";
 
@@ -19,7 +19,7 @@ export const ProjectsFilterButtons: React.FC = () => {
       <Button
         onClick={() => {
           actions.display_deleted_projects(!deleted);
-          analytics_event("projects_page", "clicked_deleted_filter");
+          user_activity("projects_page", "clicked_deleted_filter");
         }}
         bsStyle={style}
         cocalc-test={"deleted-filter"}
@@ -36,7 +36,7 @@ export const ProjectsFilterButtons: React.FC = () => {
       <Button
         onClick={() => {
           actions.display_hidden_projects(!hidden);
-          analytics_event("projects_page", "clicked_hidden_filter");
+          user_activity("projects_page", "clicked_hidden_filter");
         }}
         bsStyle={style}
         cocalc-test={"hidden-filter"}

--- a/src/smc-webapp/tracker/index.ts
+++ b/src/smc-webapp/tracker/index.ts
@@ -35,3 +35,9 @@ export function analytics_pageview(...args): void {
 export function analytics_event(...args): void {
   analytics("event", ...args);
 }
+
+export function user_activity(..._args): void {
+  // NOOP. arguments are tree like chains, where leaves are options/actions.
+  // the use case is to track certain UI usage of users to learn what is used and how.
+  // the reporting aspect must be reported properly.
+}


### PR DESCRIPTION
# Description

related to #4661 ... getting rid of analytics event, renaming it/noop. once we have a clear plan and a specific use case, we will revisit this.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
