### PR TITLE
jupyter/formatting: avoid messing up code cells starting  with the escape sequence

### DIFF
--- a/src/smc-webapp/jupyter/parsing.ts
+++ b/src/smc-webapp/jupyter/parsing.ts
@@ -58,21 +58,23 @@ export function process_magics(
 
   switch (mode) {
     case "escape":
+      // this avoids unescaping a line that was never escaped
+      if (code.match(/^#\%{3}#/gm)?.length > 0) {
+        throw new Error(
+          "Cells with lines starting with '#%%%#' cannot be formatted."
+        );
+      }
       return code
         .split("\n")
         .map((line) =>
-          line.replace(/^\%(.*)$/, (m, g1) =>
-            g1 != null ? `#%%%#%${g1}` : /* should not happen */ m
-          )
+          line.replace(/^\%(.*)$/, (m, g1) => (g1 != null ? `#%%%#%${g1}` : m))
         )
         .join("\n");
     case "unescape":
       return code
         .split("\n")
         .map((line) =>
-          line.replace(/^#\%{3}#(.*)$/, (m, g1) =>
-            g1 != null ? `${g1}` : /* should not happen */ m
-          )
+          line.replace(/^#\%{3}#(.*)$/, (m, g1) => (g1 != null ? `${g1}` : m))
         )
         .join("\n");
   }


### PR DESCRIPTION
# Description

This reduces the chances of messing up the code. Usual content should work as before, except when a line starts with `#%%%#`. This pops up an error message.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
