### PR TITLE
webapp/admin/license: enable "memeber"  by default

### DIFF
--- a/src/smc-webapp/site-licenses/admin/component.tsx
+++ b/src/smc-webapp/site-licenses/admin/component.tsx
@@ -23,6 +23,7 @@ import { actions } from "./actions";
 import { List, Map, Set } from "immutable";
 import { Button, Popconfirm } from "antd";
 import { License } from "./license";
+import { COLORS } from "smc-util/theme";
 
 interface Props {
   view?: boolean; // if true, open for viewing/editing
@@ -177,7 +178,7 @@ class SiteLicenses extends Component<Props> {
             }
           }}
         />
-        <div style={{ color: "#666" }}>
+        <div style={{ color: COLORS.GRAY }}>
           Search licenses by id, title, description, info, manager name and
           email address.
         </div>

--- a/src/smc-webapp/site-licenses/admin/quota.tsx
+++ b/src/smc-webapp/site-licenses/admin/quota.tsx
@@ -29,11 +29,12 @@ export const EditQuota: React.FC<EditProps> = ({
   license_field,
   quota,
 }) => {
-  const q = quota?.toJS() ?? {};
+  const q = quota?.toJS() ?? { member: true };
   return (
     <QuotaEditor
       hideExtra={true}
       quota={q}
+      show_advanced_default={true}
       onChange={(change) => {
         const new_quota = fromJS({ ...q, ...change });
         actions.set_edit(license_id, license_field, new_quota);

--- a/src/smc-webapp/site-licenses/purchase/quota-editor.tsx
+++ b/src/smc-webapp/site-licenses/purchase/quota-editor.tsx
@@ -46,6 +46,7 @@ interface Props {
   onChange: (change: Quota) => void;
   hideExtra?: boolean; // hide extra boxes, etc. -- this is used for admin editing, where they know what is up.
   disabled?: boolean;
+  show_advanced_default?: boolean; // if the "advanced" part should pop up by default
 }
 
 export const QuotaEditor: React.FC<Props> = ({
@@ -53,8 +54,11 @@ export const QuotaEditor: React.FC<Props> = ({
   onChange,
   hideExtra,
   disabled,
+  show_advanced_default,
 }) => {
-  const [show_advanced, set_show_advanced] = useState<boolean>(false);
+  const [show_advanced, set_show_advanced] = useState<boolean>(
+    show_advanced_default ?? false
+  );
   const hosting_multiplier = useMemo(() => {
     return (
       (quota.member ? COSTS.custom_cost.member : 1) *


### PR DESCRIPTION
# Description

Way too often I forgot to enable member hosting for a trial. With that, it's on by default and shown to the admin. No implications for a general user. Only webapp affected...



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
