### PR TITLE
frontend: support assembler code

### DIFF
--- a/src/packages/frontend/codemirror/modes.js
+++ b/src/packages/frontend/codemirror/modes.js
@@ -73,6 +73,7 @@ require("codemirror/mode/xquery/xquery.js");
 require("codemirror/mode/yaml/yaml.js");
 require("codemirror/mode/yaml-frontmatter/yaml-frontmatter.js");
 require("codemirror/mode/z80/z80.js");
+require("codemirror/mode/gas/gas.js");
 
 /*
 * In mode/python/python.js I add our unicode output character to be a comment starter:

--- a/src/packages/frontend/file-associations.ts
+++ b/src/packages/frontend/file-associations.ts
@@ -16,8 +16,9 @@ import { IconName } from "./r_misc/icon";
 
 const codemirror_associations: { [ext: string]: string } = {
   adb: "ada",
+  asm: "text/x-gas",
   c: "text/x-c",
-  zig: "text/x-c",  // wrong, but much better than nothing
+  zig: "text/x-c", // wrong, but much better than nothing
   "c++": "text/x-c++src",
   cob: "text/x-cobol",
   cql: "text/x-sql",
@@ -130,6 +131,7 @@ const MODE_TO_ICON: { [mode: string]: IconName } = {
   "text/x-rustsrc": "cog",
   r: "r",
   rmd: "r",
+  "text/x-gas": "microchip",
 };
 
 for (const ext in codemirror_associations) {


### PR DESCRIPTION
# Description

my goal here is to support assembler code in `*.asm` files. problem: syntax highlighting doesn't do anything. strange. I must be missing some detail.

ref: https://codemirror.net/mode/gas/index.html

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
