### PR TITLE
fix issue with stop/start project sagemathinc/cocalc-docker#97

### DIFF
--- a/src/smc_pyutil/smc_pyutil/smc_compute.py
+++ b/src/smc_pyutil/smc_pyutil/smc_compute.py
@@ -104,13 +104,14 @@ def cmd(s,
                     stdin=PIPE,
                     stdout=PIPE,
                     stderr=PIPE,
+                    encoding='utf8',
                     shell=not isinstance(s, list))
         x = out.stdout.read() + out.stderr.read()
         # this must be *after* the out.stdout.read(), etc. above or will hang when output large!
         e = out.wait()
         if e:
             if ignore_errors:
-                return (x.decode("utf-8") + "ERROR").strip()
+                return (x + "ERROR").strip()
             else:
                 raise RuntimeError(x)
         if verbose >= 2:


### PR DESCRIPTION
# Description
Workaround for stop/start project issue  described in https://github.com/sagemathinc/cocalc-docker/issues/97

This probably not compatible with python 2 if this still matters.

With this change project can be correctly stopped and strarted using current cocalc in docker.
