### PR TITLE
project capabilities: check if html2pdf via chrome/chromium is available

### DIFF
--- a/src/smc-project/configuration.ts
+++ b/src/smc-project/configuration.ts
@@ -136,6 +136,12 @@ async function sshd(): Promise<boolean> {
   return await have("/usr/sbin/sshd");
 }
 
+// we check if we can use cc-ipynb-to-pdf, which uses chrome or chromium
+// smc_pyutil/ipynb_to_pdf.py
+async function html2pdf(): Promise<boolean> {
+  return (await have("chromium-browser")) || (await have("google-chrome"));
+}
+
 // this is for rnw RMarkdown files.
 // This just tests R, which provides knitr out of the box?
 async function rmd(): Promise<boolean> {
@@ -211,6 +217,7 @@ async function capabilities(): Promise<MainCapabilities> {
     spellcheck: await spellcheck(),
     library: await library(),
     sshd: await sshd(),
+    html2pdf: await html2pdf(),
   };
   const sage = await sage_info_future;
   caps.sage = sage.exists;

--- a/src/smc-webapp/project/settings/project-capabilites.tsx
+++ b/src/smc-webapp/project/settings/project-capabilites.tsx
@@ -60,6 +60,7 @@ export const ProjectCapabilities = rclass<ReactProps>(
         ["library", "Library of documents"],
         ["x11", "Graphical applications"],
         ["latex", "LaTeX editor"],
+        ["html2pdf", "HTML to PDF via Chrome/Chromium"],
       ];
       const features: JSX.Element[] = [];
       let any_nonavail = false;

--- a/src/smc-webapp/project_configuration.ts
+++ b/src/smc-webapp/project_configuration.ts
@@ -49,6 +49,7 @@ export interface MainCapabilities {
   spellcheck: boolean;
   library: boolean;
   sshd: boolean;
+  html2pdf: boolean; // via chrome/chromium
 }
 
 export interface Available {
@@ -61,12 +62,13 @@ export interface Available {
   rmd: boolean; // TODO besides R, what's necessary?
   spellcheck: boolean;
   library: boolean;
+  html2pdf: boolean;
   formatting: Capabilities | boolean;
 }
 
 export type AvailableFeatures = TypedMap<Available>;
 
-const NO_AVAIL: Readonly<Available> = Object.freeze({
+const NO_AVAIL: Readonly<Available> = {
   jupyter_lab: false,
   jupyter_notebook: false,
   jupyter: false,
@@ -77,9 +79,10 @@ const NO_AVAIL: Readonly<Available> = Object.freeze({
   spellcheck: false,
   library: false,
   formatting: false,
-});
+  html2pdf: false,
+} as const;
 
-export const ALL_AVAIL: Readonly<Available> = Object.freeze({
+export const ALL_AVAIL: Readonly<Available> = {
   jupyter_lab: true,
   jupyter_notebook: true,
   jupyter: true,
@@ -90,7 +93,8 @@ export const ALL_AVAIL: Readonly<Available> = Object.freeze({
   spellcheck: true,
   library: true,
   formatting: true,
-});
+  html2pdf: true,
+} as const;
 
 // detecting certain datastructures, only used for TS typing
 function isMainCapabilities(
@@ -185,6 +189,7 @@ export function is_available(configuration?: ProjectConfiguration): Available {
       x11: !!capabilities.x11,
       spellcheck: !!capabilities.spellcheck,
       library: !!capabilities.library,
+      html2pdf: capabilities.html2pdf ?? true,
       formatting,
     };
   } else {

--- a/src/smc_pyutil/smc_pyutil/ipynb_to_pdf.py
+++ b/src/smc_pyutil/smc_pyutil/ipynb_to_pdf.py
@@ -10,6 +10,8 @@ faster and more reliable, but potentially doesn't "look" as good,
 depending on your tastes.  It also has a dependency on chromium.
 """
 
+# ATTN: make sure to keep dependencies of this in sync with smc-project/configuration.ts
+
 from __future__ import absolute_import, print_function
 from shutil import which
 import os, sys, time


### PR DESCRIPTION
# Description
* this adds a field to the main project capabilities regarding converting html2pdf via chrome/chromium
* it's not doing anything beyond that, that's for another PR
* if the project is still an old one and no data is available, it defaults to "true"
* this is intended to be released as static first, and then later on the project (no rush)

![screenshot-cocalc com-2020 09 08-15_21_35](https://user-images.githubusercontent.com/207405/92483086-ae779280-f1e8-11ea-958c-0c350d7d7f65.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
