### PR TITLE
webapp: make the Search Input & co more antd-like

### DIFF
--- a/src/smc-webapp/_antd_fix.sass
+++ b/src/smc-webapp/_antd_fix.sass
@@ -33,3 +33,7 @@ html
 
 .ant-popover-inner-content>.cocalc-account-button-dropdown-links
   margin: -12px -16px //Accomodate untouchable padding in inner-content just for .cocalc-account-button-dropdown-links
+
+.ant-input-group > span.ant-input-group-addon
+  padding: 0
+  border: 0

--- a/src/smc-webapp/antd-bootstrap.tsx
+++ b/src/smc-webapp/antd-bootstrap.tsx
@@ -163,7 +163,7 @@ export function Button(props: {
       tabIndex={props.tabIndex}
       id={props.id}
     >
-      <span>{props.children}</span>
+      <>{props.children}</>
     </antd.Button>
   );
 }

--- a/src/smc-webapp/course/configuration/terminal-command.tsx
+++ b/src/smc-webapp/course/configuration/terminal-command.tsx
@@ -74,18 +74,14 @@ class TerminalCommandPanel extends Component<Props> {
             this.run_terminal_command();
           }}
         >
-          <Form.Item>
-            <Input.Group>
-              <Input
-                style={{ width: "80%" }}
-                placeholder="Terminal command..."
-                onChange={(e) => {
-                  this.set_field("input", e.target.value);
-                }}
-              />
-              {this.render_button(running)}
-            </Input.Group>
-          </Form.Item>
+          <Input
+            style={{ width: "80%" }}
+            placeholder="Terminal command..."
+            onChange={(e) => {
+              this.set_field("input", e.target.value);
+            }}
+          />
+          {this.render_button(running)}
         </Form>
       </div>
     );

--- a/src/smc-webapp/project/explorer/mini-terminal.tsx
+++ b/src/smc-webapp/project/explorer/mini-terminal.tsx
@@ -15,15 +15,11 @@ IDEAS FOR LATER:
 
 */
 
-import { React, ReactDOM } from "../../app-framework";
+import { React } from "../../app-framework";
 import { user_activity } from "../../tracker";
 import { ProjectActions } from "../../project_actions";
-import {
-  Button,
-  FormControl,
-  InputGroup,
-  FormGroup,
-} from "smc-webapp/antd-bootstrap";
+import { Input } from "antd";
+import { Button } from "smc-webapp/antd-bootstrap";
 import { Icon } from "smc-webapp/r_misc";
 import { useStudentProjectFunctionality } from "smc-webapp/course";
 
@@ -37,7 +33,7 @@ export const output_style_searchbox: React.CSSProperties = {
   boxShadow: "0px 0px 7px #aaa",
   maxHeight: "450px",
   overflow: "auto",
-};
+} as const;
 
 export const output_style_miniterm: React.CSSProperties = {
   position: "absolute",
@@ -48,7 +44,7 @@ export const output_style_miniterm: React.CSSProperties = {
   right: 0,
   maxWidth: "80%",
   marginRight: "5px",
-};
+} as const;
 
 const BAD_COMMANDS = {
   sage: "Create a Sage worksheet instead,\nor type 'sage' in a full terminal.",
@@ -63,7 +59,7 @@ const BAD_COMMANDS = {
     "Type emacs in a full terminal instead,\nor just click on the file in the listing.",
   open:
     "The open command is not yet supported\nin the miniterminal.  See\nhttps://github.com/sagemathinc/cocalc/issues/230",
-};
+} as const;
 
 const EXEC_TIMEOUT = 10; // in seconds
 
