### PR TITLE
webapp/frame title bar: react-bootstrap → antd

### DIFF
--- a/src/smc-webapp/frame-editors/frame-tree/save-button.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/save-button.tsx
@@ -3,9 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-const { Button } = require("react-bootstrap");
+import { React, CSS } from "../../app-framework";
 import { Icon, VisibleMDLG } from "smc-webapp/r_misc";
-import { React } from "../../app-framework";
+import { Button, ButtonSize } from "../../antd-bootstrap";
 import { UncommittedChanges } from "../../r_misc";
 
 interface Props {
@@ -15,10 +15,11 @@ interface Props {
   is_public?: boolean;
   is_saving?: boolean;
   no_labels?: boolean;
-  size?: string;
-  onClick?: Function;
+  size?: ButtonSize;
+  onClick?: (e) => void;
   show_uncommitted_changes?: boolean;
   set_show_uncommitted_changes?: Function;
+  style?: CSS;
 }
 
 export const SaveButton: React.FC<Props> = React.memo((props: Props) => {
@@ -33,6 +34,7 @@ export const SaveButton: React.FC<Props> = React.memo((props: Props) => {
     onClick,
     show_uncommitted_changes,
     set_show_uncommitted_changes,
+    style,
   } = props;
 
   function make_label() {
@@ -63,7 +65,7 @@ export const SaveButton: React.FC<Props> = React.memo((props: Props) => {
       bsSize={size}
       disabled={disabled}
       onClick={onClick}
-      style={{ whiteSpace: "nowrap" }}
+      style={{ ...style, ...{ whiteSpace: "nowrap" } }}
     >
       <Icon name={icon} style={{ width: "15px", display: "inline-block" }} />{" "}
       <VisibleMDLG>{label}</VisibleMDLG>

--- a/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/title-bar.tsx
@@ -16,14 +16,18 @@ import {
   useRedux,
   useRef,
   useState,
+  CSS,
 } from "../../app-framework";
 import { is_safari } from "../generic/browser";
-import * as CSS from "csstype";
 import { Popconfirm } from "antd";
 import { SaveButton } from "./save-button";
 
 const { debounce } = require("underscore");
-const { ButtonGroup, Button } = require("react-bootstrap");
+import {
+  ButtonGroup,
+  Button as AntdButton,
+  ButtonStyle,
+} from "../../antd-bootstrap";
 
 import { get_default_font_size } from "../generic/client";
 
@@ -72,7 +76,7 @@ const COL_BAR_BACKGROUND = "#f8f8f8";
 const COL_BAR_BACKGROUND_DARK = "#ddd";
 const COL_BAR_BORDER = "rgb(204,204,204)";
 
-const title_bar_style: CSS.Properties = {
+const title_bar_style: CSS = {
   background: COL_BAR_BACKGROUND_DARK,
   border: `1px solid ${COL_BAR_BORDER}`,
   padding: "1px",
@@ -83,7 +87,7 @@ const title_bar_style: CSS.Properties = {
   minHeight: "34px",
 };
 
-const TITLE_STYLE: CSS.Properties = {
+const TITLE_STYLE: CSS = {
   background: COL_BAR_BACKGROUND_DARK,
   padding: "5px 5px 0 5px",
   color: "#333",
@@ -93,7 +97,7 @@ const TITLE_STYLE: CSS.Properties = {
   display: "inline-block",
 };
 
-const CONNECTION_STATUS_STYLE: CSS.Properties = {
+const CONNECTION_STATUS_STYLE: CSS = {
   padding: "5px 5px 0 5px",
   fontSize: "10pt",
   float: "right",
@@ -112,12 +116,12 @@ function connection_status_color(status: ConnectionStatus): string {
   }
 }
 
-const ICON_STYLE: CSS.Properties = {
+const ICON_STYLE: CSS = {
   width: "20px",
   display: "inline-block",
 };
 
-const close_style: CSS.Properties | undefined = IS_TOUCH
+const close_style: CSS | undefined = IS_TOUCH
   ? undefined
   : {
       background: "transparent",
@@ -229,6 +233,21 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
     return props.is_only || props.is_full ? "34px" : "30px";
   }
 
+  function button_style(style?: CSS): CSS {
+    return {
+      ...style,
+      ...{ height: button_height(), marginBottom: "5px" },
+    };
+  }
+
+  function Button(props) {
+    return (
+      <AntdButton {...props} style={button_style(props.style)}>
+        {props.children}
+      </AntdButton>
+    );
+  }
+
   function is_visible(action_name: string, explicit?: boolean): boolean {
     if (props.editor_actions[action_name] == null) {
       return false;
@@ -332,7 +351,7 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
 
   function render_control(): Rendered {
     const is_active = props.active_id === props.id;
-    const style: CSS.Properties = {
+    const style: CSS = {
       padding: 0,
       paddingLeft: "4px",
       background: is_active ? COL_BAR_BACKGROUND : COL_BAR_BACKGROUND_DARK,
@@ -986,6 +1005,7 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
         is_saving={is_saving}
         no_labels={!labels}
         size={button_size()}
+        style={button_style()}
         onClick={() => {
           props.editor_actions.save(true);
           props.actions.explicit_save();
@@ -1134,7 +1154,7 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
     if (!is_visible("pause")) {
       return;
     }
-    let icon: string, title: string, style: string | undefined;
+    let icon: string, title: string, style: ButtonStyle | undefined;
     if (props.is_paused) {
       icon = "play";
       title = "Play";
@@ -1379,7 +1399,7 @@ export const FrameTitleBar: React.FC<Props> = (props) => {
   function render_main_buttons(): Rendered {
     // This is complicated below (with the flex display) in order to have a drop down menu that actually appears
     // and *ALSO* have buttons that vanish when there are many of them.
-    const style: CSS.Properties = {
+    const style: CSS = {
       flexFlow: "row nowrap",
       display: "flex",
     };


### PR DESCRIPTION
# Description

this is for the frame title bar: it changes the buttons to be antd based, and well, the only real change here is to adjust height and margin – similar to the other dropdowns. it looks ok in FF and Chrome.

![Screenshot from 2021-03-09 14-52-08](https://user-images.githubusercontent.com/207405/110481310-b8227a00-80e7-11eb-8cc5-c4e7827943e0.png)
![Screenshot from 2021-03-09 14-51-46](https://user-images.githubusercontent.com/207405/110481311-b8bb1080-80e7-11eb-9c17-2d51fc2da195.png)
![Screenshot from 2021-03-09 14-51-40](https://user-images.githubusercontent.com/207405/110481313-b953a700-80e7-11eb-82c4-1cd78e024100.png)
![Screenshot from 2021-03-09 14-51-31](https://user-images.githubusercontent.com/207405/110481314-b9ec3d80-80e7-11eb-9f43-1571218afbdd.png)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
