### PR TITLE
app landing page: make sure a title is set 

### DIFF
--- a/src/webapp-lib/app-init.ts
+++ b/src/webapp-lib/app-init.ts
@@ -22,7 +22,8 @@ function script_error() {
 function style() {
   const NAME = CUSTOMIZE.site_name || "CoCalc";
   HELP_EMAIL = CUSTOMIZE.help_email || "help@cocalc.com";
-  document.title = NAME;
+  const SITE_DESCR = CUSTOMIZE.site_description || "";
+  document.title = `${NAME} – ${SITE_DESCR}`;
   const msg = document.getElementById("cc-message");
   if (msg == null) {
     // happens when loading is very quick and message is already removed

--- a/src/webapp-lib/app.pug
+++ b/src/webapp-lib/app.pug
@@ -7,7 +7,7 @@ doctype html
 html(lang="en")
   head
     include _inc_head.pug
-    title= fulltitle
+    title= CoCalc
   body
     style.
       #{require('!postcss-loader!app-startup-style.css')}


### PR DESCRIPTION
# Description

it might be the case that #4247 is already fixed ... in any case, this sets the title of the initial landing page to name/description.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
