### PR TITLE
Onprem course no trials

### DIFF
--- a/src/packages/frontend/course/students/students-panel.tsx
+++ b/src/packages/frontend/course/students/students-panel.tsx
@@ -1119,7 +1119,7 @@ class Student extends Component<StudentProps, StudentState> {
   }
 
   render_hosting() {
-    const { description, tip, state } = util.projectStatus(
+    const { description, tip, state, icon } = util.projectStatus(
       this.props.student.get("project_id"),
       redux
     );
@@ -1128,13 +1128,13 @@ class Student extends Component<StudentProps, StudentState> {
         placement="left"
         title={
           <span>
-            <Icon name="check" /> {description}
+            <Icon name={icon} /> {description}
           </span>
         }
         tip={tip}
       >
         <span style={{ color: "#888", cursor: "pointer" }}>
-          <Icon name="check" /> {description}
+          <Icon name={icon} /> {description}
           {state}
         </span>
       </Tip>

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -4343,7 +4343,7 @@ def julia(code=None, **kwargs):
 
     """
     if julia.jupyter_kernel is None:
-        julia.jupyter_kernel = jupyter("julia-1.3")
+        julia.jupyter_kernel = jupyter("julia-1.7")
     return julia.jupyter_kernel(code, **kwargs)
 
 


### PR DESCRIPTION
# Description

- student list for onprem/docker just show "Ready" for a project. no need to talk about trial/upgrades/hosting.
- this exposes the "icon" in the UI, it was just the checkmark all the time
- using a hourglass to symbol activity when a student is added

![Screenshot from 2022-01-14 20-16-18](https://user-images.githubusercontent.com/207405/149572497-785ef827-66b2-48e9-a89c-c1ac236107a6.png)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
