### PR TITLE
hub/syncstring maintenance: do not order by string_id to speed up the query

### DIFF
--- a/src/smc-hub/postgres-blobs.coffee
+++ b/src/smc-hub/postgres-blobs.coffee
@@ -620,7 +620,6 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     query    : 'SELECT string_id FROM syncstrings'
                     where    : [{'last_active <= $::TIMESTAMP' : misc.days_ago(opts.age_days)}, 'archived IS NULL']
                     limit    : opts.limit
-                    order_by : 'string_id'
                     cb       : all_results 'string_id', (err, v) =>
                         syncstrings = v
                         cb(err)


### PR DESCRIPTION
# Description

this query takes about `query_time_ms=5456`, despite indexing. without sorting, there is no need to look through all found results, right? and there is no pressing need to archive them in order...

deploy: hub syncstring restart

testing: I didn't test this

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
