### PR TITLE
update pricing spec date

### DIFF
--- a/src/smc-util/upgrade-spec.js
+++ b/src/smc-util/upgrade-spec.js
@@ -5,7 +5,7 @@
 
 // IMPORTANT: If you change this file, also update this date, which appears in webapp-lib/policies/pricing.pug
 
-exports.CURRENT_DATE = "August 2019";
+exports.CURRENT_DATE = "September 2020";
 
 // Define upgrades to projects.
 //


### PR DESCRIPTION
# Description

I think we should update the pricing timestamp? Or is it left like that intentionally?

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
