### PR TITLE
path nav (files, etc.): transition to antd

### DIFF
--- a/src/smc-webapp/_projects.sass
+++ b/src/smc-webapp/_projects.sass
@@ -80,10 +80,23 @@
   > .dropdown.btn-group
     display: flex
 
-.cc-project-files-path
-  .breadcrumb
-    .active
-      font-weight: bold
+.cc-path-navigator
+  flex: "5 1 auto"
+  marginRight: "10px"
+  marginBottom: "15px"
+  max-width: "50vw"
+  padding: 3px
+  border-radius: 2px
+  background-color: $COL_GRAY_LL
+
+.cc-path-navigator-history
+  cursor: "pointer"
+  color: "#c0c0c0"
+.cc-path-navigator-active
+  cursor: "pointer"
+  font-weight: bold
+.cc-path-navigator-basic
+  cursor: "pointer"
 
 .cc-custom-image-desc
   h1

--- a/src/smc-webapp/_projects.sass
+++ b/src/smc-webapp/_projects.sass
@@ -85,9 +85,6 @@
     .active
       font-weight: bold
 
-.cc-project-files-path
-  background: #eee
-
 .cc-custom-image-desc
   h1
     font-size: 125%

--- a/src/smc-webapp/_projects.sass
+++ b/src/smc-webapp/_projects.sass
@@ -80,23 +80,29 @@
   > .dropdown.btn-group
     display: flex
 
+.cc-project-files-path-nav
+  min-width: 35vw
+  > div
+    background-color: $COL_GRAY_LLL
+    border-radius: 3px
+
 .cc-path-navigator
-  flex: "5 1 auto"
-  marginRight: "10px"
-  marginBottom: "15px"
-  max-width: "50vw"
-  padding: 3px
-  border-radius: 2px
-  background-color: $COL_GRAY_LL
+  flex: 5 1 auto
+  margin-bottom: 15px
+  max-width: 50vw
+  padding: 5px
+  //background-color: $COL_GRAY_LL
+
+.cc-path-navigator > span
+  cursor: pointer
+  color: $COL_BS_BLUE_TEXT
 
 .cc-path-navigator-history
-  cursor: "pointer"
-  color: "#c0c0c0"
+  color: $COL_GRAY
 .cc-path-navigator-active
-  cursor: "pointer"
   font-weight: bold
+  color: black
 .cc-path-navigator-basic
-  cursor: "pointer"
 
 .cc-custom-image-desc
   h1

--- a/src/smc-webapp/_projects.sass
+++ b/src/smc-webapp/_projects.sass
@@ -90,8 +90,7 @@
   flex: 5 1 auto
   margin-bottom: 15px
   max-width: 50vw
-  padding: 5px
-  //background-color: $COL_GRAY_LL
+  padding: 5px 10px
 
 .cc-path-navigator > span
   cursor: pointer

--- a/src/smc-webapp/project/explorer/explorer.tsx
+++ b/src/smc-webapp/project/explorer/explorer.tsx
@@ -620,16 +620,7 @@ export const Explorer = rclass(
               {this.render_new_file()}
             </div>
           )}
