### PR TITLE
subscription ←→ license sync

### DIFF
--- a/src/smc-hub/postgres-server-queries.coffee
+++ b/src/smc-hub/postgres-server-queries.coffee
@@ -2608,8 +2608,8 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
     # account_id is optional; if not given iterates over all users
     # with stripe_customer field set.
     # async/await:
-    sync_site_license_subscriptions: (account_id) =>
-        return await sync_site_license_subscriptions(@, account_id)
+    sync_site_license_subscriptions: (account_id, test_mode) =>
+        return await sync_site_license_subscriptions(@, account_id, test_mode)
 
     # Return the sum total of all user upgrades to a particular project
     get_project_upgrades: (opts) =>

--- a/src/smc-hub/postgres/site-license/sync-subscriptions.ts
+++ b/src/smc-hub/postgres/site-license/sync-subscriptions.ts
@@ -16,6 +16,9 @@ without a set expiration date, but now there is no subscription any more.
 This is only run if there is no specific account_id set.
 */
 
+import * as debug from "debug";
+const L = debug("hub:sync-subscriptions");
+
 import { PostgreSQL } from "../types";
 import { TIMEOUT_S } from "./const";
 import { delay } from "awaiting";
@@ -23,18 +26,81 @@ import { delay } from "awaiting";
 // wait this long after writing to the DB, to avoid overwhelming it...
 const WAIT_AFTER_UPDATE_MS = 5;
 
