### PR TITLE
course: remove license if student is deleted

### DIFF
--- a/src/smc-webapp/course/student-projects/actions.ts
+++ b/src/smc-webapp/course/student-projects/actions.ts
@@ -563,6 +563,11 @@ export class StudentProjectsActions {
             "site_license",
           ]);
           let already_done: boolean = false;
+          if (store.get_student(student_id)?.get("deleted")) {
+            // remove license if student is deleted
+            license_id = "";
+            already_done = true;
+          }
           for (const id in site_license) {
             if (license_run_limits[id] != null) {
               license_run_limits[id] -= 1;


### PR DESCRIPTION
# Description

* see #4875

ok, I'm not sure about this. there must be somewhere some code that removes a license from a project if the student is deleted, but I don't know where. I also saw in a real course that a deleted student project had a license. So, I don't know, maybe this here helps as an additional safeguard or it makes things even worse.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
