### PR TITLE
hub:  set server settings via environment variables

### DIFF
--- a/src/packages/database/postgres-server-queries.coffee
+++ b/src/packages/database/postgres-server-queries.coffee
@@ -237,7 +237,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
             value : required
             cb    : required
         async.series([
-            (cb) ->
+            (cb) =>
                 @_query
                     query  : 'INSERT INTO server_settings'
                     values :
@@ -246,7 +246,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     conflict : 'name'
                     cb     : cb
             # also set a timestamp
-            (cb) ->
+            (cb) =>
                 @_query
                     query  : 'INSERT INTO server_settings'
                     values :
@@ -254,7 +254,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                         'value::TEXT' : (new Date()).toISOString()
                     conflict : 'name'
                     cb     : cb
-        ], (err) ->
+        ], (err) =>
             # clear the cache no matter what (e.g., server_settings might have partly changed then errored)
             @reset_server_settings_cache()
             opts.cb(err)

--- a/src/packages/database/postgres/types.ts
+++ b/src/packages/database/postgres/types.ts
@@ -131,6 +131,7 @@ export interface PostgreSQL extends EventEmitter {
 
   get_server_setting(opts: { name: string; cb: CB }): void;
   get_server_settings_cached(opts: { cb: CB }): void;
+  set_server_setting(opts: { name: string; value: string; cb: CB }): void;
   server_settings_synctable(): any; // returns a table
 
   create_account(opts: {

--- a/src/packages/hub/hub.ts
+++ b/src/packages/hub/hub.ts
@@ -37,6 +37,7 @@ import initProjectControl from "@cocalc/server/projects/control";
 import initIdleTimeout from "@cocalc/server/projects/control/stop-idle-projects";
 import initVersionServer from "./servers/version";
 import initPrimus from "./servers/primus";
+import { load_server_settings_from_env } from "@cocalc/server/settings/server-settings";
 
 // Logger tagged with 'hub' for this file.
 const winston = getLogger("hub");
@@ -136,6 +137,13 @@ async function startServer(): Promise<void> {
   if (program.updateDatabaseSchema) {
     winston.info("Update database schema");
     await callback2(database.update_schema);
+
+    // in those cases where we initialize the database upon startup
+    // (essentially only relevant for kucalc's hub-websocket)
+    // set server settings based on environment variables
+    if (program.mode === "kucalc") {
+      await load_server_settings_from_env(database);
+    }
   }
 
   if (program.agentPort) {


### PR DESCRIPTION
# Description

This is for configuring cocalc instances via environment variables, i.e. `COCALC_SETTING_DNS`, `COCALC_SETTING_EMAIL_SMTP_SERVER`, `COCALC_SETTING_EMAIL_SMTP_PASSWORD`, ...

One detail where I was stuck is how to properly call the `set_server_setting` method. In the end I had to change the arrows in coffeescript 🤷🏻

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
