### PR TITLE
webapp/generic: do not open docx automatically

### DIFF
--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -771,19 +771,18 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     }
   }
 
-  private async open_word_document(opts): Promise<void> {
+  public async open_word_document(path): Promise<void> {
     // Microsoft Word Document
     alert_message({
       type: "info",
-      message: `Opening converted plain text file instead of '${opts.path}...`,
+      message: `Opening converted plain text file instead of '${path}...`,
     });
     try {
-      const path: string = await this.convert_docx_file(opts.path);
+      const converted: string = await this.convert_docx_file(path);
       await this.open_file({
-        path,
-        foreground: opts.foreground,
-        foreground_project: opts.foreground_project,
-        chat: opts.chat,
+        path: converted,
+        foreground: true,
+        foreground_project: true,
       });
     } catch (err) {
       alert_message({
@@ -958,11 +957,6 @@ export class ProjectActions extends Actions<ProjectStoreState> {
 
     if (!is_public && (ext === "sws" || ext.slice(0, 4) === "sws~")) {
       await this.open_sagenb_worksheet(opts);
-      return;
-    }
-
-    if (!is_public && ext === "docx") {
-      await this.open_word_document(opts);
       return;
     }
 


### PR DESCRIPTION
# Description
this is #4660 + some general cleanup/modernization

# Testing Steps
![Screenshot from 2020-06-17 11-42-43](https://user-images.githubusercontent.com/207405/84882552-b6afae00-b08f-11ea-8988-a757fd8a4b56.png)

![Screenshot from 2020-06-17 11-42-35](https://user-images.githubusercontent.com/207405/84882555-b7484480-b08f-11ea-9375-11cafdfefcd1.png)

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
