### PR TITLE
latexmk in ubuntu 20.04 has a slightly different output

### DIFF
--- a/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
+++ b/src/smc-webapp/frame-editors/latex-editor/latex-log-parser.ts
@@ -200,7 +200,8 @@ export class LatexParser {
   }
 
   currentLineIsDependenciesList(): boolean {
-    return this.currentLine.startsWith("#===Dependents for");
+    // with ubuntu 20.04, this changed to #===Dependents, and related info, for ...
+    return this.currentLine.startsWith("#===Dependents");
   }
 
   currentLineIsDependenciesListEnd(): boolean {


### PR DESCRIPTION
# Description

Just a small change.

# Testing Steps
a multifile doc in my dev project shows up the documents and builds fine

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
