### PR TITLE
hub/syncstrings: deleting patches incrementally

### DIFF
--- a/src/smc-hub/postgres-blobs.coffee
+++ b/src/smc-hub/postgres-blobs.coffee
@@ -30,6 +30,7 @@ misc_node = require('smc-util-node/misc_node')
 required = defaults.required
 
 {expire_time, one_result, all_results} = require('./postgres-base')
+{delete_patches} = require('./postgres/delete-patches')
 
 {filesystem_bucket} = require('./filesystem-bucket')
 
@@ -720,11 +721,8 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
             (cb) =>
                 if last_active? and last_active >= opts.cutoff
                     cb(); return
-                dbg("actually delete patches")
-                @_query
-                    query : "DELETE FROM patches"
-                    where : where
-                    cb    : cb
+                dbg("actually deleting patches")
+                delete_patches(db:@, string_id: opts.string_id, cb:cb)
         ], (err) => opts.cb?(err))
 
     unarchive_patches: (opts) =>

--- a/src/smc-hub/postgres/delete-patches.ts
+++ b/src/smc-hub/postgres/delete-patches.ts
@@ -1,0 +1,66 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// This manages deleting patches. The underlying problem is that there could be a large number of patches, which stalls the DB.
+// It's better to keep the number of row deletions small, to speed up the operation, only lock less rows for a shorter amount of time, etc.
+
+import * as debug from "debug";
+const L = debug("hub:db:delete-patches");
+import { PostgreSQL } from "./types";
+import { delay } from "awaiting";
+
+// max number of patches to delete at once – 10000 should take a few seconds
+const MAX_AT_ONCE = 10000;
+// delay between deleting a chunk of patches
+const DELAY_S = 1;
+
+interface DeletePatchesOpts {
+  db: PostgreSQL;
+  string_id: string;
+  cb?: Function;
+}
+
+async function patchset_limit(opts: {
+  db: PostgreSQL;
+  string_id: string;
+}): Promise<string | undefined> {
+  const { db, string_id } = opts;
+  const q = await db.async_query({
+    query: "SELECT time FROM patches",
+    where: { "string_id = $::CHAR(40)": string_id },
+    limit: 1,
+    offset: MAX_AT_ONCE,
+  });
+  if (q.rows.length == 0) {
+    return undefined;
+  } else {
+    return q.rows[0].time;
+  }
+}
+
+export async function delete_patches(opts: DeletePatchesOpts): Promise<void> {
+  const { db, string_id, cb } = opts;
+
+  while (true) {
+    const limit = await patchset_limit({ db, string_id });
+
+    L(`deleting patches string_id='${string_id}' until limit='${limit}'`);
+    const where = { "string_id = $::CHAR(40)": string_id };
+    if (limit != null) {
+      where["time <= $::TIMESTAMP"] = limit;
+    }
+    await db.async_query({
+      query: "DELETE FROM patches",
+      where,
+    });
+    if (limit != null) {
+      await delay(DELAY_S * 1000);
+    } else {
+      break;
+    }
+  }
+
+  if (typeof cb === "function") cb();
+}

--- a/src/smc-hub/postgres/delete-patches.ts
+++ b/src/smc-hub/postgres/delete-patches.ts
@@ -12,9 +12,11 @@ import { PostgreSQL } from "./types";
 import { delay } from "awaiting";
 
 // max number of patches to delete at once – 10000 should take a few seconds
-const MAX_AT_ONCE = 10000;
+const MAX_AT_ONCE = parseInt(
+  process.env.SYNCSTRING_DELETE_MAX_AT_ONCE ?? "10000"
+);
 // delay between deleting a chunk of patches
-const DELAY_S = 1;
+const DELAY_S = parseInt(process.env.SYNCSTRING_DELETE_DELAY_CHUNK_S ?? "1");
 
 interface DeletePatchesOpts {
   db: PostgreSQL;

--- a/src/smc-hub/postgres/types.ts
+++ b/src/smc-hub/postgres/types.ts
@@ -29,6 +29,8 @@ export interface QueryOptions {
   jsonb_merge?: object;
   cache?: boolean;
   retry_until_success?: any; // todo
+  offset?: number;
+  limit?: number;
   cb?: Function;
 }
 


### PR DESCRIPTION
# Description

incrementally deleting patches when archiving syncstrings

I tested this in "test" (earlier archive time and chunks of just "5") and it looked good. This runs in prod now, with the default values. So, regarding deployment, nothing needs to be done.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
