### PR TITLE
hub/licenses: actualy remove a license if it is no longer valid

### DIFF
--- a/src/packages/hub/postgres/site-license/hook.ts
+++ b/src/packages/hub/postgres/site-license/hook.ts
@@ -199,6 +199,9 @@ async function site_license_hook0(
       }
     } else {
       dbg(`Not currently valid license -- "${license_id}".`);
+      // due to how jsonb_set works, we have to set this to null,
+      // because otherwise an existing license entry continues to exist.
+      new_site_license[license_id] = null;
     }
   }
 


### PR DESCRIPTION
# Description

~~I didn't test this yet.~~ I do know from the log, that the hook ends with

```
"Not currently valid license -- \"...\"."
"setup site license={}"
```

for an expired license.

well, I made a quick test. what happens is that the license goes away like "poof". 

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
