### PR TITLE
webapp/admin: hide stats section header

### DIFF
--- a/src/smc-webapp/admin/stats/historical-stats.tsx
+++ b/src/smc-webapp/admin/stats/historical-stats.tsx
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { React, useTypedRedux } from "../../app-framework";
+import { React } from "../../app-framework";
 import { A, Icon } from "../../r_misc";
 
 // This is a URL only visible to certain users of https://cocalc.com!
@@ -11,10 +11,6 @@ const STATS_URL =
   "https://cocalc.com/7561f68d-3d97-4530-b97e-68af2fb4ed13/raw/stats.html";
 
 export const HistoricalStats: React.FC = () => {
-  const is_cocalc_com = useTypedRedux("customize", "is_cocalc_com");
-  if (!is_cocalc_com) {
-    return <></>;
-  }
   return (
     <span>
       <Icon name="line-chart" fixedWidth />{" "}

--- a/src/smc-webapp/admin/stats/page.tsx
+++ b/src/smc-webapp/admin/stats/page.tsx
@@ -3,15 +3,20 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { React } from "../../app-framework";
+import { React, useTypedRedux } from "../../app-framework";
 
 import { HistoricalStats } from "./historical-stats";
 
 export const UsageStatistics: React.FC = () => {
-  return (
-    <div>
-      <h3>Usage Statistics</h3>
-      <HistoricalStats />
-    </div>
-  );
+  const is_cocalc_com = useTypedRedux("customize", "is_cocalc_com");
+  if (!is_cocalc_com) {
+    return <></>;
+  } else {
+    return (
+      <div>
+        <h3>Usage Statistics</h3>
+        <HistoricalStats />
+      </div>
+    );
+  }
 };


### PR DESCRIPTION


# Description

 its confusing to see a search stat header outside of cocalc.com if there is nothing in it

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
