### PR TITLE
project/jupyter:  rename _identity to identity

### DIFF
--- a/src/smc-project/jupyter/jupyter.ts
+++ b/src/smc-project/jupyter/jupyter.ts
@@ -37,9 +37,7 @@ import * as pidusage from "pidusage";
 const { do_not_laod_transpilers } = require("../init-program");
 
 if (do_not_laod_transpilers) {
-  console.warn(
-    "[project/jupyter] coffeescript transpiler is not enabled!"
-  );
+  console.warn("[project/jupyter] coffeescript transpiler is not enabled!");
 } else {
   // because of misc and misc_node below.  Delete this when those are typescript'd
   require("coffee-register");
@@ -214,9 +212,10 @@ The kernel does *NOT* start up until either spawn is explicitly called, or
 code execution is explicitly requested.  This makes it possible to
 call process_output without spawning an actual kernel.
 */
-const _jupyter_kernels = {};
+const _jupyter_kernels: { [path: string]: JupyterKernel } = {};
 
-export class JupyterKernel extends EventEmitter
+export class JupyterKernel
+  extends EventEmitter
   implements JupyterKernelInterface {
   public name: string;
   public store: any; // used mainly for stdin support right now...
@@ -500,7 +499,7 @@ export class JupyterKernel extends EventEmitter
       delete this.store;
     }
     const kernel = _jupyter_kernels[this._path];
-    if (kernel != null && kernel._identity === this.identity) {
+    if (kernel != null && kernel.identity === this.identity) {
       delete _jupyter_kernels[this._path];
     }
     this.removeAllListeners();


### PR DESCRIPTION
# Description

well, while working on that project info, I'm also adding TS types here and there. When I do that for the known jupyter kernel instances, this popped out. I'm sure this is a typo, but please check if this is maybe not so good (so far, that `if` was always false)

the only thing I tested is that I can start/halt a kernel.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
