### PR TITLE
admin/site-settings: domain on top and hide email settings if disabled

### DIFF
--- a/src/smc-util/db-schema/site-settings-extras.ts
+++ b/src/smc-util/db-schema/site-settings-extras.ts
@@ -9,6 +9,7 @@
 
 import {
   Config,
+  is_email_enabled,
   only_for_smtp,
   only_for_sendgrid,
   only_for_password_reset_smtp,
@@ -122,6 +123,7 @@ export const EXTRAS: SettingsExtras = {
       "The type of backend for sending emails ('none' means there is none).",
     default: "",
     valid: ["none", "sendgrid", "smtp"],
+    show: is_email_enabled,
   },
   sendgrid_key: {
     name: "Sendgrid API key",
@@ -179,6 +181,7 @@ export const EXTRAS: SettingsExtras = {
       "For 'smtp', password reset and email verification emails are sent via the 'Secondary SMTP' configuration",
     default: "default",
     valid: ["default", "smtp"],
+    show: is_email_enabled,
   },
   password_reset_smtp_server: {
     name: "Secondary SMTP server",


### PR DESCRIPTION
# Description
1. domain setting is important, move it to the top and show unconditionally, and add a quick validation for immediate feedback
2. see #4662

# Testing Steps
no fundamental change in functionality

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
