### PR TITLE
webapp: open project and file tabs via shift-click with a hint

### DIFF
--- a/src/smc-webapp/project/open-file.ts
+++ b/src/smc-webapp/project/open-file.ts
@@ -66,11 +66,12 @@ export async function open_file(
   });
   opts.path = normalize(opts.path);
 
-  // intercept any requests if in kiosk mode
-  if (
+  const is_kiosk = () =>
     !opts.ignore_kiosk &&
-    (redux.getStore("page") as any).get("fullscreen") === "kiosk"
-  ) {
+    (redux.getStore("page") as any).get("fullscreen") === "kiosk";
+
+  // intercept any requests if in kiosk mode
+  if (is_kiosk()) {
     alert_message({
       type: "error",
       message: `CoCalc is in Kiosk mode, so you may not open new files.  Please try visiting ${document.location.origin} directly.`,
@@ -82,7 +83,9 @@ export async function open_file(
   if (opts.new_browser_window) {
     // options other than path are ignored in this case.
     // TODO: do not ignore anchor option.
-    actions.open_in_new_browser_window(opts.path);
+    // if there is no path, we open the entire project and want to show the tabs – unless in kiosk mode
+    const fullscreen = is_kiosk() ? "kiosk" : opts.path ? "default" : "";
+    actions.open_in_new_browser_window(opts.path, fullscreen);
     return;
   }
 

--- a/src/smc-webapp/project/page/file-tab.tsx
+++ b/src/smc-webapp/project/page/file-tab.tsx
@@ -152,6 +152,44 @@ export const FileTab: React.FC<Props> = React.memo((props: Props) => {
     }
   }
 
+  function render_displayed_label({ path, label }) {
+    if (path != null) {
+      // We ONLY show tooltip for filename (it provides the full path).
+      // The "ltr" below is needed because of the direction 'rtl' in label_style, which
+      // we have to compensate for in some situations, e.g.., a file name "this is a file!"
+      // will have the ! moved to the beginning by rtl.
+      const shift_open_info = (
+        <span style={{ color: COLORS.GRAY }}>
+          Hint: Shift-Click to open in new window.
+        </span>
+      );
+      // The ! after name is needed since TS doesn't infer that if path is null then name is not null,
+      // though our union type above guarantees this.
+      const tooltip = (
+        <span style={{ fontWeight: "bold" }}>
+          {path != null ? path : FIXED_PROJECT_TABS[name!].tooltip}
+        </span>
+      );
+
+      return (
+        <div style={label_style}>
+          <span style={{ direction: "ltr" }}>
+            <Tip
+              title={tooltip}
+              tip={shift_open_info}
+              stable={false}
+              placement={"bottom"}
+            >
+              {label}
+            </Tip>
+          </span>
+        </div>
+      );
+    } else {
+      return <HiddenXS>{label}</HiddenXS>;
+    }
+  }
+
   let style: React.CSSProperties;
   if (path != null) {
     if (is_selected) {
@@ -227,33 +265,12 @@ export const FileTab: React.FC<Props> = React.memo((props: Props) => {
     x_button_style.color = "lightblue";
   }
 
-  // The ! after name is needed since TS doesn't infer that if path is null then name is not null,
-  // though our union type above guarantees this.
-  const tooltip = path != null ? path : FIXED_PROJECT_TABS[name!].tooltip;
   const icon =
     path != null
       ? file_options(path)?.icon ?? "code-o"
       : FIXED_PROJECT_TABS[name!].icon;
 
-  let displayed_label: JSX.Element =
-    path != null ? <>{label}</> : <HiddenXS>{label}</HiddenXS>;
-
-  if (path != null) {
-    // We ONLY show tooltip for filename (it provides the full path).
-    // The "ltr" below is needed because of the direction 'rtl' in label_style, which
-    // we have to compensate for in some situations, e.g.., a file name "this is a file!"
-    // will have the ! moved to the beginning by rtl.
-    displayed_label = (
-      <div style={label_style}>
-        <span style={{ direction: "ltr" }}>
-          <Tip title={tooltip} stable={false} placement={"bottom"}>
-            {" "}
-            {displayed_label}{" "}
-          </Tip>
-        </span>
-      </div>
-    );
-  }
+  const displayed_label: JSX.Element = render_displayed_label({ path, label });
 
   const color = is_selected
     ? "white"

--- a/src/smc-webapp/project_actions.ts
+++ b/src/smc-webapp/project_actions.ts
@@ -690,15 +690,14 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     });
   }
 
-  public open_in_new_browser_window(path: string): void {
-    let url =
-      (window.app_base_url != null ? window.app_base_url : "") +
-      this._url_in_project(`files/${path}`);
-    url += "?session=&fullscreen=kiosk";
-    open_popup_window(url, {
-      width: 800,
-      height: 640,
-    });
+  public open_in_new_browser_window(path: string, fullscreen = "kiosk"): void {
+    let url = window.app_base_url ?? "";
+    url += this._url_in_project(`files/${path}`);
+    url += "?session=";
+    if (fullscreen) url += `&fullscreen=${fullscreen}`;
+    const width = Math.round(window.screen.width * 0.75);
+    const height = Math.round(window.screen.height * 0.75);
+    open_popup_window(url, { width, height });
   }
 
   public async open_word_document(path): Promise<void> {

--- a/src/smc-webapp/projects/projects-nav.tsx
+++ b/src/smc-webapp/projects/projects-nav.tsx
@@ -13,6 +13,7 @@ import { COMPUTE_STATES } from "smc-util/schema";
 import { IS_TOUCH } from "../feature";
 import { set_window_title } from "../browser";
 import {
+  redux,
   React,
   ReactDOM,
   useActions,
@@ -168,6 +169,28 @@ const ProjectTab: React.FC<ProjectTabProps> = React.memo(
         <Icon name={COMPUTE_STATES[project_state]?.icon ?? "bullhorn"} />
       );
 
+    function click_title(e) {
+      // we intercept a click with a modification key in order to open that project in a new window
+      if (e.ctrlKey || e.shiftKey || e.metaKey) {
+        e.stopPropagation();
+        e.preventDefault();
+        const actions = redux.getProjectActions(project_id);
+        actions.open_file({ path: "", new_browser_window: true });
+      }
+    }
+
+    function render_tip() {
+      return (
+        <>
+          <div>{trunc(project?.get("description") ?? "", 128)}</div>
+          <hr />
+          <div style={{ color: COLORS.GRAY }}>
+            Hint: Shift-Click to open in new window.
+          </div>
+        </>
+      );
+    }
+
     return (
       <SortableNavTab
         ref={tab_ref}
@@ -181,13 +204,8 @@ const ProjectTab: React.FC<ProjectTabProps> = React.memo(
           {render_websocket_indicator()}
           {render_close_x()}
         </div>
-        <div style={PROJECT_NAME_STYLE}>
-          <Tip
-            title={title}
-            tip={trunc(project?.get("description") ?? "", 128)}
-            placement="bottom"
-            size="small"
-          >
+        <div style={PROJECT_NAME_STYLE} onClick={click_title}>
+          <Tip title={title} tip={render_tip()} placement="bottom" size="small">
             {icon}
             <span style={{ marginLeft: 5, position: "relative" }}>
               {trunc(title, 24)}


### PR DESCRIPTION
# Description

see #5162 and this also adds this for the project tabs

I didn't test this thoroughly, but there isn't much that could go wrong either

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
