### PR TITLE
webapp/rst: fix inactive reload buttons

### DIFF
--- a/src/smc-webapp/frame-editors/rst-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/rst-editor/actions.ts
@@ -58,6 +58,19 @@ export class Actions extends CodeEditorActions {
     }
   }
 
+  reload(id: string, hash?: number) {
+    const node = this._get_frame_node(id);
+    if (!node) return;
+    const type = node.get("type");
+    if (type === "cm") {
+      this._run_rst2html();
+    } else {
+      // the html editor, which also has an iframe, calls somehow super.reload
+      hash = hash || new Date().getTime();
+      this.set_reload("rst", hash);
+    }
+  }
+
   print(id: string): void {
     const node = this._get_frame_node(id);
     if (!node) return;


### PR DESCRIPTION
# Description
The rst editor has a reload button for the code and also for the iframe view. Both aren't doing anything. This adds some code for this.

# Testing Steps
click the buttons, they should do something

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
