### PR TITLE
Prevent duplicate spawning of local_hub.

### DIFF
--- a/src/smc-project/bin/smc-local-hub
+++ b/src/smc-project/bin/smc-local-hub
@@ -1,9 +1,32 @@
 #!/usr/bin/env python
 
 import os, sys
+import psutil
+
+def is_running(pid_file, process_name):
+    if not os.path.exists(pid_file):
+        return False
+
+    with open(pid_file, "r") as f:
+        try:
+            pid = int(f.read())
+        except (OSError, ValueError):
+            return False
+        if not psutil.pid_exists(pid):
+            return False
+        try:
+            cmd1 = psutil.Process(pid).cmdline()[0]
+            return cmd1 == process_name
+        except psutil.AccessDenied:
+            return False
 
 if not 'SMC' in os.environ:
     os.environ['SMC'] = os.path.join(os.environ['HOME'], '.smc')
+
+pidfile = os.path.join(os.environ['SMC'], 'local_hub', 'local_hub.pid' )
+if sys.argv[1] == 'start' and is_running(pidfile, 'node'):
+    # already running
+    sys.exit(0)
 
 data = os.path.join(os.environ['SMC'], 'local_hub')
 if not os.path.exists(data):


### PR DESCRIPTION
# Description
This is workaround for issue described here sagemathinc/cocalc-docker#106

This code prevents starting duplicated local_hub, which is happens often for me on projects with a lot of files, which requires long time to chown. 

This code requires python-psutil to be installed

You can detect project with duplicated local_hub by seeing Loading... for every notebook and by something like this output in terminal 

```
~$ forever list
info:    Forever processes running
data:        uid  command script                                   forever pid   id logfile                                                                     uptime        
data:    [0] T1VV coffee  /cocalc/src/smc-project/local_hub.coffee 11046   11068    /projects/28943c77-d1bc-405c-9e40-cf2b82b9a645/.smc/local_hub/local_hub.log 0:0:20:4.871  
data:    [1] n8Kj coffee  /cocalc/src/smc-project/local_hub.coffee 11142   11153    /projects/28943c77-d1bc-405c-9e40-cf2b82b9a645/.smc/local_hub/local_hub.log 0:0:19:39.155 
data:    [2] H0AI coffee  /cocalc/src/smc-project/local_hub.coffee 11196   11207    /projects/28943c77-d1bc-405c-9e40-cf2b82b9a645/.smc/local_hub/local_hub.log 0:0:19:8.101  
data:    [3] 1UHy coffee  /cocalc/src/smc-project/local_hub.coffee 11265   11276    /projects/28943c77-d1bc-405c-9e40-cf2b82b9a645/.smc/local_hub/local_hub.log 0:0:18:38.428

```

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
