### PR TITLE
use registration table to determine anon login

### DIFF
--- a/src/smc-hub/open-cocalc-server.ts
+++ b/src/smc-hub/open-cocalc-server.ts
@@ -18,6 +18,7 @@ import * as express from "express";
 import * as path_module from "path";
 const auth = require("./auth");
 import { get_smc_root } from "./utils";
+import { have_active_registration_tokens } from "./utils";
 //import { SiteSettingsKeys } from "smc-util/db-schema/site-defaults";
 import * as winston from "winston";
 
@@ -39,7 +40,7 @@ function fallback(val: string | undefined, fallback: string): string {
 async function get_params(opts: GetData) {
   const { db, base_url } = opts;
   const settings = await callback2(db.get_server_settings_cached, {});
-  const ANONYMOUS_SIGNUP = !settings.account_creation_token;
+  const ANONYMOUS_SIGNUP = !(await have_active_registration_tokens(db));
   const NAME = settings.site_name;
   const DESCRIPTION = settings.site_description;
   const PREFIX = ""; // this is unrelated of base_url, used for subdirectories

--- a/src/smc-hub/postgres/types.ts
+++ b/src/smc-hub/postgres/types.ts
@@ -125,6 +125,7 @@ export interface PostgreSQL extends EventEmitter {
 
   get_server_setting(opts: { name: string; cb: Function }): void;
   get_server_settings_cached(opts: { cb: CB }): void;
+  server_settings_synctable(): any; // returns a table
 
   create_account(opts: {
     first_name: string;


### PR DESCRIPTION
# Description
well, where there is new code there are new bugs. this migrates from using account_creation_token to have_active_registration_tokens to determine if anon login is allowed.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
