### PR TITLE
webapp: loading compute_images in minimal mode 

### DIFF
--- a/src/smc-webapp/custom-software/init.ts
+++ b/src/smc-webapp/custom-software/init.ts
@@ -6,7 +6,6 @@
 // Manage DB <-> UI integration of available *custom* compute images
 // TODO: also get rid of hardcoded official software images
 
-import { COCALC_MINIMAL } from "../fullscreen";
 const { redux, Store, Actions, Table } = require("../app-framework");
 import { Map as iMap } from "immutable";
 import { NAME } from "./util";
@@ -161,7 +160,7 @@ class ComputeImagesTable extends Table {
 }
 
 export function init() {
-  if (!COCALC_MINIMAL && !redux.hasStore(NAME)) {
+  if (!redux.hasStore(NAME)) {
     redux.createStore(NAME, ComputeImagesStore, {});
     redux.createActions(NAME, ComputeImagesActions);
     redux.createTable(NAME, ComputeImagesTable);


### PR DESCRIPTION
# Description

I was testing embedding cocalc. I noticed that when all projects should close, an exception appears. It's somehow happening with those react store hooks and the project listing. I don't know how to really fix this, and well, since this might happen elsewhere as well, I enabled pulling in the compute image data for the embedded mode. (or is there a way to say that a certain store might not always exist?)

The call triggering this below is `page_actions.close_project_tab(project_id);` for the last open project.

![Screenshot from 2020-09-04 12-49-06](https://user-images.githubusercontent.com/207405/92231583-41dd5a80-eead-11ea-96b1-a572148eb859.png)


# Testing Steps
1.
1.
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
