### PR TITLE
project: remove a use of this.log after closing

### DIFF
--- a/src/smc-project/sync/server.ts
+++ b/src/smc-project/sync/server.ts
@@ -436,7 +436,6 @@ class SyncTableChannel {
 
   private close(): void {
     if (this.closed) {
-      this.log("close: already closed!");
       return;
     }
     this.log("close: closing");


### PR DESCRIPTION
# Description

I'm building this now, and if it works I'll deploy it. If you have a better fix for this, it should be a follow up…

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
