### PR TITLE
hub/db: speed up searching for blobs to archive

### DIFF
--- a/src/smc-util/db-schema/blobs.ts
+++ b/src/smc-util/db-schema/blobs.ts
@@ -59,6 +59,9 @@ Table({
     desc:
       "Table that stores blobs mainly generated as output of Sage worksheets.",
     primary_key: "id",
+    // these indices speed up the search been done in 'copy_all_blobs_to_gcloud'
+    // less important to make this query fast, but we want to avoid thrashing cache
+    pg_indexes: ["((expire IS NULL))", "((gcloud IS NULL))", "last_active"],
     user_query: {
       get: {
         async instead_of_query(database, opts, cb): Promise<void> {


### PR DESCRIPTION
# Description

well, this is an optimization for searching old blobs. the drawback is it adds about 1 gb of data for the indices, but I think this isn't that bad and the free disk space is already there anyways – and future postgres updates will give us smaller index sizes.
the real benefit is to avoid reading all those rows/pages every few minutes. if there is a period of high load, such a query might throw off caching.

deployment: nothing to do. I already added exactly these indices "concurrently" 


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
