### PR TITLE
hub/prom: metrics() changed to be a promise since december 2020

### DIFF
--- a/src/smc-hub/hub_http_server.coffee
+++ b/src/smc-hub/hub_http_server.coffee
@@ -153,7 +153,7 @@ exports.init_express_http_server = (opts) ->
         metricsRecorder = MetricsRecorder.get()
         if metricsRecorder?
             # res.send(JSON.stringify(opts.metricsRecorder.get(), null, 2))
-            res.send(metricsRecorder.metrics())
+            res.send(await metricsRecorder.metrics())
         else
             res.send(JSON.stringify(error:'Metrics recorder not initialized.'))
 

--- a/src/smc-hub/metrics-recorder.coffee
+++ b/src/smc-hub/metrics-recorder.coffee
@@ -121,7 +121,7 @@ class MetricsRecorder
         metrics = (m for _, m of exports.client_metrics)
 
         registry = prom_client.AggregatorRegistry.aggregate(metrics)
-        return registry.metrics()
+        return await registry.metrics()
 
     metrics: =>
         ###
@@ -129,8 +129,8 @@ class MetricsRecorder
         (was a dict that should be JSON, now it is for prometheus)
         it's only called by hub_http_server for the /metrics endpoint
         ###
-        hub     = prom_client.register.metrics()
-        clients = @client_metrics()
+        hub     = await prom_client.register.metrics()
+        clients = await @client_metrics()
         return hub + clients
 
     register_collector: (collector) =>


### PR DESCRIPTION
# Description

I bet this was in january. prom-client update and this snuck in.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
