### PR TITLE
jupyter: fix row/col to make headers have their own "row"

### DIFF
--- a/src/smc-webapp/jupyter/select-kernel.tsx
+++ b/src/smc-webapp/jupyter/select-kernel.tsx
@@ -21,6 +21,7 @@ import {
   Checkbox,
   Alert,
 } from "../antd-bootstrap";
+import * as Antd from "antd";
 import { Kernel } from "./util";
 import { COLORS } from "smc-util/theme";
 import { JupyterActions } from "./browser-actions";
@@ -176,8 +177,10 @@ export class KernelSelector extends Component<
 
     return (
       <Row style={row_style}>
-        <h4>Suggested kernels</h4>
-        <Col>{entries}</Col>
+        <Col>
+          <h4>Suggested kernels</h4>
+          {entries}
+        </Col>
       </Row>
     );
   }
@@ -185,10 +188,12 @@ export class KernelSelector extends Component<
   private render_custom(): Rendered {
     return (
       <Row style={row_style}>
-        <h4>Custom kernels</h4>
-        <a onClick={() => this.props.actions.custom_jupyter_kernel_docs()}>
-          How to create a custom kernel...
-        </a>
+        <Col>
+          <h4>Custom kernels</h4>
+          <a onClick={() => this.props.actions.custom_jupyter_kernel_docs()}>
+            How to create a custom kernel...
+          </a>
+        </Col>
       </Row>
     );
   }
@@ -236,8 +241,10 @@ export class KernelSelector extends Component<
 
     return (
       <Row style={row_style}>
-        <h4>All kernels by language</h4>
-        <Col>{this.render_all_langs()}</Col>
+        <Col>
+          <h4>All kernels by language</h4>
+          {this.render_all_langs()}
+        </Col>
       </Row>
     );
   }
@@ -251,11 +258,13 @@ export class KernelSelector extends Component<
 
     return (
       <Row style={row_style}>
-        <h4>Quick selection</h4>
-        <div>
-          Your most recently selected kernel is{" "}
-          {this.render_kernel_button(name)}.
-        </div>
+        <Col>
+          <h4>Quick selection</h4>
+          <div>
+            Your most recently selected kernel is{" "}
+            {this.render_kernel_button(name)}.
+          </div>
+        </Col>
       </Row>
     );
   }
@@ -386,12 +395,12 @@ export class KernelSelector extends Component<
 
   render_head(): Rendered {
     return (
-      <Row style={row_style}>
-        <h3>
-          {"Select a Kernel"}
-          {this.render_close_button()}
-        </h3>
-      </Row>
+      <Antd.Row justify="space-between">
+        <Antd.Col flex={1}>
+          <h3>Select a Kernel</h3>
+        </Antd.Col>
+        <Antd.Col flex={"auto"}>{this.render_close_button()}</Antd.Col>
+      </Antd.Row>
     );
   }
 


### PR DESCRIPTION
# Description

In general this could be prettier, but for now, this PR just fixes the row/col setup in such a way, that headers are headers and don't somehow float/melt with the content beneath. below are before/after pix.

![Screenshot from 2020-11-18 15-05-50](https://user-images.githubusercontent.com/207405/99542611-8fe50300-29b2-11eb-929e-56676fe7010c.png)

---

![Screenshot from 2020-11-18 15-24-35](https://user-images.githubusercontent.com/207405/99542650-9a070180-29b2-11eb-8d73-5c69756fd2f8.png)

This is a webapp only fix.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
