### PR TITLE
frontend: highlight minimize button when a frame is maximized

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -365,6 +365,7 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
           key={"compress"}
           bsSize={button_size()}
           onClick={() => props.actions.unset_frame_full()}
+          bsStyle={"warning"}
         >
           <Icon name={"compress"} />
         </StyledButton>


### PR DESCRIPTION
# Description

way too often I overlook I had a frame maximized. this highlights that button to get back, that's all.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
