### PR TITLE
webapp/latex: fix tab switching in build panel logs 

### DIFF
--- a/src/smc-webapp/antd-bootstrap.tsx
+++ b/src/smc-webapp/antd-bootstrap.tsx
@@ -304,13 +304,15 @@ export function Tabs(props: {
   animation?: boolean;
   style?: React.CSSProperties;
   tabBarExtraContent?: React.ReactNode;
+  tabPosition?: "left" | "top" | "right" | "bottom";
+  size?: "small";
   children: any;
 }) {
   // We do this because for antd, "There must be `tab` property on children of Tabs."
   let tabs: Rendered[] | Rendered = [];
   if (Symbol.iterator in Object(props.children)) {
     for (const x of props.children) {
-      if (!x.props) continue;
+      if (x == null || !x.props) continue;
       tabs.push(Tab(x.props));
     }
   } else {
@@ -323,6 +325,8 @@ export function Tabs(props: {
       animated={props.animation ?? false}
       style={props.style}
       tabBarExtraContent={props.tabBarExtraContent}
+      tabPosition={props.tabPosition}
+      size={props.size}
     >
       {tabs}
     </antd.Tabs>

--- a/src/smc-webapp/frame-editors/latex-editor/build.tsx
+++ b/src/smc-webapp/frame-editors/latex-editor/build.tsx
@@ -12,8 +12,7 @@ import { path_split } from "smc-util/misc2";
 import { React, Rendered, useRedux } from "../../app-framework";
 import { BuildCommand } from "./build-command";
 import { Loading } from "smc-webapp/r_misc";
-import { Tabs } from "antd";
-const { TabPane } = Tabs;
+import { Tab, Tabs } from "../../antd-bootstrap";
 import { COLORS } from "../../../smc-util/theme";
 import { BuildLogs } from "./actions";
 import { use_build_logs } from "./hooks";
@@ -118,7 +117,7 @@ export const Build: React.FC<Props> = React.memo((props) => {
       whiteSpace: "pre-line",
       color: COLORS.GRAY_D,
       background: COLORS.GRAY_LLL,
-      display: "block",
+      display: active_tab === title ? "block" : "none",
       width: "100%",
       padding: "5px",
       fontSize: `${font_size}px`,
@@ -128,10 +127,10 @@ export const Build: React.FC<Props> = React.memo((props) => {
     const err_style = error ? { background: COLORS.ATND_BG_RED_L } : undefined;
     const tab_button = <div style={err_style}>{title}</div>;
     return (
-      <TabPane tab={tab_button} key={title} style={style}>
+      <Tab key={title} eventKey={title} title={tab_button} style={style}>
         {time_str && `Build time: ${time_str}\n\n`}
         <Ansi>{value}</Ansi>
-      </TabPane>
+      </Tab>
     );
   }
 
@@ -166,17 +165,13 @@ export const Build: React.FC<Props> = React.memo((props) => {
 
   function render_logs(): Rendered {
     if (status) return;
-    // Regarding scrolling, it would be way better to have height 100% on Tabs and also on
-    // the container of the tab body, and then only overflowY on the tab body, so only the log
-    // itself scrolls rather than the tabs too.  But I don't see how to do that given what
-    // antd trivially exposes.  I'll leave that to followup works.
     return (
       <Tabs
-        style={{ height: "100%", overflowY: "auto" }}
+        activeKey={active_tab}
+        onSelect={set_active_tab}
         tabPosition={"left"}
         size={"small"}
-        activeKey={active_tab}
-        onTabClick={(key) => set_active_tab(key)}
+        style={{ height: "100%", overflowY: "auto" }}
       >
         {render_log("latex")}
         {render_log("sagetex")}


### PR DESCRIPTION
# Description

* this should fix #4973, a very subtle issue with the style
* switches to use this antd wrapper instead of using it directly
* removes an outdated comment

testing tells me it is fine now, but I should double check this

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
