### PR TITLE
project:fix event emitter leak and exception

### DIFF
--- a/src/smc-project/project-info/server.ts
+++ b/src/smc-project/project-info/server.ts
@@ -320,7 +320,7 @@ export class ProjectInfoServer extends EventEmitter {
 
   public async start(): Promise<void> {
     if (this.running) {
-      this.dbg("alerady running, cannot be started twice");
+      this.dbg("project-info/server: already running, cannot be started twice");
     } else {
       await this._start();
     }

--- a/src/smc-project/project-status/server.ts
+++ b/src/smc-project/project-status/server.ts
@@ -178,7 +178,9 @@ export class ProjectStatusServer extends EventEmitter {
 
   public async start(): Promise<void> {
     if (this.running) {
-      this.dbg("alerady running, cannot be started twice");
+      this.dbg(
+        "project-status/server: already running, cannot be started twice"
+      );
     } else {
       await this._start();
     }

--- a/src/smc-project/sync/project-info.ts
+++ b/src/smc-project/sync/project-info.ts
@@ -3,7 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-// import { delay } from "awaiting";
 import { reuseInFlight } from "async-await-utils/hof";
 import { close } from "../smc-util/misc";
 import { SyncTable } from "../smc-util/sync/table";
@@ -27,16 +26,13 @@ class ProjectInfoTable {
     this.project_id = project_id;
     this.logger = logger;
     this.log("register");
-    this.publish = reuseInFlight(this.publish_impl);
+    this.publish = reuseInFlight(this.publish_impl).bind(this);
     this.table = table;
     this.table.on("closed", () => this.close());
     // initializing project info server + reacting when it has something to say
     this.info_server = get_ProjectInfoServer(this.logger.debug.bind(this));
     this.info_server.start();
-    this.info_server.on("info", (info) => {
-      //this.log?.("info_server event 'info'", info.timestamp);
-      this.publish?.(info);
-    });
+    this.info_server.on("info", this.publish);
   }
 
   private async publish_impl(info: ProjectInfo): Promise<void> {
@@ -48,15 +44,18 @@ class ProjectInfoTable {
       } catch (err) {
         this.log(`error saving ${err}`);
       }
-    } else {
+    } else if (this.log != null) {
       this.log(
-        `ProjectInfoTable ${this.state} and table is ${this.table.get_state()}`
+        `ProjectInfoTable state = '${
+          this.state
+        }' and table is '${this.table?.get_state()}'`
       );
     }
   }
 
   public close(): void {
     this.log("close");
+    this.info_server.off("info", this.publish);
     this.table?.close_no_async();
     close(this);
     this.state = "closed";
@@ -77,12 +76,12 @@ export function register_project_info_table(
 ): void {
   logger.debug("register_project_info_table");
   if (project_info_table != null) {
-    // There was one sitting around wasting space so clean it up
-    // before making a new one.
+    logger.debug(
+      "register_project_info_table: cleaning up an already existing one"
+    );
     project_info_table.close();
   }
   project_info_table = new ProjectInfoTable(table, logger, project_id);
-  return;
 }
 
 export function get_project_info_table(): ProjectInfoTable | undefined {

--- a/src/smc-project/sync/project-status.ts
+++ b/src/smc-project/sync/project-status.ts
@@ -3,7 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-// import { delay } from "awaiting";
 import { reuseInFlight } from "async-await-utils/hof";
 import { close } from "../smc-util/misc";
 import { SyncTable } from "../smc-util/sync/table";
@@ -26,6 +25,7 @@ class ProjectStatusTable {
     logger: { debug: Function },
     project_id: string
   ) {
+    this.status_handler = this.status_handler.bind(this);
     this.project_id = project_id;
     this.logger = logger;
     this.log("register");
@@ -35,10 +35,12 @@ class ProjectStatusTable {
     // initializing project status server + reacting when it has something to say
     this.status_server = get_ProjectStatusServer(this.logger.debug.bind(this));
     this.status_server.start();
-    this.status_server.on("status", (status) => {
-      this.log?.("status_server event 'status'", status.timestamp);
-      this.publish?.(status);
-    });
+    this.status_server.on("status", this.status_handler);
+  }
+
+  private status_handler(status): void {
+    this.log?.("status_server event 'status'", status.timestamp);
+    this.publish?.(status);
   }
 
   private async publish_impl(status: ProjectStatus): Promise<void> {
@@ -50,17 +52,18 @@ class ProjectStatusTable {
       } catch (err) {
         this.log(`error saving ${err}`);
       }
-    } else {
+    } else if (this.log != null) {
       this.log(
-        `ProjectStatusTable ${
+        `ProjectStatusTable '${
           this.state
-        } and table is ${this.table.get_state()}`
+        }' and table is ${this.table?.get_state()}`
       );
     }
   }
 
   public close(): void {
     this.log("close");
+    this.status_server.off("status", this.status_handler);
     this.table?.close_no_async();
     close(this);
     this.state = "closed";
@@ -81,12 +84,12 @@ export function register_project_status_table(
 ): void {
   logger.debug("register_project_status_table");
   if (project_status_table != null) {
-    // There was one sitting around wasting space so clean it up
-    // before making a new one.
+    logger.debug(
+      "register_project_status_table: cleaning up an already existing one"
+    );
     project_status_table.close();
   }
   project_status_table = new ProjectStatusTable(table, logger, project_id);
-  return;
 }
 
 export function get_project_status_table(): ProjectStatusTable | undefined {


### PR DESCRIPTION
# Description

I saw repeated exceptions for the chain `ProjectInfoServer.emit` → `ProjectInfoTable.publish_impl` → `sync/project-info: TypeError: Cannot read property 'get_state' of undefined` which must be in the log. Well, addressing this is fine, but why is it even being called? This removes itself from the events. The only real problem is I can't reproduce it properly.

well, this works in cc-in-cc, in the end there aren't any substantial changes. I'm building this in "test" now...

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
