### PR TITLE
X11: octave gui and spyder

### DIFF
--- a/src/packages/frontend/frame-editors/x11-editor/apps.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/apps.ts
@@ -154,7 +154,7 @@ export const APPS: Readonly<APPS_Interface> = Object.freeze({
     label: "Scribus",
   },
   spyder: {
-    command: "spyder3",
+    command: "spyder",
     desc: "Spyder is a powerful scientific environment written in Python, for Python, and designed by and for scientists, engineers and data analysts.",
     icon: "calculator",
     label: "Spyder",

--- a/src/packages/frontend/frame-editors/x11-editor/apps.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/apps.ts
@@ -106,13 +106,19 @@ export const APPS: Readonly<APPS_Interface> = Object.freeze({
     label: "RStudio",
   },
   /* See https://github.com/sagemathinc/cocalc/issues/5427
+  Sometimes, Octave GUI works, sometimes not.
+  If it works, write an executable mini script launching it.
+  That avoids registering the launch icon even though it is broken.
+  $ cat octave-gui
+  #!/usr/bin/env bash
+  exec octave --gui "$@"
+  */
   octave: {
     icon: "octave",
     desc: "Scientific programming largely compatible with Matlab",
     label: "Octave",
-    command: "octave",
-    args: ["--force-gui"],
-  },*/
+    command: "octave-gui",
+  },
   texmacs: {
     icon: "tex-file",
     desc: "A wysiwyw (what you see is what you want) editing platform with special features for scientists",


### PR DESCRIPTION
# Description

* if octave gui works, check if there is a simple wrapper script. that way it won't be activated if gui is broken
* fix spyder exe name


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
