### PR TITLE
jupyter/snippets: removing a border

### DIFF
--- a/src/smc-webapp/frame-editors/jupyter-editor/snippets/main.tsx
+++ b/src/smc-webapp/frame-editors/jupyter-editor/snippets/main.tsx
@@ -345,7 +345,7 @@ export const JupyterSnippets: React.FC<Props> = React.memo((props: Props) => {
       HEADER_SORTER,
       ([k, _]) => k,
     ]);
-    const style: CSS = { overflowY: "auto" };
+    const style: CSS = { overflowY: "auto", border: "0" };
     // when searching, expand the first three to aid the user
     const active_search =
       search === ""


### PR DESCRIPTION
# Description

this gets rid of a border – i.e. what bugs me if I move the mouse to the right to scroll, it misses the scrollbar by 1px and instead selects text.

what did I did try to fix, actually, is some toggle-issue. I thought it has to do with antd, but building it works fine. so, not sure yet what's going on.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
