### PR TITLE
db/types: add type info for synctable 

### DIFF
--- a/src/packages/database/postgres/types.ts
+++ b/src/packages/database/postgres/types.ts
@@ -236,4 +236,15 @@ export interface PostgreSQL extends EventEmitter {
     ttl: number;
     cb: CB;
   }): void;
+
+  synctable(opts: {
+    table: string;
+    columns?: string[];
+    where?: { [key: string]: string | string[] } | string;
+    limit?: number;
+    order_by?: any;
+    where_function?: Function;
+    idle_timeout_s?: number;
+    cb: CB;
+  });
 }


### PR DESCRIPTION
# Description

the exact definition is probably wrong, but this is still more helpful for doing backend dev than having none at all (and hence an error)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
