### PR TITLE
Terminal Guide

### DIFF
--- a/src/smc-project/terminal/server.ts
+++ b/src/smc-project/terminal/server.ts
@@ -9,6 +9,8 @@ Terminal server
 
 const { spawn } = require("node-pty");
 import { readFile, writeFile } from "fs";
+import { promises as fsPromises } from "fs";
+const { readlink } = fsPromises;
 import { len, merge, path_split } from "../smc-util/misc2";
 const { console_init_filename } = require("smc-util/misc");
 import { exists } from "../jupyter/async-utils-node";
@@ -316,7 +318,7 @@ export async function terminal(
       delete terminals[name].client_sizes[spark.id];
       resize();
     });
-    spark.on("data", function (data) {
+    spark.on("data", async function (data) {
       //logger.debug("terminal: browser --> term", name, JSON.stringify(data));
       if (typeof data === "string") {
         try {
@@ -349,6 +351,23 @@ export async function terminal(
           case "kill":
             // send kill signal
             process.kill(terminals[name].term.pid, "SIGKILL");
+            break;
+
+          case "cwd":
+            // we reply with the current working directory of the underlying terminal process
+            const pid = terminals[name].term.pid;
+            const home = process.env.HOME ?? "/home/user";
+            try {
+              const cwd = await readlink(`/proc/${pid}/cwd`);
+              logger.debug(`terminal cwd sent back: ${cwd}`);
+              // we send back a relative path, because the webapp does not understand absolute paths
+              const path = cwd.startsWith(home)
+                ? cwd.slice(home.length + 1)
+                : cwd;
+              spark.write({ cmd: "cwd", payload: path });
+            } catch {
+              // ignoring errors
+            }
             break;
 
           case "boot":

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1185,6 +1185,10 @@ export class Actions<
     open_new_tab(url);
   }
 
+  guide(id: string, type: string): void {
+    console.warn(`Guide for ${type} not implemented. (id=${id})`);
+  }
+
   set_zoom(zoom: number, id?: string) {
     this.change_font_size(undefined, id, zoom);
   }

--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -1330,6 +1330,10 @@ export class Actions<
     return this.terminals.get_terminal(id, parent);
   }
 
+  public set_terminal_cwd(id: string, cwd: string): void {
+    this.save_editor_state(id, { cwd });
+  }
+
   // Open a code editor, optionally at the given line.
   // TODO: try to eliminate the async.
   async open_code_editor(opts: {

--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -211,6 +211,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
           complete={this.props.complete}
           derived_file_types={this.props.derived_file_types}
           available_features={this.props.available_features}
+          local_view_state={this.props.local_view_state}
         />
       </div>
     );

--- a/src/smc-webapp/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/frame-tree.tsx
@@ -111,6 +111,7 @@ interface FrameTreeProps {
   complete: Map<string, any>;
   derived_file_types: Set<string>;
   available_features: AvailableFeatures;
+  local_view_state: Map<string, any>;
 }
 
 interface FrameTreeState {
@@ -156,6 +157,7 @@ export class FrameTree extends Component<FrameTreeProps, FrameTreeState> {
         "complete",
         "derived_file_types",
         "available_features",
+        "local_view_state",
       ])
     );
   }
@@ -191,6 +193,7 @@ export class FrameTree extends Component<FrameTreeProps, FrameTreeState> {
         complete={this.props.complete}
         derived_file_types={this.props.derived_file_types}
         available_features={this.props.available_features}
+        local_view_state={this.props.local_view_state}
       />
     );
   }
@@ -303,6 +306,7 @@ export class FrameTree extends Component<FrameTreeProps, FrameTreeState> {
         status={this.props.status}
         derived_file_types={this.props.derived_file_types}
         available_features={this.props.available_features}
+        local_view_state={this.props.local_view_state}
         actions={actions}
         component={component}
         desc={desc}

--- a/src/smc-webapp/frame-editors/frame-tree/leaf.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/leaf.tsx
@@ -41,6 +41,7 @@ interface Props {
   is_fullscreen: boolean;
   reload?: number;
   is_subframe: boolean;
+  local_view_state: Map<string, any>;
 }
 
 interface ReduxProps {
@@ -123,6 +124,7 @@ class FrameTreeLeaf extends Component<Props & ReduxProps> {
           this.props.complete && this.props.complete.get(desc.get("id"))
         }
         derived_file_types={this.props.derived_file_types}
+        local_view_state={this.props.local_view_state}
         desc={desc}
         available_features={this.props.available_features}
         is_subframe={this.props.is_subframe}

--- a/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
@@ -920,6 +920,31 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
     );
   }
 
+  function render_guide(labels: boolean): Rendered {
+    if (!is_visible("guide", true) || is_public) {
+      return;
+    }
+    const {title, descr} = props.editor_spec[props.type].guide_info ?? {
+      title: "Guide",
+      descr: "Show guidebook"
+    }
+    return (
+      <Button
+        key={"guide"}
+        title={descr}
+        bsSize={button_size()}
+        onClick={() =>
+          typeof props.actions.help === "function"
+            ? props.actions.guide(props.id, props.type)
+            : undefined
+        }
+      >
+        <Icon name="book" />{" "}
+        <VisibleMDLG>{labels ? title : undefined}</VisibleMDLG>
+      </Button>
+    );
+  }
+
   function render_restart(): Rendered {
     if (!is_visible("restart", true)) {
       return;
@@ -1294,6 +1319,7 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
     v.push(render_format());
     v.push(render_shell());
     v.push(render_print());
+    v.push(render_guide(labels));
     v.push(render_help(labels));
 
     const w: Rendered[] = [];

--- a/src/smc-webapp/frame-editors/frame-tree/types.ts
+++ b/src/smc-webapp/frame-editors/frame-tree/types.ts
@@ -59,6 +59,7 @@ export interface EditorDescription {
   renderer?: string; // e.g., "canvas" or "svg"
   hide_public?: boolean; // if true, do not show this editor option (in title bar dropdown) when viewing file publicly.
   clear_info?: { text: string; confirm: string };
+  guide_info?: { title: string; descr: string };
 }
 
 export interface EditorSpec {

--- a/src/smc-webapp/frame-editors/terminal-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/actions.ts
@@ -22,8 +22,12 @@ export class TerminalActions extends Actions {
     return { type: "terminal" };
   }
 
-  public guide_command(id: string, cmd: string): void {
-    console.log("cmd", cmd, "id", id);
+  public get_terminal(id: string) {
+    return this.terminals.get(id);
+  }
+
+  // this sends a given line "cmd" to the actual terminal
+  public run_command(cmd: string): void {
     const last_terminal_id = this._get_most_recent_active_frame_id_of_type(
       "terminal"
     );
@@ -35,7 +39,12 @@ export class TerminalActions extends Actions {
       const terminal = this.terminals.get(last_terminal_id);
       console.log("terminal " + last_terminal_id, "→", terminal);
       if (terminal == null) return;
-      terminal.conn_write("ls\n");
+      // we clean up the input line before we send the command
+      // Ctrl-e & Ctrl-u: move cursor to end of line and backwards delete the entire line
+      // "$ showkey -a" helped me to get the hex codes:
+      // ^E 	  5 0005 0x05
+      // ^U 	 21 0025 0x15
+      terminal.conn_write(`\x05\x15${cmd}\n`);
     }
   }
 

--- a/src/smc-webapp/frame-editors/terminal-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/actions.ts
@@ -13,10 +13,10 @@ const { open_new_tab } = require("smc-webapp/misc_page");
 const HELP_URL = "https://doc.cocalc.com/terminal.html";
 
 interface CmdOpts {
-  run?: boolean;
-  cleanup?: boolean;
-  userarg?: boolean;
-  special?: string;
+  run?: boolean; // if true (default) also send a return key
+  cleanup?: boolean; // if true (default), the current line is cleared before the cmd is entered
+  userarg?: boolean; // append " '|'" to the command, where | is where the user's cursor ends up (think of git commit -m '[bla]')
+  special?: string; // instead of the cmd arg, this sends a special character sequence (like, [tab])
 }
 
 export class TerminalActions extends Actions {
@@ -34,6 +34,7 @@ export class TerminalActions extends Actions {
   }
 
   // this sends a given line "cmd" to the actual terminal
+  // the extra options slightly modify what it does – check the interface for the explanation
   public run_command(cmd: string, opts: CmdOpts): void {
     const { run = true, cleanup = true, userarg = false, special } = opts;
     const last_terminal_id = this._get_most_recent_active_frame_id_of_type(

--- a/src/smc-webapp/frame-editors/terminal-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/actions.ts
@@ -46,7 +46,6 @@ export class TerminalActions extends Actions {
       this.focus(last_terminal_id);
       this.set_active_id(last_terminal_id);
       const terminal = this.terminals.get(last_terminal_id);
-      console.log("terminal " + last_terminal_id, "→", terminal);
       if (terminal == null) return;
       // note: don't try to set these special char sequences in react – they're escaped
       switch (special) {

--- a/src/smc-webapp/frame-editors/terminal-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/actions.ts
@@ -22,7 +22,37 @@ export class TerminalActions extends Actions {
     return { type: "terminal" };
   }
 
-  help(): void {
+  public guide_command(id: string, cmd: string): void {
+    console.log("cmd", cmd, "id", id);
+    const last_terminal_id = this._get_most_recent_active_frame_id_of_type(
+      "terminal"
+    );
+    if (last_terminal_id != null) {
+      // De-maximize if in full screen mode.
+      this.unset_frame_full();
+      this.focus(last_terminal_id);
+      this.set_active_id(last_terminal_id);
+      const terminal = this.terminals.get(last_terminal_id);
+      console.log("terminal " + last_terminal_id, "→", terminal);
+      if (terminal == null) return;
+      terminal.conn_write("ls\n");
+    }
+  }
+
+  public help(): void {
     open_new_tab(HELP_URL);
+  }
+
+  public async guide(): Promise<void> {
+    const id = this.show_focused_frame_of_type(
+      "commands_guide",
+      "col",
+      false,
+      3 / 4
+    );
+    // the click to select TOC focuses the active id back on the notebook
+    await delay(0);
+    if (this._state === "closed") return;
+    this.set_active_id(id, true);
   }
 }

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide-components.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide-components.tsx
@@ -1,0 +1,136 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// they are used in commands-guide.tsx, that's all
+
+import { CSS, React, useMemo } from "../../app-framework";
+import { Button, Row, Col, Select, Typography } from "antd";
+import { TerminalActions } from "./actions";
+import { TerminalActionsContext } from "./commands-guide";
+
+// ------------------------------------
+
+interface SelectFileProps {
+  list: string[];
+  selected?: string;
+  select: (string) => void;
+}
+
+export const SelectFile: React.FC<SelectFileProps> = React.memo(
+  (props: SelectFileProps) => {
+    const { list, selected, select } = props;
+    return (
+      <Select
+        value={selected}
+        allowClear={true}
+        showSearch={true}
+        placeholder="Select an entry"
+        optionFilterProp="value"
+        onChange={select}
+        filterOption={(input, option) =>
+          option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0
+        }
+        style={{ width: "100%" }}
+      >
+        {list.map((val) => (
+          <Select.Option key={val} value={val}>
+            {val}
+          </Select.Option>
+        ))}
+      </Select>
+    );
+  }
+);
+
+// ------------------------
+
+interface RowLayoutProps {
+  left: JSX.Element | string;
+  right: JSX.Element | string;
+}
+
+const RowLayout: React.FC<RowLayoutProps> = React.memo(
+  (props: RowLayoutProps) => {
+    return (
+      <Row gutter={[16, 8]}>
+        <Col flex={"0 1 50%"}>{props.left}</Col>
+        <Col flex={"auto"}>{props.right}</Col>
+      </Row>
+    );
+  }
+);
+
+interface CommandProps {
+  cmd?: string;
+  special?: string; // bypass processing the cmd
+  title?: string;
+  descr: string;
+  userarg?: boolean; // if yes, user will have to input an argument in the terminal
+  args?: (string | undefined)[];
+}
+
+const CMD_BTN_STYLE: CSS = {
+  whiteSpace: "nowrap",
+  fontFamily: "monospace",
+  fontSize: "90%",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  maxWidth: "100%",
+};
+
+// a simple templating approach is used to bolt together the actual command
+function calc_cmd_args(
+  cmd0?: string,
+  args: (string | undefined)[] = []
+): { cmdargs: string; run: boolean } {
+  let used_args = args.length == 0; // no args to use
+  let cmd = cmd0 ?? "";
+  args.forEach((val, idx) => {
+    if (val == null) return;
+    used_args = true;
+    if (cmd.includes(`${idx + 1}`)) {
+      // TODO quote "'" inside of file names as "'\''" or something similar?
+      cmd = cmd.replace(new RegExp(`\\$${idx + 1}`, "g"), `'${val}'`);
+    } else {
+      cmd += ` ${val}`;
+    }
+  });
+  return { cmdargs: cmd, run: used_args };
+}
+
+export const Command: React.FC<CommandProps> = React.memo(
+  (props: CommandProps) => {
+    const { cmd, special, title, descr, args, userarg } = props;
+    const { cmdargs, run } = useMemo(
+      () =>
+        special != null
+          ? { cmdargs: "", run: false }
+          : calc_cmd_args(cmd, args),
+      [cmd, args]
+    );
+
+    const actions: TerminalActions | undefined = React.useContext(
+      TerminalActionsContext
+    );
+
+    return (
+      <RowLayout
+        left={
+          <Button
+            onClick={() =>
+              actions?.run_command(cmdargs, { special, run, userarg })
+            }
+            shape={"round"}
+            size={"small"}
+            title={cmdargs}
+          >
+            <span style={CMD_BTN_STYLE}>{title ?? cmdargs}</span>
+          </Button>
+        }
+        right={<Typography.Text type="secondary">{descr}</Typography.Text>}
+      />
+    );
+  }
+);

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide-components.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide-components.tsx
@@ -5,7 +5,7 @@
 
 // they are used in commands-guide.tsx, that's all
 
-import { CSS, React, useMemo } from "../../app-framework";
+import { CSS, React, useMemo, useState } from "../../app-framework";
 import { Button, Row, Col, Select, Typography } from "antd";
 import { TerminalActions } from "./actions";
 import { TerminalActionsContext } from "./commands-guide";
@@ -21,14 +21,27 @@ interface SelectFileProps {
 export const SelectFile: React.FC<SelectFileProps> = React.memo(
   (props: SelectFileProps) => {
     const { list, selected, select } = props;
+
+    const [search, set_search] = useState<string>("");
+
+    // we do this explicitly, because otherwise it only allows to select known elements
+    const input_key_down = (e) => {
+      // return key
+      if (e.keyCode == 13) {
+        select(search);
+      }
+    };
+
     return (
       <Select
         value={selected}
         allowClear={true}
         showSearch={true}
-        placeholder="Select an entry"
-        optionFilterProp="value"
+        placeholder={"Select or enter name"}
+        optionFilterProp={"value"}
         onChange={select}
+        onSearch={(val) => set_search(val)}
+        onInputKeyDown={input_key_down}
         filterOption={(input, option) =>
           option?.value?.toLowerCase().indexOf(input.toLowerCase()) >= 0
         }
@@ -81,6 +94,7 @@ const CMD_BTN_STYLE: CSS = {
 };
 
 // a simple templating approach is used to bolt together the actual command
+// either append non-nullish args or insert them everywhere where $1, $2, etc. is
 function calc_cmd_args(
   cmd0?: string,
   args: (string | undefined)[] = []

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -1,0 +1,37 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { React } from "../../app-framework";
+// import { delay } from "awaiting";
+// import { List, Map } from "immutable";
+// import { Icon, Loading } from "../../r_misc";
+import { Button } from "../../antd-bootstrap";
+
+import { TerminalActions } from "./actions";
+
+interface Props {
+  id: string;
+  font_size: number;
+  actions: TerminalActions;
+}
+
+export const CommandsGuide: React.FC<Props> = React.memo((props) => {
+  const { font_size, actions, id } = props;
+  console.log("font_size", font_size, " -- ", actions);
+
+  function render_btn() {
+    return (
+      <Button onClick={() => actions.guide_command(id, "ls")}>Listing</Button>
+    );
+  }
+
+  return (
+    <>
+      <div>Terminal Commands</div>
+
+      {render_btn()}
+    </>
+  );
+});

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -3,27 +3,97 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { React } from "../../app-framework";
+import {
+  React,
+  useEffect,
+  useState,
+  useActions,
+  useTypedRedux,
+} from "../../app-framework";
 // import { delay } from "awaiting";
-// import { List, Map } from "immutable";
+import { Map } from "immutable";
 // import { Icon, Loading } from "../../r_misc";
 import { Button } from "../../antd-bootstrap";
 
 import { TerminalActions } from "./actions";
 
 interface Props {
-  id: string;
   font_size: number;
+  project_id: string;
   actions: TerminalActions;
+  local_view_state: Map<string, any>;
 }
 
+//function is_equal(prev, next) {
+//  return prev.font_size == next.font_size;
+//}
+
 export const CommandsGuide: React.FC<Props> = React.memo((props) => {
-  const { font_size, actions, id } = props;
+  const { font_size, actions, local_view_state, project_id } = props;
+  console.log("local_view_state", local_view_state.toJS());
   console.log("font_size", font_size, " -- ", actions);
+
+  const project_actions = useActions({ project_id });
+  const directory_listings = useTypedRedux(
+    { project_id },
+    "directory_listings"
+  );
+  const [terminal_id, set_terminal_id] = useState<string | undefined>();
+  const [cwd, set_cwd] = useState<string | undefined>();
+  const [listing, set_listing] = useState<any | undefined>();
+
+  useEffect(() => {
+    const tid = actions._get_most_recent_active_frame_id_of_type("terminal");
+    if (tid == null) return;
+    if (terminal_id != tid) set_terminal_id(tid);
+  }, [local_view_state]);
+
+  function cwd2path(cwd: string): string {
+    return cwd.charAt(0) === "/" ? ".smc/root" + cwd : cwd;
+  }
+
+  useEffect(() => {
+    //const terminal = actions.get_terminal(tid);
+    const next_cwd = local_view_state.getIn([
+      "editor_state",
+      terminal_id,
+      "cwd",
+    ]);
+    if (next_cwd != null && cwd != next_cwd) {
+      set_cwd(next_cwd);
+      project_actions?.fetch_directory_listing({ path: cwd2path(next_cwd) });
+    }
+  }, [terminal_id, local_view_state]);
+
+  useEffect(() => {
+    if (cwd == null) return;
+    const next_listing = directory_listings?.get(cwd2path(cwd));
+    if (next_listing != null && next_listing != listing) {
+      set_listing(next_listing);
+    }
+  }, [directory_listings, cwd, terminal_id]);
+
+  function render_files() {
+    return (
+      <p>
+        cwd:<code>{cwd}</code>
+        <br />
+        <pre>{JSON.stringify(listing ?? {}, null, 2)}</pre>
+      </p>
+    );
+  }
 
   function render_btn() {
     return (
-      <Button onClick={() => actions.guide_command(id, "ls")}>Listing</Button>
+      <>
+        <Button onClick={() => actions.run_command("ls")}>Listing</Button>
+        <Button onClick={() => actions.run_command("ls -la")}>
+          Long full listing
+        </Button>
+        <Button onClick={() => actions.run_command("date")}>Date</Button>
+        <br />
+        {render_files()}
+      </>
     );
   }
 
@@ -34,4 +104,4 @@ export const CommandsGuide: React.FC<Props> = React.memo((props) => {
       {render_btn()}
     </>
   );
-});
+}); //, is_equal);

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -9,13 +9,17 @@ import {
   useState,
   useActions,
   useTypedRedux,
+  TypedMap,
 } from "../../app-framework";
+import { Collapse, Descriptions } from "antd";
+const { Panel } = Collapse;
 // import { delay } from "awaiting";
-import { Map } from "immutable";
+import { Map, List } from "immutable";
 // import { Icon, Loading } from "../../r_misc";
 import { Button } from "../../antd-bootstrap";
-
+import { plural, round1 } from "smc-util/misc";
 import { TerminalActions } from "./actions";
+import { DirectoryListingEntry } from "../../project/explorer/types";
 
 interface Props {
   font_size: number;
@@ -24,13 +28,21 @@ interface Props {
   local_view_state: Map<string, any>;
 }
 
+const ListingStatsInit = {
+  total: 0,
+  num_files: 0,
+  num_dirs: 0,
+  size_mib: 0,
+};
+
+const info = "info";
+
 //function is_equal(prev, next) {
 //  return prev.font_size == next.font_size;
 //}
 
 export const CommandsGuide: React.FC<Props> = React.memo((props) => {
   const { font_size, actions, local_view_state, project_id } = props;
-  console.log("local_view_state", local_view_state.toJS());
   console.log("font_size", font_size, " -- ", actions);
 
   const project_actions = useActions({ project_id });
@@ -39,9 +51,13 @@ export const CommandsGuide: React.FC<Props> = React.memo((props) => {
     "directory_listings"
   );
   const [terminal_id, set_terminal_id] = useState<string | undefined>();
-  const [cwd, set_cwd] = useState<string | undefined>();
-  const [listing, set_listing] = useState<any | undefined>();
-
+  const [cwd, set_cwd] = useState<string>(""); // default home directory
+  const [listing, set_listing] = useState<
+    List<TypedMap<DirectoryListingEntry>>
+  >(List([])); // empty immutable js list
+  const [listing_stats, set_listing_stats] = useState<typeof ListingStatsInit>(
+    ListingStatsInit
+  );
   useEffect(() => {
     const tid = actions._get_most_recent_active_frame_id_of_type("terminal");
     if (tid == null) return;
@@ -70,38 +86,79 @@ export const CommandsGuide: React.FC<Props> = React.memo((props) => {
     const next_listing = directory_listings?.get(cwd2path(cwd));
     if (next_listing != null && next_listing != listing) {
       set_listing(next_listing);
+      const nf = next_listing.count((val) => val.get("isdir"));
+      const total = next_listing.size;
+      const size =
+        next_listing.reduce(
+          (cur, val) => cur + (val.get("isdir") ? 0 : val.get("size")),
+          0
+        ) /
+        (1024 * 1024);
+      set_listing_stats({
+        total,
+        num_files: nf,
+        num_dirs: total - nf,
+        size_mib: size,
+      });
     }
   }, [directory_listings, cwd, terminal_id]);
 
   function render_files() {
     return (
-      <p>
-        cwd:<code>{cwd}</code>
-        <br />
-        <pre>{JSON.stringify(listing ?? {}, null, 2)}</pre>
-      </p>
+      <pre style={{ fontSize: "80%" }}>
+        {JSON.stringify(listing ?? {}, null, 2)}
+      </pre>
     );
   }
 
   function render_btn() {
     return (
-      <>
+      <div>
         <Button onClick={() => actions.run_command("ls")}>Listing</Button>
         <Button onClick={() => actions.run_command("ls -la")}>
           Long full listing
         </Button>
         <Button onClick={() => actions.run_command("date")}>Date</Button>
-        <br />
-        {render_files()}
-      </>
+      </div>
     );
   }
 
-  return (
-    <>
-      <div>Terminal Commands</div>
+  function render_info() {
+    const dir = cwd.startsWith("/") ? cwd : cwd === "" ? "~" : `~/${cwd}`;
+    return (
+      <Descriptions size="small" bordered column={1}>
+        <Descriptions.Item label="Directory">
+          <code>{dir}</code>
+        </Descriptions.Item>
+        <Descriptions.Item label="Content">
+          <code>{listing_stats.num_files}</code>{" "}
+          {plural(listing_stats.num_files, "file")},{" "}
+          <code>{listing_stats.num_dirs}</code>{" "}
+          {plural(listing_stats.num_dirs, "directory", "directories")},{" "}
+          <code>{round1(listing_stats.size_mib)}</code> MiB
+        </Descriptions.Item>
+      </Descriptions>
+    );
+  }
 
-      {render_btn()}
-    </>
+  function render_git() {
+    return <p>Git</p>;
+  }
+
+  return (
+    <Collapse defaultActiveKey={[info]}>
+      <Panel header="General information" key={info}>
+        {render_info()}
+      </Panel>
+      <Panel header="File commands" key="file-commands">
+        {render_btn()}
+      </Panel>
+      <Panel header="Git" key="git">
+        {render_git()}
+      </Panel>
+      <Panel header="Files" key="files">
+        {render_files()}
+      </Panel>
+    </Collapse>
   );
 }); //, is_equal);

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -312,7 +312,7 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
       <>
         <Command cmd="git status" descr="current status" />
         <Command cmd="git diff" descr="content changes" />
-        <Command cmd="git grep" descr="search file content" />
+        <Command cmd="git grep" descr="search file content" userarg={true} />
         <Command cmd="git pull" descr="pull changes" />
 
         <Divider orientation="left" plain>

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -214,7 +214,7 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
         <Command cmd="mv -v" descr="move files" args={[fn1, fn2]} />
         <Command cmd="rm -v" descr="remove a file" args={[fn1]} />
         <Command cmd="stat" descr="file information" args={[fn1]} />
-        <Command cmd="type" descr="file type" args={[fn1]} />
+        <Command cmd="file" descr="file type" args={[fn1]} />
         <Command cmd="head" descr="start of text file" args={[fn1]} />
         <Command cmd="tail" descr="end of text file" args={[fn1]} />
         <Command cmd="less" descr="show text file conent" args={[fn1]} />

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -417,6 +417,14 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
           }
           key={info}
         >
+          <p>
+            This panel shows you the current directory and statistics about the
+            files in it. You can select the first and second argument for
+            commands below that consume files or a directory name. If there is
+            an argument selected, clicking on the command in a panel below will
+            evaluate it.
+          </p>
+
           {render_info()}
         </Panel>
         <Panel

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -227,7 +227,7 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
     return (
       <>
         <Command cmd="ls" descr="list files" />
-        <Command cmd="ls -l" descr="full file listing" />
+        <Command cmd="ls -lh" descr="full file listing" />
         <Command cmd="pwd" descr="current directory" />
         <Command cmd="cd" descr="change directory" args={[dir1]} />
         <Command cmd="mkdir" descr="create directory" args={[dir1]} />

--- a/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/connected-terminal.ts
@@ -14,6 +14,7 @@ extra support for being connected to:
 import { Map } from "immutable";
 import { callback, delay } from "awaiting";
 import { redux, ProjectActions } from "../../app-framework";
+import { debounce } from "lodash";
 
 import { aux_file } from "../frame-tree/util";
 
@@ -108,6 +109,7 @@ export class Terminal<T extends CodeEditorState = CodeEditorState> {
     args?: string[]
   ) {
     bind_methods(this);
+    this.ask_for_cwd = debounce(this.ask_for_cwd);
 
     this.actions = actions;
     this.account_store = redux.getStore("account");
@@ -308,6 +310,7 @@ export class Terminal<T extends CodeEditorState = CodeEditorState> {
     }
     this.conn_write_buffer = [];
     this.set_connection_status("connected");
+    this.ask_for_cwd();
   }
 
   async reload(): Promise<void> {
@@ -315,7 +318,7 @@ export class Terminal<T extends CodeEditorState = CodeEditorState> {
   }
 
   conn_write(data): void {
-    if (this.state == 'closed') return;  // no-op  -- see #4918
+    if (this.state == "closed") return; // no-op  -- see #4918
     if (this.conn === undefined) {
       this.conn_write_buffer.push(data);
       return;
@@ -378,6 +381,7 @@ export class Terminal<T extends CodeEditorState = CodeEditorState> {
     this.terminal.onTitleChange((title) => {
       if (title != null) {
         this.actions.set_title(this.id, title);
+        this.ask_for_cwd();
       }
     });
   }
@@ -467,6 +471,9 @@ export class Terminal<T extends CodeEditorState = CodeEditorState> {
         if (typeof mesg.rows == "number" && typeof mesg.cols == "number") {
           this.terminal_resize({ rows: mesg.rows, cols: mesg.cols });
         }
+        break;
+      case "cwd":
+        this.actions.set_terminal_cwd(this.id, mesg.payload);
         break;
       case "burst":
         this.burst_on();
@@ -676,6 +683,10 @@ export class Terminal<T extends CodeEditorState = CodeEditorState> {
     this.is_paused = false;
     this.render(this.render_buffer);
     this.render_buffer = "";
+  }
+
+  ask_for_cwd(): void {
+    this.conn_write({ cmd: "cwd" });
   }
 
   kick_other_users_out(): void {

--- a/src/smc-webapp/frame-editors/terminal-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/editor.ts
@@ -40,14 +40,14 @@ export const terminal = {
     confirm: "Yes, clean up!",
   },
   guide_info: {
-    title: "Commands",
-    descr: "Show terminal commands handbook",
+    title: "Guide",
+    descr: "Show a panel guiding you working with the terminal.",
   },
 };
 
 const commands_guide = {
-  short: "Commands",
-  name: "Commands Reference",
+  short: "Guide",
+  name: "Guide",
   icon: "book",
   component: CommandsGuide,
   buttons: set(["decrease_font_size", "increase_font_size"]),

--- a/src/smc-webapp/frame-editors/terminal-editor/editor.ts
+++ b/src/smc-webapp/frame-editors/terminal-editor/editor.ts
@@ -9,6 +9,7 @@ Top-level React component for the terminal
 
 import { createEditor } from "../frame-tree/editor";
 import { TerminalFrame } from "./terminal";
+import { CommandsGuide } from "./commands-guide";
 import { set } from "smc-util/misc2";
 
 export const terminal = {
@@ -29,6 +30,7 @@ export const terminal = {
     "clear",
     "help",
     "connection_status",
+    "guide",
     /*"reload" */
   ]),
   hide_public: true, // never show this editor option for public view
@@ -37,10 +39,23 @@ export const terminal = {
       "Clearing this Terminal terminates a running program, respawns the shell, and cleans up the display buffer.",
     confirm: "Yes, clean up!",
   },
+  guide_info: {
+    title: "Commands",
+    descr: "Show terminal commands handbook",
+  },
+};
+
+const commands_guide = {
+  short: "Commands",
+  name: "Commands Reference",
+  icon: "book",
+  component: CommandsGuide,
+  buttons: set(["decrease_font_size", "increase_font_size"]),
 };
 
 const EDITOR_SPEC = {
   terminal,
+  commands_guide,
 };
 
 export const Editor = createEditor({

--- a/src/smc-webapp/project/explorer/types.ts
+++ b/src/smc-webapp/project/explorer/types.ts
@@ -7,3 +7,10 @@ export interface ListingItem {
   name: string;
   isdir: boolean;
 }
+
+export interface DirectoryListingEntry {
+  name: string;
+  size: number;
+  mtime: number;
+  isdir?: boolean;
+}

--- a/src/smc-webapp/share/directory-listing.tsx
+++ b/src/smc-webapp/share/directory-listing.tsx
@@ -14,11 +14,11 @@ import { Component, React, Rendered } from "../app-framework";
 //import { PublicPathInfo } from "./public-path-info";
 const { PublicPathInfo } = require("./public-path-info");
 
-import { DirectoryListingEntry } from "../../project/explorer/types";
+import { DirectoryListingEntry as DirectoryListingEntryType } from "../../project/explorer/types";
 
 interface DirectoryListingProps {
   info?: Map<string, any>;
-  files: DirectoryListingEntry[];
+  files: DirectoryListingEntryType[];
   viewer: string;
   path: string;
   hidden?: boolean; // // if true, show hidden dot files (will be controlled by a query param)

--- a/src/smc-webapp/share/directory-listing.tsx
+++ b/src/smc-webapp/share/directory-listing.tsx
@@ -14,12 +14,7 @@ import { Component, React, Rendered } from "../app-framework";
 //import { PublicPathInfo } from "./public-path-info";
 const { PublicPathInfo } = require("./public-path-info");
 
-interface DirectoryListingEntry {
-  name: string;
-  size: number;
-  mtime: number;
-  isdir?: boolean;
-}
+import { DirectoryListingEntry } from "../../project/explorer/types";
 
 interface DirectoryListingProps {
   info?: Map<string, any>;

--- a/src/smc-webapp/share/directory-listing.tsx
+++ b/src/smc-webapp/share/directory-listing.tsx
@@ -14,7 +14,7 @@ import { Component, React, Rendered } from "../app-framework";
 //import { PublicPathInfo } from "./public-path-info";
 const { PublicPathInfo } = require("./public-path-info");
 
-import { DirectoryListingEntry as DirectoryListingEntryType } from "../../project/explorer/types";
+import { DirectoryListingEntry as DirectoryListingEntryType } from "../project/explorer/types";
 
 interface DirectoryListingProps {
   info?: Map<string, any>;


### PR DESCRIPTION
# Description

This adds a side panel to the terminal, which I called "Guide" … but  I'm not sure if there is a better word. It "guides" you a little bit with terminal commands, very basic. I'm happy with the basics I have and I don't want to spend more time on this right now. There are many more details to add and enhance, but that's for later. Rather, I want to also implement such a "guide" concept for latex and jupyter. 

The only detail I was stuck was how to share some state-information across frames, such that updates about one frame travel to all other ones  … and in particular, this one here can react to it. I used `save_editor_state(id, object)` which might or might not be a good idea.

Regarding release: it also needs a newer project, but it works fine for older ones. The current directory is just wrong, that's all.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
