### PR TITLE
webapp/files: fixing +new dropdown

### DIFF
--- a/src/smc-webapp/project/ask-filename.tsx
+++ b/src/smc-webapp/project/ask-filename.tsx
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Component, React, /* ReactDOM,*/ Rendered } from "../app-framework";
+import { React } from "../app-framework";
 const { file_options } = require("../editor");
 const {
   Col,
@@ -27,116 +27,118 @@ interface Props {
   other_settings: any;
 }
 
-interface State {}
+export const AskNewFilename: React.FC<Props> = (props: Props) => {
+  const {
+    actions,
+    ext_selection,
+    current_path,
+    new_filename,
+    other_settings,
+  } = props;
 
-export class AskNewFilename extends Component<Props, State> {
-  componentWillReceiveProps(next): void {
-    const curr_rfn = this.props.other_settings.get(NEW_FILENAMES);
-    const next_rfn = next.other_settings.get(NEW_FILENAMES);
-    if (curr_rfn != next_rfn) {
-      this.shuffle();
-    }
+  const rfn = other_settings.get(NEW_FILENAMES);
+  const selected = rfn != null ? rfn : NewFilenames.default_family;
+
+  React.useEffect(() => {
+    shuffle();
+  }, [rfn]);
+
+  function cancel(): void {
+    actions.ask_filename(undefined);
   }
 
-  cancel = (): void => {
-    this.props.actions.ask_filename(undefined);
-  };
+  function shuffle(): void {
+    actions.ask_filename(ext_selection);
+  }
 
-  shuffle = (): void => {
-    this.props.actions.ask_filename(this.props.ext_selection);
-  };
-
-  create = (name, focus): void => {
-    this.props.actions.ask_filename(undefined);
-    if (this.props.ext_selection == "/") {
-      this.props.actions.create_folder({
+  function create(name, focus): void {
+    actions.ask_filename(undefined);
+    if (ext_selection == "/") {
+      actions.create_folder({
         name: name,
-        current_path: this.props.current_path,
+        current_path: current_path,
         switch_over: focus,
       });
     } else {
-      this.props.actions.create_file({
+      actions.create_file({
         name: name,
-        ext: this.props.ext_selection,
-        current_path: this.props.current_path,
+        ext: ext_selection,
+        current_path: current_path,
         switch_over: focus,
       });
     }
-  };
+  }
 
-  submit = (val: string, opts: any): void => {
-    this.create(val, !opts.ctrl_down);
-  };
+  function submit(val: string, opts: any): void {
+    create(val, !opts.ctrl_down);
+  }
 
-  create_click = (): void => {
-    this.create(this.props.new_filename, true);
-  };
+  function create_click(): void {
+    create(new_filename, true);
+  }
 
-  change = (val: string): void => {
-    this.props.actions.setState({ new_filename: val });
-  };
+  function change(val: string): void {
+    actions.setState({ new_filename: val });
+  }
 
-  filename(): string {
-    const data: FileSpec = file_options(`foo.${this.props.ext_selection}`);
+  function filename(): string {
+    const data: FileSpec = file_options(`foo.${ext_selection}`);
     return data.name;
   }
 
-  change_family = (family: string): void => {
-    this.props.actions.set_new_filename_family(family);
-  };
-
-  render(): Rendered {
-    if (this.props.new_filename == null) return <div>Loading …</div>;
-    const rfn = this.props.other_settings.get(NEW_FILENAMES);
-    const selected = rfn != null ? rfn : NewFilenames.default_family;
-    return (
-      <Row style={{ marginBottom: "10px" }}>
-        <Col md={6} mdOffset={0} lg={4} lgOffset={0}>
-          <ControlLabel>
-            Enter name for new {this.filename()}{" "}
-            {this.props.ext_selection == "/" ? "folder" : "file"}:
-          </ControlLabel>
-          <Form>
-            <SearchInput
-              autoFocus={!IS_TOUCH}
-              autoSelect={!IS_TOUCH}
-              value={this.props.new_filename}
-              placeholder={"Enter filename..."}
-              on_submit={this.submit}
-              on_escape={this.cancel}
-              on_change={this.change}
-            />
-            <Row>
-              <Col md={5}>
-                <SelectorInput
-                  selected={selected}
-                  options={NewFilenameFamilies}
-                  on_change={this.change_family}
-                />
-              </Col>
-
-              <Col md={7}>
-                <ButtonToolbar style={{ whiteSpace: "nowrap", padding: "0" }}>
-                  <Button onClick={this.shuffle}>
-                    <Icon name={"sync-alt"} />
-                  </Button>
-                  <Button
-                    className={"pull-right"}
-                    bsStyle={"primary"}
-                    onClick={this.create_click}
-                    disabled={this.props.new_filename.length == 0}
-                  >
-                    <Icon name={"plus-circle"} /> Create
-                  </Button>
-                  <Button className={"pull-right"} onClick={this.cancel}>
-                    Cancel
-                  </Button>
-                </ButtonToolbar>
-              </Col>
-            </Row>
-          </Form>
-        </Col>
-      </Row>
-    );
+  function change_family(family: string): void {
+    actions.set_new_filename_family(family);
   }
-}
+
+  if (new_filename == null) return <div>Loading …</div>;
+
+  return (
+    <Row style={{ marginBottom: "10px" }}>
+      <Col md={6} mdOffset={0} lg={4} lgOffset={0}>
+        <ControlLabel>
+          Enter name for new {filename()}{" "}
+          {ext_selection == "/" ? "folder" : "file"}:
+        </ControlLabel>
+        <Form>
+          <SearchInput
+            autoFocus={!IS_TOUCH}
+            autoSelect={!IS_TOUCH}
+            value={new_filename}
+            placeholder={"Enter filename..."}
+            on_submit={submit}
+            on_escape={cancel}
+            on_change={change}
+          />
+          <Row>
+            <Col md={5}>
+              <SelectorInput
+                selected={selected}
+                options={NewFilenameFamilies}
+                on_change={change_family}
+              />
+            </Col>
+
+            <Col md={7}>
+              <ButtonToolbar style={{ whiteSpace: "nowrap", padding: "0" }}>
+                <Button onClick={shuffle}>
+                  <Icon name={"sync-alt"} />
+                </Button>
+                <Button
+                  className={"pull-right"}
+                  bsStyle={"primary"}
+                  onClick={create_click}
+                  disabled={new_filename.length == 0}
+                >
+                  <Icon name={"plus-circle"} /> Create
+                </Button>
+                <Button className={"pull-right"} onClick={cancel}>
+                  Cancel
+                </Button>
+              </ButtonToolbar>
+            </Col>
+          </Row>
+        </Form>
+      </Col>
+    </Row>
+  );
+};

--- a/src/smc-webapp/project/ask-filename.tsx
+++ b/src/smc-webapp/project/ask-filename.tsx
@@ -27,7 +27,7 @@ interface Props {
   other_settings: any;
 }
 
-export const AskNewFilename: React.FC<Props> = (props: Props) => {
+export const AskNewFilename: React.FC<Props> = React.memo((props: Props) => {
   const {
     actions,
     ext_selection,
@@ -141,4 +141,4 @@ export const AskNewFilename: React.FC<Props> = (props: Props) => {
       </Col>
     </Row>
   );
-};
+});

--- a/src/smc-webapp/project/explorer/new-button.tsx
+++ b/src/smc-webapp/project/explorer/new-button.tsx
@@ -54,11 +54,11 @@ export const NewButton: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function file_dropdown_item(i: number, ext: string): JSX.Element {
+  function file_dropdown_item(ext: string): JSX.Element {
     const { file_options } = require("../../editor");
     const data = file_options("x." + ext);
     return (
-      <MenuItem eventKey={i} key={i} onClick={() => choose_extension(ext)}>
+      <MenuItem key={ext}>
         <Icon name={data.icon} />{" "}
         <span style={{ textTransform: "capitalize" }}>{data.name} </span>{" "}
         <span style={{ color: "#666" }}>(.{ext})</span>
@@ -75,16 +75,26 @@ export const NewButton: React.FC<Props> = (props: Props) => {
     }
   }
 
-  const on_create_folder_button_clicked = (): void => {
+  function on_create_folder_button_clicked(): void {
     if (file_search.length === 0) {
       actions.ask_filename("/");
     } else {
       create_folder();
     }
-  };
+  }
+
+  function on_dropdown_entry_clicked(key: string) {
+    switch (key) {
+      case "folder":
+        on_create_folder_button_clicked();
+        break;
+      default:
+        choose_extension(key);
+    }
+  }
 
   // Go to new file tab if no file is specified
-  const on_create_button_clicked = (): void => {
+  function on_create_button_clicked(): void {
     if (file_search.length === 0) {
       actions.set_active_tab("new");
     } else if (file_search[file_search.length - 1] === "/") {
@@ -92,7 +102,9 @@ export const NewButton: React.FC<Props> = (props: Props) => {
     } else {
       create_file();
     }
-  };
+  }
+
+  // console.log("ProjectFilesNew configuration", configuration?.toJS())
 
   return (
     <Button.Group>
@@ -100,41 +112,17 @@ export const NewButton: React.FC<Props> = (props: Props) => {
         {file_dropdown_icon()}{" "}
       </Button>
 
-      <DropdownMenu title={""} onClick={on_create_button_clicked} button={true}>
-        {new_file_button_types().map((ext, index) =>
-          file_dropdown_item(index, ext)
-        )}
+      <DropdownMenu
+        title={""}
+        onClick={on_dropdown_entry_clicked}
+        button={true}
+      >
+        {new_file_button_types().map(file_dropdown_item)}
         <MenuDivider />
-        <MenuItem
-          eventKey="folder"
-          key="folder"
-          onSelect={on_create_folder_button_clicked}
-        >
+        <MenuItem key="folder">
           <Icon name="folder" /> Folder
         </MenuItem>
       </DropdownMenu>
     </Button.Group>
   );
-
-  // console.log("ProjectFilesNew configuration", @props.configuration?.toJS())
-  // return (
-  //   <SplitButton
-  //     id={"new_file_dropdown"}
-  //     title={file_dropdown_icon()}
-  //     onClick={on_create_button_clicked}
-  //     disabled={disabled}
-  //   >
-  //     {new_file_button_types().map((ext, index) =>
-  //       file_dropdown_item(index, ext)
-  //     )}
-  //     <MenuItem divider />
-  //     <MenuItem
-  //       eventKey="folder"
-  //       key="folder"
-  //       onSelect={on_create_folder_button_clicked}
-  //     >
-  //       <Icon name="folder" /> Folder
-  //     </MenuItem>
-  //   </SplitButton>
-  // );
 };

--- a/src/smc-webapp/project/explorer/new-button.tsx
+++ b/src/smc-webapp/project/explorer/new-button.tsx
@@ -3,13 +3,13 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import * as React from "react";
+import { React } from "../../app-framework";
 import { Configuration } from "./explorer";
 import { EXTs as ALL_FILE_BUTTON_TYPES } from "./file-listing/utils";
-import { Icon } from "../../r_misc";
+import { Button } from "antd";
+import { Icon, MenuItem, MenuDivider, DropdownMenu } from "../../r_misc";
 import { ProjectActions } from "smc-webapp/project_store";
-
-const { MenuItem, SplitButton } = require("react-bootstrap");
+//import { MenuItem, SplitButton } from "react-bootstrap";
 
 interface Props {
   file_search: string;
@@ -21,14 +21,20 @@ interface Props {
   disabled: boolean;
 }
 
-export class NewButton extends React.Component<Props> {
-  static defaultProps = {
-    file_search: "",
-  };
+export const NewButton: React.FC<Props> = (props: Props) => {
+  const {
+    file_search = "",
+    /*current_path,*/
+    actions,
+    create_folder,
+    create_file,
+    configuration,
+    disabled,
+  } = props;
 
-  new_file_button_types() {
-    if (this.props.configuration != undefined) {
-      const { disabled_ext } = this.props.configuration.get("main", {
+  function new_file_button_types() {
+    if (configuration != undefined) {
+      const { disabled_ext } = configuration.get("main", {
         disabled_ext: undefined,
       });
       if (disabled_ext != undefined) {
@@ -40,12 +46,7 @@ export class NewButton extends React.Component<Props> {
     return ALL_FILE_BUTTON_TYPES;
   }
 
-  // Rendering doesnt rely on props...
-  shouldComponentUpdate() {
-    return false;
-  }
-
-  file_dropdown_icon(): JSX.Element {
+  function file_dropdown_icon(): JSX.Element {
     return (
       <span style={{ whiteSpace: "nowrap" }}>
         <Icon name="plus-circle" /> New
@@ -53,11 +54,11 @@ export class NewButton extends React.Component<Props> {
     );
   }
 
-  file_dropdown_item(i: number, ext: string): JSX.Element {
+  function file_dropdown_item(i: number, ext: string): JSX.Element {
     const { file_options } = require("../../editor");
     const data = file_options("x." + ext);
     return (
-      <MenuItem eventKey={i} key={i} onClick={() => this.choose_extension(ext)}>
+      <MenuItem eventKey={i} key={i} onClick={() => choose_extension(ext)}>
         <Icon name={data.icon} />{" "}
         <span style={{ textTransform: "capitalize" }}>{data.name} </span>{" "}
         <span style={{ color: "#666" }}>(.{ext})</span>
@@ -65,57 +66,75 @@ export class NewButton extends React.Component<Props> {
     );
   }
 
-  choose_extension(ext: string): void {
-    if (this.props.file_search.length === 0) {
+  function choose_extension(ext: string): void {
+    if (file_search.length === 0) {
       // Tell state to render an error in file search
-      this.props.actions.ask_filename(ext);
+      actions.ask_filename(ext);
     } else {
-      this.props.create_file(ext);
+      create_file(ext);
     }
   }
 
-  on_create_folder_button_clicked = () : void => {
-    if (this.props.file_search.length === 0) {
-      this.props.actions.ask_filename('/');
+  const on_create_folder_button_clicked = (): void => {
+    if (file_search.length === 0) {
+      actions.ask_filename("/");
     } else {
-      this.props.create_folder();
-    }
-  }
-
-  // Go to new file tab if no file is specified
-  on_create_button_clicked = (): void => {
-    if (this.props.file_search.length === 0) {
-      this.props.actions.set_active_tab('new');
-    } else if (
-      this.props.file_search[this.props.file_search.length - 1] === "/"
-    ) {
-      this.props.create_folder();
-    } else {
-      this.props.create_file();
+      create_folder();
     }
   };
 
-  render(): JSX.Element {
-    // console.log("ProjectFilesNew configuration", @props.configuration?.toJS())
-    return (
-      <SplitButton
-        id={"new_file_dropdown"}
-        title={this.file_dropdown_icon()}
-        onClick={this.on_create_button_clicked}
-        disabled={this.props.disabled}
-      >
-        {this.new_file_button_types().map((ext, index) => {
-          return this.file_dropdown_item(index, ext);
-        })}
-        <MenuItem divider />
+  // Go to new file tab if no file is specified
+  const on_create_button_clicked = (): void => {
+    if (file_search.length === 0) {
+      actions.set_active_tab("new");
+    } else if (file_search[file_search.length - 1] === "/") {
+      create_folder();
+    } else {
+      create_file();
+    }
+  };
+
+  return (
+    <Button.Group>
+      <Button onClick={on_create_button_clicked} disabled={disabled}>
+        {file_dropdown_icon()}{" "}
+      </Button>
+
+      <DropdownMenu title={""} onClick={on_create_button_clicked} button={true}>
+        {new_file_button_types().map((ext, index) =>
+          file_dropdown_item(index, ext)
+        )}
+        <MenuDivider />
         <MenuItem
           eventKey="folder"
           key="folder"
-          onSelect={this.on_create_folder_button_clicked}
+          onSelect={on_create_folder_button_clicked}
         >
           <Icon name="folder" /> Folder
         </MenuItem>
-      </SplitButton>
-    );
-  }
-}
+      </DropdownMenu>
+    </Button.Group>
+  );
+
+  // console.log("ProjectFilesNew configuration", @props.configuration?.toJS())
+  // return (
+  //   <SplitButton
+  //     id={"new_file_dropdown"}
+  //     title={file_dropdown_icon()}
+  //     onClick={on_create_button_clicked}
+  //     disabled={disabled}
+  //   >
+  //     {new_file_button_types().map((ext, index) =>
+  //       file_dropdown_item(index, ext)
+  //     )}
+  //     <MenuItem divider />
+  //     <MenuItem
+  //       eventKey="folder"
+  //       key="folder"
+  //       onSelect={on_create_folder_button_clicked}
+  //     >
+  //       <Icon name="folder" /> Folder
+  //     </MenuItem>
+  //   </SplitButton>
+  // );
+};

--- a/src/smc-webapp/r_misc/dropdown-menu.tsx
+++ b/src/smc-webapp/r_misc/dropdown-menu.tsx
@@ -5,7 +5,7 @@
 
 import { Menu, Dropdown, Button } from "antd";
 import { DownOutlined } from "@ant-design/icons";
-import { CSS, Component, React } from "../app-framework";
+import { CSS,  React } from "../app-framework";
 import { IS_TOUCH } from "../feature";
 
 interface Props {
@@ -17,33 +17,55 @@ interface Props {
   button?: boolean; // show menu as a *Button* (disabled on touch devices -- https://github.com/sagemathinc/cocalc/issues/5113)
   hide_down?: boolean;
   maxHeight?: string;
+  children: React.ReactNode;
 }
 
 const STYLE = { margin: "6px 10px", cursor: "pointer" } as CSS;
 
-export class DropdownMenu extends Component<Props> {
-  on_click(e): void {
-    if (this.props.onClick !== undefined) {
-      this.props.onClick(e.key);
+export const DropdownMenu: React.FC<Props> = (props: Props) => {
+  const {
+    title,
+    id,
+    onClick,
+    style,
+    disabled,
+    button,
+    hide_down,
+    maxHeight,
+    children,
+  } = props;
+
+  function on_click(e): void {
+    if (onClick !== undefined) {
+      onClick(e.key);
     }
   }
 
-  render_body() {
-    if (this.props.button && !IS_TOUCH) {
+  function render_title() {
+    if (title !== "") {
       return (
-        <Button
-          style={this.props.style}
-          disabled={this.props.disabled}
-          id={this.props.id}
-        >
-          {this.props.title} {!this.props.hide_down && <DownOutlined />}
+        <>
+          {title} {!hide_down && <DownOutlined />}
+        </>
+      );
+    } else {
+      // emtpy string implies to only show the downward caret sign
+      return <DownOutlined />;
+    }
+  }
+
+  function render_body() {
+    if (button && !IS_TOUCH) {
+      return (
+        <Button style={style} disabled={disabled} id={id}>
+          {render_title()}
         </Button>
       );
     } else {
-      if (this.props.disabled) {
+      if (disabled) {
         return (
           <span
-            id={this.props.id}
+            id={id}
             style={{
               ...{
                 color: "#777",
@@ -52,46 +74,46 @@ export class DropdownMenu extends Component<Props> {
               ...STYLE,
             }}
           >
-            <span style={this.props.style}>{this.props.title}</span>
+            <span style={style}>{title}</span>
           </span>
         );
       } else {
         return (
-          <span style={{ ...STYLE, ...this.props.style }} id={this.props.id}>
-            {this.props.title}
+          <span style={{ ...STYLE, ...style }} id={id}>
+            {title}
           </span>
         );
       }
     }
   }
 
-  render() {
-    const body = this.render_body();
-    if (this.props.disabled) {
-      return body;
-    }
-    const menu = (
-      <Menu
-        onClick={this.on_click.bind(this)}
-        style={{
-          maxHeight: this.props.maxHeight ? this.props.maxHeight : "70vH",
-          overflow: "auto",
-        }}
-      >
-        {this.props.children}
-      </Menu>
-    );
-    return (
-      <Dropdown
-        overlay={menu}
-        trigger={!this.props.button ? ["click"] : undefined}
-        placement={"bottomLeft"}
-      >
-        {body}
-      </Dropdown>
-    );
+  const body = render_body();
+  if (disabled) {
+    return body;
   }
-}
+
+  const menu = (
+    <Menu
+      onClick={on_click.bind(this)}
+      style={{
+        maxHeight: maxHeight ? maxHeight : "70vH",
+        overflow: "auto",
+      }}
+    >
+      {children}
+    </Menu>
+  );
+
+  return (
+    <Dropdown
+      overlay={menu}
+      trigger={!button ? ["click"] : undefined}
+      placement={"bottomLeft"}
+    >
+      {body}
+    </Dropdown>
+  );
+};
 
 // NOTE: we wrap and put in a fake onItemHover to work around this bug:
 //     https://github.com/react-component/menu/issues/142

--- a/src/smc-webapp/r_misc/dropdown-menu.tsx
+++ b/src/smc-webapp/r_misc/dropdown-menu.tsx
@@ -5,7 +5,7 @@
 
 import { Menu, Dropdown, Button } from "antd";
 import { DownOutlined } from "@ant-design/icons";
-import { CSS,  React } from "../app-framework";
+import { CSS, React } from "../app-framework";
 import { IS_TOUCH } from "../feature";
 
 interface Props {

--- a/src/smc-webapp/r_misc/search-input.tsx
+++ b/src/smc-webapp/r_misc/search-input.tsx
@@ -37,6 +37,9 @@ export const SearchInput: React.FC<Props> = React.memo((props) => {
   const [value, set_value] = useState<string>(
     props.value ?? props.default_value ?? ""
   );
+  // if value changes, we update as well!
+  React.useEffect(() => set_value(props.value ?? ""), [props.value]);
+
   const [ctrl_down, set_ctrl_down] = useState<boolean>(false);
 
   const input_ref = useRef(null);


### PR DESCRIPTION
# Description

See #5230

* core idea is to replace the split button with `<Button.Group>`
* FC-ing the dropdown menu component
* FC-ing AskNewFilename, and while testing discovered a bug: the SearchInput  didn't re-render upon changing `value` (that box in AskNewFilename).

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
