### PR TITLE
WCAG: remove vertical divider between CoCalc info and Help

### DIFF
--- a/src/smc-webapp/app/page.tsx
+++ b/src/smc-webapp/app/page.tsx
@@ -15,7 +15,7 @@ const { CreateSupportTicket } = require("../support");
 
 import { COLORS } from "smc-util/theme";
 
-import { Button, Navbar, Nav, NavItem } from "../antd-bootstrap";
+import { Button, Navbar, Nav } from "../antd-bootstrap";
 import {
   React,
   useActions,
@@ -284,7 +284,6 @@ export const Page: React.FC = () => {
           active_top_tab={active_top_tab}
           hide_label={!show_label}
         />
-        <NavItem className="divider-vertical hidden-xs" />
         {render_support()}
         {logged_in && render_account_tab()}
         {render_bell()}


### PR DESCRIPTION
# Description

THIS PR IS NOT FULLY TESTED: Even before this patch, when I built cc-in-cc with current master and ran it, I did not see the Help button at upper right between "CoCalc" and "Account". And that is with "Commercial" set to "yes" in site settings. 

I did check that, after this change, cc-in-cc appears to work otherwise.

This is the first WCAG issue reported in a recent support request. I do not see the purpose of the vertical divider that is causing the issue, so I simply deleted the divider in this PR. To see the WCAG issue reported, sign into CoCalc in Firefox, right-click on Help, and in the context menu, select "Inspect Accessibility Properties", and look a few lines up for the element flagged "! text label".

<img width="992" alt="wcag-00" src="https://user-images.githubusercontent.com/528072/124701706-a80f8100-deb4-11eb-8ccc-a382d8fcb804.png">


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
