### PR TITLE
tweak save button

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -112,6 +112,7 @@ export interface CodeEditorState {
   misspelled_words: Set<string> | string;
   has_unsaved_changes: boolean;
   has_uncommitted_changes: boolean;
+  show_uncommitted_changes: boolean;
   is_saving: boolean;
   is_loaded: boolean;
   gutter_markers: GutterMarkers;
@@ -200,6 +201,7 @@ export class Actions<
       misspelled_words: Set(),
       has_unsaved_changes: false,
       has_uncommitted_changes: false,
+      show_uncommitted_changes: false,
       is_saving: false,
       gutter_markers: Map(),
       cursors: Map(),
@@ -348,12 +350,21 @@ export class Actions<
       this.close();
     });
 
-    this._syncstring.on("has-uncommitted-changes", (has_uncommitted_changes) =>
-      this.setState({ has_uncommitted_changes })
+    this._syncstring.on(
+      "has-uncommitted-changes",
+      (has_uncommitted_changes) => {
+        this.setState({ has_uncommitted_changes });
+        if (!has_uncommitted_changes) {
+          this.set_show_uncommitted_changes(false);
+        }
+      }
     );
 
     this._syncstring.on("has-unsaved-changes", (has_unsaved_changes) => {
       this.setState({ has_unsaved_changes });
+      if (!has_unsaved_changes) {
+        this.set_show_uncommitted_changes(false);
+      }
     });
   }
 
@@ -2519,5 +2530,9 @@ export class Actions<
       }
       if (match) return id;
     }
+  }
+
+  public set_show_uncommitted_changes(val: boolean): void {
+    this.setState({ show_uncommitted_changes: val });
   }
 }

--- a/src/smc-webapp/frame-editors/frame-tree/save-button.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/save-button.tsx
@@ -4,11 +4,8 @@
  */
 
 const { Button } = require("react-bootstrap");
-
 import { Icon, VisibleMDLG } from "smc-webapp/r_misc";
