### PR TITLE
x11: fix "xsel" hanging in 20.04

### DIFF
--- a/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
+++ b/src/smc-webapp/frame-editors/x11-editor/xpra-server.ts
@@ -225,12 +225,13 @@ export class XpraServer {
 
   // get the current contents of the X11 clipboard
   async get_clipboard(): Promise<string> {
-    return (
-      await this.exec({
-        command: "xsel",
-        err_on_exit: true,
-        timeout: 5,
-      })
-    ).stdout;
+    const clip = await this.exec({
+      command: "xsel",
+      err_on_exit: true,
+      timeout: 5,
+      args: ["--output"], // necessary in ubuntu 20.04, with a newer xpra
+    });
+    console.log("get_clipboard", clip);
+    return clip.stdout;
   }
 }


### PR DESCRIPTION
# Description

problem: xsel does hang when copying a buffer out of an X11 window

log:

```
2020-08-04T14:26:29.221Z - debug: primus-api request object {"cmd":"exec","opts":{"path":"","command":"xsel","args":[],"timeout":5,"bash":false,"err_on_exit":true,"env":{"DISPLAY":":1485505426"}}}
2020-08-04T14:26:29.222Z - debug: execute_code: "xsel "
2020-08-04T14:26:29.222Z - debug: Spawning the command xsel with given args  and timeout of 5s...
2020-08-04T14:26:29.296Z - debug: Listen for stdout, stderr and exit events.
2020-08-04T14:26:33.058Z - debug: Client.handle_mesg({"event":"heartbeat"}): no callback
2020-08-04T14:26:33.058Z - debug: received heartbeat on socket '80d2dfc7-d21f-4032-84ab-ae7313b6f647'
2020-08-04T14:26:33.122Z - debug: Client.active_socket(id=80d2dfc7-d21f-4032-84ab-ae7313b6f647,ip='127.0.0.1'): heartbeat -- socket is working
2020-08-04T14:26:34.297Z - debug: execute_code: subprocess did not exit after 5 seconds, so killing with SIGKILL
2020-08-04T14:26:34.297Z - debug: finished exec of xsel (took 5.075000047683716s)
2020-08-04T14:26:34.297Z - debug: stdout='fawe', stderr='', exit_code=1
```

by adding "--output" to xsel, it only gets the selection and does not wait on any stdin input – this is ubuntu 20.04/newer xpra specific.

# Testing Steps
well, I ran `xsel --output` in our default environment. in fact, the version and the documentation of that command look the same. so, not sure why there is even a difference. maybe this bug was always around – just not being triggered.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
