### PR TITLE
hub: stopgap for importing pkgs in manage

### DIFF
--- a/src/smc-hub/stripe/client.ts
+++ b/src/smc-hub/stripe/client.ts
@@ -5,10 +5,14 @@
 
 import { reuseInFlight } from "async-await-utils/hof";
 import { callback } from "awaiting";
-import { callback2 } from "smc-util/async-utils";
-import { trunc_middle } from "smc-util/misc";
-import * as message from "smc-util/message";
-import { available_upgrades, get_total_upgrades } from "smc-util/upgrades";
+// STOPGAP FIX: relative dirs necessary for manage service
+import { callback2 } from "../../smc-util/async-utils";
+import { trunc_middle } from "../../smc-util/misc";
+import * as message from "../../smc-util/message";
+import {
+  available_upgrades,
+  get_total_upgrades,
+} from "../../smc-util/upgrades";
 import { PostgreSQL } from "../postgres/types";
 
 import Stripe from "stripe";

--- a/src/smc-hub/stripe/connection.ts
+++ b/src/smc-hub/stripe/connection.ts
@@ -10,7 +10,8 @@ Configure via the admin panel in account settings of an admin user.
 */
 
 import Stripe from "stripe";
-import { callback2 } from "smc-util/async-utils";
+// STOPGAP FIX: relative dirs necessary for manage service
+import { callback2 } from "../../smc-util/async-utils";
 
 // See https://stripe.com/docs/api/versioning
 const apiVersion = "2020-03-02";

--- a/src/smc-hub/stripe/plans.ts
+++ b/src/smc-hub/stripe/plans.ts
@@ -10,7 +10,8 @@ Stripe API docs https://stripe.com/docs/api/node#create_plan
 */
 
 import Stripe from "stripe";
-import { upgrades } from "smc-util/upgrade-spec";
+// STOPGAP FIX: relative dirs necessary for manage service
+import { upgrades } from "../../smc-util/upgrade-spec";
 import { init_stripe } from "./connection";
 import { PostgreSQL } from "../postgres/types";
 

--- a/src/smc-hub/stripe/sync.ts
+++ b/src/smc-hub/stripe/sync.ts
@@ -12,7 +12,8 @@ Should get done eventually mostly via webhooks, etc., -- but for now this is OK.
 import { delay } from "awaiting";
 import { create_missing_plans } from "./plans";
 import { get_stripe, init_stripe } from "./connection";
-import { callback2 } from "smc-util/async-utils";
+// STOPGAP FIX: relative dirs necessary for manage service
+import { callback2 } from "../../smc-util/async-utils";
 import { PostgreSQL } from "../postgres/types";
 
 export async function stripe_sync({


### PR DESCRIPTION
# Description

well, I got bitten by this. I'm building it with that fix to see if it works then.

ok: with these two commits manage builds again. there should be no side effects.

```

/home/manage/src/node_modules/ts-node/dist/index.js:181
        return new TSError(diagnosticText, diagnosticCodes);
               ^
TSError: ⨯ Unable to compile TypeScript:
../../../cocalc/src/smc-hub/stripe/client.ts(8,27): error TS2307: Cannot find module 'smc-util/async-utils' or its corresponding type declarations.
../../../cocalc/src/smc-hub/stripe/client.ts(9,30): error TS2307: Cannot find module 'smc-util/misc' or its corresponding type declarations.
../../../cocalc/src/smc-hub/stripe/client.ts(10,26): error TS2307: Cannot find module 'smc-util/message' or its corresponding type declarations.
../../../cocalc/src/smc-hub/stripe/client.ts(11,56): error TS2307: Cannot find module 'smc-util/upgrades' or its corresponding type declarations.

    at createTSError (/home/manage/src/node_modules/ts-node/dist/index.js:181:16)
    at getOutput (/home/manage/src/node_modules/ts-node/dist/index.js:277:23)
    at Object.compile (/home/manage/src/node_modules/ts-node/dist/index.js:407:18)
    at Module.m._compile (/home/manage/src/node_modules/ts-node/dist/index.js:327:49)
    at Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
    at Object.require.extensions.<computed> [as .ts] (/home/manage/src/node_modules/ts-node/dist/index.js:329:16)
    at Module.load (/cocalc/src/smc-hub/node_modules/coffeescript/lib/coffeescript/register.js:53:36)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:903:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/cocalc/src/smc-hub/postgres-server-queries.js:89:20)
    at Object.<anonymous> (/cocalc/src/smc-hub/postgres-server-queries.js:4886:4)
    at Module._compile (internal/modules/cjs/loader.js:1015:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
    at Module.load (/cocalc/src/smc-hub/node_modules/coffeescript/lib/coffeescript/register.js:53:36)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:903:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/cocalc/src/smc-hub/postgres.js:41:18)
    at Object.<anonymous> (/cocalc/src/smc-hub/postgres.js:48:4)
    at Module._compile (internal/modules/cjs/loader.js:1015:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
    at Module.load (internal/modules/cjs/loader.js:879:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
[...]
```

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
