### PR TITLE
db/always_running: x IN <array>, not x NOT IN <array>!

### DIFF
--- a/src/smc-util/db-schema/projects.ts
+++ b/src/smc-util/db-schema/projects.ts
@@ -27,6 +27,7 @@ Table({
       "USING GIN (state)", // so getting all running projects is fast (e.g. for site_license_usage_log... but also manage-state)
       "((state #>> '{state}'))", // projecting the "state" (running, etc.) for its own index – the GIN index above still causes a scan, which we want to avoid.
       "((state ->> 'state'))", // same reason as above. both syntaxes appear and we have to index both.
+      "((state IS NULL))", // not coverd by the above
       "((settings ->> 'always_running'))", // to quickly know which projects have this setting
       "((run_quota ->> 'always_running'))", // same reason as above
     ],


### PR DESCRIPTION
# Description

optimizing a query, without breaking functionality, hopefully ;-)

deployment: manage and hub

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
