### PR TITLE
frontend: no need to set version cookie only for https 

### DIFF
--- a/src/packages/frontend/set-version-cookie.js
+++ b/src/packages/frontend/set-version-cookie.js
@@ -26,7 +26,7 @@ import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 // the code the client has loaded, and the version only goes up.  It does not provide
 // any form of authentication.
 const days = 300;
-const future = new Date(new Date().getTime() + days * 24 * 60 * 60 * 1000);
-const opts = { expires: future, path: "/", secure: true, sameSite: "none" };
+const future = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+const opts = { expires: future, path: "/", sameSite: "none" };
 const NAME = versionCookieName(appBasePath);
 cookies.set(NAME, version, opts);


### PR DESCRIPTION


# Description

* this cookie is not really a secret
* Date.now is more concise

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
