### PR TITLE
misc_page: sagews_canonical_mode no longer defined, moving it 

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -33,6 +33,7 @@ IS_MOBILE = feature.IS_MOBILE
 
 misc = require('smc-util/misc')
 misc_page = require('./misc_page')
+{sagews_canonical_mode} = require('./misc-page')
 
 # Ensure CodeMirror is available and configured
 require('./codemirror/codemirror')
@@ -1958,25 +1959,3 @@ cm_refresh = (cm) ->
     catch err
         console.warn("cm refresh err", err)
 
-
-
-sagews_canonical_mode = (name, default_mode) ->
-    switch name
-        when 'markdown'
-            return 'md'
-        when 'xml'
-            return 'html'
-        when 'mediawiki'
-            return 'mediawiki'
-        when 'stex'
-            return 'tex'
-        when 'python'
-            return 'python'
-        when 'r'
-            return 'r'
-        when 'sagews'
-            return 'sage'
-        when 'shell'
-            return 'shell'
-        else
-            return default_mode

--- a/src/smc-webapp/misc-page/index.ts
+++ b/src/smc-webapp/misc-page/index.ts
@@ -6,6 +6,7 @@
 declare var $: any;
 
 export { open_new_tab, open_popup_window } from "./open-browser-tab";
+export { sagews_canonical_mode } from "./sagews-canonical-mode";
 
 export function html_to_text(html: string): string {
   return $($.parseHTML(html)).text();

--- a/src/smc-webapp/misc-page/sagews-canonical-mode.ts
+++ b/src/smc-webapp/misc-page/sagews-canonical-mode.ts
@@ -1,0 +1,27 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+export function sagews_canonical_mode(name, default_mode) {
+  switch (name) {
+    case "markdown":
+      return "md";
+    case "xml":
+      return "html";
+    case "mediawiki":
+      return "mediawiki";
+    case "stex":
+      return "tex";
+    case "python":
+      return "python";
+    case "r":
+      return "r";
+    case "sagews":
+      return "sage";
+    case "shell":
+      return "shell";
+    default:
+      return default_mode;
+  }
+}

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -13,6 +13,7 @@ misc        = require('smc-util/misc')
 markdown    = require('./markdown')
 theme       = require('smc-util/theme')
 {QueryParams} = require('./misc/query-params')
+{sagews_canonical_mode} = require('./misc-page')
 
 get_inspect_dialog = (editor) ->
     dialog = $('''
@@ -525,7 +526,7 @@ exports.define_codemirror_extensions = () ->
             default_mode = cm.get_edit_mode()
 
         canonical_mode = (name) ->
-            exports.sagews_canonical_mode(name, default_mode)
+            sagews_canonical_mode(name, default_mode)
 
         args = opts.args
         cmd = opts.cmd


### PR DESCRIPTION
# Description

well, this is a quick fix. not sure if this should end up in page misc or not. we can move this around later.

fixes #5098

building and deploying now

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
