### PR TITLE
show stacktraces to users

### DIFF
--- a/src/smc-webapp/crash.html
+++ b/src/smc-webapp/crash.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
   License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  -->
@@ -26,4 +26,6 @@
       Thank you!
     </p>
   </div>
+
+  <div id="cocalc-error-report-react"></div>
 </div>

--- a/src/smc-webapp/index.sass
+++ b/src/smc-webapp/index.sass
@@ -108,6 +108,9 @@ div#cocalc-react-crash
   border-radius: 5px
   font-size: 12pt
 
+div#cocalc-react-crash > div > pre
+  font-size: 11px
+
   /* mezzo-small, larger than xs, smaller than sm, like the old tasklist button size */
 
 .btn-ms

--- a/src/smc-webapp/last.coffee
+++ b/src/smc-webapp/last.coffee
@@ -37,6 +37,8 @@ window.MathJax = MathJaxConfig
 $ = window.$
 $("#smc-startup-banner")?.remove()
 $('#smc-startup-banner-status')?.remove()
+$('#cocalc-error-report-startup')?.remove()
+
 $ ->
     try
         $(parent).trigger('initialize:frame')

--- a/src/webapp-lib/app-init.ts
+++ b/src/webapp-lib/app-init.ts
@@ -1,0 +1,89 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// first, load the customize endpoint → check if any images are customized and render banner accordingly. also use the proper name.
+// if the endpoint doesn't work, we have a problem. report back accordingly…
+
+declare const CUSTOMIZE: any;
+let HELP_EMAIL = "help@cocalc.com";
+
+function email() {
+  return `<a href="mailto:${HELP_EMAIL}" target="_blank" rel="noopener">${HELP_EMAIL}</a>`;
+}
+
+function script_error() {
+  document.body.innerHTML =
+    "<h1 style='text-align:center;margin-top:10vh'>Initialization problem. Please try again in a minute ...</h1>";
+  window.stop();
+}
+
+function style() {
+  const NAME = CUSTOMIZE.site_name || "CoCalc";
+  HELP_EMAIL = CUSTOMIZE.help_email || "help@cocalc.com";
+  document.title = NAME;
+  const msg = document.getElementById("cc-message");
+  if (msg == null) {
+    // happens when loading is very quick and message is already removed
+    return;
+  }
+  msg.innerHTML += `
+  Timeout while loading ${NAME}.
+  <br/>
+  Try hitting shift and reload the page, restart your browser, or <a target="_blank" rel="noopener" href="https://doc.cocalc.com/howto/connectivity-issues.html">follow these steps</a>.
+  If the problem persists, email ${email()}.`;
+  if (CUSTOMIZE.logo_square || CUSTOMIZE.logo_rectangular) {
+    const banner = document.getElementById("cc-banner2");
+    if (banner == null) return;
+    banner.style.display = "block";
+    banner.innerHTML = `<img class="logo-square" src="${CUSTOMIZE.logo_square}">`;
+    banner.innerHTML += `<img class="logo-rectangular" src="${CUSTOMIZE.logo_rectangular}">`;
+  } else {
+    const banner = document.getElementById("cc-banner1");
+    if (banner == null) return;
+    banner.style.display = "block";
+  }
+}
+
+const customizeScript = document.createElement("script");
+customizeScript.onerror = script_error;
+customizeScript.onload = style;
+document.head.appendChild(customizeScript);
+customizeScript.src = `${window.app_base_url}/customize?type=embed`;
+
+function error_msg({ msg, lineNo, columnNo, url, stack, show_explanation }) {
+  const explanation = show_explanation
+    ? `<div>
+Please report the full error, your browser and operating system to ${email()}.
+In the mean time, try switching to another browser or upating it to a newer version.
+</div>`
+    : "";
+  return `<div><strong>Application Error:</strong> <code>${msg} @ ${lineNo}/${columnNo} of ${url}</code></div>
+${explanation}
+<pre>
+${stack}
+</pre>`;
+}
+
+window.onerror = function (msg, url, lineNo, columnNo, error) {
+  let errorbox = document.getElementById("cocalc-error-report-startup");
+  let show_explanation = true;
+  if (errorbox == null) {
+    // app did startup, hence the banner is removed from the DOM
+    // instead, check if there is the react error report banner and insert it there!
+    errorbox = document.getElementById("cocalc-error-report-react");
+    show_explanation = false;
+    if (errorbox == null) return;
+  }
+  errorbox.style.display = "block";
+  const stack = error != null ? error.stack : "<no stacktrace>";
+  errorbox.innerHTML = error_msg({
+    msg,
+    lineNo,
+    columnNo,
+    url,
+    stack,
+    show_explanation,
+  });
+};

