### PR TITLE
password reset tweak

### DIFF
--- a/src/smc-webapp/account/actions.ts
+++ b/src/smc-webapp/account/actions.ts
@@ -14,6 +14,7 @@ import { alert_message } from "../alerts";
 import { show_announce_start, show_announce_end } from "./dates";
 import { AccountState } from "./types";
 import { AccountClient } from "../client/account";
+import { delete_password_cookie } from "../client/password-reset";
 
 import * as misc from "smc-util/misc2";
 import { server_days_ago } from "smc-util/misc";
@@ -224,6 +225,7 @@ If that doesn't work after a few minutes, try these ${doc_conn} or email ${this.
     // success
     // TODO: can we automatically log them in?  Should we?  Seems dangerous.
     window.history.pushState("", document.title, window.location.pathname);
+    delete_password_cookie();
     this.setState({ reset_key: "", reset_password_error: "" });
   }
 

--- a/src/smc-webapp/account/actions.ts
+++ b/src/smc-webapp/account/actions.ts
@@ -14,7 +14,6 @@ import { alert_message } from "../alerts";
 import { show_announce_start, show_announce_end } from "./dates";
 import { AccountState } from "./types";
 import { AccountClient } from "../client/account";
-import { delete_password_cookie } from "../client/password-reset";
 
 import * as misc from "smc-util/misc2";
 import { server_days_ago } from "smc-util/misc";
@@ -225,7 +224,6 @@ If that doesn't work after a few minutes, try these ${doc_conn} or email ${this.
     // success
     // TODO: can we automatically log them in?  Should we?  Seems dangerous.
     window.history.pushState("", document.title, window.location.pathname);
-    delete_password_cookie();
     this.setState({ reset_key: "", reset_password_error: "" });
   }
 

--- a/src/smc-webapp/account/init.ts
+++ b/src/smc-webapp/account/init.ts
@@ -9,6 +9,7 @@ import { AccountActions } from "./actions";
 import { AccountStore } from "./store";
 import { AccountTable } from "./table";
 import { init_dark_mode } from "./dark-mode";
