### PR TITLE
webapp/jupyter/nbgrader: fix broken assignment  

### DIFF
--- a/src/smc-webapp/jupyter/nbgrader/actions.ts
+++ b/src/smc-webapp/jupyter/nbgrader/actions.ts
@@ -154,8 +154,9 @@ export class NBGraderActions {
     const project_id = this.jupyter_actions.store.get("project_id");
     const project_actions = this.redux.getProjectActions(project_id);
     await project_actions.open_file({ path: filename, foreground: true });
-    let actions = this.redux.getEditorActions(project_id, filename);
+    let actions: any = undefined;
     while (true) {
+      actions = this.redux.getEditorActions(project_id, filename);
       if (actions != null) break;
       await delay(200);
     }
@@ -165,17 +166,6 @@ export class NBGraderActions {
     actions.jupyter_actions.syncdb.from_str(
       this.jupyter_actions.syncdb.to_str()
     );
-    project_actions.close_file(filename);
-    await delay(200);
-    await project_actions.open_file({ path: filename, foreground: true });
-    while (true) {
-      actions = this.redux.getEditorActions(project_id, filename);
-      if (actions != null) break;
-      await delay(200);
-    }
-    if (actions.jupyter_actions.syncdb.get_state() == "init") {
-      await once(actions.jupyter_actions.syncdb, "ready");
-    }
     await actions.jupyter_actions.nbgrader_actions.apply_assign_transformations();
     await actions.jupyter_actions.save();
   }


### PR DESCRIPTION
# Description
I tried to address #4696 but I have no idea what's really going on. 
* I'm 100% sure the while loop in line 158 never stops, that's what debugging shows clearly
* The remainder is a problem with closing the file and opening it again. E.g. it just hangs at `await once(actions.jupyter_actions.syncdb, "ready");` indefinitiely.



# Testing Steps
* fresh: students dir + file does NOT exist → new notebook should appear
* update: it exists → notebook should get modified cells.

With the fix below it almost works, but updating the notebook seems to be flaky. E.g. I get errors about cells being unmodifiable. However, running it twice seems to work. So, maybe a step towards fixing this, but this change here is not enough.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
