### PR TITLE
don't attempt to init stripe in commercial==no setting

### DIFF
--- a/src/smc-webapp/billing/actions.ts
+++ b/src/smc-webapp/billing/actions.ts
@@ -40,6 +40,10 @@ export class BillingActions extends Actions<BillingStoreState> {
   }
 
   public async update_customer(): Promise<void> {
+    const is_commercial = redux
+      .getStore("customize")
+      .get("is_commercial", false);
+    if (!is_commercial) return;
     this.setState({ action: "Updating billing information" });
     try {
       const resp = await this.stripe.get_customer();


### PR DESCRIPTION
# Description
* this is #4583
* the whole point is that there is a call to update customers in `project/explorer/explorer.tsx` … this just disables this method if there is no commercial stripe setup


# Testing Steps
too late & too tired to test this now, but I'm pretty confident this should do it

# Relevant Issues
#4583

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
