### PR TITLE
webapp/terminal: init files are bash scripts

### DIFF
--- a/src/smc-webapp/file-associations.ts
+++ b/src/smc-webapp/file-associations.ts
@@ -46,6 +46,7 @@ const codemirror_associations: { [ext: string]: string } = {
   hs: "text/x-haskell",
   lhs: "text/x-haskell",
   html: "htmlmixed",
+  init: "shell",
   java: "text/x-java",
   jl: "text/x-julia",
   js: "javascript",


### PR DESCRIPTION
# Description

terminal → edit init file rocket. instead of showing this as an unknown file type, we can associate init extensions with the code editor with shell syntax highlighting.



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
