### PR TITLE
database index  improvements

### DIFF
--- a/src/smc-hub/postgres-base.coffee
+++ b/src/smc-hub/postgres-base.coffee
@@ -983,7 +983,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
         f = (info, cb) =>
             query = info.query
             # Shorthand index is just the part in parens.
-            query = "CREATE INDEX #{info.name} ON #{table} #{query}"
+            query = "CREATE INDEX CONCURRENTLY #{info.name} ON #{table} #{query}"
             @_query
                 query : query
                 cb    : cb
@@ -1128,7 +1128,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                     switch task.action
                         when 'create'
                             @_query
-                                query : "CREATE INDEX #{task.name} ON #{table} #{task.query}"
+                                query : "CREATE INDEX CONCURRENTLY #{task.name} ON #{table} #{task.query}"
                                 cb    : cb
                         when 'delete'
                             @_query

--- a/src/smc-util/db-schema/projects.ts
+++ b/src/smc-util/db-schema/projects.ts
@@ -20,10 +20,13 @@ Table({
 
     pg_indexes: [
       "last_edited",
+      "created", // TODO: this could have a fillfactor of 100
       "USING GIN (users)", // so get_collaborator_ids is fast
       "USING GIN (host jsonb_path_ops)", // so get_projects_on_compute_server is fast
       "lti_id",
       "USING GIN (state)", // so getting all running projects is fast (e.g. for site_license_usage_log... but also manage-state)
+      "((state #>> '{state}'))", // projecting the "state" (running, etc.) for its own index – the GIN index above still causes a scan, which we want to avoid.
+      "((state ->> 'state'))", // same reason as above. both syntaxes appear and we have to index both.
     ],
 
     user_query: {


### PR DESCRIPTION
# Description

* indexing the state of a project has a significant. instead of iterating in parallel over the jsonb objects, it uses this index.
* creating an index should happen concurrently, because otherwise a table could end up being locked for writes for minutes.

deployment: hub update, and then in production, we have to remove two indices I created for testing: `project_state` and `project_state2`


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
