### PR TITLE
webapp/jupyter: custom snippets introduce too many newlines

### DIFF
--- a/src/smc-webapp/frame-editors/jupyter-editor/snippets/utils.ts
+++ b/src/smc-webapp/frame-editors/jupyter-editor/snippets/utils.ts
@@ -76,10 +76,10 @@ function cells2snippets(cells?: JupyterNotebook["cells"]): SnippetEntry {
           // lvl2_title might modify cell.source!
           title = lvl2_title(cell.source ?? []);
         }
-        md = `${md ?? ""}\n\n${(cell.source ?? []).join("\n")}`;
+        md = `${md ?? ""}\n\n${(cell.source ?? []).join("").trim()}`;
         break;
       case "code":
-        const cs = (cell.source ?? []).join("\n");
+        const cs = (cell.source ?? []).join("").trim();
         if (cs.trim()) code.push(cs);
         if (no_markdown) finish();
         break;


### PR DESCRIPTION
# Description

the background of this is that the `cell.source` array lines already contain a line break. I didn't realize that.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
