### PR TITLE
frontent: record "project_started" duration + project classification

### DIFF
--- a/src/packages/frontend/projects/actions.ts
+++ b/src/packages/frontend/projects/actions.ts
@@ -815,6 +815,7 @@ export class ProjectsActions extends Actions<ProjectsState> {
       return false;
     }
     let did_start = false;
+    const t0 = webapp_client.server_time().getTime();
     const action_request = this.current_action_request(project_id);
     if (action_request == null || action_request != "start") {
       // need to make an action request:
@@ -836,6 +837,8 @@ export class ProjectsActions extends Actions<ProjectsState> {
     });
     this.project_log(project_id, {
       event: "project_started",
+      duration_ms: webapp_client.server_time().getTime() - t0,
+      ...store.classify_project(project_id),
     });
     return did_start;
   }
@@ -847,6 +850,7 @@ export class ProjectsActions extends Actions<ProjectsState> {
       return false;
     }
     let did_stop = false;
+    const t0 = webapp_client.server_time().getTime();
     const action_request = this.current_action_request(project_id);
     if (action_request == null || action_request != "stop") {
       // need to do it!
@@ -873,6 +877,8 @@ export class ProjectsActions extends Actions<ProjectsState> {
     });
     this.project_log(project_id, {
       event: "project_stopped",
+      duration_ms: webapp_client.server_time().getTime() - t0,
+      ...store.classify_project(project_id),
     });
     return did_stop;
   }

--- a/src/packages/util/upgrades/types.ts
+++ b/src/packages/util/upgrades/types.ts
@@ -11,7 +11,8 @@ export interface Upgrades {
   memory_request?: number;
   mintime?: number;
   network?: number;
-  member_host?: number;
+  member_host?: boolean;
   ephemeral_state?: number;
   ephemeral_disk?: number;
+  always_running?: boolean;
 }


### PR DESCRIPTION
# Description

this is a little enhancement of those `project_started|_stopped` events. it also records some basic info about the type of project.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