@@ -261,7 +257,6 @@ class MiniTerminal0 extends React.Component<Props, State> {
   };
 
   render() {
-    // NOTE: The style in form below offsets Bootstrap's form margin-bottom of +15 to look good.
     // We don't use inline, since we still want the full horizontal width.
     return (
       <>
@@ -270,29 +265,25 @@ class MiniTerminal0 extends React.Component<Props, State> {
             e.preventDefault();
             this.execute_command();
           }}
-          style={{ marginBottom: "-10px" }}
         >
-          <FormGroup>
-            <InputGroup>
-              <FormControl
-                type="text"
-                value={this.state.input}
-                ref="input"
-                placeholder="Terminal command..."
-                onChange={(e) => {
-                  e.preventDefault();
-                  const input = ReactDOM.findDOMNode(this.refs.input)?.value;
-                  if (input == null) return;
-                  this.setState({ input });
-                }}
-                onKeyDown={this.keydown}
-              />
-              <InputGroup.Button>
+          <Input
+            type="text"
+            value={this.state.input}
+            placeholder="Terminal command..."
+            onChange={(e) => {
+              e.preventDefault();
+              const input = e?.target?.value;
+              if (input == null) return;
+              this.setState({ input });
+            }}
+            onKeyDown={this.keydown}
+            addonAfter={
+              <>
                 {this.render_clear()}
                 {this.render_button()}
-              </InputGroup.Button>
-            </InputGroup>
-          </FormGroup>
+              </>
+            }
+          />
         </form>
         <div style={output_style_miniterm}>
           {this.render_output(this.state.error, {

--- a/src/smc-webapp/projects/token.tsx
+++ b/src/smc-webapp/projects/token.tsx
@@ -45,7 +45,6 @@ export const AddToProjectToken: React.FC = React.memo(() => {
         on_submit={do_add}
         buttonAfter={
           <Button
-            style={{ height: "34px" }}
             onClick={() =>
               open_popup_window(
                 "https://doc.cocalc.com/howto/project-invitation-tokens.html"

--- a/src/smc-webapp/r_misc/search-input.tsx
+++ b/src/smc-webapp/r_misc/search-input.tsx
@@ -9,7 +9,9 @@
    - `esc` to clear
 */
 
-import { Button, FormGroup, InputGroup, FormControl } from "../antd-bootstrap";
+import { Input } from "antd";
+import { Button } from "../antd-bootstrap";
+//import { , FormGroup, InputGroup, FormControl } from "../antd-bootstrap";
 import { Icon } from "./icon";
 import { React, ReactDOM, useEffect, useState, useRef } from "../app-framework";
 
@@ -138,26 +140,24 @@ export const SearchInput: React.FC<Props> = React.memo((props) => {
   }
 
   return (
-    <FormGroup style={props.style}>
-      <InputGroup className={props.input_class}>
-        <FormControl
-          cocalc-test="search-input"
-          autoFocus={props.autoFocus}
-          ref={input_ref}
-          type="text"
-          placeholder={props.placeholder}
-          value={value}
-          onChange={() => {
-            const value = ReactDOM.findDOMNode(input_ref.current)?.value ?? "";
-            set_value(value);
-            props.on_change?.(value, get_opts());
-          }}
-          onKeyDown={key_down}
-          onKeyUp={key_up}
-          disabled={props.disabled}
-        />
-        <InputGroup.Button>{search_button()}</InputGroup.Button>
-      </InputGroup>
-    </FormGroup>
+    <Input
+      style={props.style}
+      cocalc-test="search-input"
+      autoFocus={props.autoFocus}
+      ref={input_ref}
+      type="text"
+      placeholder={props.placeholder}
+      value={value}
+      onChange={(e) => {
+        e.preventDefault();
+        const value = e.target?.value ?? "";
+        set_value(value);
+        props.on_change?.(value, get_opts());
+      }}
+      onKeyDown={key_down}
+      onKeyUp={key_up}
+      disabled={props.disabled}
+      addonAfter={search_button()}
+    />
   );
 });


### PR DESCRIPTION
# Description

This makes the file search box look more like the usual Antd. I checked searching assignments, terminal input in files, running a command across courses, and searching jupyter keyboard shortcuts in Chrome and Firefox. All of them look fine to me.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
