### PR TITLE
html viewer fix +/- zoom button

### DIFF
--- a/src/smc-webapp/frame-editors/html-editor/iframe-html.tsx
+++ b/src/smc-webapp/frame-editors/html-editor/iframe-html.tsx
@@ -16,7 +16,14 @@ import {
   list_alternatives,
 } from "smc-util/misc2";
 import { throttle } from "underscore";
-import { Component, React, ReactDOM, Rendered } from "../../app-framework";
+import {
+  Component,
+  React,
+  ReactDOM,
+  Rendered,
+  redux,
+} from "../../app-framework";
+import { DEFAULT_FONT_SIZE } from "smc-util/db-schema/defaults";
 
 import * as CSS from "csstype";
 
@@ -151,6 +158,15 @@ export class IFrameHTML extends Component<PropTypes, {}> {
     elt.contentDocument.location.reload(true);
   }
 
+  base_font_size(): number {
+    const account = redux.getStore("account");
+    if (account != null) {
+      return account.get("font_size", DEFAULT_FONT_SIZE);
+    } else {
+      return DEFAULT_FONT_SIZE;
+    }
+  }
+
   set_iframe_style(font_size?: number): void {
     const elt = ReactDOM.findDOMNode(this.refs.iframe);
     if (elt == null) {
@@ -159,7 +175,12 @@ export class IFrameHTML extends Component<PropTypes, {}> {
     const j = $(elt);
     j.css("opacity", 1);
     const body = j.contents().find("body");
-    body.css("zoom", (font_size != null ? font_size : 16) / 16);
+    const base = this.base_font_size();
+    const scale = (font_size != null ? font_size : base) / base;
+    // don't use "zoom: ...", which is not a standard property
+    // https://github.com/sagemathinc/cocalc/issues/4438
+    body.css("transform", `scale(${scale})`);
+    body.css("transform-origin", "0 0");
     if (this.props.is_fullscreen && this.props.fullscreen_style != null) {
       body.css(this.props.fullscreen_style);
     }


### PR DESCRIPTION
# Description
* fix +/- zoom in iframe viewer. it uses IE's "zoom" which is nonstandard. [reference](https://caniuse.com/#feat=css-zoom)  and see  #4438
* respect the default font size. there was a hardcoded number 16, which makes no sense. i.e. the first time you click + or -, it should be more or less based on your default font size -- not 16.

# Testing Steps
all I did was to make rmd file and +/- zoon in the iframe html viewer

# Relevant Issues
 #4438


### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
