### PR TITLE
Enforce SSO for certain domains

### DIFF
--- a/src/smc-hub/auth.ts
+++ b/src/smc-hub/auth.ts
@@ -74,7 +74,7 @@ type login_info_keys =
   | "full_name"
   | "emails";
 
-interface PassportStrategyDB extends PassportStrategy {
+export interface PassportStrategyDB extends PassportStrategy {
   clientID?: string; // Google, Twitter, ... and OAuth2
   clientSecret?: string; // Google, Twitter, ... and OAuth2
   authorizationURL?: string; // OAuth2
@@ -83,6 +83,7 @@ interface PassportStrategyDB extends PassportStrategy {
   login_info?: { [key in login_info_keys]?: string };
   public?: boolean; // if true it's a public SSO. this is only used in the UI, i.e. when there are no public ones, we allow token based email sign up
   disabled?: boolean; // if true, ignore this entry. default false.
+  exclusive_domains?: string[];
 }
 
 const { defaults, required } = misc;

--- a/src/smc-hub/auth.ts
+++ b/src/smc-hub/auth.ts
@@ -466,6 +466,7 @@ export class PassportManager {
         "type",
         "icon",
         "public",
+        "exclusive_domains",
       ]);
       data.push(info);
     }

--- a/src/smc-hub/client/create-account.ts
+++ b/src/smc-hub/client/create-account.ts
@@ -11,7 +11,7 @@ const MAX_ACCOUNTS_PER_30MIN = 150;
 const MAX_ACCOUNTS_PER_30MIN_GOLD = 1500;
 
 const auth = require("../auth");
-
+import { parseDomain, ParseResultType } from "parse-domain";
 import * as message from "smc-util/message";
 import {
   walltime,
@@ -24,7 +24,11 @@ import { is_valid_email_address, len, to_json } from "smc-util/misc2";
 import { callback2 } from "smc-util/async-utils";
 import { PostgreSQL } from "../postgres/types";
 const { api_key_action } = require("../api/manage");
-import { get_server_settings, have_active_registration_tokens } from "../utils";
+import {
+  get_server_settings,
+  have_active_registration_tokens,
+  get_passports,
+} from "../utils";
 
 export function is_valid_password(password: string) {
   if (typeof password !== "string") {
@@ -62,6 +66,30 @@ async function get_db_client(db: PostgreSQL) {
     }
   }
   throw new Error("Unable to get a database client");
+}
+
+// if the email address's domain should go through SSO, return the domain name
+async function is_domain_exclusive_sso(
+  db: PostgreSQL,
+  email: string
+): Promise<string | undefined> {
+  const raw_domain = email.split("@")[1]?.trim().toLowerCase();
+  if (raw_domain == null) return;
+  const parsed = parseDomain(raw_domain);
+  const passports = await get_passports(db);
+  const blocked = new Set<string>([]);
+  for (const pp of passports) {
+    for (const domain of pp.conf.exclusive_domains ?? []) {
+      blocked.add(domain);
+    }
+  }
+  if (parsed.type == ParseResultType.Listed) {
+    const { domain, topLevelDomains } = parsed;
+    const canonical = [domain ?? "", ...topLevelDomains].join(".");
+    if (blocked.has(canonical)) {
+      return canonical;
+    }
+  }
 }
 
 // return true if allowed to continue creating an account (either no token required or token matches)
@@ -267,6 +295,18 @@ export async function create_account(
     );
     if (check_token) {
       reason = { token: check_token };
+      throw Error();
+    }
+
+    dbg("check if email domain has to go through an SSO mechanism");
+    const check_domain = await is_domain_exclusive_sso(
+      opts.database,
+      opts.mesg.email_address
+    );
+    if (check_domain != null) {
+      reason = {
+        email_address: `To sign up with "@${check_domain}", you have to use the corresponding SSO connect mechanism listed above!`,
+      };
       throw Error();
     }
 

--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -359,6 +359,21 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
             query : 'SELECT strategy, conf FROM passport_settings'
             cb    : all_results(opts.cb)
 
+    get_all_passport_settings_cached: (opts) =>
+        opts = defaults opts,
+            cb       : required
+        passports = SERVER_SETTINGS_CACHE.get('passports')
+        if passports != null
+            opts.cb(undefined, passports)
+            return
+        @get_all_passport_settings
+            cb: (err, res) =>
+                if err
+                    opts.cb(err)
+                else
+                    SERVER_SETTINGS_CACHE.set('passports', res)
+                    opts.cb(undefined, res)
+
     ###
     API Key Management
     ###

--- a/src/smc-hub/postgres/types.ts
+++ b/src/smc-hub/postgres/types.ts
@@ -189,6 +189,7 @@ export interface PostgreSQL extends EventEmitter {
   });
   get_passport_settings(opts: { strategy: string; cb: Function });
   get_all_passport_settings(opts: { cb: Function });
