### PR TITLE
project info: info.processes could be undefined

### DIFF
--- a/src/smc-project/project-info/types.ts
+++ b/src/smc-project/project-info/types.ts
@@ -95,7 +95,7 @@ export type Processes = { [pid: string]: Process };
 
 export interface ProjectInfo {
   timestamp: number;
-  processes: Processes;
+  processes?: Processes;
   cgroup?: CGroup; // only in "kucalc" mode
   disk_usage: DiskUsage;
   uptime: number; // secs, uptime of the machine

--- a/src/smc-webapp/project/info/project-info.tsx
+++ b/src/smc-webapp/project/info/project-info.tsx
@@ -224,6 +224,10 @@ export const ProjectInfoFC: React.FC<Props> = React.memo(
     }, [project_state]);
 
     function update_top(info: ProjectInfo) {
+      // this shouldn't be the case, but somehow I saw this happening once
+      // the ProjectInfo type is updated to refrect this edge case and here we bail out
+      // and wait for the next update of "info" to get all processes…
+      if (info.processes == null) return;
       const pchildren: string[] = [];
       const pt_stats = { ...pt_stats_init };
       const new_ptree =


### PR DESCRIPTION
# Description

I'm not sure why at all, but apparently this could be undefined. Updated type info and rejecting an incomplete object.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
