### PR TITLE
webapp/landing: tweak error display a little bit

### DIFF
--- a/src/smc-webapp/landing-page/sign-in.tsx
+++ b/src/smc-webapp/landing-page/sign-in.tsx
@@ -50,12 +50,10 @@ export const SignIn: React.FC<Props> = (props) => {
 
   function render_error(): JSX.Element | undefined {
     if (!props.sign_in_error) return;
-    // TODO: please fix ErrorDisplay typing so the conversion
-    // to unknown below is not needed.
     return (
       <ErrorDisplay
-        style={{ marginRight: 0 }}
         error_component={<Markdown value={props.sign_in_error} />}
+        body_style={{ fontSize: "100%" }}
         onClose={() => actions.setState({ sign_in_error: undefined })}
       />
     );

--- a/src/smc-webapp/r_misc/error-display.tsx
+++ b/src/smc-webapp/r_misc/error-display.tsx
@@ -16,7 +16,7 @@ const ELEMENT_STYLE: React.CSSProperties = {
 // use "body_style" prop to customize
 const BODY_STYLE: React.CSSProperties = {
   marginRight: "10px",
-  whiteSpace: "pre",
+  whiteSpace: "pre-wrap",
   fontSize: "85%",
 } as const;
 


### PR DESCRIPTION
# Description

well, that's a fallout of that display error fix I made last week. although, it's still fully working and accessible, this just adds line breaks and makes it larger. the whole landing page should be redone, though.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
