### PR TITLE
moving to python 3.x print

### DIFF
--- a/src/smc-hub/scripts/compute
+++ b/src/smc-hub/scripts/compute
@@ -3,5 +3,5 @@
 import os, sys
 os.chdir(os.path.split(os.path.realpath(__file__))[0] + '/..')
 cmd = "node run/compute.js %s"%(' '.join(["%s"%x for x in sys.argv[1:]]))
-print cmd
+print (cmd)
 os.system(cmd)


### PR DESCRIPTION
due to this the  Dockerfile.gpu  build doesnot start properly. in the tensorflow the default python is 3.x

# Description

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
