### PR TITLE
database/always_running: does not respect admin settings

### DIFF
--- a/src/packages/database/postgres/always-running.ts
+++ b/src/packages/database/postgres/always-running.ts
@@ -10,13 +10,15 @@ import { PostgreSQL } from "./types";
 // but are not in the running or starting state.
 // We only check for stable states, i.e. there is no state transition going on right now.
 // Ref: @cocalc/util/compute-states.js
-// Performance: only an `x IN <array>` clause uses the index, not a `NOT IN`.
+// Performance:
+// - only an `x IN <array>` clause uses the index, not a `NOT IN`.
+// - settings ->> 'always_running' is indexed as TEXT, hence we match on the string "1" (no INT conversations)
 export async function projects_that_need_to_be_started(
   database: PostgreSQL,
   limit = 10
 ): Promise<string[]> {
   const result = await database.async_query({
-    query: `SELECT project_id FROM projects WHERE (run_quota ->> 'always_running' = 'true') AND (state ->> 'state' IN ('archived', 'closed', 'opened') OR state IS NULL) LIMIT ${limit}`,
+    query: `SELECT project_id FROM projects WHERE (run_quota ->> 'always_running' = 'true' OR (settings ->> 'always_running')::TEXT = '1') AND (state ->> 'state' IN ('archived', 'closed', 'opened') OR state IS NULL) LIMIT ${limit}`,
   });
   const projects: string[] = [];
   for (const row of result.rows) {


### PR DESCRIPTION
# Description

pretty minimal, shouldn't impact the DB, since it is already indexed. looks like this case was not ported over? in any case, what's missing is updating the DB version, but I don't want to cause a merge conflict.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
