### PR TITLE
Fix close x error 

### DIFF
--- a/src/smc-webapp/_antd_fix.sass
+++ b/src/smc-webapp/_antd_fix.sass
@@ -37,3 +37,13 @@ html
 .ant-input-group > span.ant-input-group-addon
   padding: 0
   border: 0
+
+.cc-error-display
+  margin: 0
+  padding: 0
+  max-height: 30%
+  position: relative
+  display: flex
+  flex-direction: column
+  > .ant-alert-banner
+    display: block

--- a/src/smc-webapp/course/common.tsx
+++ b/src/smc-webapp/course/common.tsx
@@ -630,7 +630,7 @@ export class StudentAssignmentInfo extends Component<
       <ErrorDisplay
         key="error"
         error={error}
-        style={{ maxHeight: "140px", overflow: "auto" }}
+        style={{ maxHeight: "140px", overflow: "auto", display: "block" }}
       />
     );
   }

--- a/src/smc-webapp/frame-editors/course-editor/course-panel-wrapper.tsx
+++ b/src/smc-webapp/frame-editors/course-editor/course-panel-wrapper.tsx
@@ -200,17 +200,14 @@ class CoursePanelWrapper extends Component<FrameProps & ReduxProps> {
   private render_error(name: string): Rendered {
     if (!this.props.error) return;
     return (
-      <div
-        style={{ margin: "5px 15px", maxHeight: "30vh", overflowY: "scroll" }}
-      >
-        <ErrorDisplay
-          error={this.props.error}
-          onClose={() => {
-            const actions = redux.getActions(name) as CourseActions;
-            if (actions != null) actions.set_error("");
-          }}
-        />
-      </div>
+      <ErrorDisplay
+        banner={true}
+        error={this.props.error}
+        onClose={() => {
+          const actions = redux.getActions(name) as CourseActions;
+          if (actions != null) actions.set_error("");
+        }}
+      />
     );
   }
 

--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -228,7 +228,6 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
     }
     const style: any = {
       maxWidth: "100%",
-      margin: "1ex",
       maxHeight: "30%",
       overflowY: "scroll",
     };

