### PR TITLE
latex: trigger build if dependency file changes

### DIFF
--- a/src/smc-webapp/frame-editors/code-editor/actions.ts
+++ b/src/smc-webapp/frame-editors/code-editor/actions.ts
@@ -146,6 +146,9 @@ export class Actions<
   private _active_id_history: string[] = [];
   private _spellcheck_is_supported: boolean = false;
 
+  // multifile support. this will be set to the path of the parent file (master)
+  protected parent_file: string | undefined = undefined;
+
   _init(
     project_id: string,
     path: string,
@@ -2580,5 +2583,9 @@ export class Actions<
 
   public set_show_uncommitted_changes(val: boolean): void {
     this.setState({ show_uncommitted_changes: val });
+  }
+
+  public set_parent_file(path: string) {
+    this.parent_file = path;
   }
 }


### PR DESCRIPTION
# Description

right now, automatic builds are only triggered after changing & saving the parent (master) file. with this, the children are made aware of the parent and trigger a build as well.

to test this, include a simple file, switch to it, and then save it after a change.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
