### PR TITLE
make files listings git aware

### DIFF
--- a/src/smc-project/directory-listing.ts
+++ b/src/smc-project/directory-listing.ts
@@ -17,12 +17,11 @@ Use ?random= or ?time= if you're worried about cacheing.
 Browser client code only uses this through the websocket anyways.
 */
 
-import { join } from "path";
 import { lstat, stat, readdir, readlink, Dirent, Stats } from "fs";
 import { callback } from "awaiting";
-import { spawn as child_process_spawn } from "child_process";
+import { execFile as child_process_execFile } from "child_process";
 import { promisify } from "util";
-const spawn = promisify(child_process_spawn);
+const execFile = promisify(child_process_execFile);
 import { DirectoryListingEntry } from "./smc-util/types";
 
 // SMC_LOCAL_HUB_HOME is used for developing cocalc inside cocalc...
@@ -100,13 +99,15 @@ export async function get_listing(
 
 export async function get_git_dir(path: string): Promise<string | undefined> {
   try {
-    const cwd = join(HOME, path);
-    const ret = await spawn("git", ["rev-parse", "--absolute-git-dir"], {
-      cwd,
-    });
-    return ret.stdout.trim();
+    const cwd = HOME + "/" + path;
+    const { stdout } = await execFile(
+      "git",
+      ["rev-parse", "--absolute-git-dir"],
+      { cwd }
+    );
+    return stdout.trim();
   } catch {
-    // we ignore any errors
+    // we ignore errors
   }
 }
 

--- a/src/smc-project/sync/listings.ts
+++ b/src/smc-project/sync/listings.ts
@@ -16,7 +16,7 @@ import {
 } from "../smc-util/misc2";
 import { field_cmp, seconds_ago } from "../smc-util/misc";
 import { DirectoryListingEntry } from "../smc-util/types";
-import { get_listing } from "../directory-listing";
+import { get_listing, get_git_dir } from "../directory-listing";
 import {
   WATCH_TIMEOUT_MS,
   MAX_FILES_PER_PATH,
@@ -56,6 +56,7 @@ interface Listing {
   missing?: number;
   error?: string;
   deleted?: string[];
+  git_dir?: string;
 }
 export type ImmutableListing = TypedMap<Listing>;
 
@@ -224,9 +225,12 @@ class ListingsTable {
 
   private async compute_listing(path: string): Promise<void> {
     const time = new Date();
-    let listing;
+    let listing, git_dir;
     try {
-      listing = await get_listing(path, true);
+      [listing, git_dir] = await Promise.all([
+        get_listing(path, true),
+        get_git_dir(path),
+      ]);
       if (!this.is_ready()) return;
     } catch (err) {
       if (!this.is_ready()) return;
@@ -275,7 +279,7 @@ class ListingsTable {
     // save fine to the database. (TODO: this is just a workaround.)
     const error = y?.get("error") != null ? "" : undefined;
 
-    this.set({ path, listing, time, missing, deleted, error });
+    this.set({ path, listing, time, missing, deleted, error, git_dir });
   }
 
   private start_watching(path: string): void {

--- a/src/smc-util/db-schema/listings.ts
+++ b/src/smc-util/db-schema/listings.ts
@@ -65,6 +65,11 @@ Table({
       desc:
         "Paths within this directory that have been explicitly deleted by a user",
     },
+    git_dir: {
+      type: "string",
+      desc:
+        "For the given directory, either the absolute path of an associated Git directory or null.",
+    },
   },
   rules: {
     desc: "Directory listings in projects",
@@ -82,6 +87,7 @@ Table({
           interest: null,
           error: null,
           deleted: null,
+          git_dir: null,
         },
       },
       set: {
@@ -110,6 +116,7 @@ Table({
           interest: null,
           error: null,
           deleted: null,
+          git_dir: null,
         },
       },
       set: {
@@ -125,6 +132,7 @@ Table({
           interest: true,
           error: true,
           deleted: true,
+          git_dir: null,
         },
       },
     },

--- a/src/smc-util/types.ts
+++ b/src/smc-util/types.ts
@@ -1,3 +1,8 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 /* Misc types that are used in frontends, backends, etc. */
 
 export interface DirectoryListingEntry {

--- a/src/smc-util/types.ts
+++ b/src/smc-util/types.ts
@@ -7,10 +7,17 @@
 
 export interface DirectoryListingEntry {
   name: string;
+  display_name?: string; // this appears in project_store
+  mask?: boolean; // appears in project_store
   isdir?: boolean;
   issymlink?: boolean;
   link_target?: string; // set if issymlink is true and we're able to determine the target of the link
   size?: number; // bytes for file, number of entries for directory (*including* . and ..).
   mtime?: number;
   error?: string;
+}
+
+export interface DirectoryListing {
+  files?: DirectoryListingEntry[];
+  git_dir?: string;
 }

--- a/src/smc-webapp/project/directory-listing.ts
+++ b/src/smc-webapp/project/directory-listing.ts
@@ -147,7 +147,7 @@ export async function get_directory_listing2(opts: ListingOpts): Promise<any> {
       if (store.getIn(["directory_listings", opts.path]) != null) {
         // just update an already loading listing:
         try {
-          return { files: await listings.get_listing_directly(opts.path) };
+          return await listings.get_listing_directly(opts.path);
         } catch (err) {
           console.warn(
             `WARNING: problem getting directory listing ${err}; falling back`
@@ -163,7 +163,7 @@ export async function get_directory_listing2(opts: ListingOpts): Promise<any> {
     // return what we have now:
     const files = await listings.get(opts.path);
     if (files != null) {
-      return { files };
+      return files;
     }
     await once(listings, "change");
   }

--- a/src/smc-webapp/project/explorer/explorer.tsx
+++ b/src/smc-webapp/project/explorer/explorer.tsx
@@ -106,9 +106,10 @@ interface ReduxProps {
   ext_selection?: string;
   new_filename?: string;
   displayed_listing: {
-    listing: ListingItem[];
+    files: ListingItem[];
     error: any;
     file_map: Map<string, any>;
+    git_dir?: string;
   };
   new_name?: string;
   library?: object;
@@ -775,16 +776,16 @@ export const Explorer = rclass(
       const public_view = my_group === "public";
 
       const displayed_listing = this.props.displayed_listing;
-      const { listing, file_map } = displayed_listing;
+      const { files, file_map } = displayed_listing;
       const directory_error = displayed_listing.error;
 
       const file_listing_page_size = this.file_listing_page_size();
-      if (listing != undefined) {
+      if (files != undefined) {
         const { start_index, end_index } = pager_range(
           file_listing_page_size,
           this.props.page_number
         );
-        visible_listing = listing.slice(start_index, end_index);
+        visible_listing = files.slice(start_index, end_index);
       }
 
       const FLEX_ROW_STYLE = {
@@ -830,9 +831,9 @@ export const Explorer = rclass(
                   minWidth: "20em",
                 }}
               >
-                {listing != undefined
+                {files != undefined
                   ? this.render_files_actions(
-                      listing,
+                      files,
                       public_view,
                       project_is_running
                     )
@@ -869,9 +870,9 @@ export const Explorer = rclass(
               directory_error,
               public_view
             )}
-            {listing != undefined
+            {files != undefined
               ? this.render_paging_buttons(
-                  Math.ceil(listing.length / file_listing_page_size)
+                  Math.ceil(files.length / file_listing_page_size)
                 )
               : undefined}
           </div>

--- a/src/smc-webapp/project/websocket/listings.ts
+++ b/src/smc-webapp/project/websocket/listings.ts
@@ -17,7 +17,7 @@ import { deleted_file_variations } from "smc-util/delete-files";
 import { exec, query } from "../../frame-editors/generic/client";
 
 import { get_directory_listing } from "../directory-listing";
-import { DirectoryListingEntry } from "smc-util/types";
+import { DirectoryListingEntry, DirectoryListing } from "smc-util/types";
 
 import { WATCH_TIMEOUT_MS } from "smc-util/db-schema/listings";
 export const WATCH_THROTTLE_MS = WATCH_TIMEOUT_MS / 2;
@@ -86,7 +86,7 @@ export class Listings extends EventEmitter {
     });
   }
 
-  public async get(path: string): Promise<DirectoryListingEntry[] | undefined> {
+  public async get(path: string): Promise<DirectoryListing | undefined> {
     if (this.state != "ready") {
       try {
         const listing = await this.get_using_database(path);
@@ -111,7 +111,7 @@ export class Listings extends EventEmitter {
 
     const x = this.get_record(path);
     if (x == null || x.get("error")) return;
-    return x.get("listing")?.toJS();
+    return { files: x.get("listing")?.toJS(), git_dir: x.get("git_dir") };
   }
 
   public async get_deleted(path: string): Promise<List<string> | undefined> {
@@ -230,20 +230,24 @@ export class Listings extends EventEmitter {
 
   public async get_using_database(
     path: string
-  ): Promise<DirectoryListingEntry[] | undefined> {
+  ): Promise<DirectoryListing | undefined> {
     const q = await query({
       query: {
         listings: {
           project_id: this.project_id,
           path,
           listing: null,
+          git_dir: null,
         },
       },
     });
     if (q.query.listings?.error) {
       throw Error(q.query.listings?.error);
     }
-    return q.query.listings?.listing;
+    return {
+      files: q.query.listings?.listing,
+      git_dir: q.query.listings?.git_dir,
+    };
   }
 
   public get_missing(path: string): number | undefined {
@@ -253,9 +257,7 @@ export class Listings extends EventEmitter {
       ?.get("missing");
   }
 
-  public async get_listing_directly(
-    path: string
-  ): Promise<DirectoryListingEntry[]> {
+  public async get_listing_directly(path: string): Promise<DirectoryListing> {
     const store = redux.getStore("projects");
     // make sure that our relationship to this project is known.
     if (store == null) throw Error("bug");
@@ -273,7 +275,7 @@ export class Listings extends EventEmitter {
     if (x.error != null) {
       throw Error(x.error);
     } else {
-      return x.files;
+      return { files: x.files, git_dir: x.git_dir };
     }
   }
 

--- a/src/smc-webapp/project/websocket/listings.ts
+++ b/src/smc-webapp/project/websocket/listings.ts
@@ -35,7 +35,9 @@ interface Listing {
   missing?: number;
   error?: string;
   deleted?: string[];
+  git_dir?: string;
 }
+
 export type ImmutableListing = TypedMap<Listing>;
 
 export class Listings extends EventEmitter {
@@ -214,7 +216,9 @@ export class Listings extends EventEmitter {
   //  - undefined if directory listing not known (and error not known either).
   public async get_for_store(
     path: string
-  ): Promise<List<ImmutablePathEntry> | undefined | string> {
+  ): Promise<
+    { git_dir?: string; files?: List<ImmutablePathEntry> } | undefined | string
+  > {
     if (this.state != "ready") {
       const x = await this.get_using_database(path);
       if (x == null) return x;
@@ -225,7 +229,7 @@ export class Listings extends EventEmitter {
     if (x.get("error")) {
       return x.get("error");
     }
-    return x.get("listing");
+    return { files: x.get("listing"), git_dir: x.get("git_dir") };
   }
 
   public async get_using_database(

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -1169,9 +1169,13 @@ export class ProjectActions extends Actions<ProjectStoreState> {
         }
         if (path == null) throw Error("bug"); // make typescript happy
         if (the_listing != null) {
-          const map = store
-            .get("directory_listings")
-            .set(path, err ? err : immutable.fromJS(the_listing.files));
+          const update = err
+            ? err
+            : immutable.fromJS({
+                files: the_listing.files,
+                git_dir: the_listing.git_dir,
+              });
+          const map = store.get("directory_listings").set(path, update);
           this.setState({ directory_listings: map });
         }
         // done! releasing lock, then executing callback(s)
@@ -1196,10 +1200,10 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     if (store == null) return;
     const listings = store.get_listings();
     try {
-      const files = await listings.get_listing_directly(path);
+      const dir_listing = await listings.get_listing_directly(path);
       const directory_listings = store
         .get("directory_listings")
-        .set(path, immutable.fromJS(files));
+        .set(path, immutable.fromJS(dir_listing));
       this.setState({ directory_listings });
     } catch (err) {
       console.warn(`Unable to fetch all files -- "${err}"`);
@@ -1397,7 +1401,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
       return undefined; // simple fallback
     }
     if (listing != null) {
-      listing.map(function (x) {
+      listing.get("files").map(function (x) {
         files_in_dir[x.get("name")] = true;
       });
     }

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -1284,7 +1284,7 @@ export class ProjectActions extends Actions<ProjectStoreState> {
       const current_path = store.get("current_path");
       const names = store
         .get("displayed_listing")
-        .listing.map((a) => misc.path_to_file(current_path, a.name));
+        .files.map((a) => misc.path_to_file(current_path, a.name));
       range = misc.get_array_range(names, most_recent, file);
     }
 

--- a/src/smc-webapp/project_store.ts
+++ b/src/smc-webapp/project_store.ts
@@ -592,22 +592,22 @@ export class ProjectStore extends Store<ProjectStoreState> {
         let directory_listings = this.get("directory_listings");
         for (const path of paths) {
           if (this.listings == null) return; // won't happen
-          let files;
+          let data;
           if (this.listings.get_missing(path)) {
             try {
-              files = immutable.fromJS(
+              data = immutable.fromJS(
                 await this.listings.get_listing_directly(path)
               );
             } catch (err) {
               console.warn(
                 `WARNING: problem getting directory listing ${err}; falling back`
               );
-              files = await this.listings.get_for_store(path);
+              data = await this.listings.get_for_store(path);
             }
           } else {
-            files = await this.listings.get_for_store(path);
+            data = await this.listings.get_for_store(path);
           }
-          directory_listings = directory_listings.set(path, files);
+          directory_listings = directory_listings.set(path, data);
         }
         const actions = redux.getProjectActions(this.project_id);
         actions.setState({ directory_listings });

--- a/src/smc-webapp/project_store.ts
+++ b/src/smc-webapp/project_store.ts
@@ -39,6 +39,7 @@ import { ProjectLogMap } from "./project/history/types";
 import { alert_message } from "./alerts";
 import { Listings, listings } from "./project/websocket/listings";
 import { deleted_file_variations } from "smc-util/delete-files";
+import { DirectoryListing, DirectoryListingEntry } from "smc-util/types";
 
 export { FILE_ACTIONS as file_actions, ProjectActions };
 
@@ -317,45 +318,51 @@ export class ProjectStore extends Store<ProjectStoreState> {
       ] as const,
       fn: () => {
         const search_escape_char = "/";
-        let listing = this.get("directory_listings").get(
+        const listing_raw = this.get("directory_listings").get(
           this.get("current_path")
         );
-        if (typeof listing === "string") {
+        if (listing_raw == null) {
+          return {};
+        }
+        const listing_files = listing_raw.get("files");
+        if (typeof listing_files === "string") {
           if (
-            listing.indexOf("ECONNREFUSED") !== -1 ||
-            listing.indexOf("ENOTFOUND") !== -1
+            listing_files.indexOf("ECONNREFUSED") !== -1 ||
+            listing_files.indexOf("ENOTFOUND") !== -1
           ) {
             return { error: "no_instance" }; // the host VM is down
-          } else if (listing.indexOf("o such path") !== -1) {
+          } else if (listing_files.indexOf("o such path") !== -1) {
             return { error: "no_dir" };
-          } else if (listing.indexOf("ot a directory") !== -1) {
+          } else if (listing_files.indexOf("ot a directory") !== -1) {
             return { error: "not_a_dir" };
-          } else if (listing.indexOf("not running") !== -1) {
+          } else if (listing_files.indexOf("not running") !== -1) {
             // yes, no underscore.
             return { error: "not_running" };
           } else {
-            return { error: listing };
+            return { error: listing_files };
           }
         }
-        if (listing == null) {
+        if (listing_files == null) {
           return {};
         }
-        if ((listing != null ? listing.errno : undefined) != null) {
-          return { error: misc.to_json(listing) };
+        if ((listing_files != null ? listing_files.errno : undefined) != null) {
+          return { error: misc.to_json(listing_files) };
         }
-        listing = listing.toJS();
+
+        // this this point we know we have good data and no error
+        const listing: DirectoryListing = listing_raw.toJS();
 
         if (this.get("other_settings").get("mask_files")) {
-          _compute_file_masks(listing);
+          _compute_file_masks(listing.files ?? []);
         }
 
         if (this.get("current_path") === ".snapshots") {
-          _compute_snapshot_display_names(listing);
+          _compute_snapshot_display_names(listing.files);
         }
 
         const search = this.get("file_search");
         if (search && search[0] !== search_escape_char) {
-          listing = _matched_files(search.toLowerCase(), listing);
+          listing.files = _matched_files(search.toLowerCase(), listing.files);
         }
 
         const sorter = (() => {
@@ -382,16 +389,19 @@ export class ProjectStore extends Store<ProjectStoreState> {
           }
         })();
 
-        listing.sort(sorter);
+        if (listing.files == null)
+          throw new Error("listing.files must be defined");
+
+        listing.files.sort(sorter);
 
         if (this.get("active_file_sort").get("is_descending")) {
-          listing.reverse();
+          listing.files.reverse();
         }
 
         if (!this.get("show_hidden")) {
-          listing = (() => {
-            const result: string[] = [];
-            for (const l of listing) {
+          listing.files = (() => {
+            const result: DirectoryListingEntry[] = [];
+            for (const l of listing.files) {
               if (!l.name.startsWith(".")) {
                 result.push(l);
               }
@@ -404,35 +414,36 @@ export class ProjectStore extends Store<ProjectStoreState> {
           // if we do not gray out files (and hence haven't computed the file mask yet)
           // we do it now!
           if (!this.get("other_settings").get("mask_files")) {
-            _compute_file_masks(listing);
+            _compute_file_masks(listing.files ?? []);
           }
 
-          const filtered: string[] = [];
-          for (const f of listing) {
+          const filtered: DirectoryListingEntry[] = [];
+          for (const f of listing.files) {
             if (!f.mask) filtered.push(f);
           }
-          listing = filtered;
+          listing.files = filtered;
         }
 
         const map = {};
-        for (var x of listing) {
+        for (const x of listing.files) {
           map[x.name] = x;
         }
 
-        x = {
-          listing,
+        const res = {
+          git_dir: listing.git_dir,
+          files: listing.files,
           public: {},
           path: this.get("current_path"),
           file_map: map,
         };
 
         _compute_public_files(
-          x,
+          res,
           this.get("stripped_public_paths"),
           this.get("current_path")
         );
 
-        return x;
+        return res;
       },
     },
 
@@ -609,7 +620,7 @@ export class ProjectStore extends Store<ProjectStoreState> {
   }
 }
 
-function _match(words, s, is_dir) {
+function _match(words: string[], s: string, is_dir): boolean {
   s = s.toLowerCase();
   for (const t of words) {
     if (t[t.length - 1] === "/") {
@@ -625,30 +636,31 @@ function _match(words, s, is_dir) {
   return true;
 }
 
-function _matched_files(search, listing) {
-  if (listing == null) {
+function _matched_files(
+  search: string,
+  files?: DirectoryListingEntry[]
+): DirectoryListingEntry[] {
+  if (files == null) {
     return [];
   }
   const words = search.split(" ");
-  return (() => {
-    const result: string[] = [];
-    for (const x of listing) {
-      if (
-        _match(words, x.display_name != null ? x.display_name : x.name, x.isdir)
-      ) {
-        result.push(x);
-      }
+  const result: DirectoryListingEntry[] = [];
+  for (const x of files) {
+    if (
+      _match(words, x.display_name != null ? x.display_name : x.name, x.isdir)
+    ) {
+      result.push(x);
     }
-    return result;
-  })();
+  }
+  return result;
 }
 
-function _compute_file_masks(listing): void {
+function _compute_file_masks(files: DirectoryListingEntry[]): void {
   // mask compiled files, e.g. mask 'foo.class' when 'foo.java' exists
   // the general outcome of this function is to set for some file entry objects
   // in "listing" the attribute <file>.mask=true
-  const filename_map = misc.dict(listing.map((item) => [item.name, item])); // map filename to file
-  for (const file of listing) {
+  const filename_map = misc.dict(files.map((item) => [item.name, item])); // map filename to file
+  for (const file of files) {
     // mask certain known directories
     if (MASKED_FILENAMES.indexOf(file.name) >= 0) {
       filename_map[file.name].mask = true;
@@ -714,7 +726,7 @@ function _compute_snapshot_display_names(listing) {
 
 // Mutates data to include info on public paths.
 function _compute_public_files(data, public_paths, current_path) {
-  const { listing } = data;
+  const { files } = data;
   const pub = data.public;
   if (public_paths != null && public_paths.size > 0) {
     const head = current_path ? current_path + "/" : "";
@@ -726,7 +738,7 @@ function _compute_public_files(data, public_paths, current_path) {
     }
     return (() => {
       const result: any = [];
-      for (x of listing) {
+      for (x of files) {
         const full = head + x.name;
         const p = misc.containing_public_path(full, paths);
         if (p != null) {


### PR DESCRIPTION
# Description

I wanted to start with a simple step to make the files listing git aware. So, if the listing is part of a git repo, it should tell the front end where the home of the git directory is. That's minimal overhead and from there we can expose commands, etc.

However, in order to do that, I had to refactor some parts of the file listing code and stumbled over some details. e.g. the type info says it is a string, but it isn't etc. with what's here, I can browse around and it also updates if a file appears or is deleted. Where it fails is reacting to creating/removing a directory and listing files in a new empty directory. I'm unable to figure out what part of the code is getting triggered and why this doesn't work.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
