### PR TITLE
pyutil fix a python 3.8 incompatibility

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
@@ -225,12 +225,13 @@ export class XpraServer {
 
   // get the current contents of the X11 clipboard
   async get_clipboard(): Promise<string> {
-    return (
-      await this.exec({
-        command: "xsel",
-        err_on_exit: true,
-        timeout: 5,
-      })
-    ).stdout;
+    const clip = await this.exec({
+      command: "xsel",
+      err_on_exit: true,
+      timeout: 5,
+      args: ["--output"], // necessary in ubuntu 20.04, with a newer xpra
+    });
+    console.log("get_clipboard", clip);
+    return clip.stdout;
   }
 }

--- a/src/smc_pyutil/smc_pyutil/smc_compute.py
+++ b/src/smc_pyutil/smc_pyutil/smc_compute.py
@@ -145,7 +145,10 @@ def uid(project_id, kubernetes=False):
     # 2^31-1=max uid which works with FUSE and node (and Linux, which goes up to 2^32-2).
     # 2^29 was the biggest that seemed to work with Docker on my crostini pixelbook, so shrinking to that.
     # This is NOT used in production anymore, so should be fine.
-    n = int(hashlib.sha512(project_id).hexdigest()[:8], 16)  # up to 2^32
+    # 2020-08-04: But it's used for cc-in-cc dev projects, and probably also docker?
+    # adding .encode('utf-8') in order to fix a bug with Ubuntu 20.04's Python 3.8
+    # This works all the way back to Python 2 as well.
+    n = int(hashlib.sha512(project_id.encode('utf-8')).hexdigest()[:8], 16)  # up to 2^32
     n //= 8  # up to 2^29  (floor div so will work with python3 too)
     return n if n > 65537 else n + 65537  # 65534 used by linux for user sync, etc.
 


### PR DESCRIPTION
# Description

this makes smc_compute fit for running a cc-in-cc dev proj in ubuntu 20.04

# Testing Steps
well, I ran this hashlib + encoding('utf8') line in the older python3 and python2 interpreters. works fine everywhere.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