+import { reset_password_key } from "../client/password-reset";
 
 export function init(redux) {
   // Register account store
@@ -29,6 +30,9 @@ export function init(redux) {
   init_dark_mode(store);
 
   redux.createTable("account", AccountTable);
+
+  // Password reset
+  actions.setState({ reset_key: reset_password_key() });
 
   // Login status
   webapp_client.on("signed_in", function (mesg) {

--- a/src/smc-webapp/client/password-reset.ts
+++ b/src/smc-webapp/client/password-reset.ts
@@ -14,6 +14,8 @@ export function reset_password_key() {
   // we set a temporary session cookie earlier
   const forgot_cookie = cookies.get(NAME);
   if (forgot_cookie != null) {
+    // we immediately get rid of the cookie with the secret token
+    cookies.remove(NAME);
     return forgot_cookie.toLowerCase();
   } else {
     // some mail transport agents will uppercase the URL -- see https://github.com/sagemathinc/cocalc/issues/294
@@ -23,8 +25,4 @@ export function reset_password_key() {
     }
   }
   return undefined;
-}
-
-export function delete_password_cookie() {
-  cookies.remove(NAME);
 }

--- a/src/smc-webapp/client/password-reset.ts
+++ b/src/smc-webapp/client/password-reset.ts
@@ -4,12 +4,27 @@
  */
 
 import { QueryParams } from "../misc/query-params";
+const { APP_BASE_URL } = require("../misc_page");
+const NAME = `${encodeURIComponent(APP_BASE_URL)}PWRESET`;
+
+import Cookies from "universal-cookie";
+const cookies = new Cookies();
 
 export function reset_password_key() {
-  // some mail transport agents will uppercase the URL -- see https://github.com/sagemathinc/cocalc/issues/294
-  const forgot = QueryParams.get("forgot");
-  if (forgot && typeof forgot == "string") {
-    return forgot.toLowerCase();
+  // we set a temporary session cookie earlier
+  const forgot_cookie = cookies.get(NAME);
+  if (forgot_cookie != null) {
+    return forgot_cookie.toLowerCase();
+  } else {
+    // some mail transport agents will uppercase the URL -- see https://github.com/sagemathinc/cocalc/issues/294
+    const forgot = QueryParams.get("forgot");
+    if (forgot && typeof forgot == "string") {
+      return forgot.toLowerCase();
+    }
   }
   return undefined;
+}
+
+export function delete_password_cookie() {
+  cookies.remove(NAME);
 }

--- a/src/smc-webapp/landing-page/landing-page.tsx
+++ b/src/smc-webapp/landing-page/landing-page.tsx
@@ -41,7 +41,6 @@ const DESC_FONT = "sans-serif";
 // import { ShowSupportLink } from "../support";
 const { ShowSupportLink } = require("../support");
 import { PassportStrategy } from "../account/passport-types";
-import { reset_password_key } from "../client/password-reset";
 import { capitalize } from "smc-util/misc2";
 import { DOC_URL } from "smc-util/theme";
 import { APP_ICON_WHITE, APP_LOGO_NAME_WHITE } from "../art";
@@ -134,7 +133,7 @@ class LandingPage extends Component<Props & reduxProps, State> {
   }
 
   private render_password_reset(): Rendered {
-    const reset_key = reset_password_key();
+    const reset_key = this.props.reset_key;
     if (!reset_key) {
       return;
     }

--- a/src/smc-webapp/landing-page/reset-password.tsx
+++ b/src/smc-webapp/landing-page/reset-password.tsx
@@ -8,11 +8,8 @@ Password reset modal dialog
 */
 
 import { Component, React, ReactDOM, redux, Rendered } from "../app-framework";
-
 import { HelpEmailLink } from "../customize";
-
 import { Modal, FormGroup, FormControl, Row, Button } from "../antd-bootstrap";
-
 import { Space } from "../r_misc";
 
 interface Props {

--- a/src/smc-webapp/landing-page/reset-password.tsx
+++ b/src/smc-webapp/landing-page/reset-password.tsx
@@ -7,20 +7,9 @@
 Password reset modal dialog
 */
 
-import {
-  React,
-  ReactDOM,
-  redux,
-  Rendered,
-} from "../app-framework";
+import { React, ReactDOM, redux, Rendered } from "../app-framework";
 import { HelpEmailLink } from "../customize";
-import {
-  Modal,
-  FormGroup,
-  FormControl,
-  Row,
-  Button,
-} from "../antd-bootstrap";
+import { Modal, FormGroup, FormControl, Row, Button } from "../antd-bootstrap";
 import { Space, Loading } from "../r_misc";
 import { unreachable } from "smc-util/misc2";
 
@@ -122,7 +111,10 @@ export const ResetPassword: React.FC<Props> = (props: Props) => {
                 disabled={mode === "resetting"}
                 onClick={(e) => reset_password(e)}
               >
-                {mode === "resetting" && <Loading />} Reset Password
+                {mode === "resetting" && (
+                  <Loading text={""} style={{ display: "inline" }} />
+                )}{" "}
+                Reset Password
               </Button>
             </div>
           </Row>


### PR DESCRIPTION
# Description

* change forgot and reset modals to be functional components
* forgot password: disable the send button once it is sent
* reset password: there were some strange inconsistencies
* progress spinners while something is happening
* move setting the reset key out of react into the account initialization. this is particularly weird, because the key was set in a function while the global redux prop wasn't used. well, at least I'm confused about what's going on and I moved things a bit around
* prepare the password reset key to use a cookie instead of the query param

# Testing Steps
1. enter email, request email with a token
2. enter a password with 3 letters only → error
3. and with a longer password, it sets it fine

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
