### PR TITLE
Purchase tab: remove course buttons

### DIFF
--- a/src/packages/frontend/billing/add-subscription.tsx
+++ b/src/packages/frontend/billing/add-subscription.tsx
@@ -93,30 +93,6 @@ export class AddSubscription extends Component<Props, State> {
           >
             Yearly Subscriptions
           </Button>
-          <Button
-            bsStyle={
-              this.state.selected_button === "week" ? "primary" : undefined
-            }
-            onClick={() => this.set_button_and_deselect_plans("week")}
-          >
-            1-Week Workshops
-          </Button>
-          <Button
-            bsStyle={
-              this.state.selected_button === "month4" ? "primary" : undefined
-            }
-            onClick={() => this.set_button_and_deselect_plans("month4")}
-          >
-            4-Month Courses
-          </Button>
-          <Button
-            bsStyle={
-              this.state.selected_button === "year1" ? "primary" : undefined
-            }
-            onClick={() => this.set_button_and_deselect_plans("year1")}
-          >
-            Yearly Courses
-          </Button>
         </ButtonGroup>
       </div>
     );

--- a/src/packages/frontend/billing/add-subscription.tsx
+++ b/src/packages/frontend/billing/add-subscription.tsx
@@ -204,14 +204,7 @@ export class AddSubscription extends Component<Props, State> {
   }
 
   private what_is_selected(): string {
-    // very simple code for now since there are only two options.
-    if (!this.props.selected_plan) {
-      return "Subscription or Course Package";
-    } else if (this.props.selected_plan.indexOf("course") != -1) {
-      return "Course Package";
-    } else {
-      return "Subscription";
-    }
+    return "Subscription";
   }
 
   private render_create_subscription_confirm(plan_data): Rendered {


### PR DESCRIPTION
# Description

Remove 3 course buttons from Account / Purchases tab. Change wording of button at bottom from "Buy Subscription or Course Package" to "Buy Subscription.

Tested in cc-in-cc and passes `npm run tsc`.

To test: in account with no active subscriptions, select "Account" / "Purchases. See 2 buttons instead of 5, "Monthly Subscriptions" and  "Yearly Subscriptions". Button at lower right (disabled) says "Buy Subscription.




## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
