### PR TITLE
improve rmd build 

### DIFF
--- a/src/smc-util/theme.js
+++ b/src/smc-util/theme.js
@@ -91,6 +91,8 @@ const COLORS = {
   BG_RED: "#d9534f", // the red bootstrap color of the button background
   FG_RED: "#c9302c", // red used for text
   FG_BLUE: "#428bca", // blue used for text
+
+  ATND_BG_RED_L: "#fff2f0",
 };
 
 // The definitions below add semantic meaning by using the colors

--- a/src/smc-webapp/frame-editors/markdown-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/actions.ts
@@ -18,6 +18,9 @@ import { FrameTree } from "../frame-tree/types";
 
 interface MarkdownEditorState extends CodeEditorState {
   custom_pdf_error_message: string; // currently used only in rmd editor, but we could easily add pdf output to the markdown editor
+  build_log: string; // for Rmd
+  build_err: string; // for Rmd
+  build_exit: number; // for Rmd
 }
 
 export class Actions extends CodeEditorActions<MarkdownEditorState> {

--- a/src/smc-webapp/frame-editors/markdown-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/markdown-editor/actions.ts
@@ -18,6 +18,7 @@ import { FrameTree } from "../frame-tree/types";
 
 interface MarkdownEditorState extends CodeEditorState {
   custom_pdf_error_message: string; // currently used only in rmd editor, but we could easily add pdf output to the markdown editor
+  building: boolean; // for Rmd
   build_log: string; // for Rmd
   build_err: string; // for Rmd
   build_exit: number; // for Rmd

--- a/src/smc-webapp/frame-editors/rmd-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/actions.ts
@@ -47,6 +47,7 @@ output: html_document
 
 export class RmdActions extends Actions {
   private _last_save_time: number = 0;
+  private _last_build_rmd: string = "";
   private is_building: boolean = false;
   private run_rmd_converter: Function;
 
@@ -73,11 +74,15 @@ export class RmdActions extends Actions {
       this._last_save_time = time;
       this.run_rmd_converter();
     });
+    this._syncstring.on("after-change", () => {
+      if (this._last_build_rmd != this._syncstring.to_str()) {
+        this.build();
+      }
+    });
     this._syncstring.once("ready", () => this._run_rmd_converter());
   }
 
-  async build(id: string): Promise<void> {
-    console.log("build", id);
+  async build(id?: string): Promise<void> {
     if (id) {
       const cm = this._get_cm(id);
       if (cm) {
@@ -154,6 +159,7 @@ export class RmdActions extends Actions {
       // fire this at any time.
       return;
     }
+    this._last_build_rmd = this._syncstring.to_str();
     this.set_status("Running RMarkdown...");
     this.set_error("");
     this.setState({ build_log: "", build_err: "" });

--- a/src/smc-webapp/frame-editors/rmd-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/actions.ts
@@ -161,6 +161,7 @@ export class RmdActions extends Actions {
     }
     this._last_build_rmd = this._syncstring.to_str();
     this.set_status("Running RMarkdown...");
+    this.setState({ building: true });
     this.set_error("");
     this.setState({ build_log: "", build_err: "" });
     let markdown = "";
@@ -196,6 +197,7 @@ export class RmdActions extends Actions {
       return;
     } finally {
       this.set_status("");
+      this.setState({ building: false });
     }
     this.setState({ value: markdown });
   }

--- a/src/smc-webapp/frame-editors/rmd-editor/build-log.tsx
+++ b/src/smc-webapp/frame-editors/rmd-editor/build-log.tsx
@@ -4,11 +4,53 @@
  */
 
 import * as React from "react";
+import Ansi from "ansi-to-react";
+import { Loading } from "smc-webapp/r_misc";
+import { Rendered, useRedux } from "../../app-framework";
+import { COLORS } from "../../../smc-util/theme";
+import { Button } from "smc-webapp/antd-bootstrap";
 
 interface BuildLogProps {
-  name: String;
+  name: string;
   actions: any;
 }
+
+const STYLE_LOADING: React.CSSProperties = {
+  margin: "auto",
+};
+
+const STYLE_HEADER: React.CSSProperties = {
+  margin: "1rem 1rem 0 1rem",
+  borderBottom: `1px solid ${COLORS.GRAY}`,
+  color: COLORS.GRAY,
+};
+
+const STYLE_OUTER: React.CSSProperties = {
+  display: "flex",
+  flex: "1 1 auto",
+  flexDirection: "column",
+  overflow: "auto",
+};
+
+const STYLE_LOG: React.CSSProperties = {
+  flex: "1 1 auto",
+  fontSize: "11px",
+};
+
+const STYLE_PRE: React.CSSProperties = {
+  whiteSpace: "pre-wrap",
+  margin: "0",
+  borderRadius: "0",
+  border: "0",
+  backgroundColor: "inherit",
+};
+
+const STYLE_ERR: React.CSSProperties = {
+  ...STYLE_LOG,
+  fontSize: "11px",
+  fontWeight: "bold",
+  backgroundColor: COLORS.ATND_BG_RED_L,
+};
 
 const BuildLogFC: React.FC<BuildLogProps> = (props) => {
   const {
@@ -23,9 +65,74 @@ const BuildLogFC: React.FC<BuildLogProps> = (props) => {
     /*font_size,*/
   } = props;
 
-  console.log("name", name, "actions", actions);
+  const status = useRedux([name, "status"]);
+  const build_log = useRedux([name, "build_log"]) || "";
+  const build_err = useRedux([name, "build_err"]) || "";
+  const have_err = (useRedux([name, "build_exit"]) || 0) != 0;
+  const [show_stdout, set_show_stdout] = React.useState(false);
 
-  return <div>Build Log {name}</div>;
+  function stderr(): Rendered {
+    if (!have_err) return;
+    const header = show_stdout ? (
+      <h4 style={STYLE_HEADER}>Error output</h4>
+    ) : undefined;
+    return (
+      <div style={STYLE_ERR}>
+        {header}
+        <pre style={STYLE_PRE}>
+          <Ansi>{build_err}</Ansi>
+        </pre>
+      </div>
+    );
+  }
+
+  function stdout(): Rendered {
+    if (!build_log) return;
+    if (!have_err || show_stdout) {
+      return (
+        <div style={STYLE_LOG}>
+          {show_stdout && <h4 style={STYLE_HEADER}>Standard output</h4>}
+          <pre style={STYLE_PRE}>
+            <Ansi>{build_log}</Ansi>
+          </pre>
+        </div>
+      );
+    } else {
+      return (
+        <Button bsSize={"small"} onClick={() => set_show_stdout(true)}>
+          Show full output
+        </Button>
+      );
+    }
+  }
+
+  function body(): Rendered {
+    return (
+      <>
+        {stderr()}
+        {stdout()}
+      </>
+    );
+  }
+
+  if (status) {
+    return <Loading style={STYLE_LOADING} text={status} />;
+  } else if (!build_log && !build_err) {
+    return (
+      <div style={{ margin: "1rem" }}>
+        Document not built:{" "}
+        <Button bsSize={"small"} onClick={() => actions.run_rmd_converter()}>
+          build now
+        </Button>
+        .
+      </div>
+    );
+  } else {
+    return <div style={STYLE_OUTER}>{body()}</div>;
+  }
 };
 
-export const BuildLog = React.memo(BuildLogFC);
+export const BuildLog = React.memo(
+  BuildLogFC,
+  (prev, next) => prev.name != next.name
+);

--- a/src/smc-webapp/frame-editors/rmd-editor/build-log.tsx
+++ b/src/smc-webapp/frame-editors/rmd-editor/build-log.tsx
@@ -13,6 +13,7 @@ import { Button } from "smc-webapp/antd-bootstrap";
 interface BuildLogProps {
   name: string;
   actions: any;
+  font_size: number;
 }
 
 const STYLE_LOADING: React.CSSProperties = {
@@ -34,7 +35,6 @@ const STYLE_OUTER: React.CSSProperties = {
 
 const STYLE_LOG: React.CSSProperties = {
   flex: "1 1 auto",
-  fontSize: "11px",
 };
 
 const STYLE_PRE: React.CSSProperties = {
@@ -47,7 +47,6 @@ const STYLE_PRE: React.CSSProperties = {
 
 const STYLE_ERR: React.CSSProperties = {
   ...STYLE_LOG,
-  fontSize: "11px",
   fontWeight: "bold",
   backgroundColor: COLORS.ATND_BG_RED_L,
 };
@@ -62,14 +61,21 @@ const BuildLogFC: React.FC<BuildLogProps> = (props) => {
     /*project_id,*/
     /*path,*/
     /*reload,*/
-    /*font_size,*/
+    font_size: font_size_orig,
   } = props;
 
-  const status = useRedux([name, "status"]);
+  const font_size = 0.8 * font_size_orig;
+
+  const status = useRedux([name, "building"]);
   const build_log = useRedux([name, "build_log"]) || "";
   const build_err = useRedux([name, "build_err"]) || "";
   const have_err = (useRedux([name, "build_exit"]) || 0) != 0;
   const [show_stdout, set_show_stdout] = React.useState(false);
+
+  function style(type: "log" | "err") {
+    const style = type == "log" ? STYLE_LOG : STYLE_ERR;
+    return { ...{ fontSize: `${font_size}px` }, ...style };
+  }
 
   function stderr(): Rendered {
     if (!have_err) return;
@@ -77,7 +83,7 @@ const BuildLogFC: React.FC<BuildLogProps> = (props) => {
       <h4 style={STYLE_HEADER}>Error output</h4>
     ) : undefined;
     return (
-      <div style={STYLE_ERR}>
+      <div style={style("err")}>
         {header}
         <pre style={STYLE_PRE}>
           <Ansi>{build_err}</Ansi>
@@ -90,7 +96,7 @@ const BuildLogFC: React.FC<BuildLogProps> = (props) => {
     if (!build_log) return;
     if (!have_err || show_stdout) {
       return (
-        <div style={STYLE_LOG}>
+        <div style={style("log")}>
           {show_stdout && <h4 style={STYLE_HEADER}>Standard output</h4>}
           <pre style={STYLE_PRE}>
             <Ansi>{build_log}</Ansi>
@@ -116,7 +122,7 @@ const BuildLogFC: React.FC<BuildLogProps> = (props) => {
   }
 
   if (status) {
-    return <Loading style={STYLE_LOADING} text={status} />;
+    return <Loading style={STYLE_LOADING} text={"Running rmarkdown::render ..."} />;
   } else if (!build_log && !build_err) {
     return (
       <div style={{ margin: "1rem" }}>

--- a/src/smc-webapp/frame-editors/rmd-editor/build-log.tsx
+++ b/src/smc-webapp/frame-editors/rmd-editor/build-log.tsx
@@ -1,0 +1,31 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import * as React from "react";
+
+interface BuildLogProps {
+  name: String;
+  actions: any;
+}
+
+const BuildLogFC: React.FC<BuildLogProps> = (props) => {
+  const {
+    /*id,*/
+    name,
+    actions,
+    /*editor_state,*/
+    /*is_fullscreen,*/
+    /*project_id,*/
+    /*path,*/
+    /*reload,*/
+    /*font_size,*/
+  } = props;
+
+  console.log("name", name, "actions", actions);
+
+  return <div>Build Log {name}</div>;
+};
+
+export const BuildLog = React.memo(BuildLogFC);

--- a/src/smc-webapp/frame-editors/rmd-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/editor.ts
@@ -102,7 +102,7 @@ const EDITOR_SPEC = {
     icon: "gears",
     component: BuildLog,
     style: { background: "#525659" },
-    buttons: set(["build"]),
+    buttons: set(["build", "decrease_font_size", "increase_font_size"]),
   },
 
   terminal,

--- a/src/smc-webapp/frame-editors/rmd-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/editor.ts
@@ -18,6 +18,7 @@ import { PDFJS } from "../latex-editor/pdfjs";
 import { pdfjs_buttons } from "../latex-editor/editor";
 import { terminal } from "../terminal-editor/editor";
 import { time_travel } from "../time-travel-editor/editor";
+import { BuildLog } from "./build-log";
 
 const EDITOR_SPEC = {
   cm: {
@@ -40,6 +41,7 @@ const EDITOR_SPEC = {
       "undo",
       "redo",
       "format",
+      "build",
     ]),
   },
 
@@ -92,6 +94,15 @@ const EDITOR_SPEC = {
       "time_travel",
       "reload",
     ]),
+  },
+
+  build: {
+    short: "Build Log",
+    name: "Build Log",
+    icon: "gears",
+    component: BuildLog,
+    style: { background: "#525659" },
+    buttons: set(["build"]),
   },
 
   terminal,

--- a/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
+++ b/src/smc-webapp/frame-editors/rmd-editor/rmd-converter.ts
@@ -28,12 +28,10 @@ export async function convert(
     frontmatter.indexOf("self_contained") >= 0 ||
     frontmatter.indexOf("output:") >= 0
   ) {
-    // , output_file = '${outfile}'
     cmd = `rmarkdown::render('${infile}', output_format = NULL, run_pandoc = TRUE)`;
   } else {
     cmd = `rmarkdown::render('${infile}', output_format = NULL, run_pandoc = TRUE, output_options = list(self_contained = FALSE))`;
   }
-  // console.log("rmd cmd", cmd);
 
   return await exec({
     timeout: 4 * 60,
@@ -43,7 +41,7 @@ export async function convert(
     env: { MPLBACKEND: "Agg" }, // for python plots -- https://github.com/sagemathinc/cocalc/issues/4202
     project_id: project_id,
     path: x.head,
-    err_on_exit: true,
+    err_on_exit: false,
     aggregate: time,
   });
 }


### PR DESCRIPTION
# Description
* build button
* make it so clicking the build button always rebuilds
* make the refresh button of the iframe work
* save the file itself
* show build log and (if it exists) show the error log
* rebuild if content changes, see #3188 ... although, no idea if this is a good way to do this. is there a documentation for this syncstring attribute?

# Testing Steps
* my test document just had a bit of text and couple of cells like
```{r}
rnorm(4)
```
* To trigger a problem, I changed it to e.g. `rnorm(5+5+)`

# Relevant Issues
#4578
#3188

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
