### PR TITLE
webapp/accounts: sign out button, 3rd (?) iteration

### DIFF
--- a/src/smc-webapp/account/account-page.tsx
+++ b/src/smc-webapp/account/account-page.tsx
@@ -321,13 +321,7 @@ class AccountPage extends Component<Props> {
   }
 
   private render_signout(): Rendered {
-    return (
-      <Tab
-        key="signout"
-        eventKey="signout"
-        title={<SignOut everywhere={false} highlight={true} />}
-      ></Tab>
-    );
+    return <SignOut everywhere={false} highlight={true} />;
   }
 
   private render_logged_in_view(): Rendered {
@@ -339,9 +333,9 @@ class AccountPage extends Component<Props> {
         <div style={{ margin: "5% 10%" }}>{this.render_account_settings()}</div>
       );
     }
-    const tabs: Rendered[] = [this.render_account_tab()]
-      .concat(this.render_special_tabs())
-      .concat(this.render_signout());
+    const tabs: Rendered[] = [this.render_account_tab()].concat(
+      this.render_special_tabs()
+    );
     return (
       <Row>
         <Col md={12}>
@@ -349,6 +343,7 @@ class AccountPage extends Component<Props> {
             activeKey={this.props.active_page ?? "account"}
             onSelect={this.handle_select.bind(this)}
             animation={false}
+            tabBarExtraContent={this.render_signout()}
           >
             {tabs}
           </Tabs>

--- a/src/smc-webapp/antd-bootstrap.tsx
+++ b/src/smc-webapp/antd-bootstrap.tsx
@@ -264,6 +264,7 @@ export function Tabs(props: {
   onSelect?: (activeKey: string) => void;
   animation?: boolean;
   style?: React.CSSProperties;
+  tabBarExtraContent?: React.ReactNode;
   children: any;
 }) {
   // We do this because for antd, "There must be `tab` property on children of Tabs."
@@ -282,6 +283,7 @@ export function Tabs(props: {
       onChange={props.onSelect}
       animated={props.animation ?? false}
       style={props.style}
+      tabBarExtraContent={props.tabBarExtraContent}
     >
       {tabs}
     </antd.Tabs>


### PR DESCRIPTION
# Description

typical sunday evening fix

narrow:

![Screenshot from 2020-06-28 20-33-10](https://user-images.githubusercontent.com/207405/85955428-bca26a80-b97e-11ea-8dae-64c15e2401cb.png)


wide

![Screenshot from 2020-06-28 20-33-20](https://user-images.githubusercontent.com/207405/85955431-c0ce8800-b97e-11ea-849f-89c4e3c06e6d.png)


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
