### PR TITLE
webapp/lean: safeguard debounced calls -- addresses some of #4893

### DIFF
--- a/src/smc-webapp/frame-editors/lean-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/lean-editor/actions.ts
@@ -55,16 +55,22 @@ export class Actions extends BaseActions<LeanEditorState> {
     this.data_queue = [];
 
     this.debounced_process_data_queue = debounce(() => {
+      if (this._state === "closed") return;
       this.process_data_queue();
     }, DEBOUNCE_MS);
 
     this.debounced_update_info = debounce(() => {
+      if (this._state === "closed") return;
       this.update_info();
     }, DEBOUNCE_MS);
+
     this.debounced_update_gutters = debounce(() => {
+      if (this._state === "closed") return;
       this.update_gutters();
     }, DEBOUNCE_MS);
+
     this.debounced_update_status_bar = debounce(() => {
+      if (this._state === "closed") return;
       this.update_status_bar();
     }, DEBOUNCE_MS);
 
@@ -169,8 +175,8 @@ export class Actions extends BaseActions<LeanEditorState> {
         // pass
       }
     }
-    close(this);
     super.close();
+    close(this);
   }
 
   update_status_bar = (): void => {


### PR DESCRIPTION
# Description

See #4893

I also changed the ordering of close calls: i.e. first set the field in the parent + close there, then the derived child. The other way around some attributes get deleted before the `_state` is changed.

well, maybe changing that ordering isn't a good idea. or not, IDK.  I'm confused. in both cases I get an exception upon closing:

```
Uncaught (in promise) TypeError: Cannot read property 'close' of undefined
    at Actions.close (actions.ts?47df:500)
    at Actions.close (actions.ts?81f3:179)
    at Object.remove (register.ts?99e9:85)
```

The above is strange: tries to close any terminals via `this.terminals.close();` but I don't see how that terminal manager got removed. It shouldn't be removed before it cleaned up any terminals, right?

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