-          <div
-            className="cc-project-files-path"
-            style={{
-              flex: "5 1 auto",
-              marginRight: "10px",
-              marginBottom: "15px",
-            }}
-          >
-            <PathNavigator project_id={this.props.project_id} />
-          </div>
+          <PathNavigator project_id={this.props.project_id} />
           {!public_view && (
             <>
               <div

--- a/src/smc-webapp/project/explorer/explorer.tsx
+++ b/src/smc-webapp/project/explorer/explorer.tsx
@@ -620,7 +620,7 @@ export const Explorer = rclass(
               {this.render_new_file()}
             </div>
           )}
-          <PathNavigator project_id={this.props.project_id} />
+          <div className="cc-project-files-path-nav"><PathNavigator project_id={this.props.project_id} /></div>
           {!public_view && (
             <>
               <div

--- a/src/smc-webapp/project/explorer/path-navigator.tsx
+++ b/src/smc-webapp/project/explorer/path-navigator.tsx
@@ -4,10 +4,10 @@
  */
 
 import { React, useTypedRedux, useActions } from "../../app-framework";
-import { PathSegmentLink } from "./path-segment-link";
 import { trunc_middle } from "smc-util/misc";
 import { HomeOutlined } from "@ant-design/icons";
 import { Breadcrumb } from "antd";
+import { PathSegmentLink } from "./path-segment-link";
 
 interface Props {
   project_id: string;
@@ -24,13 +24,14 @@ export const PathNavigator: React.FC<Props> = React.memo((props: Props) => {
   function make_path(): JSX.Element[] {
     const v: JSX.Element[] = [];
     v.push(
-      <PathSegmentLink
-        path=""
-        display={<HomeOutlined />}
-        full_name={""}
-        key={0}
-        on_click={() => actions?.open_directory("", true, false)}
-      />
+      // yes, must be called as a normal function
+      PathSegmentLink({
+        path: "",
+        display: <HomeOutlined />,
+        full_name: "",
+        key: 0,
+        on_click: () => actions?.open_directory("", true, false),
+      })
     );
 
     const is_root = current_path[0] === "/";
@@ -43,15 +44,16 @@ export const PathNavigator: React.FC<Props> = React.memo((props: Props) => {
       const is_current = i === current_path_depth;
       const is_history = i > current_path_depth;
       v.push(
-        <PathSegmentLink
-          path={history_segments.slice(0, +i + 1 || undefined).join("/")}
-          display={trunc_middle(segment, 15)}
-          full_name={segment}
-          key={i + 1}
-          on_click={(path) => actions?.open_directory(path, true, false)}
-          active={is_current}
-          history={is_history}
-        />
+        // yes, must be called as a normal function
+        PathSegmentLink({
+          path: history_segments.slice(0, i + 1 || undefined).join("/"),
+          display: trunc_middle(segment, 15),
+          full_name: segment,
+          key: i + 1,
+          on_click: (path) => actions?.open_directory(path, true, false),
+          active: is_current,
+          history: is_history,
+        })
       );
     });
     return v;

--- a/src/smc-webapp/project/explorer/path-navigator.tsx
+++ b/src/smc-webapp/project/explorer/path-navigator.tsx
@@ -5,18 +5,18 @@
 
 import { React, useTypedRedux, useActions } from "../../app-framework";
 import { PathSegmentLink } from "./path-segment-link";
-import { Icon } from "../../r_misc";
 import { trunc_middle } from "smc-util/misc";
-import { Breadcrumb } from "react-bootstrap";
+import { HomeOutlined } from "@ant-design/icons";
+import { Breadcrumb } from "antd";
 
-// This path consists of several PathSegmentLinks
-export function PathNavigator({
-  project_id,
-  style,
-}: {
+interface Props {
   project_id: string;
   style?: React.CSSProperties;
-}): JSX.Element {
+}
+
+// This path consists of several PathSegmentLinks
+export const PathNavigator: React.FC<Props> = React.memo((props: Props) => {
+  const { project_id, style } = props;
   const current_path = useTypedRedux({ project_id }, "current_path");
   const history_path = useTypedRedux({ project_id }, "history_path");
   const actions = useActions({ project_id });
@@ -26,7 +26,7 @@ export function PathNavigator({
     v.push(
       <PathSegmentLink
         path=""
-        display={<Icon name="home" />}
+        display={<HomeOutlined />}
         full_name={""}
         key={0}
         on_click={() => actions?.open_directory("", true, false)}
@@ -60,10 +60,8 @@ export function PathNavigator({
   // Background color below is so that things look good even for
   // multiline long paths.
   return (
-    <Breadcrumb
-      style={{ ...{ marginBottom: "0", backgroundColor: "inherit" }, ...style }}
-    >
+    <Breadcrumb style={style} className="cc-path-navigator">
       {make_path()}
     </Breadcrumb>
   );
-}
+});

--- a/src/smc-webapp/project/explorer/path-segment-link.tsx
+++ b/src/smc-webapp/project/explorer/path-segment-link.tsx
@@ -40,17 +40,7 @@ export const PathSegmentLink: React.FC<Props> = React.memo(
       }
     }
 
-    function style() {
-      // if (history) {
-      //   return { cursor: "pointer", color: "#c0c0c0" };
-      // } else if (active) {
-      //   return {
-      //     cursor: "pointer",
-      //     color: COLORS.BS_BLUE_BGRND,
-      //     fontWeight: "bold",
-      //   };
-      // }
-      // return { cursor: "pointer" };
+    function cls() {
       if (history) {
         return "cc-path-navigator-history";
       } else if (active) {
@@ -61,7 +51,7 @@ export const PathSegmentLink: React.FC<Props> = React.memo(
     }
 
     return (
-      <Breadcrumb.Item onClick={() => on_click(path)} className={style()}>
+      <Breadcrumb.Item onClick={() => on_click(path)} className={cls()}>
         {render_content()}
       </Breadcrumb.Item>
     );

--- a/src/smc-webapp/project/explorer/path-segment-link.tsx
+++ b/src/smc-webapp/project/explorer/path-segment-link.tsx
@@ -14,46 +14,47 @@ interface Props {
   full_name?: string;
   history?: boolean;
   active?: boolean;
+  key: number;
 }
 
 // One segment of the directory links at the top of the files listing.
-export const PathSegmentLink: React.FC<Props> = React.memo(
-  (props: Props): JSX.Element => {
-    const {
-      path = "",
-      display,
-      on_click,
-      full_name,
-      history,
-      active = false,
-    } = props;
+// this can't be a react component, because "Breadcrumb" only works with Breadcrumb.Item children!
+export function PathSegmentLink(props: Props) {
+  const {
+    path = "",
+    display,
+    on_click,
+    full_name,
+    history,
+    active = false,
+    key,
+  } = props;
 
-    function render_content(): JSX.Element | string | undefined {
-      if (full_name && full_name !== display) {
-        return (
-          <Tip tip={full_name} placement="bottom" title="Full name">
-            {display}
-          </Tip>
-        );
-      } else {
-        return display;
-      }
+  function render_content(): JSX.Element | string | undefined {
+    if (full_name && full_name !== display) {
+      return (
+        <Tip tip={full_name} placement="bottom" title="Full name">
+          {display}
+        </Tip>
+      );
+    } else {
+      return display;
     }
-
-    function cls() {
-      if (history) {
-        return "cc-path-navigator-history";
-      } else if (active) {
-        return "cc-path-navigator-active";
-      } else {
-        return "cc-path-navigator-basic";
-      }
-    }
-
-    return (
-      <Breadcrumb.Item onClick={() => on_click(path)} className={cls()}>
-        {render_content()}
-      </Breadcrumb.Item>
-    );
   }
-);
+
+  function cls() {
+    if (history) {
+      return "cc-path-navigator-history";
+    } else if (active) {
+      return "cc-path-navigator-active";
+    } else {
+      return "cc-path-navigator-basic";
+    }
+  }
+
+  return (
+    <Breadcrumb.Item onClick={() => on_click(path)} className={cls()} key={key}>
+      {render_content()}
+    </Breadcrumb.Item>
+  );
+}

--- a/src/smc-webapp/project/explorer/path-segment-link.tsx
+++ b/src/smc-webapp/project/explorer/path-segment-link.tsx
@@ -4,10 +4,8 @@
  */
 
 import * as React from "react";
+import { Breadcrumb } from "antd";
 import { Tip } from "../../r_misc";
-import { COLORS } from "smc-util/theme";
-
-const { Breadcrumb } = require("react-bootstrap");
 
 interface Props {
   path: string;
@@ -19,42 +17,53 @@ interface Props {
 }
 
 // One segment of the directory links at the top of the files listing.
-export function PathSegmentLink({
-  path = "",
-  display,
-  on_click,
-  full_name,
-  history,
-  active = false,
-}: Props): JSX.Element {
-  function render_content(): JSX.Element | string | undefined {
-    if (full_name && full_name !== display) {
-      return (
-        <Tip tip={full_name} placement="bottom" title="Full name">
-          {display}
-        </Tip>
-      );
-    } else {
-      return display;
-    }
-  }
+export const PathSegmentLink: React.FC<Props> = React.memo(
+  (props: Props): JSX.Element => {
+    const {
+      path = "",
+      display,
+      on_click,
+      full_name,
+      history,
+      active = false,
+    } = props;
 
-  function style(): React.CSSProperties {
-    if (history) {
-      return { cursor: "pointer", color: "#c0c0c0" };
-    } else if (active) {
-      return { cursor: "pointer", color: COLORS.BS_BLUE_BGRND };
+    function render_content(): JSX.Element | string | undefined {
+      if (full_name && full_name !== display) {
+        return (
+          <Tip tip={full_name} placement="bottom" title="Full name">
+            {display}
+          </Tip>
+        );
+      } else {
+        return display;
+      }
     }
-    return { cursor: "pointer" };
-  }
 
-  return (
-    <Breadcrumb.Item
-      onClick={() => on_click(path)}
-      active={active}
-      style={style()}
-    >
-      {render_content()}
-    </Breadcrumb.Item>
-  );
-}
+    function style() {
+      // if (history) {
+      //   return { cursor: "pointer", color: "#c0c0c0" };
+      // } else if (active) {
+      //   return {
+      //     cursor: "pointer",
+      //     color: COLORS.BS_BLUE_BGRND,
+      //     fontWeight: "bold",
+      //   };
+      // }
+      // return { cursor: "pointer" };
+      if (history) {
+        return "cc-path-navigator-history";
+      } else if (active) {
+        return "cc-path-navigator-active";
+      } else {
+        return "cc-path-navigator-basic";
+      }
+    }
+
+    return (
+      <Breadcrumb.Item onClick={() => on_click(path)} className={style()}>
+        {render_content()}
+      </Breadcrumb.Item>
+    );
+  }
+);

--- a/src/smc-webapp/project/search/header.tsx
+++ b/src/smc-webapp/project/search/header.tsx
@@ -1,18 +1,27 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { React } from "../../app-framework";
 import { Icon } from "../../r_misc";
 import { PathNavigator } from "../explorer/path-navigator";
+
+const SIZE = "20px";
 
 export const ProjectSearchHeader: React.FC<{ project_id: string }> = ({
   project_id,
 }) => {
   return (
-    <h1 style={{ marginTop: "0px" }}>
+    <div style={{ marginTop: "0px", fontSize: SIZE }}>
       <Icon name="search" /> Search{" "}
       <span className="hidden-xs">
-        {" "}
-        in{" "}
-        <PathNavigator project_id={project_id} style={{ display: "inline" }} />
+        {" in "}
+        <PathNavigator
+          project_id={project_id}
+          style={{ display: "inline", fontSize: SIZE }}
+        />
       </span>
-    </h1>
+    </div>
   );
 };


### PR DESCRIPTION
# Description

this will replace react bootstrap with antd. and well, I'm ok with this for now.after all of these react bootstrap is gone, we should overhaul all of this. here are some screenshot, i.e. I did check if long paths wrap around.

![Screenshot from 2021-03-04 16-51-45](https://user-images.githubusercontent.com/207405/109990968-31962300-7d0a-11eb-90cb-57c3d8d85bb4.png)
![Screenshot from 2021-03-04 16-51-35](https://user-images.githubusercontent.com/207405/109990974-322eb980-7d0a-11eb-8d14-03ff28cff4c8.png)
![Screenshot from 2021-03-04 16-51-23](https://user-images.githubusercontent.com/207405/109990979-32c75000-7d0a-11eb-9ee1-5d7316b7f613.png)
![Screenshot from 2021-03-04 16-50-32](https://user-images.githubusercontent.com/207405/109990986-32c75000-7d0a-11eb-946e-c35df13648f4.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
