### PR TITLE
webapp/course: inherit teacher project compute  image or be explicitly

### DIFF
--- a/src/smc-webapp/course/configuration/actions.ts
+++ b/src/smc-webapp/course/configuration/actions.ts
@@ -148,17 +148,24 @@ export class ConfigurationActions {
     });
   }
 
-  public set_inherit_compute_image(inherit: boolean): void {
-    this.set({ inherit_compute_image: inherit, table: "settings" });
+  public set_inherit_compute_image(image?: string): void {
+    this.set({ inherit_compute_image: image != null, table: "settings" });
+    if (image != null) {
+      this.set_compute_image(image);
+    }
   }
 
-  public set_software_environment(state: SoftwareEnvironmentState): void {
-    const custom_image = derive_project_img_name(state);
+  public set_compute_image(image: string) {
     this.set({
-      custom_image,
+      custom_image: image,
       table: "settings",
     });
     this.course_actions.student_projects.configure_all_projects();
     this.course_actions.shared_project.set_project_compute_image();
+  }
+
+  public set_software_environment(state: SoftwareEnvironmentState): void {
+    const image = derive_project_img_name(state);
+    this.set_compute_image(image);
   }
 }

--- a/src/smc-webapp/course/configuration/actions.ts
+++ b/src/smc-webapp/course/configuration/actions.ts
@@ -148,6 +148,10 @@ export class ConfigurationActions {
     });
   }
 
+  public set_inherit_compute_image(inherit: boolean): void {
+    this.set({ inherit_compute_image: inherit, table: "settings" });
+  }
+
   public set_software_environment(state: SoftwareEnvironmentState): void {
     const custom_image = derive_project_img_name(state);
     this.set({

--- a/src/smc-webapp/course/configuration/configuration-panel.tsx
+++ b/src/smc-webapp/course/configuration/configuration-panel.tsx
@@ -643,6 +643,7 @@ export const ConfigurationPanel: React.FC<Props> = React.memo(
             <StudentProjectSoftwareEnvironment
               actions={actions.configuration}
               software_image={settings.get("custom_image")}
+              course_project_id={project_id}
               inherit_compute_image={settings.get("inherit_compute_image")}
             />
           </Col>

--- a/src/smc-webapp/course/configuration/configuration-panel.tsx
+++ b/src/smc-webapp/course/configuration/configuration-panel.tsx
@@ -643,6 +643,7 @@ export const ConfigurationPanel: React.FC<Props> = React.memo(
             <StudentProjectSoftwareEnvironment
               actions={actions.configuration}
               software_image={settings.get("custom_image")}
+              inherit_compute_image={settings.get("inherit_compute_image")}
             />
           </Col>
         </Row>

--- a/src/smc-webapp/course/sync.ts
+++ b/src/smc-webapp/course/sync.ts
@@ -110,17 +110,22 @@ export function create_sync_db(
     }
     actions.students.lookup_nonregistered_students();
 
-    const course_compute_image = actions
-      .get_store()
-      .getIn(["settings", "custom_image"]);
-    if (course_compute_image == null) {
+    const course_compute_image = store.getIn(["settings", "custom_image"]);
+    const inherit_compute_image =
+      store.getIn(["settings", "inherit_compute_image"]) ?? true;
+    // if the compute image isn't set or should be inherited, we configure it for all controlled projects
+    if (course_compute_image == null || inherit_compute_image) {
       const course_project_compute_image = projects_store.getIn([
         "project_map",
         course_project_id,
         "compute_image",
       ]);
       actions.set(
-        { custom_image: course_project_compute_image, table: "settings" },
+        {
+          custom_image: course_project_compute_image,
+          inherit_compute_image,
+          table: "settings",
+        },
         true
       );
     }

--- a/src/smc-webapp/course/types.ts
+++ b/src/smc-webapp/course/types.ts
@@ -22,6 +22,7 @@ export interface SyncDBRecordSettings {
   nbgrader_cell_timeout_ms?: number;
   nbgrader_timeout_ms?: number;
   custom_image?: string; // if falsy use default environment; if true-ish, use this software image for student projects. it should be called compute_image or software_image
+  inherit_compute_image?: boolean; // if true (default), set the compute_image of student projects to the one of the project hosting the course
 }
 
 // This is closely related to store.AssignmentRecord...


### PR DESCRIPTION
# Description
probem: changing the compute image of a course project, while student projects are already configured. by default, it should eventually be in sync.

# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