--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -230,11 +230,11 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
     const style: CSS = {};
     if (this.props.errorstyle === "monospace") {
       style.fontFamily = "monospace";
-      style.fontSize = "85%";
       style.whiteSpace = "pre-wrap";
     }
     return (
       <ErrorDisplay
+        banner={true}
         error={this.props.error}
         onClose={() => this.props.actions.set_error("")}
         style={style}

--- a/src/smc-webapp/frame-editors/frame-tree/editor.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/editor.tsx
@@ -5,6 +5,7 @@
 
 import {
   React,
+  CSS,
   rclass,
   rtypes,
   Component,
@@ -226,11 +227,7 @@ const FrameTreeEditor0 = class extends Component<FrameTreeEditorProps, {}> {
     if (!this.props.error) {
       return;
     }
-    const style: any = {
-      maxWidth: "100%",
-      maxHeight: "30%",
-      overflowY: "scroll",
-    };
+    const style: CSS = {};
     if (this.props.errorstyle === "monospace") {
       style.fontFamily = "monospace";
       style.fontSize = "85%";

--- a/src/smc-webapp/frame-editors/frame-tree/leaf.tsx
+++ b/src/smc-webapp/frame-editors/frame-tree/leaf.tsx
@@ -153,13 +153,12 @@ class FrameTreeLeaf extends Component<Props & ReduxProps> {
     }
     return (
       <ErrorDisplay
+        banner={true}
         error={this.props.error}
         onClose={() => this.props.editor_actions.set_error("")}
-        style={{
+        body_style={{
           maxWidth: "100%",
-          margin: "1ex",
           maxHeight: "30%",
-          overflowY: "scroll",
           fontFamily: "monospace",
           fontSize: "85%",
           whiteSpace: "pre-wrap",

--- a/src/smc-webapp/jupyter/main.tsx
+++ b/src/smc-webapp/jupyter/main.tsx
@@ -60,7 +60,6 @@ const KERNEL_STYLE: CSS = {
 
 export const ERROR_STYLE: CSS = {
   whiteSpace: "pre" as "pre",
-  fontSize: "12px",
   fontFamily: "monospace" as "monospace",
   maxHeight: "30vh",
   overflow: "auto",
@@ -345,6 +344,7 @@ export const JupyterEditor: React.FC<Props> = React.memo((props: Props) => {
     if (error) {
       return (
         <ErrorDisplay
+          banner={true}
           error={error}
           style={ERROR_STYLE}
           onClose={() => actions.set_error(undefined)}

--- a/src/smc-webapp/jupyter/main.tsx
+++ b/src/smc-webapp/jupyter/main.tsx
@@ -59,7 +59,6 @@ const KERNEL_STYLE: CSS = {
 } as const;
 
 export const ERROR_STYLE: CSS = {
-  margin: "1ex",
   whiteSpace: "pre" as "pre",
   fontSize: "12px",
   fontFamily: "monospace" as "monospace",

--- a/src/smc-webapp/r_misc/close-x.tsx
+++ b/src/smc-webapp/r_misc/close-x.tsx
@@ -9,25 +9,24 @@ import { Icon } from "./icon";
 const closex_style: React.CSSProperties = {
   float: "right",
   marginLeft: "5px",
-};
+} as const;
 
-export function CloseX({
-  on_close,
-  style,
-}: {
+interface Props {
   on_close: () => void;
   style?: React.CSSProperties;
-}) {
-  const onClick = (e) => {
-    if (e != undefined) {
-      e.preventDefault();
-    }
+}
+
+export const CloseX: React.FC<Props> = (props: Props) => {
+  const { on_close, style } = props;
+
+  function onClick(e) {
+    e?.preventDefault();
     on_close();
-  };
+  }
 
   return (
     <a href="" style={closex_style} onClick={onClick}>
       <Icon style={style} name="times" />
     </a>
   );
-}
+};

--- a/src/smc-webapp/r_misc/error-display.tsx
+++ b/src/smc-webapp/r_misc/error-display.tsx
@@ -67,13 +67,13 @@ export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
     }
   }
 
-  function type() {
+  function type(): string {
     if (
       // only types that antd has...
       bsStyle != null &&
       ["success", "info", "warning", "error"].includes(bsStyle)
     ) {
-      bsStyle;
+      return bsStyle;
     } else {
       return "error";
     }

--- a/src/smc-webapp/r_misc/error-display.tsx
+++ b/src/smc-webapp/r_misc/error-display.tsx
@@ -5,17 +5,36 @@
 
 import * as React from "react";
 import * as misc from "smc-util/misc";
-import { Alert } from "antd";
+import { Icon } from "./index";
+import { Alert, Button } from "antd";
 
+// use "element_style" to customize
 const ELEMENT_STYLE: React.CSSProperties = {
-  maxHeight: "30%",
   overflowY: "auto",
 } as const;
 
+// use "style" prop to customize
 const BODY_STYLE: React.CSSProperties = {
   marginRight: "10px",
   whiteSpace: "pre",
   fontSize: "85%",
+} as const;
+
+const CLOSE_X: React.CSSProperties = {
+  float: "right",
+  position: "absolute",
+  top: "5px",
+  right: "10px",
+  zIndex: 1,
+} as const;
+
+const WRAPPER_STYLE: React.CSSProperties = {
+  margin: 0,
+  padding: 0,
+  maxHeight: "30%",
+  position: "relative",
+  display: "flex",
+  flexDirection: "column",
 } as const;
 
 interface Props {
@@ -57,15 +76,13 @@ export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
 
   function type() {
     if (
-      bsStyle != "success" &&
-      bsStyle != "info" &&
-      bsStyle != "warning" &&
-      bsStyle != "error"
-    ) {
       // only types that antd has...
-      return "error";
-    } else {
+      bsStyle != null &&
+      ["success", "info", "warning", "error"].includes(bsStyle)
+    ) {
       bsStyle;
+    } else {
+      return "error";
     }
   }
 
@@ -83,18 +100,34 @@ export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
     }
   }
 
+  function render_close() {
+    if (onClose == null) return;
+    return (
+      <Button
+        style={CLOSE_X}
+        shape="circle"
+        size="small"
+        type="text"
+        onClick={onClose}
+      >
+        <Icon style={style} name="times" />
+      </Button>
+    );
+  }
+
   const [message, description] = msgdesc();
 
   return (
-    <Alert
-      banner
-      showIcon={false}
-      style={{ ...ELEMENT_STYLE, ...element_style }}
-      type={type() as any}
-      message={message}
-      description={description}
-      closable={onClose != null}
-      onClose={onClose}
-    />
+    <div style={WRAPPER_STYLE}>
+      {render_close()}
+      <Alert
+        banner
+        showIcon={false}
+        style={{ ...ELEMENT_STYLE, ...element_style }}
+        type={type() as any}
+        message={message}
+        description={description}
+      />
+    </div>
   );
 });

--- a/src/smc-webapp/r_misc/error-display.tsx
+++ b/src/smc-webapp/r_misc/error-display.tsx
@@ -8,14 +8,13 @@ import * as misc from "smc-util/misc";
 import { Alert } from "antd";
 
 const ERROR_TEXT_STYLE: React.CSSProperties = {
-  marginRight: "1ex",
   whiteSpace: "pre-line",
-};
+} as const;
 
 const BODY_STYLE: React.CSSProperties = {
   overflowX: "auto",
   marginRight: "10px",
-};
+} as const;
 
 interface Props {
   error?: string | object;
@@ -26,61 +25,64 @@ interface Props {
   onClose?: () => void;
 }
 
-export class ErrorDisplay extends React.Component<Props> {
-  render_title() {
-    return <h4>{this.props.title}</h4>;
+export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
+  const { error, error_component, title, style, bsStyle, onClose } = props;
+
+  function render_title() {
+    return <h4>{title}</h4>;
   }
 
-  render() {
-    let error, style;
-
-    if (this.props.style != undefined) {
-      style = misc.copy(ERROR_TEXT_STYLE);
-      misc.merge(style, this.props.style);
-    } else {
-      style = ERROR_TEXT_STYLE;
-    }
-
-    if (this.props.error != undefined) {
-      if (typeof this.props.error === "string") {
-        error = this.props.error;
+  function render_error() {
+    if (error != undefined) {
+      if (typeof error === "string") {
+        return error;
       } else {
-        error = misc.to_json(this.props.error);
+        return misc.to_json(error);
       }
     } else {
-      error = this.props.error_component;
+      return error_component;
     }
+  }
 
-    let type = this.props.bsStyle;
+  function type() {
     if (
-      type != "success" &&
-      type != "info" &&
-      type != "warning" &&
-      type != "error"
+      bsStyle != "success" &&
+      bsStyle != "info" &&
+      bsStyle != "warning" &&
+      bsStyle != "error"
     ) {
       // only types that antd has...
-      type = "error";
-    }
-
-    let description: any = undefined,
-      message: any;
-    if (this.props.title) {
-      message = this.props.title;
-      description = <div style={BODY_STYLE}>{error}</div>;
+      return "error";
     } else {
-      message = <div style={BODY_STYLE}>{error}</div>;
+      bsStyle;
     }
-
-    return (
-      <div style={style}>
-        <Alert
-          type={type as any}
-          message={message}
-          description={description}
-          closable={this.props.onClose != null}
-          onClose={this.props.onClose}
-        />
-      </div>
-    );
   }
-}
+
+  function msgdesc() {
+    if (title) {
+      return {
+        message: render_title(),
+        description: <div style={BODY_STYLE}>{render_error()}</div>,
+      };
+    } else {
+      return {
+        message: <div style={BODY_STYLE}>{render_error()}</div>,
+        description: undefined,
+      };
+    }
+  }
+
+  const { message, description } = msgdesc();
+
+  return (
+    <div style={{ ...ERROR_TEXT_STYLE, ...style }}>
+      <Alert
+        type={type() as any}
+        message={message}
+        description={description}
+        closable={onClose != null}
+        onClose={onClose}
+      />
+    </div>
+  );
+});

--- a/src/smc-webapp/r_misc/error-display.tsx
+++ b/src/smc-webapp/r_misc/error-display.tsx
@@ -8,12 +8,12 @@ import * as misc from "smc-util/misc";
 import { Icon } from "./index";
 import { Alert, Button } from "antd";
 
-// use "element_style" to customize
+// use "style" to customize
 const ELEMENT_STYLE: React.CSSProperties = {
   overflowY: "auto",
 } as const;
 
-// use "style" prop to customize
+// use "body_style" prop to customize
 const BODY_STYLE: React.CSSProperties = {
   marginRight: "10px",
   whiteSpace: "pre",
@@ -28,23 +28,15 @@ const CLOSE_X: React.CSSProperties = {
   zIndex: 1,
 } as const;
 
-const WRAPPER_STYLE: React.CSSProperties = {
-  margin: 0,
-  padding: 0,
-  maxHeight: "30%",
-  position: "relative",
-  display: "flex",
-  flexDirection: "column",
-} as const;
-
 interface Props {
   error?: string | object;
   error_component?: JSX.Element | JSX.Element[];
   title?: string;
   style?: React.CSSProperties;
-  element_style?: React.CSSProperties;
+  body_style?: React.CSSProperties;
   bsStyle?: string;
   onClose?: () => void;
+  banner?: boolean;
 }
 
 export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
@@ -52,10 +44,11 @@ export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
     error,
     error_component,
     title,
+    body_style,
     style,
-    element_style,
     bsStyle,
     onClose,
+    banner = false,
   } = props;
 
   function render_title() {
@@ -90,18 +83,19 @@ export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
     if (title) {
       return [
         render_title(),
-        <div style={{ ...BODY_STYLE, ...style }}>{render_error()}</div>,
+        <div style={{ ...BODY_STYLE, ...body_style }}>{render_error()}</div>,
       ];
     } else {
       return [
-        <div style={{ ...BODY_STYLE, ...style }}>{render_error()}</div>,
+        <div style={{ ...BODY_STYLE, ...body_style }}>{render_error()}</div>,
         undefined,
       ];
     }
   }
 
+  // must be rendered as the first child element!
   function render_close() {
-    if (onClose == null) return;
+    if (onClose == null || banner === false) return;
     return (
       <Button
         style={CLOSE_X}
@@ -115,19 +109,29 @@ export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
     );
   }
 
-  const [message, description] = msgdesc();
-
-  return (
-    <div style={WRAPPER_STYLE}>
-      {render_close()}
+  function render_alert() {
+    const [message, description] = msgdesc();
+    // tweak the case where it's not a banner
+    const extra = banner ? undefined : { closable: true, onClose };
+    return (
       <Alert
-        banner
+        banner={banner}
         showIcon={false}
-        style={{ ...ELEMENT_STYLE, ...element_style }}
+        style={{ ...ELEMENT_STYLE, ...style }}
         type={type() as any}
         message={message}
         description={description}
+        {...extra}
       />
+    );
+  }
+
+  const divprops = banner ? { className: "cc-error-display" } : undefined;
+
+  return (
+    <div {...divprops}>
+      {render_close()}
+      {render_alert()}
     </div>
   );
 });

--- a/src/smc-webapp/r_misc/error-display.tsx
+++ b/src/smc-webapp/r_misc/error-display.tsx
@@ -7,13 +7,15 @@ import * as React from "react";
 import * as misc from "smc-util/misc";
 import { Alert } from "antd";
 
-const ERROR_TEXT_STYLE: React.CSSProperties = {
-  whiteSpace: "pre-line",
+const ELEMENT_STYLE: React.CSSProperties = {
+  maxHeight: "30%",
+  overflowY: "auto",
 } as const;
 
 const BODY_STYLE: React.CSSProperties = {
-  overflowX: "auto",
   marginRight: "10px",
+  whiteSpace: "pre",
+  fontSize: "85%",
 } as const;
 
 interface Props {
@@ -21,12 +23,21 @@ interface Props {
   error_component?: JSX.Element | JSX.Element[];
   title?: string;
   style?: React.CSSProperties;
+  element_style?: React.CSSProperties;
   bsStyle?: string;
   onClose?: () => void;
 }
 
 export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
-  const { error, error_component, title, style, bsStyle, onClose } = props;
+  const {
+    error,
+    error_component,
+    title,
+    style,
+    element_style,
+    bsStyle,
+    onClose,
+  } = props;
 
   function render_title() {
     return <h4>{title}</h4>;
@@ -60,29 +71,30 @@ export const ErrorDisplay: React.FC<Props> = React.memo((props: Props) => {
 
   function msgdesc() {
     if (title) {
-      return {
-        message: render_title(),
-        description: <div style={BODY_STYLE}>{render_error()}</div>,
-      };
+      return [
+        render_title(),
+        <div style={{ ...BODY_STYLE, ...style }}>{render_error()}</div>,
+      ];
     } else {
-      return {
-        message: <div style={BODY_STYLE}>{render_error()}</div>,
-        description: undefined,
-      };
+      return [
+        <div style={{ ...BODY_STYLE, ...style }}>{render_error()}</div>,
+        undefined,
+      ];
     }
   }
 
-  const { message, description } = msgdesc();
+  const [message, description] = msgdesc();
 
   return (
-    <div style={{ ...ERROR_TEXT_STYLE, ...style }}>
-      <Alert
-        type={type() as any}
-        message={message}
-        description={description}
-        closable={onClose != null}
-        onClose={onClose}
-      />
-    </div>
+    <Alert
+      banner
+      showIcon={false}
+      style={{ ...ELEMENT_STYLE, ...element_style }}
+      type={type() as any}
+      message={message}
+      description={description}
+      closable={onClose != null}
+      onClose={onClose}
+    />
   );
 });


### PR DESCRIPTION
# Description

* basic motivator is #5252
* this uses the alert's banner mode, looks and works much better, but the stock close-x is not an option, so I came up with a better solution. that's also the reason for the small CSS fix, because otherwise parts of the text stay hidden.
* however, because this is used in so many places, I tweaked this in several ways to keep it as compatible as possible. well, it's also the case, that there are some subtle issues in some situations. but in general, it's much better now and if there is some odd case, it shouldn't be hard to fix (the element itself and also the displayed body CSS can be touched up now)

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
