### PR TITLE
db: index run_quota->>always_running

### DIFF
--- a/src/smc-util/db-schema/projects.ts
+++ b/src/smc-util/db-schema/projects.ts
@@ -28,6 +28,7 @@ Table({
       "((state #>> '{state}'))", // projecting the "state" (running, etc.) for its own index – the GIN index above still causes a scan, which we want to avoid.
       "((state ->> 'state'))", // same reason as above. both syntaxes appear and we have to index both.
       "((settings ->> 'always_running'))", // to quickly know which projects have this setting
+      "((run_quota ->> 'always_running'))", // same reason as above
     ],
 
     user_query: {


### PR DESCRIPTION
# Description

This was an oversight in #5294 – that index is important. It's already in the DB, this is the corresponding code.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
