### PR TITLE
hub/analytics: compile analytics-script.ts with a different config.

### DIFF
--- a/src/smc-hub/analytics.ts
+++ b/src/smc-hub/analytics.ts
@@ -31,7 +31,9 @@ import { getLogger } from "./logger";
 // dist/analytics.js and also analytics-script.ts
 // gets compiled to dist/analytics-script.js.
 export const analytics_js = UglifyJS.minify(
-  fs.readFileSync(join(__dirname, "analytics-script.js")).toString()
+  fs
+    .readFileSync(join(__dirname, "analytics", "analytics-script.js"))
+    .toString()
 ).code;
 
 function create_log(name) {

--- a/src/smc-hub/analytics/analytics-script.ts
+++ b/src/smc-hub/analytics/analytics-script.ts
@@ -79,6 +79,3 @@ window
   })
   //.then(response => console.log("Success:", response))
   .catch((error) => console.error("Error:", error));
-
-// so it is a module.
-export {}

--- a/src/smc-hub/analytics/tsconfig.json
+++ b/src/smc-hub/analytics/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../packages/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "../dist/analytics/",
+    "isolatedModules": false,
+    "target": "es5"
+  }
+}

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -120,7 +120,7 @@
     "typescript": "^4.3.5"
   },
   "scripts": {
-    "build": "tsc && coffee -m -c -o dist/ .",
+    "build": "tsc && cd analytics/ && tsc && cd .. && coffee -m -c -o dist/ .",
     "hub-project-dev": "npm run build && unset DATA SMC_ROOT BASE_PATH && PGUSER='smc' PGHOST=$INIT_CWD/../data/postgres/socket DEBUG='cocalc:*,-cocalc:silly:*' NODE_ENV=development NODE_OPTIONS='--trace-warnings --enable-source-maps' npx cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",
     "hub-project-dev-nobuild": "unset DATA SMC_ROOT BASE_PATH && PGUSER='smc' PGHOST=$INIT_CWD/../data/postgres/socket DEBUG='cocalc:*,-cocalc:silly:*' NODE_ENV=development NODE_OPTIONS=--enable-source-maps npx cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",
     "hub-project-prod": "npm run build && unset DATA SMC_ROOT  BASE_PATH && PGUSER='smc' PGHOST=$INIT_CWD/../data/postgres/socket DEBUG='cocalc:*,-cocalc:silly:*' NODE_ENV=production NODE_OPTIONS=--enable-source-maps npx cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",

--- a/src/smc-hub/tsconfig.json
+++ b/src/smc-hub/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist",
     "lib": ["ESNext"]
   },
-  "exclude": ["node_modules", "dist", "test"]
+  "exclude": ["node_modules", "dist", "test", "analytics"]
 }


### PR DESCRIPTION
# Description

problem is, firefox crashes right upon start, because it doesn't know how to deal with that implicit `exports` variable in `/analytics.js` ... the code started with `Object.defineProperty(exports,"__esModule",{value:!0}); ` and with this fix here, it's gone

This is an attempt to compile that file differently … in particular to target browsers. I hope I understood this right, i.e. the file ends in `./dist/analytics/` now

made this a blocker, because fixing this holds us back from updating the hub

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
