### PR TITLE
webapp/jupyter/nbconvert: fix #4816

### DIFF
--- a/src/smc-webapp/jupyter/browser-actions.ts
+++ b/src/smc-webapp/jupyter/browser-actions.ts
@@ -122,7 +122,7 @@ export class JupyterActions extends JupyterActions0 {
     }
   }
 
-  private activity() : void {
+  private activity(): void {
     this.redux.getProjectActions(this.project_id).flag_file_activity(this.path);
   }
 
@@ -453,6 +453,10 @@ export class JupyterActions extends JupyterActions0 {
     if (this.nbconvert_has_started()) {
       // can't run it while it is already running.
       throw Error("nbconvert is already running");
+    }
+    if (this.syncdb == null) {
+      console.warn("nbconvert: syncdb not available, aborting...");
+      return;
     }
     this.syncdb.set({
       type: "nbconvert",


### PR DESCRIPTION
# Description
this is a simple idea to fix #4816

but I don't know what this actually does and I wonder if there are also other usages of `this.syncdb` should be safeguarded …

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
