### PR TITLE
small terminal guide fixes

### DIFF
--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide-components.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide-components.tsx
@@ -104,11 +104,11 @@ function calc_cmd_args(
   args.forEach((val, idx) => {
     if (val == null) return;
     used_args = true;
-    if (cmd.includes(`${idx + 1}`)) {
+    if (cmd.includes(`$${idx + 1}`)) {
       // TODO quote "'" inside of file names as "'\''" or something similar?
       cmd = cmd.replace(new RegExp(`\\$${idx + 1}`, "g"), `'${val}'`);
     } else {
-      cmd += ` ${val}`;
+      cmd += ` '${val}'`;
     }
   });
   return { cmdargs: cmd, run: used_args };

--- a/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/smc-webapp/frame-editors/terminal-editor/commands-guide.tsx
@@ -417,13 +417,16 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
           }
           key={info}
         >
-          <p>
+          <Typography.Paragraph
+            ellipsis={{ rows: 1, expandable: true, symbol: "more…" }}
+          >
             This panel shows you the current directory and statistics about the
             files in it. You can select the first and second argument for
             commands below that consume files or a directory name. If there is
             an argument selected, clicking on the command in a panel below will
-            evaluate it.
-          </p>
+            evaluate it. To enter an arbitrary (non-existing) filename, type it
+            in an hit the return key.
+          </Typography.Paragraph>
 
           {render_info()}
         </Panel>


### PR DESCRIPTION
# Description

1. make this intro text expandable on demand (so, in the usual case, it doesn't use up as much space)
2. a missing "$" sign for appending arguments to a command
3. quote filenames (there could be a heuristic with proper escaping, but for now I just wrap them in `'`)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
