### PR TITLE
various latex error processing improvements

### DIFF
--- a/src/smc-project/browser-websocket/canonical-path.ts
+++ b/src/smc-project/browser-websocket/canonical-path.ts
@@ -15,12 +15,14 @@ import { resolve } from "path";
 
 export function canonical_paths(paths: string[]): string[] {
   const v: string[] = [];
+
+  const { HOME } = process.env;
+  if (HOME == null) {
+    throw Error("HOME environment variable must be defined");
+  }
+
   for (let path of paths) {
     path = resolve(path);
-    const { HOME } = process.env;
-    if (HOME == null) {
-      throw Error("HOME environment variable must be defined");
-    }
     if (path.startsWith(HOME)) {
       v.push(path.slice(HOME.length + 1));
     } else {

--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -695,6 +695,10 @@ export class Actions extends BaseActions<LatexEditorState> {
       return;
     }
     this.set_status("");
+    // resetting parsed_output_log is ok, even if we do two passes.
+    // the reason is that in pythontex or sagetex there is a merge *after* this step.
+    // therefore, resetting this here will get rid of then stale errors related to
+    // missing tokens, because pythontex or sagetex just computed them.
     this.parsed_output_log = output.parse = new LatexParser(output.stdout, {
       ignoreDuplicates: true,
     }).parse();

--- a/src/smc-webapp/frame-editors/latex-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/actions.ts
@@ -18,6 +18,8 @@ const VIEWERS: ReadonlyArray<string> = [
 
 import { delay } from "awaiting";
 import * as CodeMirror from "codemirror";
+import { normalize as path_normalize } from "path";
+import { union } from "lodash";
 
 import { fromJS, List, Map } from "immutable";
 import { once } from "smc-util/async-utils";
@@ -518,8 +520,8 @@ export class Actions extends BaseActions<LatexEditorState> {
     }
   }
 
-  clean(): void {
-    this.build_action("clean");
+  async clean(): Promise<void> {
+    await this.build_action("clean");
   }
 
   async run_build(time: number, force: boolean): Promise<void> {
@@ -597,7 +599,8 @@ export class Actions extends BaseActions<LatexEditorState> {
     } finally {
       this.set_status("");
     }
-    this.parsed_output_log = output.parse = knitr_errors(output).toJS();
+    output.parse = knitr_errors(output).toJS();
+    this.merge_parsed_output_log(output.parse);
     this.set_build_logs({ knitr: output });
     this.update_gutters();
     this.setState({ knitr_error: output.parse?.errors?.length > 0 });
@@ -709,6 +712,27 @@ export class Actions extends BaseActions<LatexEditorState> {
     }
   }
 
+  // this *merges* errors from log into an eventually already existing this.parsed_output_log
+  // the whole point is to keep latex errors while we add additional errors from
+  // pythontex, sagetex, etc.
+  private merge_parsed_output_log(log: IProcessedLatexLog) {
+    // easy case, never supposed to happen
+    if (this.parsed_output_log == null) {
+      this.parsed_output_log = log;
+      return;
+    }
+    for (const key of ["errors", "warnings", "typesetting", "all"]) {
+      const existing = this.parsed_output_log[key];
+      log[key].forEach((error) => existing.push(error));
+    }
+    for (const key of ["files", "deps"]) {
+      this.parsed_output_log[key] = union(
+        this.parsed_output_log[key],
+        log[key]
+      );
+    }
+  }
+
   private async update_gutters_soon(): Promise<void> {
     await delay(500);
     if (this._state == "closed") return;
@@ -716,6 +740,8 @@ export class Actions extends BaseActions<LatexEditorState> {
   }
 
   private update_gutters(): void {
+    // if we pass in a parsed log, we don't clean the gutters
+    // it is meant to add to what we already have, e.g. for PythonTeX
     if (this.parsed_output_log == null) return;
     this.clear_gutters();
     update_gutters({
@@ -731,10 +757,14 @@ export class Actions extends BaseActions<LatexEditorState> {
   }
 
   private set_gutter(path: string, line: number, component: any): void {
-    if (this.canonical_paths[path] != null) {
-      path = this.canonical_paths[path];
+    const canon_path = this.get_canonical_path(path);
+    if (canon_path != null) {
+      path = canon_path;
     }
-    const actions = this.redux.getEditorActions(this.project_id, path);
+    const actions = this.redux.getEditorActions(
+      this.project_id,
+      path_normalize(path)
+    );
     if (actions == null) {
       return; // file not open
     }
@@ -743,6 +773,13 @@ export class Actions extends BaseActions<LatexEditorState> {
       component,
       gutter_id: "Codemirror-latex-errors",
     });
+  }
+
+  // transform a relative path like file.tex or ./x/name.tex
+  // to the canonical path
+  private get_canonical_path(path: string): string {
+    const norm = path_normalize(path);
+    return this.canonical_paths[norm];
   }
 
   private async set_switch_to_files(files: string[]): Promise<void> {
@@ -756,6 +793,7 @@ export class Actions extends BaseActions<LatexEditorState> {
       switch_to_files = [];
     }
 
+    // if we're not in the home directory, prefix it to all relative paths
     let files1: string[];
     const dir = path_split(this.path).head;
     if (dir == "") {
@@ -771,15 +809,18 @@ export class Actions extends BaseActions<LatexEditorState> {
       }
     }
 
-    const files2 = await (await project_api(this.project_id)).canonical_paths(
-      files1
-    );
+    // get canonical path names for each file
+    const api = await project_api(this.project_id);
+    const files2 = await api.canonical_paths(files1);
+
+    // record all relative paths
     for (let i = 0; i < files2.length; i++) {
-      const path = files2[i];
-      if (!path.startsWith("/")) {
-        switch_to_files.push(path);
-        this.relative_paths[path] = files[i];
-        this.canonical_paths[files[i]] = path;
+      const canon_path = files2[i];
+      if (!canon_path.startsWith("/")) {
+        switch_to_files.push(canon_path);
+        const relnorm_path = path_normalize(files[i]);
+        this.relative_paths[canon_path] = relnorm_path;
+        this.canonical_paths[relnorm_path] = canon_path;
       }
     }
     // sort and make unique.
@@ -873,10 +914,8 @@ export class Actions extends BaseActions<LatexEditorState> {
 
     if (output != null) {
       // process any errors
-      this.parsed_output_log = output.parse = sagetex_errors(
-        path_split(this.path).tail,
-        output
-      ).toJS();
+      output.parse = sagetex_errors(path_split(this.path).tail, output).toJS();
+      this.merge_parsed_output_log(output.parse);
       this.set_build_logs({ sagetex: output });
       // there is no line information in the sagetex errors (and no concordance info either),
       // hence we can't update the gutters.
@@ -899,9 +938,9 @@ export class Actions extends BaseActions<LatexEditorState> {
         this.get_output_directory()
       );
       // Now run latex again, since we had to run pythontex, which changes
-      // the inserted snippets. This +1 forces re-running latex... but still dedups
-      // it in case of multiple users.
-      await this.run_latex(time + 1, force);
+      // the inserted snippets. This +2 forces re-running latex... but still dedups
+      // it in case of multiple users. (+1 is for sagetex)
+      await this.run_latex(time + 2, force);
     } catch (err) {
       this.set_error(err);
       // this.setState({ pythontex_error: true });
@@ -911,10 +950,8 @@ export class Actions extends BaseActions<LatexEditorState> {
       this.set_status("");
     }
     // this is similar to how knitr errors are processed
-    this.parsed_output_log = output.parse = pythontex_errors(
-      path_split(this.path).tail,
-      output
-    ).toJS();
+    output.parse = pythontex_errors(path_split(this.path).tail, output).toJS();
+    this.merge_parsed_output_log(output.parse);
     this.set_build_logs({ pythontex: output });
     this.update_gutters();
   }
@@ -1099,22 +1136,22 @@ export class Actions extends BaseActions<LatexEditorState> {
     const now: number = server_time().valueOf();
     switch (action) {
       case "build":
-        this.run_build(now, false);
+        await this.run_build(now, false);
         return;
       case "latex":
-        this.run_latex(now, false);
+        await this.run_latex(now, false);
         return;
       case "bibtex":
-        this.run_bibtex(now, false);
+        await this.run_bibtex(now, false);
         return;
       case "sagetex":
-        this.run_sagetex(now, false);
+        await this.run_sagetex(now, false);
         return;
       case "pythontex":
-        this.run_pythontex(now, false);
+        await this.run_pythontex(now, false);
         return;
       case "clean":
-        this.run_clean();
+        await this.run_clean();
         return;
       default:
         this.set_error(`unknown build action '${action}'`);

--- a/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -8,19 +8,13 @@ Show errors and warnings.
 */
 
 import { Map } from "immutable";
+import { sortBy } from "lodash";
 import { capitalize, is_different, path_split } from "smc-util/misc2";
-import {
-  Component,
-  React,
-  rclass,
-  rtypes,
-  Rendered,
-} from "../../app-framework";
+import { React, Rendered, useRedux } from "../../app-framework";
 import { TypedMap } from "../../app-framework/TypedMap";
-
 import { BuildLogs } from "./actions";
-
 import { Icon, Loading } from "smc-webapp/r_misc";
+import { COLORS } from "../../../smc-util/theme";
 
 function group_to_level(group: string): string {
   switch (group) {
@@ -90,77 +84,83 @@ interface ItemProps {
   item: TypedMap<item>;
 }
 
-class Item extends Component<ItemProps, {}> {
-  shouldComponentUpdate(props: ItemProps): boolean {
-    return this.props.item !== props.item;
-  }
+const ItemFC: React.FC<ItemProps> = (props) => {
+  const { actions, item } = props;
 
-  edit_source(e: React.SyntheticEvent<any>): void {
+  function edit_source(e: React.SyntheticEvent<any>): void {
     e.stopPropagation();
-    if (!this.props.item.get("file")) return; // not known
-    const line: number = parseInt(this.props.item.get("line"));
-    let path = this.props.item.get("file");
-    const head = path_split(this.props.actions.path).head;
+    if (!item.get("file")) return; // not known
+    const line: number = parseInt(item.get("line"));
+    let path = item.get("file");
+    const head = path_split(actions.path).head;
     if (head != "") {
       path = head + "/" + path;
     }
     if (!path) return;
-    this.props.actions.goto_line_in_file(line, path);
-    this.props.actions.synctex_tex_to_pdf(line, 0, this.props.item.get("file"));
+    actions.goto_line_in_file(line, path);
+    actions.synctex_tex_to_pdf(line, 0, item.get("file"));
   }
 
-  render_location(): React.ReactElement<any> | undefined {
-    if (!this.props.item.get("line")) {
+  function render_location(): React.ReactElement<any> | undefined {
+    if (!item.get("line")) {
       return;
     }
     // https://github.com/sagemathinc/cocalc/issues/3413
-    const file = this.props.item.get("file");
+    const file = item.get("file");
 
     if (file) {
       return (
         <div>
           <a
-            onClick={(e) => this.edit_source(e)}
+            onClick={(e) => edit_source(e)}
             style={{ cursor: "pointer", float: "right" }}
           >
-            Line {this.props.item.get("line")} of {file}
+            Line {item.get("line")} of {file}
           </a>
         </div>
       );
     } else {
-      return <div>Line {this.props.item.get("line")}</div>;
+      return <div>Line {item.get("line")}</div>;
     }
   }
 
-  render_message(): React.ReactElement<any> | undefined {
-    const message = this.props.item.get("message");
+  function render_message(): React.ReactElement<any> | undefined {
+    const message = item.get("message");
     if (!message) {
       return;
     }
     return <div>{message}</div>;
   }
 
-  render_content(): React.ReactElement<any> | undefined {
-    const content = this.props.item.get("content");
+  function render_content(): React.ReactElement<any> | undefined {
+    const content = item.get("content");
     if (!content) {
       return;
     }
     return <pre>{content}</pre>;
   }
 
-  render(): React.ReactElement<any> {
-    return (
-      <div style={ITEM_STYLES[this.props.item.get("level")]}>
-        {this.render_location()}
-        {this.render_message()}
-        {this.render_content()}
-      </div>
-    );
-  }
+  return (
+    <div style={ITEM_STYLES[item.get("level")]}>
+      {render_location()}
+      {render_message()}
+      {render_content()}
+    </div>
+  );
+};
+
+const Item = React.memo(ItemFC, (prev, next) => prev.item === next.item);
+
+interface MsgGroup {
+  rendered: Rendered;
+  level: string;
+  group: string;
+  size: number;
 }
 
 interface ErrorsAndWarningsProps {
   id: string;
+  name: string;
   actions: any;
   editor_state: Map<string, any>;
   is_fullscreen: boolean;
@@ -168,42 +168,42 @@ interface ErrorsAndWarningsProps {
   path: string;
   reload: number;
   font_size: number;
-
-  // reduxProps:
-  build_logs: BuildLogs;
-  status: string;
-  knitr: boolean;
 }
 
-class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
-  static defaultProps = { build_logs: Map<string, any>(), status: "" };
+const ErrorsAndWarningsFC: React.FC<ErrorsAndWarningsProps> = (props) => {
+  const {
+    /*id,*/
+    name,
+    actions,
+    /*editor_state,*/
+    /*is_fullscreen,*/
+    /*project_id,*/
+    /*path,*/
+    /*reload,*/
+    /*font_size,*/
+  } = props;
 
-  static reduxProps({ name }) {
-    return {
-      [name]: {
-        build_logs: rtypes.immutable.Map,
-        status: rtypes.string,
-        knitr: rtypes.bool,
-      },
-    };
+  const build_logs_next: BuildLogs =
+    useRedux([name, "build_logs"]) ?? Map<string, any>();
+  const [build_logs, set_build_logs] = React.useState<BuildLogs>(
+    Map<string, any>()
+  );
+
+  // only update if any parsed logs differ
+  for (const key of ["latex", "knitr", "pythontex", "sagetex"]) {
+    if (
+      build_logs_next.getIn([key, "parse"]) != build_logs.getIn([key, "parse"])
+    ) {
+      set_build_logs(build_logs_next);
+      break;
+    }
   }
 
-  shouldComponentUpdate(props): boolean {
-    return (
-      is_different(this.props, props, ["status", "font_size", "knitr"]) ||
-      this.props.build_logs.getIn(["latex", "parse"]) !=
-        props.build_logs.getIn(["latex", "parse"]) ||
-      this.props.build_logs.getIn(["knitr", "parse"]) !=
-        props.build_logs.getIn(["knitr", "parse"]) ||
-      this.props.build_logs.getIn(["pythontex", "parse"]) !=
-        props.build_logs.getIn(["pythontex", "parse"]) ||
-      this.props.build_logs.getIn(["sagetex", "parse"]) !=
-        props.build_logs.getIn(["sagetex", "parse"])
-    );
-  }
+  const status: string = useRedux([name, "status"]) ?? "";
+  const knitr: boolean = useRedux([name, "knitr"]);
 
-  render_status(): Rendered {
-    if (this.props.status) {
+  function render_status(): Rendered {
+    if (status) {
       return (
         <div
           style={{
@@ -214,10 +214,10 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
           }}
         >
           <Loading
-            text={this.props.status}
+            text={status}
             style={{
               fontSize: "10pt",
-              color: "#666",
+              color: COLORS.GRAY,
             }}
           />
         </div>
@@ -225,28 +225,33 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
     }
   }
 
-  render_item(item, key): Rendered {
-    return <Item key={key} item={item} actions={this.props.actions} />;
+  function render_item(item, key): Rendered {
+    return <Item key={key} item={item} actions={actions} />;
   }
 
-  render_group_content(content): Rendered {
+  function render_group_content(content): Rendered {
     if (content.size === 0) {
       return <div>None</div>;
     } else {
       const w: Rendered[] = [];
       content.forEach((item) => {
-        w.push(this.render_item(item, w.length));
+        w.push(render_item(item, w.length));
       });
       return <div>{w}</div>;
     }
   }
 
-  render_group(tool: string, group: string, num: number): Rendered {
-    if (tool == "knitr" && !this.props.knitr) {
+  function render_group(
+    tool: string,
+    group: string,
+    num: number
+  ): MsgGroup | undefined {
+    if (tool == "knitr" && !knitr) {
       return undefined;
     }
-    const spec: SpecItem = SPEC[group_to_level(group)];
-    const content = this.props.build_logs.getIn([tool, "parse", group]);
+    const level = group_to_level(group);
+    const spec: SpecItem = SPEC[level];
+    const content = build_logs.getIn([tool, "parse", group]);
     if (!content) {
       return;
     }
@@ -256,50 +261,78 @@ class ErrorsAndWarnings extends Component<ErrorsAndWarningsProps, {}> {
         {capitalize(group)} ({capitalize(tool)})
       </>
     );
-    return (
+    const rendered = (
       <div key={`${group}-${num}`}>
         {content.size == 0 ? <h5>{header}</h5> : <h3>{header}</h3>}
-        {this.render_group_content(content)}
+        {render_group_content(content)}
       </div>
     );
+    return { rendered, level, group, size: content.size };
   }
 
-  render_hint(): Rendered {
-    if (this.props.status || this.props.build_logs.size > 0) {
+  // in particular, we want to show actual errors at the top
+  // (otherwise, e.g. sagetex errors are burried below typesetting warnings)
+  function priority(group: MsgGroup) {
+    if (group.size == 0) return 0;
+    // lower index number comes first
+    const grouporder = ["errors", "typesetting", "warnings"];
+    // see group_to_level
+    const level = { error: 100, warning: 10 }[group.level] ?? 0;
+    return -level + grouporder.indexOf(group.group);
+  }
+
+  function render_groups(): Rendered[] {
+    const groups: MsgGroup[] = [];
+    const add = (group) => {
+      if (group != null) groups.push(group);
+    };
+    ["errors", "typesetting", "warnings"].forEach((group) =>
+      add(render_group("latex", group, 0))
+    );
+    add(render_group("sagetex", "errors", 1));
+    ["errors", "warnings"].forEach((group) =>
+      add(render_group("knitr", group, 2))
+    );
+    add(render_group("pythontex", "errors", 3));
+
+    return sortBy(groups, priority).map((g) => g.rendered);
+  }
+
+  function render_hint(): Rendered {
+    if (status || build_logs.size > 0) {
       return;
     }
     return (
-      <div style={{ color: "#666" }}>
+      <div style={{ color: COLORS.GRAY }}>
         Click the <Icon name="play-circle" /> Build button or hit shift+enter to
         run LaTeX.
       </div>
     );
   }
 
-  render(): React.ReactElement<any> {
-    return (
-      <div
-        className={"smc-vfill"}
-        style={{
-          overflowY: "scroll",
-          padding: "5px 15px",
-          fontSize: "10pt",
-        }}
-      >
-        {this.render_hint()}
-        {this.render_status()}
-        {["errors", "typesetting", "warnings"].map((group) =>
-          this.render_group("latex", group, 0)
-        )}
-        {this.render_group("sagetex", "errors", 1)}
-        {["errors", "warnings"].map((group) =>
-          this.render_group("knitr", group, 2)
-        )}
-        {this.render_group("pythontex", "errors", 3)}
-      </div>
-    );
-  }
+  return (
+    <div
+      className={"smc-vfill"}
+      style={{
+        overflowY: "scroll",
+        padding: "5px 15px",
+        fontSize: "10pt",
+      }}
+    >
+      {render_hint()}
+      {render_status()}
+      {render_groups()}
+    </div>
+  );
+};
+
+function should_memoize(prev, next): boolean {
+  const props_diff = is_different(prev, next, ["status", "font_size", "knitr"]);
+  // if props are different → don't memoize
+  return !props_diff;
 }
 
-const tmp = rclass(ErrorsAndWarnings);
-export { tmp as ErrorsAndWarnings };
+export const ErrorsAndWarnings = React.memo(
+  ErrorsAndWarningsFC,
+  should_memoize
+);

--- a/src/smc-webapp/frame-editors/latex-editor/gutters.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/gutters.tsx
@@ -23,7 +23,7 @@ export function update_gutters(opts: {
     let item: Error;
     for (item of opts.log[group]) {
       if (!item.file) continue;
-      if (item.line === null) {
+      if (item.line == null) {
         /* no gutter mark in a line if there is no line number, e.g., "there were missing refs" */
         continue;
       }

--- a/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
@@ -8,6 +8,8 @@
 // incorporating fix for https://github.com/sharelatex/latex-log-parser-sharelatex/issues/5 by HSY
 // License: MIT
 
+import { normalize as path_normalize } from "path";
+
 // Define some constants
 const LOG_WRAP_LIMIT = 79;
 const LATEX_WARNING_REGEX = /^LaTeX Warning: (.*)$/;
@@ -384,13 +386,14 @@ export class LatexParser {
     }
     //if DEBUG
     //    console.log("latex-log-parser@consumeFilePath", @currentLine, "endOfFilePath:", endOfFilePath, "-> path: '#{path}'")
-    return path;
+    return path_normalize(path);
   }
 
   postProcess(data: Error[]): ProcessedLatexLog {
     const pll = new ProcessedLatexLog();
     for (const path of this.files) {
-      if (!path.endsWith(".tex") && !path.endsWith(".bib")) continue; // only include tex and bib files
+      // only include tex and bib files
+      if (!path.endsWith(".tex") && !path.endsWith(".bib")) continue;
       pll.files.push(path);
     }
     const hashes: string[] = [];


### PR DESCRIPTION
# Description

* normalize paths for canonical lookup, in particular`./foo.tex` → `foo.tex` – otherwise there is nothing to look up in the dictionary
* processing error logs after sagetex, knitr or pythontex **replaces** the errors to display in the gutter. now, they're merge instead
* deduplicating the second latex build shouldn't use the same key for pythontex and sagetex
* modernize this errors + warnings panel. also, prioritize errors on top of all others. otherwise, for example sagetex or pythontex errors are burried below less important notices that there are no latex errors or typesetting issues
* regarding knitr, I hoped errors would also show up in the gutter (the error has the correct filename and line number) but it's too confusing for me to figure out what's going on. certainly, the canonicalization of all paths is disabled, but enabling it by itself doesn't help. 

# Testing Steps
1. made a short tex file, that includes one other tex file via `\input{...}` and I'm running `\sage` or `\py` commands throwing errors, e.g. `\py{1+1+}`.
1. I'm triggering a warning via `\PackageWarning{balbla}{foobar}` somewhere as well
1. toggle back and forth to the  `\input{...}` included file to check if the gutter is still updated fine

# Relevant Issues
#4677

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
