### PR TITLE
clean button a unicode skull and change Icon to be a FC

### DIFF
--- a/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
@@ -1158,7 +1158,7 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
       confirm: "Yes",
     };
     const title = <div style={{ maxWidth: "250px" }}>{info.text}</div>;
-    const icon = <Icon name={"trash"} />;
+    const icon = <Icon unicode={0x2620} />;
     return (
       <Popconfirm
         key={"clear"}

--- a/src/smc-webapp/project/explorer/file-listing/listing-header.tsx
+++ b/src/smc-webapp/project/explorer/file-listing/listing-header.tsx
@@ -23,7 +23,7 @@ const row_style: React.CSSProperties = {
   borderRadius: "4px",
 };
 
-const inner_icon_style = { marginright: "10px" };
+const inner_icon_style = { marginRight: "10px" };
 
 // TODO: Something should uniformly describe how sorted table headers work.
 // 5/8/2017 We have 3 right now, Course students, assignments panel and this one.


### PR DESCRIPTION
# Description

This makes the Icon a functional component  and enhances it to show unicode chars as icons as well. Here is chrome and firefox:

![Screenshot from 2020-09-30 12-20-57](https://user-images.githubusercontent.com/207405/94673785-870f7380-0317-11eb-8b4c-5df1870ed49b.png)


![Screenshot from 2020-09-30 12-20-47](https://user-images.githubusercontent.com/207405/94673770-82e35600-0317-11eb-90e1-6278c6c5939e.png)

deployment: webapp only


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