-interface Subscriptions {
+// this is each entry in the "data" field of what's in the DB in stripe_customer -> subscriptions
+interface Subscription {
+  id: string; // e.g.  sub_XXX...
+  metadata: { license_id?: string; account_id?: string };
+  object: string; // "subscription"
+  status: string;
+  created: number;
+  customer: string; // cus_XXXX...
+}
+
+interface RawSubscriptions {
   rows: {
     sub?: {
-      data: {
-        metadata: { license_id?: string };
-        status: string;
-      }[];
+      data: Subscription[];
     };
   }[];
 }
 
-function* iter_subs(subs: Subscriptions) {
+// map of license_id → list of subscription infos
+type LicenseSubs = {
+  [license_id: string]: Subscription[];
+};
+
+type LicenseInfo = {
+  [license_id: string]: { expires: Date | undefined; trial: boolean };
+};
+
+// Get all license expire times from database at once, so we don't
+// have to query for each one individually, which would take a long time.
+// If account_id is given, we only get the licenses with that user
+// as a manager.
+// TODO: SCALABILITY WARNING
+async function get_licenses(
+  db: PostgreSQL,
+  account_id?: string,
+  expires_unset = false
+): Promise<LicenseInfo> {
+  const query = {
+    select: ["id", "expires", "info"],
+    table: "site_licenses",
+  } as { select: string[]; table: string; where?: string; params?: string[] };
+  if (account_id != null && expires_unset) {
+    throw new Error("account_id requires expires_unset == false");
+  }
+  if (account_id != null) {
+    query.where = "$1 = ANY(managers)";
+    query.params = [account_id];
+  } else if (expires_unset) {
+    query.where = "expires IS NULL";
+  }
+  const results = await db.async_query(query);
+  const licenses: LicenseInfo = {};
+  for (const x of results.rows) {
+    licenses[x.id] = { expires: x.expires, trial: x.info?.trial === true };
+  }
+  return licenses;
+}
+
+// Get *all* stripe subscription data from the database.
+// TODO: SCALABILITY WARNING
+// TODO: Only the last 10 subs are here, I think, so an old sub might not get properly expired
+// for a user that has 10+ subs.  Worry about this when there are such users; maybe there never will be.
+async function get_subs(
+  db: PostgreSQL,
+  account_id?: string
+): Promise<LicenseSubs> {
+  const subs: RawSubscriptions = await db.async_query({
+    select: "stripe_customer#>'{subscriptions}' as sub",
+    table: "accounts",
+    where:
+      account_id == null ? "stripe_customer_id IS NOT NULL" : { account_id },
+    timeout_s: TIMEOUT_S,
+  });
+
+  const ret: LicenseSubs = {};
   for (const x of subs.rows) {
     if (x.sub?.data == null) continue;
     for (const sub of x.sub.data) {
@@ -42,6 +108,21 @@ function* iter_subs(subs: Subscriptions) {
       if (license_id == null) {
         continue; // not a license
       }
+      if (ret[license_id] == null) {
+        ret[license_id] = [];
+      } else {
+        L(`more than one subscription for license '${license_id}'`);
+      }
+      ret[license_id].push(sub);
+    }
+  }
+  return ret;
+}
+
+// there should only be one subscription per license id, but who knows ...
+function* iter(subs: LicenseSubs) {
+  for (const [license_id, sub_list] of Object.entries(subs)) {
+    for (const sub of sub_list) {
       yield { license_id, sub };
     }
   }
@@ -51,39 +132,12 @@ export async function sync_site_license_subscriptions(
   db: PostgreSQL,
   account_id?: string
 ): Promise<number> {
-  // Get all license expire times from database at once, so we don't
-  // have to query for each one individually, which would take a long time.
-  // If account_id is given, we only get the licenses with that user
-  // as a manager.
-  // TODO: SCALABILITY WARNING
-  const query = {
-    select: ["id", "expires"],
-    table: "site_licenses",
-  } as { select: string[]; table: string; where?: string; params?: string[] };
-  if (account_id != null) {
-    query.where = "$1 = ANY(managers)";
-    query.params = [account_id];
-  }
-  const results = await db.async_query(query);
-  const licenses: { [license_id: string]: Date | undefined } = {};
-  for (const x of results.rows) {
-    licenses[x.id] = x.expires;
-  }
-  // Get *all* stripe subscription data from the database.
-  // TODO: SCALABILITY WARNING
-  // TODO: Only the last 10 subs are here, I think, so an old sub might not get properly expired
-  // for a user that has 10+ subs.  Worry about this when there are such users; maybe there never will be.
-  const subs: Subscriptions = await db.async_query({
-    select: "stripe_customer#>'{subscriptions}' as sub",
-    table: "accounts",
-    where:
-      account_id == null ? "stripe_customer_id IS NOT NULL" : { account_id },
-    timeout_s: TIMEOUT_S,
-  });
+  const licenses: LicenseInfo = await get_licenses(db, account_id);
+  const subs = await get_subs(db, account_id);
 
   let n = 0;
-  for (const { license_id, sub } of iter_subs(subs)) {
-    const expires = licenses[license_id];
+  for (const { license_id, sub } of iter(subs)) {
+    const expires: Date | undefined = licenses[license_id].expires;
     if (sub.status == "active" || sub.status == "trialing") {
       // make sure expires is not set
       if (expires != null) {
@@ -117,29 +171,37 @@ export async function sync_site_license_subscriptions(
   return n;
 }
 
-// there is a situation, where the subscription, funding a license key, has been cancelled.
+// this handles the case when the subscription, which is funding a license key, has been cancelled.
 // hence this checks all active licenses if there is still an associated subscription.
 // if not, the license is expired.
 async function expire_cancelled_subscriptions(
   db: PostgreSQL,
-  subs: Subscriptions
+  subs: LicenseSubs
 ): Promise<number> {
   let n = 0;
+  const licenses: LicenseInfo = await get_licenses(db, undefined, true);
 
-  const query = {
-    select: ["id", "expires"],
-    table: "site_licenses",
-  };
-  const results = await db.async_query(query);
-  const licenses: { [license_id: string]: Date | undefined } = {};
-  for (const x of results.rows) {
-    licenses[x.id] = x.expires;
-  }
-
-  for (const [license_id, expires] of Object.entries(licenses)) {
-    if (expires != null) continue;
-    for (const { license_id: sub_id, sub } of iter_subs(subs)) {
-      console.log(license_id, sub, sub_id);
+  for (const license_id in licenses) {
+    // the query above already filtered by exires == null
+    let found = subs[license_id] != null && subs[license_id].length > 0;
+    if (found) {
+      L(`license_id '{$license_id}' is funded by '${subs[license_id][0].id}'`);
+      found = true;
+    } else {
+      const msg = `license_id '{$license_id}' is not funded by any subscription`;
+      // maybe trial without expiration?
+      if (licenses[license_id].trial) {
+        L(`${msg}, but it is a trial`);
+      } else {
+        L(`${msg}, and would expire it`);
+        // await db.async_query(
+        //   query: "UPDATE site_licenses",
+        //   set: { expires: new Date() },
+        //   where: { id: license_id },
+        // });
+        // await delay(WAIT_AFTER_UPDATE_MS);
+        // n += 1;
+      }
     }
   }
 

--- a/src/smc-hub/postgres/site-license/sync-subscriptions.ts
+++ b/src/smc-hub/postgres/site-license/sync-subscriptions.ts
@@ -10,10 +10,42 @@ Ensure all (or just for given account_id) site license subscriptions
 are non-expired iff subscription in stripe is "active" or "trialing".  This actually
 uses the "stripe_customer" field of the user account, so its important
 that *that* is valid.
+
+2021-03-29: this also checks for expired licenses, where there was a subscription
+without a set expiration date, but now there is no subscription any more.
+This is only run if there is no specific account_id set.
 */
 
 import { PostgreSQL } from "../types";
 import { TIMEOUT_S } from "./const";
+import { delay } from "awaiting";
+
+// wait this long after writing to the DB, to avoid overwhelming it...
+const WAIT_AFTER_UPDATE_MS = 5;
+
+interface Subscriptions {
+  rows: {
+    sub?: {
+      data: {
+        metadata: { license_id?: string };
+        status: string;
+      }[];
+    };
+  }[];
+}
+
+function* iter_subs(subs: Subscriptions) {
+  for (const x of subs.rows) {
+    if (x.sub?.data == null) continue;
+    for (const sub of x.sub.data) {
+      const license_id = sub.metadata.license_id;
+      if (license_id == null) {
+        continue; // not a license
+      }
+      yield { license_id, sub };
+    }
+  }
+}
 
 export async function sync_site_license_subscriptions(
   db: PostgreSQL,
@@ -41,7 +73,7 @@ export async function sync_site_license_subscriptions(
   // TODO: SCALABILITY WARNING
   // TODO: Only the last 10 subs are here, I think, so an old sub might not get properly expired
   // for a user that has 10+ subs.  Worry about this when there are such users; maybe there never will be.
-  const subs = await db.async_query({
+  const subs: Subscriptions = await db.async_query({
     select: "stripe_customer#>'{subscriptions}' as sub",
     table: "accounts",
     where:
@@ -50,36 +82,66 @@ export async function sync_site_license_subscriptions(
   });
 
   let n = 0;
-  for (const x of subs.rows) {
-    if (x.sub?.data == null) continue;
-    for (const sub of x.sub.data) {
-      if (sub.metadata.license_id == null) {
-        continue; // not a license
+  for (const { license_id, sub } of iter_subs(subs)) {
+    const expires = licenses[license_id];
+    if (sub.status == "active" || sub.status == "trialing") {
+      // make sure expires is not set
+      if (expires != null) {
+        await db.async_query({
+          query: "UPDATE site_licenses",
+          set: { expires: null },
+          where: { id: license_id },
+        });
+        await delay(WAIT_AFTER_UPDATE_MS);
+        n += 1;
       }
-      const expires = licenses[sub.metadata.license_id];
-      if (sub.status == "active" || sub.status == "trialing") {
-        // make sure expires is not set
-        if (expires != null) {
-          await db.async_query({
-            query: "UPDATE site_licenses",
-            set: { expires: null },
-            where: { id: sub.metadata.license_id },
-          });
-          n += 1;
-        }
-      } else {
-        // status is something other than active, so make sure license *is* expired.
-        // It will only un-expire when the subscription is active again.
-        if (expires == null || expires > new Date()) {
-          await db.async_query({
-            query: "UPDATE site_licenses",
-            set: { expires: new Date() },
-            where: { id: sub.metadata.license_id },
-          });
-          n += 1;
-        }
+    } else {
+      // status is something other than active, so make sure license *is* expired.
+      // It will only un-expire when the subscription is active again.
+      if (expires == null || expires > new Date()) {
+        await db.async_query({
+          query: "UPDATE site_licenses",
+          set: { expires: new Date() },
+          where: { id: license_id },
+        });
+        await delay(WAIT_AFTER_UPDATE_MS);
+        n += 1;
       }
     }
   }
+
+  if (account_id == null) {
+    n += await expire_cancelled_subscriptions(db, subs);
+  }
+
+  return n;
+}
+
+// there is a situation, where the subscription, funding a license key, has been cancelled.
+// hence this checks all active licenses if there is still an associated subscription.
+// if not, the license is expired.
+async function expire_cancelled_subscriptions(
+  db: PostgreSQL,
+  subs: Subscriptions
+): Promise<number> {
+  let n = 0;
+
+  const query = {
+    select: ["id", "expires"],
+    table: "site_licenses",
+  };
+  const results = await db.async_query(query);
+  const licenses: { [license_id: string]: Date | undefined } = {};
+  for (const x of results.rows) {
+    licenses[x.id] = x.expires;
+  }
+
+  for (const [license_id, expires] of Object.entries(licenses)) {
+    if (expires != null) continue;
+    for (const { license_id: sub_id, sub } of iter_subs(subs)) {
+      console.log(license_id, sub, sub_id);
+    }
+  }
+
   return n;
 }

--- a/src/smc-hub/postgres/site-license/sync-subscriptions.ts
+++ b/src/smc-hub/postgres/site-license/sync-subscriptions.ts
@@ -24,7 +24,7 @@ import { TIMEOUT_S } from "./const";
 import { delay } from "awaiting";
 
 // wait this long after writing to the DB, to avoid overwhelming it...
-const WAIT_AFTER_UPDATE_MS = 5;
+const WAIT_AFTER_UPDATE_MS = 10;
 
 // this is each entry in the "data" field of what's in the DB in stripe_customer -> subscriptions
 interface Subscription {
@@ -214,14 +214,14 @@ async function expire_cancelled_subscriptions(
             `DRYRUN: set 'expires = ${new Date().toISOString()}' where license_id='${license_id}'`
           );
         } else {
-          // await db.async_query(
-          //   query: "UPDATE site_licenses",
-          //   set: { expires: new Date() },
-          //   where: { id: license_id },
-          // });
-          // await delay(WAIT_AFTER_UPDATE_MS);
-          // n += 1;
+          await db.async_query({
+            query: "UPDATE site_licenses",
+            set: { expires: new Date() },
+            where: { id: license_id },
+          });
         }
+        await delay(WAIT_AFTER_UPDATE_MS);
+        n += 1;
       }
     }
   }

--- a/src/smc-hub/test/kucalc/sync-sitelicenses.test.coffee
+++ b/src/smc-hub/test/kucalc/sync-sitelicenses.test.coffee
@@ -1,0 +1,38 @@
+#########################################################################
+# This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+# License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+#########################################################################
+
+# run this from the smc-hub/test dir via
+# $ SMC_DB_RESET=true SMC_TEST=true ../node_modules/.bin/mocha --require  coffeescript/register kucalc/sync-sitelicenses.test.coffee
+
+init     = require('./init')
+db       = undefined
+setup    = (cb) -> (init.setup (err) -> db=init.db(); cb(err))
+teardown = init.teardown
+
+async  = require('async')
+expect = require('expect')
+
+misc = require('smc-util/misc')
+
+ss = require("smc-hub/postgres/site-license/sync-subscriptions")
+
+setup_db = (cb) ->
+    # TODO insert bogus data
+    cb()
+
+describe 'sync-sitelicenses', ->
+    @timeout(30000) # could be stuck in precompiling typescript
+    before(setup)
+    after(teardown)
+
+    it 'check', ->
+        expect(db != null).toBe(true)
+    it 'loaded the sync-subsciptions module', ->
+        expect(ss.sync_site_license_subscriptions != null).toBe(true)
+
+    it 'runs the function', ->
+        setup_db ->
+            expect(await ss.sync_site_license_subscriptions(db)).toBe(0)
+


### PR DESCRIPTION
# Description

well, I thought this through and ran tests. I'm basically confident that this will not cause severe troubles. Also, even if there is an issue, we can switch back to the previous version, which should undo all the mistakes. In the end, nothing gets deleted … only the expiration is set or unset.

I can certainly deploy it. It's currently running (with a different image) as `hub-stripesync-test` shadowing `hub-stripesync`.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