--- a/src/webapp-lib/app-startup-style.css
+++ b/src/webapp-lib/app-startup-style.css
@@ -8,16 +8,29 @@
     /* bootstrap 3.3 has this line height. fix it, if it changes! */
     line-height: 1.42857143;
     text-align: center;
-    position: fixed;
     left: 0;
     right: 0;
     top: 100px;
-    margin: auto;
+    margin: 100px auto 0 auto;
     max-width: 100%;
     max-height: 100%;
     font-family: sans-serif;
     font-size: 26px;
     color: white;
+}
+
+#cocalc-error-report-startup {
+    clear: both;
+    display: none;
+    font-size: 15px;
+    margin: 0 auto 0 auto;
+    width: 90vw;
+    padding: 10px;
+    border: 3px solid red;
+    border-radius: 5px;
+}
+#cocalc-error-report-startup pre {
+    font-size: 10px;
 }
 
 #smc-startup-banner-status {

--- a/src/webapp-lib/app.pug
+++ b/src/webapp-lib/app.pug
@@ -21,6 +21,8 @@ html(lang="en")
       div.banner-error
         div.message#cc-message
 
+    div#cocalc-error-report-startup
+
     div#smc-startup-banner-status
       | Initializing ...
 
@@ -35,42 +37,9 @@ html(lang="en")
     else
         script(type="text/javascript" src="base_url.js")
 
-    //- first, load the customize endpoint → check if any images are customized and render banner accordingly. also use the proper name.
-    //- if the endpoint doesn't work, we have a problem. report back accordingly…
-    script.
-      function error() {
-        document.body.innerHTML = "<h1 style='text-align:center;margin-top:10vh'>Initialization problem. Please try again in a minute ...</h1>";
-        window.stop();
-      }
-
-      function style() {
-        const NAME = CUSTOMIZE.site_name || 'CoCalc';
-        const HELP_EMAIL = CUSTOMIZE.help_email || 'help@cocalc.com';
-        document.title = NAME;
-        const msg = document.getElementById("cc-message");
-        if (msg == null) { // happens when loading is very quick and message is already removed
-          return;
-        }
-        msg.innerHTML += "Timeout while loading " + NAME + ".";
-        msg.innerHTML += '<br/>';
-        msg.innerHTML += 'Try hitting shift and reload the page, restart your browser, or <a target="_blank" rel="noopener" href="https://doc.cocalc.com/howto/connectivity-issues.html">follow these steps</a>. ';
-        msg.innerHTML += 'If the problem persists, email <a href="mailto:' + HELP_EMAIL + '" target="_blank" rel="noopener">' + HELP_EMAIL + '</a>.';
-        if (CUSTOMIZE.logo_square || CUSTOMIZE.logo_rectangular) {
-          const banner = document.getElementById("cc-banner2");
-          banner.style.display = 'block';
-          banner.innerHTML = '<img class="logo-square" src="'+CUSTOMIZE.logo_square+'">'
-          banner.innerHTML += '<img class="logo-rectangular" src="'+CUSTOMIZE.logo_rectangular+'">'
-        } else {
-          const banner = document.getElementById("cc-banner1");
-          banner.style.display = 'block';
-        }
-      }
-
-      const customizeScript = document.createElement("script");
-      customizeScript.onerror = error;
-      customizeScript.onload = style;
-      document.head.appendChild(customizeScript);
-      customizeScript.src = '#{BASE_URL}' + "/customize?type=embed";
+    // initialize app, expecially configuration
+    script(type="text/javascript")
+      include:typescript app-init.ts
 
     script(type="text/javascript").
         window.webapp_initial_start_time = (new Date()).getTime();


### PR DESCRIPTION
# Description
* this shows loading crashes to the user, which should help us to figure out what's going on quicker
*  typescripts app-init
* also show stacktraces in react crash box
* part of #3852

# Testing Steps
* if there is no error, everything works as usual. even if there are errors, the user will not see it anyways.
* to trigger it, here is what I did: I inserted `throw new Error("BANG")` either
  *  in the body of `app/notification-bell.tsx` (i.e. not inside a function or anything else)
  * or into the react render function.

in the first case  it crashes during startup and in the second case when react is already started. screenshots below are for case 1 and 2

![Screenshot from 2020-06-17 13-25-25](https://user-images.githubusercontent.com/207405/84894273-d13e5300-b0a0-11ea-9d4b-6eb13fcbd6ee.png)

![Screenshot from 2020-06-17 13-39-30](https://user-images.githubusercontent.com/207405/84894284-d4394380-b0a0-11ea-9c09-fce2678281c6.png)


# Relevant Issues
#3852
### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
