### PR TITLE
Server settings readonly

### DIFF
--- a/src/packages/database/postgres-server-queries.coffee
+++ b/src/packages/database/postgres-server-queries.coffee
@@ -245,7 +245,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                     'name::TEXT'  : opts.name
                     'value::TEXT' : opts.value
                 if opts.readonly?
-                    values.readonly = !!values.readonly
+                    values.readonly = !!opts.readonly
                 @_query
                     query    : 'INSERT INTO server_settings'
                     values   : values

--- a/src/packages/database/postgres-server-queries.coffee
+++ b/src/packages/database/postgres-server-queries.coffee
@@ -235,18 +235,22 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
 
     set_server_setting: (opts) =>
         opts = defaults opts,
-            name  : required
-            value : required
-            cb    : required
+            name     : required
+            value    : required
+            readonly : undefined  # boolean. if yes, that value is not controlled via any UI
+            cb       : required
         async.series([
             (cb) =>
+                values =
+                    'name::TEXT'  : opts.name
+                    'value::TEXT' : opts.value
+                if opts.readonly?
+                    values.readonly = !!values.readonly
                 @_query
-                    query  : 'INSERT INTO server_settings'
-                    values :
-                        'name::TEXT'  : opts.name
-                        'value::TEXT' : opts.value
+                    query    : 'INSERT INTO server_settings'
+                    values   : values
                     conflict : 'name'
-                    cb     : cb
+                    cb       : cb
             # also set a timestamp
             (cb) =>
                 @_query

--- a/src/packages/frontend/admin/site-settings.tsx
+++ b/src/packages/frontend/admin/site-settings.tsx
@@ -332,6 +332,8 @@ class SiteSettingsComponent extends Component<
     clearable,
     multiline
   ): Rendered {
+    const disabled = this.state.isReadonly[name] === true;
+
     if (Array.isArray(valid)) {
       /* This antd code below is broken because something about
          antd is broken.  Maybe it is a bug in antd.
@@ -356,6 +358,7 @@ class SiteSettingsComponent extends Component<
       return (
         <select
           defaultValue={value}
+          disabled={disabled}
           onChange={(event) => this.on_change_entry(name, event.target.value)}
           style={{ width: "100%" }}
         >
@@ -373,6 +376,7 @@ class SiteSettingsComponent extends Component<
             style={this.row_entry_style(value, valid)}
             value={value}
             visibilityToggle={true}
+            disabled={disabled}
             onChange={(e) => this.on_change_entry(name, e.target.value)}
           />
         );
@@ -388,6 +392,7 @@ class SiteSettingsComponent extends Component<
               ref={name}
               style={style}
               value={value}
+              disabled={disabled}
               onChange={() => this.on_change_entry(name)}
             />
           );
@@ -397,6 +402,7 @@ class SiteSettingsComponent extends Component<
               ref={name}
               style={this.row_entry_style(value, valid)}
               value={value}
+              disabled={disabled}
               onChange={() => this.on_change_entry(name)}
               // clearable disabled, otherwise it's not possible to edit the value
               allowClear={clearable && false}
@@ -439,9 +445,15 @@ class SiteSettingsComponent extends Component<
               <div style={{ fontSize: "90%", display: "inlineBlock" }}>
                 {this.render_row_version_hint(name, value)}
                 {hint}
-                {`readonly $${SERVER_SETTINGS_ENV_PREFIX}_${name.toUpperCase()}: ${
-                  this.state.isReadonly[name]
-                }`}
+                {this.state.isReadonly[name] && (
+                  <>
+                    Value controlled via{" "}
+                    <code>
+                      ${SERVER_SETTINGS_ENV_PREFIX}_{name.toUpperCase()}
+                    </code>
+                    .
+                  </>
+                )}
                 {this.render_row_entry_parsed(displayed_val)}
                 {this.render_row_entry_valid(valid)}
               </div>

--- a/src/packages/server/settings/server-settings.ts
+++ b/src/packages/server/settings/server-settings.ts
@@ -89,6 +89,21 @@ export async function load_server_settings_from_env(
       if (envval == null) continue;
       // ATTN do not expose the value, could be a password
       L.debug(`picking up $${envvar} and saving it in the database`);
+
+      // check validity
+      const valid = (CONF[key] ?? EXTRAS[key])?.valid;
+      if (valid != null) {
+        if (Array.isArray(valid) && !valid.includes(envval)) {
+          throw new Error(
+            `The value of $${envvar} is invalid. allowed are ${valid}.`
+          );
+        } else if (typeof valid == "function" && !valid(envval)) {
+          throw new Error(
+            `The validation function rejected the value of $${envvar}.`
+          );
+        }
+      }
+
       await cb2(db.set_server_setting, {
         name: key,
         value: envval,

--- a/src/packages/server/settings/server-settings.ts
+++ b/src/packages/server/settings/server-settings.ts
@@ -78,6 +78,7 @@ export async function load_server_settings_from_env(
   await db.async_query({
     query: "UPDATE server_settings",
     set: { readonly: false },
+    where: ["1=1"], // otherwise there is an exception about not restricting the query
   });
   // now, check if there are any we know of
   for (const config of [EXTRAS, CONF]) {

--- a/src/packages/server/settings/server-settings.ts
+++ b/src/packages/server/settings/server-settings.ts
@@ -7,6 +7,7 @@ import LRU from "lru-cache";
 import { AllSiteSettingsCached as ServerSettings } from "@cocalc/util/db-schema/types";
 import { EXTRAS } from "@cocalc/util/db-schema/site-settings-extras";
 import { site_settings_conf as CONF } from "@cocalc/util/schema";
+import { SERVER_SETTINGS_ENV_PREFIX } from "@cocalc/util/consts";
 import getPool from "@cocalc/database/pool";
 import { callback2 as cb2 } from "@cocalc/util/async-utils";
 import type { PostgreSQL } from "@cocalc/database/postgres/types";
@@ -73,7 +74,7 @@ Loaded once at startup, right after configuring the db schema, see hub/hub.ts.
 export async function load_server_settings_from_env(
   db: PostgreSQL
 ): Promise<void> {
-  const PREFIX = "COCALC_SETTING";
+  const PREFIX = SERVER_SETTINGS_ENV_PREFIX;
   // reset all readonly values
   await db.async_query({
     query: "UPDATE server_settings",

--- a/src/packages/util/consts/index.ts
+++ b/src/packages/util/consts/index.ts
@@ -10,3 +10,5 @@ RANDOM constants that we might use anywhere in cocalc go here.
 export { NOT_SIGNED_IN, versionCookieName } from "./auth";
 
 export { DUMMY_SECRET } from "./project";
+
+export { SERVER_SETTINGS_ENV_PREFIX } from "./server_settings";

--- a/src/packages/util/consts/server_settings.ts
+++ b/src/packages/util/consts/server_settings.ts
@@ -1,0 +1,6 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+export const SERVER_SETTINGS_ENV_PREFIX = "COCALC_SETTING";

--- a/src/packages/util/db-schema/server-settings.ts
+++ b/src/packages/util/db-schema/server-settings.ts
@@ -43,5 +43,9 @@ Table({
     value: {
       type: "string",
     },
+    readonly: {
+      type: "boolean",
+      desc: "If true, the user interface should not allow to edit that value – it is controlled externally or via an environment variable.",
+    },
   },
 });

--- a/src/packages/util/db-schema/site-settings.ts
+++ b/src/packages/util/db-schema/site-settings.ts
@@ -36,7 +36,8 @@ Table({
       set: {
         admin: true,
         fields: {
-          name: async function (obj, db) {
+          name: async (obj, db) => {
+            console.log(obj)
             if (!site_settings_fields.includes(obj.name)) {
               throw Error(`setting name='${obj.name}': does not exist`);
             }

--- a/src/packages/util/db-schema/site-settings.ts
+++ b/src/packages/util/db-schema/site-settings.ts
@@ -36,7 +36,7 @@ Table({
       set: {
         admin: true,
         fields: {
-          name(obj, db) {
+          name: async function (obj, db) {
             if (!site_settings_fields.includes(obj.name)) {
               throw Error(`setting name='${obj.name}': does not exist`);
             }


### PR DESCRIPTION
# Description

This is an extension to controlling those server settings via environment variables. I.e. there is a new column "readonly" and it's set to true if the hub sets them in "kucalc" mode. Then, the UI blocks and informs the admin about that in the server settings. Screenshot below.

Additionally, I made a change in the db-schema, where something that looks like a check is moved to a `check_hook` and I also added a protection to block readonly fields from being written to. 

Finally, the validity of env variable values is checked as well – and reported back to the admin as an exception.

The packages to update are hub+server+util for the additional field and checks, and obviously frontend to make use of it. In particular, `frontend/admin/site-settings.tsx` queries for a new field which requires updating the hubs first. … but if not, I checked by reverting the hub changes and the UI just says `user get query not allowed for site_settings.readonly` without unfolding the form. 

![Screenshot from 2021-12-29 11-28-41](https://user-images.githubusercontent.com/207405/147653040-8e23297b-9ff7-4f44-8018-840817cfd1a0.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
