### PR TITLE
formatter: fix bib, r and R in jupyter

### DIFF
--- a/src/packages/project/configuration.ts
+++ b/src/packages/project/configuration.ts
@@ -181,6 +181,9 @@ async function get_formatting(): Promise<Capabilities> {
     if (tool === ("formatR" as FormatTool)) {
       // TODO special case. must check for package "formatR" in "R" -- for now just test for R
       status.push(have("R"));
+    } else if (tool == ("bib-biber" as FormatTool)) {
+      // another special case
+      status.push(have("biber"));
     } else if (
       tool === ("html-tidy" as FormatTool) ||
       tool === ("xml-tidy" as FormatTool)

--- a/src/packages/util/code-formatter.ts
+++ b/src/packages/util/code-formatter.ts
@@ -159,8 +159,8 @@ export const syntax2tool: Readonly<Config> = Object.freeze({
   py: "python", // should be yapf or whatever …
   python: "python", // should be yapf or whatever …
   python3: "python", // should be yapf or whatever …
-  R: "r", // should be "formatR",
-  r: "r", // should be "formatR",
+  R: "formatR",
+  r: "formatR",
   zig: "zig",
   JavaScript: "babel", // in prettier
   jsx: "babel", // in prettier


### PR DESCRIPTION
# Description

with that, I can format a bib file, an `*.r` file and also R code in jupyter

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
