### PR TITLE
webapp/share: fix missing setup of jquery codemirror syntax highlighting

### DIFF
--- a/src/smc-webapp/share/server-render.ts
+++ b/src/smc-webapp/share/server-render.ts
@@ -20,6 +20,8 @@ set_share_server(true);
 
 // Load katex jQuery plugin.
 require("../jquery-plugins/katex");
+// this highlights code in .md, .ipynb, etc.
+require("../jquery-plugins/codemirror");
 
 /* Regarding the stream parameter below:
    if true, use streaming non-blocking rendering;


### PR DESCRIPTION
# Description

for shared files, all markdown code highlights were broken:

```
2020-12-17T10:49:37.931Z - debug: Uncaught exception: TypeError: elt.highlight_code is not a function
2020-12-17T10:49:37.931Z - debug: TypeError: elt.highlight_code is not a function
    at render_html (/cocalc/src/smc-webapp/r_misc/html.tsx:113:21)
    at Misc-HTML (/cocalc/src/smc-webapp/r_misc/html.tsx:141:160)
```



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
