### PR TITLE
compute images: add a pointer to the previous ubunut 20.04 image

### DIFF
--- a/src/smc-util/compute-images.ts
+++ b/src/smc-util/compute-images.ts
@@ -57,6 +57,12 @@ export const COMPUTE_IMAGES: { [key: string]: ComputeImage } = {
     descr: "Regular updates, well tested",
     group: "Main",
   },
+  "ubuntu2004-previous": {
+    title: "Ubuntu 20.04 (Previous)",
+    short: "Previous",
+    descr: "Slightly behind 20.04 (Default)",
+    group: "Ubuntu 20.04",
+  },
   "ubuntu2004-dev": {
     title: "Ubuntu 20.04 (Experimental)",
     short: "Experimental",


### PR DESCRIPTION
# Description

This is just yet another entry.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
