### PR TITLE
Site setting commercial

### DIFF
--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -173,7 +173,7 @@ function process_customize(obj) {
     const v = site_settings_conf[k];
     obj[k] = obj[k] ?? v.default;
     if (typeof v.to_val === "function") {
-      obj[k] = v.to_val(obj[k]);
+      obj[k] = v.to_val(obj[k], obj);
     }
   }
   set_customize(obj);

--- a/src/packages/hub/webapp-configuration.ts
+++ b/src/packages/hub/webapp-configuration.ts
@@ -115,7 +115,7 @@ export class WebappConfiguration {
       for (const [key, value] of Object.entries(data.theme)) {
         const config = SITE_SETTINGS_CONF[key] ?? SERVER_SETTINGS_EXTRAS[key];
         if (typeof config?.to_val == "function") {
-          theme[key] = config.to_val(value);
+          theme[key] = config.to_val(value, data.theme);
         } else {
           if (typeof value == "string" || typeof value == "boolean") {
             theme[key] = value;

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -75,8 +75,10 @@ export interface Config {
 
 export type SiteSettings = Record<SiteSettingsKeys, Config>;
 
-const fallback = (conf, name: SiteSettingsKeys): string =>
-  conf[name] ?? site_settings_conf[name].default;
+const fallback = (
+  conf: { [key in SiteSettingsKeys]: string },
+  name: SiteSettingsKeys
+): string => conf[name] ?? site_settings_conf[name].default;
 
 // little helper fuctions, used in the site settings & site settings extras
 export const is_email_enabled = (conf): boolean =>
@@ -302,11 +304,11 @@ export const site_settings_conf: SiteSettings = {
     desc: "Whether or not to include user interface elements related to for-pay upgrades and other features.  Set to 'yes' to include these elements. IMPORTANT: You must restart your server after changing this setting for it to take effect.",
     default: "no",
     valid: only_booleans,
-    to_val: (val, conf) => {
+    to_val: (val, conf: { [key in SiteSettingsKeys]: string }) => {
       // special case: only if we're in cocalc.com production mode, the commercial setting can be true at all
       const kucalc =
         conf != null
-          ? fallback(conf.kucalc, "kucalc")
+          ? fallback(conf, "kucalc")
           : site_settings_conf.kucalc.default;
       if (kucalc === KUCALC_COCALC_COM) {
         return to_bool(val);

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -59,8 +59,11 @@ export interface Config {
   readonly valid?: ConfigValid;
   readonly password?: boolean;
   readonly show?: (conf: any) => boolean;
-  // this optional function derives the actual value of this setting from current value.
-  readonly to_val?: (val: string) => boolean | string | number;
+  // this optional function derives the actual value of this setting from current value or from a global (unprocessed) setting.
+  readonly to_val?: (
+    val: string,
+    config?: { [key in SiteSettingsKeys]?: string }
+  ) => boolean | string | number;
   // this optional function derives the visual representation for the admin (fallback: to_val)
   readonly to_display?: (val: string) => string;
   readonly hint?: (val: string) => string; // markdown
@@ -299,7 +302,17 @@ export const site_settings_conf: SiteSettings = {
     desc: "Whether or not to include user interface elements related to for-pay upgrades and other features.  Set to 'yes' to include these elements. IMPORTANT: You must restart your server after changing this setting for it to take effect.",
     default: "no",
     valid: only_booleans,
-    to_val: to_bool,
+    to_val: (val, conf) => {
+      // special case: only if we're in cocalc.com production mode, the commercial setting can be true at all
+      const kucalc =
+        conf != null
+          ? fallback(conf.kucalc, "kucalc")
+          : site_settings_conf.kucalc.default;
+      if (kucalc === KUCALC_COCALC_COM) {
+        return to_bool(val);
+      }
+      return false;
+    },
     show: only_cocalc_com,
   },
   max_trial_projects: {
@@ -395,4 +408,4 @@ export const site_settings_conf: SiteSettings = {
     show: only_cocalc_com,
     cocalc_only: true,
   },
-};
+} as const;

--- a/src/packages/util/db-schema/types.ts
+++ b/src/packages/util/db-schema/types.ts
@@ -259,8 +259,8 @@ interface TableSchema<F extends Fields> {
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 type PartialSchema<F extends Fields> = Omit<TableSchema<F>, "fields">;
 
-import { SiteSettings } from "./site-defaults";
-import { SettingsExtras } from "./site-settings-extras";
+import { SiteSettings, SiteSettingsKeys } from "./site-defaults";
+import { SettingsExtras, SiteSettingsExtrasKeys } from "./site-settings-extras";
 
 // what will come out of the database and (if available) sending it through `to_val`
 export type AllSiteSettings = {
@@ -277,3 +277,5 @@ export type RegistrationTokenSetFields =
   | "disabled";
 
 export type RegistrationTokenGetFields = RegistrationTokenSetFields | "counter";
+
+export type AllSiteSettingsKeys = SiteSettingsKeys | SiteSettingsExtrasKeys;


### PR DESCRIPTION
# Description

I saw there is some confusion about setting kucalc vs. commercial. The commercial setting makes only sense in the context of production use, but in the code it's not properly used. This is a general fix for this. Whenever `kucalc != yes` → `commercial` becomes `false`. In a follow up PR I'll sort out the problem of hiding the license upgrade config for student projects in a course, when `commercial` is false.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
