### PR TITLE
dedicated VM: dynamically caluclate the per project quotas 

### DIFF
--- a/src/packages/next/pages/pricing/dedicated.tsx
+++ b/src/packages/next/pages/pricing/dedicated.tsx
@@ -38,7 +38,7 @@ const ICONS: IconName[] = [
 const VMS = [
   PRICES.vms["n2-highmem-2"],
   PRICES.vms["n2-standard-4"],
-  PRICES.vms["n2-standard-8"],
+  PRICES.vms["n2-highmem-8"],
   PRICES.vms["n2-standard-16"],
 ];
 


### PR DESCRIPTION
# Description

the general motivation here is to leave 2gb of ram on each node for system services. this adds a function to derive the quota limits form the machine spec string. besides removing a source of typo errors, adjusting the numbers later on will be much easier.

~~I have to add I haven't tested this yet, only step left, but it should be fine.~~

I've also written a function to derive the price directly from the specs. This results in almost the same numbers, hence, lots of code, no changes ;-)

new: (the example 3 is different from what's online right now, because it is twice the memory)

![Screenshot from 2021-12-08 16-14-21](https://user-images.githubusercontent.com/207405/145233236-8c9beddd-1617-4464-8411-f37c3f1a15b5.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
