### PR TITLE
admin/user_search: sort users by last created or active

### DIFF
--- a/src/smc-webapp/admin/users/actions.ts
+++ b/src/smc-webapp/admin/users/actions.ts
@@ -7,17 +7,17 @@ import { fromJS, List } from "immutable";
 
 import { Actions, redux } from "../../app-framework";
 import { user_search, User } from "../../frame-editors/generic/client";
-import { cmp } from "smc-util/misc2";
+import { sortBy } from "lodash";
 import { StoreState, User as ImmutableUser, store } from "./store";
 
-function user_sort_key(user: User): string {
+function user_sort_key(user: User): number {
   if (user.last_active) {
-    return user.last_active.toString();
+    return -user.last_active.getTime();
   }
   if (user.created) {
-    return user.created.toString();
+    return -user.created.getTime();
   }
-  return "";
+  return 0;
 }
 
 export class AdminUsersActions extends Actions<StoreState> {
@@ -47,13 +47,11 @@ export class AdminUsersActions extends Actions<StoreState> {
       return;
     }
 
-    result.sort(function (a, b) {
-      return -cmp(user_sort_key(a), user_sort_key(b));
-    });
+    const result_sorted = sortBy(result, user_sort_key);
     this.set_status("");
 
     this.setState({
-      result: fromJS(result) as List<ImmutableUser>,
+      result: fromJS(result_sorted) as List<ImmutableUser>,
     });
   }
 


### PR DESCRIPTION
# Description

the results of an admin search for users shows up in a random order, at least for me. the sort indicator tells it should be, though.

## before, some search in production:

![Screenshot from 2020-10-29 12-51-48](https://user-images.githubusercontent.com/207405/97574330-57718b00-19eb-11eb-9dbc-f5596bd30fcd.png)

## after, with data in my dev project

![Screenshot from 2020-10-29 13-33-55](https://user-images.githubusercontent.com/207405/97574356-68220100-19eb-11eb-81e0-87179092c79d.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