-
-import { React, Rendered, Component } from "../../app-framework";
-
+import { React } from "../../app-framework";
 import { UncommittedChanges } from "../../r_misc";
 
 interface Props {
@@ -20,51 +17,63 @@ interface Props {
   no_labels?: boolean;
   size?: string;
   onClick?: Function;
+  show_uncommitted_changes?: boolean;
+  set_show_uncommitted_changes?: Function;
 }
 
-export class SaveButton extends Component<Props, {}> {
-  render(): Rendered {
-    const disabled: boolean =
-      !this.props.has_unsaved_changes ||
-      !!this.props.read_only ||
-      !!this.props.is_public;
+const SaveButtonFC: React.FC<Props> = (props: Props) => {
+  const {
+    has_unsaved_changes,
+    has_uncommitted_changes,
+    read_only,
+    is_public,
+    is_saving,
+    no_labels,
+    size,
+    onClick,
+    show_uncommitted_changes,
+    set_show_uncommitted_changes,
+  } = props;
 
-    let label: string = "";
-    if (!this.props.no_labels) {
-      if (this.props.is_public) {
-        label = "Public";
-      } else if (this.props.read_only) {
-        label = "Readonly";
+  function make_label() {
+    if (!no_labels) {
+      if (is_public) {
+        return "Public";
+      } else if (read_only) {
+        return "Readonly";
       } else {
-        label = "Save";
+        return "Save";
       }
     } else {
-      label = "";
+      return "";
     }
-
-    let icon: string;
-    if (this.props.is_saving) {
-      icon = "arrow-circle-o-left";
-    } else {
-      icon = "save";
-    }
-
-    // The funny style in the icon below is because the width changes
-    // slightly depending on which icon we are showing.
-    return (
-      <Button
-        title={"Save file to disk"}
-        bsStyle={"success"}
-        bsSize={this.props.size}
-        disabled={disabled}
-        onClick={this.props.onClick}
-      >
-        <Icon name={icon} style={{ width: "15px", display: "inline-block" }} />{" "}
-        <VisibleMDLG>{label}</VisibleMDLG>
-        <UncommittedChanges
-          has_uncommitted_changes={this.props.has_uncommitted_changes}
-        />
-      </Button>
-    );
   }
-}
+
+  const disabled: boolean = !has_unsaved_changes || !!read_only || !!is_public;
+  const label = make_label();
+  const icon = is_saving ? "arrow-circle-o-left" : "save";
+
+  // The funny style in the icon below is because the width changes
+  // slightly depending on which icon we are showing.
+  // whiteSpace:"nowrap" due to https://github.com/sagemathinc/cocalc/issues/4434
+  return (
+    <Button
+      title={"Save file to disk"}
+      bsStyle={"success"}
+      bsSize={size}
+      disabled={disabled}
+      onClick={onClick}
+      style={{ whiteSpace: "nowrap" }}
+    >
+      <Icon name={icon} style={{ width: "15px", display: "inline-block" }} />{" "}
+      <VisibleMDLG>{label}</VisibleMDLG>
+      <UncommittedChanges
+        has_uncommitted_changes={has_uncommitted_changes}
+        show_uncommitted_changes={show_uncommitted_changes}
+        set_show_uncommitted_changes={set_show_uncommitted_changes}
+      />
+    </Button>
+  );
+};
+
+export const SaveButton = React.memo(SaveButtonFC);

--- a/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
@@ -185,6 +185,10 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
     props.editor_actions.name,
     "has_uncommitted_changes",
   ]);
+  const show_uncommitted_changes: boolean = useRedux([
+    props.editor_actions.name,
+    "show_uncommitted_changes",
+  ]);
   const is_saving: boolean = useRedux([props.editor_actions.name, "is_saving"]);
   const is_public: boolean = useRedux([props.editor_actions.name, "is_public"]);
 
@@ -943,6 +947,10 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
         key="save"
         has_unsaved_changes={has_unsaved_changes}
         has_uncommitted_changes={has_uncommitted_changes}
+        show_uncommitted_changes={show_uncommitted_changes}
+        set_show_uncommitted_changes={
+          props.editor_actions.set_show_uncommitted_changes
+        }
         read_only={read_only}
         is_public={is_public}
         is_saving={is_saving}

--- a/src/smc-webapp/r_misc/uncommited-changes.tsx
+++ b/src/smc-webapp/r_misc/uncommited-changes.tsx
@@ -10,6 +10,8 @@ import * as React from "react";
 interface Props {
   has_uncommitted_changes?: boolean;
   delay_ms?: number; // Default = 5000
+  show_uncommitted_changes?: boolean;
+  set_show_uncommitted_changes?: any;
 }
 
 const STYLE: React.CSSProperties = {
@@ -29,27 +31,41 @@ const STYLE: React.CSSProperties = {
  *
  * Does not work with changes to `delay_ms`
  */
-export const UncommittedChanges: React.FC<Props> = ({
-  has_uncommitted_changes,
-  delay_ms = 5000,
-}) => {
-  const [show_error, set_error] = React.useState(false);
+const UncommittedChangesFC = (props: Props) => {
+  const {
+    has_uncommitted_changes,
+    show_uncommitted_changes,
+    set_show_uncommitted_changes,
+    delay_ms = 5000,
+  } = props;
+  const init = has_uncommitted_changes && (show_uncommitted_changes ?? false);
+  const [show_error, set_error] = React.useState(init);
 
   // A new interval is created iff has_uncommitted_changes or delay_ms change
   // So error is only set to true when the prop doesn't change for ~delay_ms time
   React.useEffect(() => {
-    set_error(false);
-
+    if (!init) {
+      set_error(init);
+    }
     const interval_id = setInterval(() => {
-      if (has_uncommitted_changes) {
-        set_error(true);
+      if (
+        show_uncommitted_changes != null &&
+        set_show_uncommitted_changes != null
+      ) {
+        const next = has_uncommitted_changes;
+        set_show_uncommitted_changes(next);
+        set_error(next);
+      } else {
+        if (has_uncommitted_changes) {
+          set_error(true);
+        }
       }
     }, delay_ms + 10);
 
     return function cleanup() {
       clearInterval(interval_id);
     };
-  }, [has_uncommitted_changes, delay_ms]);
+  }, [has_uncommitted_changes, delay_ms, show_uncommitted_changes, init]);
 
   if (show_error) {
     return <span style={STYLE}>NOT saved!</span>;
@@ -57,3 +73,5 @@ export const UncommittedChanges: React.FC<Props> = ({
     return <span />; // TODO: return undefined?
   }
 };
+
+export const UncommittedChanges = React.memo(UncommittedChangesFC);


### PR DESCRIPTION
# Description
* this started by fixing #4434, but then I looked into this "react-logic" behind it and did some tests. so, I don't like how this is done at all.
* I ended up lifting up the state of showing the uncommitted information to the store. otherwise it resets each time one switches frames.


# Testing Steps
* I tested this by having two frames in a textfile, stopped my dev hub, and then tried to save a change. error shows up, and resolves once I start my dev hub again.
* The button also appears in chat, so, same there. Chat has no changes, because it is backwards compatible.

# Relevant Issues
#4434

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
