### PR TITLE
katex 0.12.0

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -12283,9 +12283,9 @@
       }
     },
     "katex": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
       "requires": {
         "commander": "^2.19.0"
       }

--- a/src/package.json
+++ b/src/package.json
@@ -53,7 +53,7 @@
     "jstransformer-markdown-it": "^2.0.0",
     "jstransformer-sass": "^1.0.0",
     "jstransformer-typescript": "^1.1.0",
-    "katex": "=0.11.1",
+    "katex": "=0.12.0",
     "less": "^3.9.0",
     "less-loader": "^4.1.0",
     "node-cjsx": "^2.0.0",

--- a/src/smc-webapp/package-lock.json
+++ b/src/smc-webapp/package-lock.json
@@ -2916,9 +2916,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "comment-json": {
       "version": "1.1.3",
@@ -5039,9 +5039,9 @@
       }
     },
     "katex": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
       "requires": {
         "commander": "^2.19.0"
       }

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -73,7 +73,7 @@
     "js-cookie": "^2.2.0",
     "json-stable-stringify": "^1.0.1",
     "jsonic": "^0.3.1",
-    "katex": "=0.11.1",
+    "katex": "=0.12.0",
     "langs": "^2.0.0",
     "latex.js": "^0.11.1",
     "lodash": "^4.17.15",

--- a/src/webapp-lib/resources/package-lock.json
+++ b/src/webapp-lib/resources/package-lock.json
@@ -25,9 +25,9 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "katex": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
       "requires": {
         "commander": "^2.19.0"
       }

--- a/src/webapp-lib/resources/package.json
+++ b/src/webapp-lib/resources/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "bootstrap": "=3.4.1",
     "codemirror": "^5.53.2",
-    "katex": "=0.11.1",
+    "katex": "=0.12.0",
     "roboto-fontface": "^0.10.0"
   }
 }


### PR DESCRIPTION
# Description
This updates katex to 0.12.0. 



# Testing Steps
tested [two new commands](https://github.com/KaTeX/KaTeX/releases/tag/v0.12.0)

![Screenshot from 2020-07-15 12-55-43](https://user-images.githubusercontent.com/207405/87537227-96790c00-c69a-11ea-9fa8-48e342116ef5.png)


# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
