### PR TITLE
hub/db: _get_remember_me casts the hash to text, which slows this down

### DIFF
--- a/src/smc-hub/postgres/remember-me.ts
+++ b/src/smc-hub/postgres/remember-me.ts
@@ -26,7 +26,8 @@ async function _get_remember_me(
       cache,
       query: "SELECT value, expire FROM remember_me",
       where: {
-        "hash = $::TEXT": hash.slice(0, 127),
+        // db-schema/auth defines the hash field as a "bpchar", hence do not cast to TEXT – otherwise this is a 100x slowdown
+        "hash = $::CHAR(127)": hash.slice(0, 127),
       },
       retry_until_success: { max_time: 60000, start_delay: 10000 }, // since we want this to be (more) robust to database connection failures.
       cb: one_result("value", cb),


### PR DESCRIPTION
# Description

This is a 200x improvement for those cookie queries. Take away: either don't cast – or cast to the correct type.

```
smc=# explain (analyze, verbose, costs) SELECT value, expire FROM remember_me WHERE hash = 'sha512$6cc3e...499'::CHAR(127);

 Index Scan using remember_me_pkey on public.remember_me  (cost=0.54..2.76 rows=1 width=162) (actual time=0.036..0.037 rows=1 loops=1)
   Output: value, expire
   Index Cond: (remember_me.hash = 'sha512$6cc..4499'::character(127))
 Planning time: 0.079 ms
 Execution time: 0.051 ms
(5 rows)

smc=# explain (analyze, verbose, costs) SELECT value, expire FROM remember_me WHERE hash = 'sha512$6cc3e...9'::TEXT;

 Seq Scan on public.remember_me  (cost=0.00..7479.69 rows=591 width=162) (actual time=0.018..108.994 rows=1 loops=1)
   Output: value, expire
   Filter: ((remember_me.hash)::text = 'sha512$...74499'::text)
   Rows Removed by Filter: 118564
 Planning time: 0.060 ms
 Execution time: 109.015 ms
(6 rows)
```

regarding deployment, this is certainly relevant for hub-proxy, but also all others using auth


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