+  get_all_passport_settings_cached(opts: { cb: Function });
 
   change_password(opts: {
     account_id: string;

--- a/src/smc-hub/utils.ts
+++ b/src/smc-hub/utils.ts
@@ -9,6 +9,7 @@ import { PostgreSQL } from "./postgres/types";
 import { AllSiteSettings } from "../smc-util/db-schema/types";
 import { expire_time } from "../smc-util/misc";
 import { callback2 as cb2 } from "../smc-util/async-utils";
+import { PassportStrategyDB } from "./auth";
 
 export function get_smc_root(): string {
   return process.env.SMC_ROOT ?? ".";
@@ -33,6 +34,22 @@ export async function have_active_registration_tokens(
     cache: true,
   });
   return resp.rows[0]?.have_tokens === true;
+}
+
+interface PassportConfig {
+  strategy: string;
+  conf: PassportStrategyDB;
+}
+export type PassportConfigs = PassportConfig[];
+
+export async function get_passports(db: PostgreSQL): Promise<PassportConfigs> {
+  return new Promise((done, fail) => {
+    db.get_all_passport_settings_cached({
+      cb: (err, passports) => {
+        err ? fail(err) : done(passports);
+      },
+    });
+  });
 }
 
 // just to make this async friendly, that's all

--- a/src/smc-webapp/account/account-page.tsx
+++ b/src/smc-webapp/account/account-page.tsx
@@ -54,6 +54,18 @@ export const AccountPage: React.FC = () => {
   const ssh_gateway = useTypedRedux("customize", "ssh_gateway");
   const is_commercial = useTypedRedux("customize", "is_commercial");
 
+  const exclusive_sso_domains = React.useMemo(() => {
+    if (strategies == null) return;
+    const domains = new Set<string>([]);
+    for (const strat of strategies) {
+      const doms = strat.get("exclusive_domains");
+      for (const dom of doms ?? []) {
+        domains.add(dom);
+      }
+    }
+    return domains;
+  }, [strategies]);
+
   function handle_select(key: string): void {
     switch (key) {
       case "billing":
@@ -73,6 +85,7 @@ export const AccountPage: React.FC = () => {
     return (
       <LandingPage
         strategies={strategies}
+        exclusive_sso_domains={exclusive_sso_domains}
         sign_up_error={sign_up_error}
         sign_in_error={sign_in_error}
         signing_in={signing_in}

--- a/src/smc-webapp/account/passport-types.ts
+++ b/src/smc-webapp/account/passport-types.ts
@@ -11,4 +11,5 @@ export interface PassportStrategy {
   type?: string; // oauth2, ldap, ...
   icon?: string; // a URL to a square image
   public?: boolean; // true, if the SSO strategy, like Google, is not private
+  exclusive_domains?: string[]; // list of domains, e.g. ["foo.com"], which must go through that SSO mechanism (and hence block normal email signup)
 }

--- a/src/smc-webapp/landing-page/landing-page.tsx
+++ b/src/smc-webapp/landing-page/landing-page.tsx
@@ -38,6 +38,7 @@ const DESC_FONT = "sans-serif";
 
 interface Props {
   strategies?: immutable.List<PassportStrategy>;
+  exclusive_sso_domains?: Set<string>;
   sign_up_error?: immutable.Map<string, any>;
   sign_in_error?: string;
   signing_in?: boolean;
@@ -391,6 +392,7 @@ class LandingPage extends Component<Props & reduxProps, State> {
               terms_of_service={this.props.terms_of_service}
               terms_of_service_url={this.props.terms_of_service_url}
               email_signup={this.props.email_signup}
+              exclusive_sso_domains={this.props.exclusive_sso_domains}
             />
           </Col>
           <Col md={6}>

--- a/src/smc-webapp/landing-page/sign-up.tsx
+++ b/src/smc-webapp/landing-page/sign-up.tsx
@@ -199,6 +199,7 @@ export class SignUp extends React.Component<Props, State> {
           placeholder="Email address"
           cocalc-test={"sign-up-email"}
           maxLength={254}
+          onChange={(e) => console.log("email change", e.target.value, e)}
         />
       </FormGroup>
     );

--- a/src/smc-webapp/landing-page/sign-up.tsx
+++ b/src/smc-webapp/landing-page/sign-up.tsx
@@ -192,7 +192,7 @@ export class SignUp extends React.Component<Props, State> {
 
   check_email(email: string) {
     // this is just a quick heuristic – a full check is done in the hub
-    const domain = email.split("@")[1]?.trim();
+    const domain = email.split("@")[1]?.trim().toLowerCase();
     if (domain != null && this.props.exclusive_sso_domains?.has(domain)) {
       this.setState({ domain_blocked: domain });
     } else if (this.state.domain_blocked != null) {
@@ -204,9 +204,9 @@ export class SignUp extends React.Component<Props, State> {
     if (this.state.domain_blocked == null) return;
     return (
       <div style={ERROR_STYLE}>
-        To sign up{" "}
+        To sign up with {" "}
         <code style={{ color: "white" }}>@{this.state.domain_blocked}</code>,
-        you have to use the corresponding SSO mechanism listed above!
+        you have to use the corresponding SSO connect mechanism listed above!
       </div>
     );
   }


### PR DESCRIPTION
# Description

This adds a field `exclusive_domains` to the passport configuration, which is a list of domain names for the given SSO mechanism. The goal is to block users from signing up using the standard email/password mechanism and in turn, be diverted to use the SSO.

This is for private installs, hence no impact regarding restarting services in production.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
