### PR TITLE
webapp: transition analytics to use gtag

### DIFF
--- a/src/smc-webapp/tracker/index.ts
+++ b/src/smc-webapp/tracker/index.ts
@@ -4,23 +4,26 @@
  */
 
 // `analytics` is a generalized wrapper for reporting data to google analytics, pwiki, parsley, ...
-// for now, it either does nothing or works with GA
+// for now, it either does nothing or works with GTAG
 // this API basically allows to send off events by name and category
 
 function analytics(type: "event" | "pageview", ...args): void {
-  // GoogleAnalyticsObject contains the possibly customized function name of GA.
-  // It's a good idea to call it differently from the default 'ga' to avoid name clashes...
-  if ((window as any).GoogleAnalyticsObject == null) {
-    return; // GA not available
-  }
-  const ga: any = window[(window as any).GoogleAnalyticsObject];
-  if (ga == null) {
-    return; // GA still not available again?
-  }
+  // GoogleGTag contains the possibly customized function name of GA.
+  // It's a good idea to call it differently from the default 'gtag' to avoid name clashes...
+  // see webapp-lib/_inc_analytics.pug
+  const gtag: any = (window as any).GoogleGTag;
+  const pv: any = (window as any).GoogleGTagPageview;
+  if (gtag == null || pv == null) return;
   switch (type) {
     case "event":
+      gtag("event", args[0], {
+        event_category: args[1],
+        event_label: args[2],
+        value: args[3],
+      });
+      return;
     case "pageview":
-      ga("send", type, ...args);
+      pv(location.pathname);
       return;
     default:
       console.warn(`unknown analytics event '${type}'`);
@@ -28,8 +31,8 @@ function analytics(type: "event" | "pageview", ...args): void {
   }
 }
 
-export function analytics_pageview(...args): void {
-  analytics("pageview", ...args);
+export function analytics_pageview(): void {
+  analytics("pageview");
 }
 
 export function analytics_event(...args): void {

--- a/src/webapp-lib/_inc_analytics.pug
+++ b/src/webapp-lib/_inc_analytics.pug
@@ -3,24 +3,13 @@
 
 if typeof GOOGLE_ANALYTICS == "string" && GOOGLE_ANALYTICS.length > 0
     //--- Google Analytics ---
+    script(async src='//www.googletagmanager.com/gtag/js?id=' + GOOGLE_ANALYTICS)
     script.
-        //- Instructs analytics.js to use the name `google_analytics`.
-        window.GoogleAnalyticsObject = 'google_analytics';
-        //- Creates an initial analytics() function.
-        //- The queued commands will be executed once analytics.js loads.
-        window.google_analytics = window.google_analytics || function() {
-          (google_analytics.q = google_analytics.q || []).push(arguments)
-        };
-        //- Sets the time (as an integer) this tag was executed.
-        //- Used for timing hits.
-        google_analytics.l = +new Date;
-        //- Creates a default tracker with automatic cookie domain configuration.
-        google_analytics('create', '#{GOOGLE_ANALYTICS}', 'auto');
-        //- Sends a pageview hit from the tracker just created.
-        google_analytics('send', 'pageview', location.pathname);
-
-    //- Sets the `async` attribute to load the script asynchronously.
-    script(async src='//www.google-analytics.com/analytics.js')
+      window.dataLayer = window.dataLayer || [];
+      function GoogleGTag(){dataLayer.push(arguments);}
+      GoogleGTag('js', new Date());
+      GoogleGTag('config', '#{GOOGLE_ANALYTICS}', { 'anonymize_ip': true });
+      function GoogleGTagPageview(path) {GoogleGTag('config', '#{GOOGLE_ANALYTICS}', { 'page_path': path })};
     //--- End Google Analytics ---
 
 //- cocalc analytics


### PR DESCRIPTION
# Description

this switches to use the newer gtag analytics

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
