### PR TITLE
Fix terminal resize

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
@@ -30,25 +30,32 @@ or
     deletable : bool
 */
 
-import { delay } from "awaiting";
-import { is_safari } from "../generic/browser";
-import { merge, copy, hidden_meta_file, is_different } from "@cocalc/util/misc";
-import { ReactDOM, Component, redux, Rendered } from "../../app-framework";
-import { Map, Set } from "immutable";
-const Draggable = require("react-draggable");
-import { drag_start_iframe_disable, drag_stop_iframe_enable } from "../../misc";
 import * as feature from "@cocalc/frontend/feature";
-import { FrameTitleBar } from "./title-bar";
-import { FrameTreeLeaf } from "./leaf";
-import * as tree_ops from "./tree-ops";
+import { copy, hidden_meta_file, is_different, merge } from "@cocalc/util/misc";
+import { delay } from "awaiting";
+import { Map, Set } from "immutable";
+import React from "react";
+import {
+  ReactDOM,
+  redux,
+  Rendered,
+  useState,
+  useEffect,
+} from "../../app-framework";
 import { Loading } from "../../components";
+import { drag_start_iframe_disable, drag_stop_iframe_enable } from "../../misc";
 import { AvailableFeatures } from "../../project_configuration";
-import { get_file_editor } from "./register";
-import { TimeTravelActions } from "../time-travel-editor/actions";
-import { EditorSpec, EditorDescription, EditorState, NodeDesc } from "./types";
 import { Actions } from "../code-editor/actions";
 import { cm as cm_spec } from "../code-editor/editor";
+import { is_safari } from "../generic/browser";
+import { TimeTravelActions } from "../time-travel-editor/actions";
 import { FrameContext } from "./frame-context";
+import { FrameTreeLeaf } from "./leaf";
+import { get_file_editor } from "./register";
+import { FrameTitleBar } from "./title-bar";
+import * as tree_ops from "./tree-ops";
+import { EditorDescription, EditorSpec, EditorState, NodeDesc } from "./types";
+const Draggable = require("react-draggable");
 
 const drag_offset = feature.IS_TOUCH ? 5 : 2;
 
@@ -105,488 +112,516 @@ interface FrameTreeProps {
   tab_is_visible: boolean;
 }
 
-interface FrameTreeState {
-  drag_hover: boolean;
-  forceReload: number; // todo -- much better way to do with react hooks
+function shouldMemoize(prev, next) {
+  return !is_different(prev, next, [
+    "frame_tree",
+    "active_id",
+    "full_id",
+    "is_only",
+    "cursors",
+    "has_unsaved_changes",
+    "has_uncommitted_changes",
+    "is_public",
+    "value",
+    "project_id",
+    "path",
+    "misspelled_words",
+    "reload",
+    "resize",
+    "is_saving",
+    "editor_settings",
+    "terminal",
+    "settings",
+    "status",
+    "complete",
+    "derived_file_types",
+    "available_features",
+    "local_view_state",
+    "is_visible",
+    "tab_is_visible",
+  ]);
 }
+export const FrameTree: React.FC<FrameTreeProps> = React.memo(
+  (props: FrameTreeProps) => {
+    const {
+      name,
+      actions,
+      path,
+      project_id,
+      active_id,
+      full_id,
+      frame_tree,
+      editor_state,
+      font_size,
+      is_only,
+      cursors,
+      read_only,
+      is_public,
+      value,
+      editor_spec,
+      reload,
+      resize,
+      misspelled_words,
+      has_unsaved_changes,
+      has_uncommitted_changes,
+      is_saving,
+      editor_settings,
+      terminal,
+      status,
+      settings,
+      complete,
+      derived_file_types,
+      available_features,
+      local_view_state,
+      is_visible,
+      tab_is_visible,
+    } = props;
 
-export class FrameTree extends Component<FrameTreeProps, FrameTreeState> {
-  constructor(props) {
-    super(props);
-    this.state = { drag_hover: false, forceReload: 0 };
-  }
+    const elementRef = React.useRef<HTMLDivElement>(null);
+    const cols_drag_bar_ref = React.useRef<HTMLDivElement>(null);
+    const cols_container_ref = React.useRef<HTMLDivElement>(null);
+    const rows_drag_bar_ref = React.useRef<HTMLDivElement>(null);
+    const rows_container_ref = React.useRef<HTMLDivElement>(null);
 
-  componentWillUnmount(): void {
-    const actions: any = this.props.actions;
-    if (actions.blur != null) {
-      actions.blur();
-    }
-  }
+    const [drag_hover, set_drag_hover] = useState<boolean>(false);
+    const [forceReload, setForceReload] = useState<number>(0);
 
-  shouldComponentUpdate(next, state): boolean {
-    return (
-      this.state.drag_hover !== state.drag_hover ||
-      this.state.forceReload != state.forceReload ||
-      is_different(this.props, next, [
-        "frame_tree",
-        "active_id",
-        "full_id",
-        "is_only",
-        "cursors",
-        "has_unsaved_changes",
-        "has_uncommitted_changes",
-        "is_public",
-        "value",
-        "project_id",
-        "path",
-        "misspelled_words",
-        "reload",
-        "resize",
-        "is_saving",
-        "editor_settings",
-        "terminal",
-        "settings",
-        "status",
-        "complete",
-        "derived_file_types",
-        "available_features",
-        "local_view_state",
-        "is_visible",
-        "tab_is_visible",
-      ])
-    );
-  }
-
-  render_frame_tree(desc) {
-    return (
-      <FrameTree
-        name={this.props.name}
-        actions={this.props.actions}
-        frame_tree={desc}
-        editor_state={this.props.editor_state}
-        active_id={this.props.active_id}
-        full_id={this.props.full_id}
-        project_id={this.props.project_id}
-        path={this.props.path}
-        font_size={this.props.font_size}
-        is_only={false}
-        cursors={this.props.cursors}
-        read_only={this.props.read_only}
-        is_public={this.props.is_public}
-        value={this.props.value}
-        editor_spec={this.props.editor_spec}
-        reload={this.props.reload}
-        resize={this.props.resize}
-        misspelled_words={this.props.misspelled_words}
-        has_unsaved_changes={this.props.has_unsaved_changes}
-        has_uncommitted_changes={this.props.has_uncommitted_changes}
-        is_saving={this.props.is_saving}
-        editor_settings={this.props.editor_settings}
-        terminal={this.props.terminal}
-        settings={this.props.settings}
-        status={this.props.status}
-        complete={this.props.complete}
-        derived_file_types={this.props.derived_file_types}
-        available_features={this.props.available_features}
-        local_view_state={this.props.local_view_state}
-        is_visible={this.props.is_visible}
-        tab_is_visible={this.props.tab_is_visible}
-      />
-    );
-  }
-
-  private async init_code_editor(id: string, path: string): Promise<void> {
-    // This async function starts the manager initializing
-    await this.props.actions.init_code_editor(id, path);
-    // OK, now it's initialized, so we need to cause a refresh...
-    this.setState({ forceReload: this.state.forceReload + 1 });
-  }
-
-  private get_editor_actions(desc: NodeDesc): Actions | undefined {
-    if (desc.get("type") == "cm" && this.props.editor_spec["cm"] == null) {
-      // make it so the spec includes info about cm editor.
-      this.props.editor_spec.cm = copy(cm_spec);
-    }
-
-    if (
-      desc.get("type") == "cm" &&
-      desc.get("path", this.props.path) != this.props.path
-    ) {
-      const manager = this.props.actions.get_code_editor(desc.get("id"));
-      if (manager == null) {
-        // This async function starts the manager initializing
-        this.init_code_editor(
-          desc.get("id"),
-          desc.get("path", this.props.path)
-        );
-
-        return undefined;
-      }
-      return manager?.get_actions();
-    } else {
-      return this.props.actions;
-    }
-  }
-
-  render_titlebar(
-    desc: NodeDesc,
-    spec: EditorDescription,
-    editor_actions: Actions
-  ): Rendered {
-    const id = desc.get("id");
-    return (
-      <FrameTitleBar
-        actions={this.props.actions}
-        editor_actions={editor_actions}
-        active_id={this.props.active_id}
-        project_id={desc.get("project_id", this.props.project_id)}
-        path={desc.get("path", this.props.path)}
-        is_full={desc.get("id") === this.props.full_id && !this.props.is_only}
-        is_only={this.props.is_only}
-        id={id}
-        is_paused={desc.get("is_paused")}
-        type={desc.get("type")}
-        editor_spec={this.props.editor_spec}
-        spec={spec}
-        status={this.props.status}
-        title={desc.get("title")}
-        connection_status={desc.get("connection_status")}
-        font_size={desc.get("font_size")}
-        available_features={this.props.available_features}
-      />
-    );
-  }
-
-  render_leaf(
-    desc: NodeDesc,
-    component: any,
-    spec: EditorDescription,
-    editor_actions: Actions
-  ) {
-    const type = desc.get("type");
-    const project_id = desc.get("project_id", this.props.project_id);
-    let name = this.props.name;
-    let actions = this.props.actions;
-
-    let path: string = desc.get("path", this.props.path);
-    if (spec.path != null) {
-      path = spec.path(path);
-    }
-
-    // UGLY/TODO: This approach to TimeTravel as a frame is not sufficiently
-    // generic and is a **temporary** hack.  It'll be rewritten
-    // soon in a more generic way that also will support multifile
-    // latex editing. See https://github.com/sagemathinc/cocalc/issues/904
-    // Note that this does NOT reference count the actions properly
-    // right now... We need to switch to something like we do with
-    // CodeEditorManager.
-    let is_subframe: boolean = false;
-    if (spec.name === "TimeTravel" && !(actions instanceof TimeTravelActions)) {
-      if (path.slice(path.length - 12) != ".time-travel") {
-        path = hidden_meta_file(path, "time-travel");
-        const editor = get_file_editor("time-travel", false);
-        if (editor == null) throw Error("bug -- editor must exist");
-        name = editor.init(path, redux, project_id);
-        const actions2: TimeTravelActions = redux.getActions(name);
-        actions2.ambient_actions = actions;
-        // [j3] Assuming this is part of the hackiness above
-        // Or just that Actions in the frame tree are confusing
-        actions = actions2 as Actions;
-        is_subframe = true;
-        // this is particularly hacky for now:
-        // ensures time travel params are set.
-        // setTimeout is needed since this can change redux store,
-        // and we are in a render function.
-        setTimeout(() => actions2.init_frame_tree(), 50);
-      }
-    } else if (type == "cm" && path != this.props.path) {
-      // A code editor inside some other editor frame tree
-      is_subframe = true;
-    }
-
-    return (
-      <FrameTreeLeaf
-        name={name}
-        path={path}
-        project_id={this.props.project_id}
-        is_public={this.props.is_public}
-        font_size={this.props.font_size}
-        editor_state={this.props.editor_state}
-        active_id={this.props.active_id}
-        editor_settings={this.props.editor_settings}
-        terminal={this.props.terminal}
-        settings={this.props.settings}
-        status={this.props.status}
-        derived_file_types={this.props.derived_file_types}
-        available_features={this.props.available_features}
-        local_view_state={this.props.local_view_state}
-        actions={actions}
-        component={component}
-        desc={desc}
-        spec={spec}
-        editor_actions={editor_actions}
-        is_fullscreen={
-          this.props.is_only || desc.get("id") === this.props.full_id
+    useEffect(() => {
+      return () => {
+        if (typeof (actions as any).blur === "function") {
+          (actions as any).blur();
         }
-        reload={this.props.reload.get(type)}
-        resize={this.props.resize}
-        is_subframe={is_subframe}
-        is_visible={this.props.is_visible}
-        tab_is_visible={this.props.tab_is_visible}
-      />
-    );
-  }
+      };
+    }, []);
 
-  async reset_frame_tree(): Promise<void> {
-    await delay(100);
-    if (this.props.actions) {
-      this.props.actions.reset_frame_tree();
+    function render_frame_tree(desc) {
+      return (
+        <FrameTree
+          name={name}
+          actions={actions}
+          frame_tree={desc}
+          editor_state={editor_state}
+          active_id={active_id}
+          full_id={full_id}
+          project_id={project_id}
+          path={path}
+          font_size={font_size}
+          is_only={false}
+          cursors={cursors}
+          read_only={read_only}
+          is_public={is_public}
+          value={value}
+          editor_spec={editor_spec}
+          reload={reload}
+          resize={resize}
+          misspelled_words={misspelled_words}
+          has_unsaved_changes={has_unsaved_changes}
+          has_uncommitted_changes={has_uncommitted_changes}
+          is_saving={is_saving}
+          editor_settings={editor_settings}
+          terminal={terminal}
+          settings={settings}
+          status={status}
+          complete={complete}
+          derived_file_types={derived_file_types}
+          available_features={available_features}
+          local_view_state={local_view_state}
+          is_visible={is_visible}
+          tab_is_visible={tab_is_visible}
+        />
+      );
     }
-  }
 
-  render_one(desc: NodeDesc): Rendered {
-    const type = desc.get("type");
-    if (type === "node") {
-      return this.render_frame_tree(desc);
+    async function init_code_editor(id: string, path: string): Promise<void> {
+      // This async function starts the manager initializing
+      await actions.init_code_editor(id, path);
+      // OK, now it's initialized, so we need to cause a refresh...
+      setForceReload(forceReload + 1);
     }
-    // NOTE: get_editor_actions may mutate props.editor_spec
-    // if necessary for subframe, etc. So we call it first!
-    let editor_actions: Actions | undefined,
-      spec: EditorDescription,
-      component: any;
-    try {
-      editor_actions = this.get_editor_actions(desc);
-      if (editor_actions == null) {
-        return <Loading />;
+
+    function get_editor_actions(desc: NodeDesc): Actions | undefined {
+      if (desc.get("type") == "cm" && editor_spec["cm"] == null) {
+        // make it so the spec includes info about cm editor.
+        editor_spec.cm = copy(cm_spec);
       }
-      spec = this.props.editor_spec[type];
-      component = spec != null ? spec.component : undefined;
-      if (component == null) throw Error(`unknown type '${type}'`);
-    } catch (err) {
-      const mesg = `Invalid frame tree ${JSON.stringify(desc)} -- ${err}`;
-      console.log(mesg);
-      // reset -- fix this disaster next time around.
-      this.reset_frame_tree();
-      return <div>{mesg}</div>;
+
+      if (desc.get("type") == "cm" && desc.get("path", path) != path) {
+        const manager = actions.get_code_editor(desc.get("id"));
+        if (manager == null) {
+          // This async function starts the manager initializing
+          init_code_editor(desc.get("id"), desc.get("path", path));
+
+          return undefined;
+        }
+        return manager?.get_actions();
+      } else {
+        return actions;
+      }
     }
-    return (
-      <FrameContext.Provider
-        value={{
-          id: desc.get("id"),
-          project_id: this.props.project_id,
-          path: this.props.path,
-          actions: editor_actions,
-        }}
-      >
+
+    function render_titlebar(
+      desc: NodeDesc,
+      spec: EditorDescription,
+      editor_actions: Actions
+    ): Rendered {
+      const id = desc.get("id");
+      return (
+        <FrameTitleBar
+          actions={actions}
+          editor_actions={editor_actions}
+          active_id={active_id}
+          project_id={desc.get("project_id", project_id)}
+          path={desc.get("path", path)}
+          is_full={desc.get("id") === full_id && !is_only}
+          is_only={is_only}
+          id={id}
+          is_paused={desc.get("is_paused")}
+          type={desc.get("type")}
+          editor_spec={editor_spec}
+          spec={spec}
+          status={status}
+          title={desc.get("title")}
+          connection_status={desc.get("connection_status")}
+          font_size={desc.get("font_size")}
+          available_features={available_features}
+        />
+      );
+    }
+
+    function render_leaf(
+      desc: NodeDesc,
+      component: any,
+      spec: EditorDescription,
+      editor_actions: Actions
+    ) {
+      const type = desc.get("type");
+      const project_id_leaf = desc.get("project_id", project_id);
+
+      let path_leaf: string = desc.get("path", path);
+      if (spec.path != null) {
+        path_leaf = spec.path(path_leaf);
+      }
+
+      // UGLY/TODO: This approach to TimeTravel as a frame is not sufficiently
+      // generic and is a **temporary** hack.  It'll be rewritten
+      // soon in a more generic way that also will support multifile
+      // latex editing. See https://github.com/sagemathinc/cocalc/issues/904
+      // Note that this does NOT reference count the actions properly
+      // right now... We need to switch to something like we do with
+      // CodeEditorManager.
+      let is_subframe: boolean = false;
+      let name_leaf = name;
+      let actions_leaf = actions;
+      if (
+        spec.name === "TimeTravel" &&
+        !(actions instanceof TimeTravelActions)
+      ) {
+        if (path_leaf.slice(path_leaf.length - 12) != ".time-travel") {
+          path_leaf = hidden_meta_file(path_leaf, "time-travel");
+          const editor = get_file_editor("time-travel", false);
+          if (editor == null) throw Error("bug -- editor must exist");
+          name_leaf = editor.init(path_leaf, redux, project_id_leaf);
+          const actions2: TimeTravelActions = redux.getActions(name_leaf);
+          actions2.ambient_actions = actions;
+          // [j3] Assuming this is part of the hackiness above
+          // Or just that Actions in the frame tree are confusing
+          actions_leaf = actions2 as Actions;
+          is_subframe = true;
+          // this is particularly hacky for now:
+          // ensures time travel params are set.
+          // setTimeout is needed since this can change redux store,
+          // and we are in a render function.
+          setTimeout(() => actions2.init_frame_tree(), 50);
+        }
+      } else if (type == "cm" && path != path_leaf) {
+        // A code editor inside some other editor frame tree
+        is_subframe = true;
+      }
+
+      return (
+        <FrameTreeLeaf
+          name={name_leaf}
+          path={path_leaf}
+          project_id={project_id_leaf}
+          is_public={is_public}
+          font_size={font_size}
+          editor_state={editor_state}
+          active_id={active_id}
+          editor_settings={editor_settings}
+          terminal={terminal}
+          settings={settings}
+          status={status}
+          derived_file_types={derived_file_types}
+          available_features={available_features}
+          local_view_state={local_view_state}
+          actions={actions_leaf}
+          component={component}
+          desc={desc}
+          spec={spec}
+          editor_actions={editor_actions}
+          is_fullscreen={is_only || desc.get("id") === full_id}
+          reload={reload.get(type)}
+          resize={resize}
+          is_subframe={is_subframe}
+          is_visible={is_visible}
+          tab_is_visible={tab_is_visible}
+        />
+      );
+    }
+
+    async function reset_frame_tree(): Promise<void> {
+      await delay(100);
+      if (actions) {
+        actions.reset_frame_tree();
+      }
+    }
+
+    function render_one(desc: NodeDesc): Rendered {
+      const type = desc.get("type");
+      if (type === "node") {
+        return render_frame_tree(desc);
+      }
+      // NOTE: get_editor_actions may mutate props.editor_spec
+      // if necessary for subframe, etc. So we call it first!
+      let editor_actions: Actions | undefined,
+        spec: EditorDescription,
+        component: any;
+      try {
+        editor_actions = get_editor_actions(desc);
+        if (editor_actions == null) {
+          return <Loading />;
+        }
+        spec = editor_spec[type];
+        component = spec != null ? spec.component : undefined;
+        if (component == null) throw Error(`unknown type '${type}'`);
+      } catch (err) {
+        const mesg = `Invalid frame tree ${JSON.stringify(desc)} -- ${err}`;
+        console.log(mesg);
+        // reset -- fix this disaster next time around.
+        reset_frame_tree();
+        return <div>{mesg}</div>;
+      }
+      return (
+        <FrameContext.Provider
+          value={{
+            id: desc.get("id"),
+            project_id: project_id,
+            path: path,
+            actions: editor_actions,
+          }}
+        >
+          <div
+            className={"smc-vfill"}
+            onClick={() => actions.set_active_id(desc.get("id"), true)}
+            onTouchStart={() => actions.set_active_id(desc.get("id"))}
+            style={spec != null ? spec.style : undefined}
+          >
+            {render_titlebar(desc, spec, editor_actions)}
+            {render_leaf(desc, component, spec, editor_actions)}
+          </div>
+        </FrameContext.Provider>
+      );
+    }
+
+    //function   render_first() {
+    //    const desc = frame_tree.get("first");
+    //    return <div className={"smc-vfill"}>{render_one(desc)}</div>;
+    //  }
+
+    function render_cols_drag_bar() {
+      const reset = () => {
+        if (cols_drag_bar_ref.current != null) {
+          (cols_drag_bar_ref.current as any).state.x = 0;
+          return $(ReactDOM.findDOMNode(cols_drag_bar_ref.current)).css(
+            "transform",
+            ""
+          );
+        }
+      };
+
+      const handle_stop = async (_, ui) => {
+        drag_stop_iframe_enable();
+        const clientX = ui.node.offsetLeft + ui.x + drag_offset;
+        const elt = ReactDOM.findDOMNode(cols_container_ref.current);
+        const pos = (clientX - elt.offsetLeft) / elt.offsetWidth;
+        reset();
+        const id = frame_tree.get("id");
+        actions.set_frame_tree({
+          id,
+          pos,
+        });
+        actions.set_resize();
+        actions.focus(); // see https://github.com/sagemathinc/cocalc/issues/3269
+      };
+
+      return (
+        <Draggable
+          ref={cols_drag_bar_ref}
+          axis={"x"}
+          onStop={handle_stop}
+          onStart={drag_start_iframe_disable}
+          defaultClassNameDragging={"cc-vertical-drag-bar-dragging"}
+        >
+          <div
+            style={drag_hover ? cols_drag_bar_drag_hover : cols_drag_bar}
+            onMouseEnter={() => set_drag_hover(true)}
+            onMouseLeave={() => set_drag_hover(false)}
+          />
+        </Draggable>
+      );
+    }
+
+    function get_pos() {
+      let left;
+      let pos = (left = parseFloat(frame_tree.get("pos"))) != null ? left : 0.5;
+      if (isNaN(pos)) {
+        pos = 0.5;
+      }
+      return pos;
+    }
+
+    function get_data(flex_direction) {
+      const pos = get_pos();
+      const data = {
+        pos,
+        first: frame_tree.get("first"),
+        style_first: { display: "flex", flex: pos },
+        second: frame_tree.get("second"),
+        style_second: { display: "flex", flex: 1 - pos },
+        outer_style: undefined as any,
+      };
+
+      if (flex_direction === "row") {
+        // overflow:'hidden' is NOT needed on chrome, but *is* needed on Firefox.
+        data.outer_style = {
+          display: "flex",
+          flexDirection: "row",
+          flex: 1,
+          overflow: "hidden",
+        };
+      }
+      return data;
+    }
+
+    function render_cols() {
+      const data = get_data("row");
+      return (
+        <div ref={cols_container_ref} style={data.outer_style}>
+          <div className={"smc-vfill"} style={data.style_first}>
+            {render_one(data.first)}
+          </div>
+          {render_cols_drag_bar()}
+          <div className={"smc-vfill"} style={data.style_second}>
+            {render_one(data.second)}
+          </div>
+        </div>
+      );
+    }
+
+    function safari_hack() {
+      if (!is_safari()) {
+        return;
+      }
+      // Workaround a major and annoying bug in Safari:
+      //     https://github.com/philipwalton/flexbugs/issues/132
+      return $(ReactDOM.findDOMNode(elementRef.current))
+        .find(".cocalc-editor-div")
+        .make_height_defined();
+    }
+
+    function render_rows_drag_bar() {
+      const reset = () => {
+        if (rows_drag_bar_ref.current != null) {
+          (rows_drag_bar_ref.current as any).state.y = 0;
+          return $(ReactDOM.findDOMNode(rows_drag_bar_ref.current)).css(
+            "transform",
+            ""
+          );
+        }
+      };
+
+      function handle_stop(_, ui) {
+        drag_stop_iframe_enable();
+        const clientY = ui.node.offsetTop + ui.y + drag_offset;
+        const elt = ReactDOM.findDOMNode(rows_container_ref.current);
+        const pos = (clientY - elt.offsetTop) / elt.offsetHeight;
+        reset();
+        actions.set_frame_tree({
+          id: frame_tree.get("id"),
+          pos,
+        });
+        actions.set_resize();
+        actions.focus();
+        safari_hack();
+      }
+
+      return (
+        <Draggable
+          ref={rows_drag_bar_ref}
+          axis={"y"}
+          onStop={handle_stop}
+          onStart={drag_start_iframe_disable}
+        >
+          <div
+            style={drag_hover ? rows_drag_bar_drag_hover : rows_drag_bar}
+            onMouseEnter={() => set_drag_hover(true)}
+            onMouseLeave={() => set_drag_hover(false)}
+          />
+        </Draggable>
+      );
+    }
+
+    function render_rows() {
+      const data = get_data("column");
+      return (
         <div
           className={"smc-vfill"}
-          onClick={() => this.props.actions.set_active_id(desc.get("id"), true)}
-          onTouchStart={() => this.props.actions.set_active_id(desc.get("id"))}
-          style={spec != null ? spec.style : undefined}
+          ref={rows_container_ref}
+          style={data.outer_style}
         >
-          {this.render_titlebar(desc, spec, editor_actions)}
-          {this.render_leaf(desc, component, spec, editor_actions)}
+          <div className={"smc-vfill"} style={data.style_first}>
+            {render_one(data.first)}
+          </div>
+          {render_rows_drag_bar()}
+          <div className={"smc-vfill"} style={data.style_second}>
+            {render_one(data.second)}
+          </div>
         </div>
-      </FrameContext.Provider>
-    );
-  }
-
-  render_first() {
-    const desc = this.props.frame_tree.get("first");
-    return <div className={"smc-vfill"}>{this.render_one(desc)}</div>;
-  }
-
-  render_cols_drag_bar() {
-    const reset = () => {
-      if (this.refs.cols_drag_bar != null) {
-        (this.refs.cols_drag_bar as any).state.x = 0;
-        return $(ReactDOM.findDOMNode(this.refs.cols_drag_bar)).css(
-          "transform",
-          ""
-        );
-      }
-    };
-
-    const handle_stop = async (_, ui) => {
-      drag_stop_iframe_enable();
-      const clientX = ui.node.offsetLeft + ui.x + drag_offset;
-      const elt = ReactDOM.findDOMNode(this.refs.cols_container);
-      const pos = (clientX - elt.offsetLeft) / elt.offsetWidth;
-      reset();
-      const id = this.props.frame_tree.get("id");
-      this.props.actions.set_frame_tree({
-        id,
-        pos,
-      });
-      this.props.actions.set_resize();
-      this.props.actions.focus(); // see https://github.com/sagemathinc/cocalc/issues/3269
-    };
-
-    return (
-      <Draggable
-        ref={"cols_drag_bar"}
-        axis={"x"}
-        onStop={handle_stop}
-        onStart={drag_start_iframe_disable}
-        defaultClassNameDragging={"cc-vertical-drag-bar-dragging"}
-      >
-        <div
-          style={
-            this.state.drag_hover ? cols_drag_bar_drag_hover : cols_drag_bar
-          }
-          onMouseEnter={() => this.setState({ drag_hover: true })}
-          onMouseLeave={() => this.setState({ drag_hover: false })}
-        />
-      </Draggable>
-    );
-  }
-
-  get_pos() {
-    let left;
-    let pos =
-      (left = parseFloat(this.props.frame_tree.get("pos"))) != null
-        ? left
-        : 0.5;
-    if (isNaN(pos)) {
-      pos = 0.5;
+      );
     }
-    return pos;
-  }
 
-  get_data(flex_direction) {
-    const pos = this.get_pos();
-    const data = {
-      pos,
-      first: this.props.frame_tree.get("first"),
-      style_first: { display: "flex", flex: pos },
-      second: this.props.frame_tree.get("second"),
-      style_second: { display: "flex", flex: 1 - pos },
-      outer_style: undefined as any,
-    };
-
-    if (flex_direction === "row") {
-      // overflow:'hidden' is NOT needed on chrome, but *is* needed on Firefox.
-      data.outer_style = {
-        display: "flex",
-        flexDirection: "row",
-        flex: 1,
-        overflow: "hidden",
-      };
-    }
-    return data;
-  }
-
-  render_cols() {
-    const data = this.get_data("row");
-    return (
-      <div ref={"cols_container"} style={data.outer_style}>
-        <div className={"smc-vfill"} style={data.style_first}>
-          {this.render_one(data.first)}
-        </div>
-        {this.render_cols_drag_bar()}
-        <div className={"smc-vfill"} style={data.style_second}>
-          {this.render_one(data.second)}
-        </div>
-      </div>
-    );
-  }
-
-  safari_hack() {
-    if (!is_safari()) {
-      return;
-    }
-    // Workaround a major and annoying bug in Safari:
-    //     https://github.com/philipwalton/flexbugs/issues/132
-    return $(ReactDOM.findDOMNode(this))
-      .find(".cocalc-editor-div")
-      .make_height_defined();
-  }
-
-  render_rows_drag_bar() {
-    const reset = () => {
-      if (this.refs.rows_drag_bar != null) {
-        (this.refs.rows_drag_bar as any).state.y = 0;
-        return $(ReactDOM.findDOMNode(this.refs.rows_drag_bar)).css(
-          "transform",
-          ""
-        );
-      }
-    };
-
-    const handle_stop = (_, ui) => {
-      drag_stop_iframe_enable();
-      const clientY = ui.node.offsetTop + ui.y + drag_offset;
-      const elt = ReactDOM.findDOMNode(this.refs.rows_container);
-      const pos = (clientY - elt.offsetTop) / elt.offsetHeight;
-      reset();
-      this.props.actions.set_frame_tree({
-        id: this.props.frame_tree.get("id"),
-        pos,
-      });
-      this.props.actions.set_resize();
-      this.props.actions.focus();
-      this.safari_hack();
-    };
-
-    return (
-      <Draggable
-        ref={"rows_drag_bar"}
-        axis={"y"}
-        onStop={handle_stop}
-        onStart={drag_start_iframe_disable}
-      >
-        <div
-          style={
-            this.state.drag_hover ? rows_drag_bar_drag_hover : rows_drag_bar
-          }
-          onMouseEnter={() => this.setState({ drag_hover: true })}
-          onMouseLeave={() => this.setState({ drag_hover: false })}
-        />
-      </Draggable>
-    );
-  }
-
-  render_rows() {
-    const data = this.get_data("column");
-    return (
-      <div
-        className={"smc-vfill"}
-        ref={"rows_container"}
-        style={data.outer_style}
-      >
-        <div className={"smc-vfill"} style={data.style_first}>
-          {this.render_one(data.first)}
-        </div>
-        {this.render_rows_drag_bar()}
-        <div className={"smc-vfill"} style={data.style_second}>
-          {this.render_one(data.second)}
-        </div>
-      </div>
-    );
-  }
-
-  render() {
-    if (this.props.value == null) {
+    if (value == null) {
       return <Loading />;
     }
-    if (this.props.reload === undefined) {
+    if (reload === undefined) {
       return <span>no props.reload</span>;
     }
-    if (this.props.full_id) {
-      // A single frame is full-tab'd:
-      const node = tree_ops.get_node(this.props.frame_tree, this.props.full_id);
-      if (node != null) {
-        // only render it if it actually exists, of course.
-        return this.render_one(node);
+
+    function render_root() {
+      if (full_id) {
+        // A single frame is full-tab'd:
+        const node = tree_ops.get_node(frame_tree, full_id);
+        if (node != null) {
+          // only render it if it actually exists, of course.
+          return render_one(node);
+        }
+      }
+
+      if (frame_tree.get("type") !== "node") {
+        return render_one(frame_tree);
+      } else if (frame_tree.get("direction") === "col") {
+        return render_cols();
+      } else {
+        return render_rows();
       }
     }
 
-    if (this.props.frame_tree.get("type") !== "node") {
-      return this.render_one(this.props.frame_tree);
-    } else if (this.props.frame_tree.get("direction") === "col") {
-      return this.render_cols();
-    } else {
-      return this.render_rows();
-    }
-  }
-}
+    // TODO we only need this additional div for that safari hack. one that's no longer an issue, remove it.
+    return (
+      <div className={"smc-vfill"} ref={elementRef}>
+        {render_root()}
+      </div>
+    );
+  },
+  shouldMemoize
+);

--- a/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
@@ -31,7 +31,7 @@ or
 */
 
 import * as feature from "@cocalc/frontend/feature";
-import { copy, hidden_meta_file, is_different, merge } from "@cocalc/util/misc";
+import { copy, hidden_meta_file, is_different } from "@cocalc/util/misc";
 import { delay } from "awaiting";
 import { Map, Set } from "immutable";
 import React from "react";
@@ -41,6 +41,7 @@ import {
   Rendered,
   useState,
   useEffect,
+  CSS,
 } from "../../app-framework";
 import { Loading } from "../../components";
 import { drag_start_iframe_disable, drag_stop_iframe_enable } from "../../misc";
@@ -57,26 +58,32 @@ import * as tree_ops from "./tree-ops";
 import { EditorDescription, EditorSpec, EditorState, NodeDesc } from "./types";
 const Draggable = require("react-draggable");
 
-const drag_offset = feature.IS_TOUCH ? 5 : 2;
+const DRAG_OFFSET = feature.IS_TOUCH ? 5 : 2;
 
-const cols_drag_bar = {
-  padding: `${drag_offset}px`,
+const COLS_DRAG_BAR: CSS = {
+  padding: `${DRAG_OFFSET}px`,
   background: "#efefef",
   cursor: "ew-resize",
-};
+} as const;
 
-const drag_hover = {
+const DRAG_HOVER: CSS = {
   background: "darkgrey",
   opacity: 0.8,
-};
+} as const;
 
-const cols_drag_bar_drag_hover = merge(copy(cols_drag_bar), drag_hover);
+const COLS_DRAG_BAR_DRAG_HOVER: CSS = {
+  ...COLS_DRAG_BAR,
+  ...DRAG_HOVER,
+} as const;
 
-const rows_drag_bar = merge(copy(cols_drag_bar), {
-  cursor: "ns-resize",
-});
+const ROWS_DRAG_BAR: CSS = {
+  ...COLS_DRAG_BAR,
+  ...{
+    cursor: "ns-resize",
+  },
+} as const;
 
-const rows_drag_bar_drag_hover = merge(copy(rows_drag_bar), drag_hover);
+const ROWS_DRAG_BAR_HOVER = { ...ROWS_DRAG_BAR, DRAG_HOVER } as const;
 
 interface FrameTreeProps {
   name: string; // just so editors (leaf nodes) can plug into reduxProps if they need to.
@@ -114,67 +121,67 @@ interface FrameTreeProps {
 
 function shouldMemoize(prev, next) {
   return !is_different(prev, next, [
-    "frame_tree",
     "active_id",
-    "full_id",
-    "is_only",
+    "available_features",
+    "complete",
     "cursors",
-    "has_unsaved_changes",
+    "derived_file_types",
+    "editor_settings",
+    "frame_tree",
+    "full_id",
     "has_uncommitted_changes",
+    "has_unsaved_changes",
+    "is_only",
     "is_public",
-    "value",
-    "project_id",
-    "path",
+    "is_saving",
+    "is_visible",
+    "local_view_state",
     "misspelled_words",
+    "path",
+    "project_id",
     "reload",
     "resize",
-    "is_saving",
-    "editor_settings",
-    "terminal",
     "settings",
     "status",
-    "complete",
-    "derived_file_types",
-    "available_features",
-    "local_view_state",
-    "is_visible",
     "tab_is_visible",
+    "terminal",
+    "value",
   ]);
 }
 export const FrameTree: React.FC<FrameTreeProps> = React.memo(
   (props: FrameTreeProps) => {
     const {
-      name,
       actions,
-      path,
-      project_id,
       active_id,
-      full_id,
-      frame_tree,
+      available_features,
+      complete,
+      cursors,
+      derived_file_types,
+      editor_settings,
+      editor_spec,
       editor_state,
       font_size,
+      frame_tree,
+      full_id,
+      has_uncommitted_changes,
+      has_unsaved_changes,
       is_only,
-      cursors,
-      read_only,
       is_public,
-      value,
-      editor_spec,
+      is_saving,
+      is_visible,
+      local_view_state,
+      misspelled_words,
+      name,
+      path,
+      project_id,
+      read_only,
       reload,
       resize,
-      misspelled_words,
-      has_unsaved_changes,
-      has_uncommitted_changes,
-      is_saving,
-      editor_settings,
-      terminal,
-      status,
       settings,
-      complete,
-      derived_file_types,
-      available_features,
-      local_view_state,
-      is_visible,
+      status,
       tab_is_visible,
+      terminal,
+      value,
     } = props;
 
     const elementRef = React.useRef<HTMLDivElement>(null);
@@ -197,37 +204,37 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
     function render_frame_tree(desc) {
       return (
         <FrameTree
-          name={name}
           actions={actions}
-          frame_tree={desc}
-          editor_state={editor_state}
           active_id={active_id}
-          full_id={full_id}
-          project_id={project_id}
-          path={path}
-          font_size={font_size}
-          is_only={false}
+          available_features={available_features}
+          complete={complete}
           cursors={cursors}
-          read_only={read_only}
-          is_public={is_public}
-          value={value}
+          derived_file_types={derived_file_types}
+          editor_settings={editor_settings}
           editor_spec={editor_spec}
+          editor_state={editor_state}
+          font_size={font_size}
+          frame_tree={desc}
+          full_id={full_id}
+          has_uncommitted_changes={has_uncommitted_changes}
+          has_unsaved_changes={has_unsaved_changes}
+          is_only={false}
+          is_public={is_public}
+          is_saving={is_saving}
+          is_visible={is_visible}
+          local_view_state={local_view_state}
+          misspelled_words={misspelled_words}
+          name={name}
+          path={path}
+          project_id={project_id}
+          read_only={read_only}
           reload={reload}
           resize={resize}
-          misspelled_words={misspelled_words}
-          has_unsaved_changes={has_unsaved_changes}
-          has_uncommitted_changes={has_uncommitted_changes}
-          is_saving={is_saving}
-          editor_settings={editor_settings}
-          terminal={terminal}
           settings={settings}
           status={status}
-          complete={complete}
-          derived_file_types={derived_file_types}
-          available_features={available_features}
-          local_view_state={local_view_state}
-          is_visible={is_visible}
           tab_is_visible={tab_is_visible}
+          terminal={terminal}
+          value={value}
         />
       );
     }
@@ -268,22 +275,22 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
       return (
         <FrameTitleBar
           actions={actions}
-          editor_actions={editor_actions}
           active_id={active_id}
-          project_id={desc.get("project_id", project_id)}
-          path={desc.get("path", path)}
+          available_features={available_features}
+          connection_status={desc.get("connection_status")}
+          editor_actions={editor_actions}
+          editor_spec={editor_spec}
+          font_size={desc.get("font_size")}
+          id={id}
           is_full={desc.get("id") === full_id && !is_only}
           is_only={is_only}
-          id={id}
           is_paused={desc.get("is_paused")}
-          type={desc.get("type")}
-          editor_spec={editor_spec}
+          path={desc.get("path", path)}
+          project_id={desc.get("project_id", project_id)}
           spec={spec}
           status={status}
           title={desc.get("title")}
-          connection_status={desc.get("connection_status")}
-          font_size={desc.get("font_size")}
-          available_features={available_features}
+          type={desc.get("type")}
         />
       );
     }
@@ -340,31 +347,31 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
 
       return (
         <FrameTreeLeaf
+          actions={actions_leaf}
+          active_id={active_id}
+          available_features={available_features}
+          component={component}
+          derived_file_types={derived_file_types}
+          desc={desc}
+          editor_actions={editor_actions}
+          editor_settings={editor_settings}
+          editor_state={editor_state}
+          font_size={font_size}
+          is_fullscreen={is_only || desc.get("id") === full_id}
+          is_public={is_public}
+          is_subframe={is_subframe}
+          is_visible={is_visible}
+          local_view_state={local_view_state}
           name={name_leaf}
           path={path_leaf}
           project_id={project_id_leaf}
-          is_public={is_public}
-          font_size={font_size}
-          editor_state={editor_state}
-          active_id={active_id}
-          editor_settings={editor_settings}
-          terminal={terminal}
-          settings={settings}
-          status={status}
-          derived_file_types={derived_file_types}
-          available_features={available_features}
-          local_view_state={local_view_state}
-          actions={actions_leaf}
-          component={component}
-          desc={desc}
-          spec={spec}
-          editor_actions={editor_actions}
-          is_fullscreen={is_only || desc.get("id") === full_id}
           reload={reload.get(type)}
           resize={resize}
-          is_subframe={is_subframe}
-          is_visible={is_visible}
+          settings={settings}
+          spec={spec}
+          status={status}
           tab_is_visible={tab_is_visible}
+          terminal={terminal}
         />
       );
     }
@@ -429,19 +436,19 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
     //  }
 
     function render_cols_drag_bar() {
-      const reset = () => {
+      function reset() {
         if (cols_drag_bar_ref.current != null) {
           (cols_drag_bar_ref.current as any).state.x = 0;
-          return $(ReactDOM.findDOMNode(cols_drag_bar_ref.current)).css(
+          $(ReactDOM.findDOMNode(cols_drag_bar_ref.current)).css(
             "transform",
             ""
           );
         }
-      };
+      }
 
       const handle_stop = async (_, ui) => {
         drag_stop_iframe_enable();
-        const clientX = ui.node.offsetLeft + ui.x + drag_offset;
+        const clientX = ui.node.offsetLeft + ui.x + DRAG_OFFSET;
         const elt = ReactDOM.findDOMNode(cols_container_ref.current);
         const pos = (clientX - elt.offsetLeft) / elt.offsetWidth;
         reset();
@@ -463,7 +470,7 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
           defaultClassNameDragging={"cc-vertical-drag-bar-dragging"}
         >
           <div
-            style={drag_hover ? cols_drag_bar_drag_hover : cols_drag_bar}
+            style={drag_hover ? COLS_DRAG_BAR_DRAG_HOVER : COLS_DRAG_BAR}
             onMouseEnter={() => set_drag_hover(true)}
             onMouseLeave={() => set_drag_hover(false)}
           />
@@ -530,19 +537,19 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
     }
 
     function render_rows_drag_bar() {
-      const reset = () => {
+      function reset() {
         if (rows_drag_bar_ref.current != null) {
           (rows_drag_bar_ref.current as any).state.y = 0;
-          return $(ReactDOM.findDOMNode(rows_drag_bar_ref.current)).css(
+          $(ReactDOM.findDOMNode(rows_drag_bar_ref.current)).css(
             "transform",
             ""
           );
         }
-      };
+      }
 
       function handle_stop(_, ui) {
         drag_stop_iframe_enable();
-        const clientY = ui.node.offsetTop + ui.y + drag_offset;
+        const clientY = ui.node.offsetTop + ui.y + DRAG_OFFSET;
         const elt = ReactDOM.findDOMNode(rows_container_ref.current);
         const pos = (clientY - elt.offsetTop) / elt.offsetHeight;
         reset();
@@ -563,7 +570,7 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
           onStart={drag_start_iframe_disable}
         >
           <div
-            style={drag_hover ? rows_drag_bar_drag_hover : rows_drag_bar}
+            style={drag_hover ? ROWS_DRAG_BAR_HOVER : ROWS_DRAG_BAR}
             onMouseEnter={() => set_drag_hover(true)}
             onMouseLeave={() => set_drag_hover(false)}
           />

--- a/src/packages/frontend/frame-editors/terminal-editor/commands-guide.tsx
+++ b/src/packages/frontend/frame-editors/terminal-editor/commands-guide.tsx
@@ -87,9 +87,8 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
   // empty immutable js list
   const [listing, set_listing] = useState<ListingImm>(List([]));
 
-  const [listing_stats, set_listing_stats] = useState<typeof ListingStatsInit>(
-    ListingStatsInit
-  );
+  const [listing_stats, set_listing_stats] =
+    useState<typeof ListingStatsInit>(ListingStatsInit);
   const [directorynames, set_directorynames] = useState<string[]>([]);
   const [filenames, set_filenames] = useState<string[]>([]);
   // directory and filenames
@@ -417,17 +416,10 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
     const style: CSS = { overflowY: "auto" };
     return (
       <Collapse defaultActiveKey={[info]} style={style}>
-        <Panel
-          header={
-            <>
-              <InfoCircleOutlined /> General
-            </>
-          }
-          key={info}
-        >
+        <Panel header="General" extra={<InfoCircleOutlined />} key={info}>
           <Typography.Paragraph
             type="secondary"
-            ellipsis={{ rows: 1, expandable: true, symbol: "more…" }}
+            ellipsis={{ rows: 1, expandable: true, symbol: "more" }}
           >
             This panel shows you the current directory and statistics about the
             files in it. You can select the first and second argument for
@@ -439,94 +431,51 @@ export const CommandsGuide: React.FC<Props> = React.memo((props: Props) => {
 
           {render_info()}
         </Panel>
-        <Panel
-          header={
-            <>
-              <Icon name="list" /> Files
-            </>
-          }
-          key="files"
-        >
+        <Panel header="Files" extra={<Icon name="list" />} key="files">
           {render_files()}
         </Panel>
         <Panel
-          header={
-            <>
-              <FileOutlined /> File commands
-            </>
-          }
+          header="File commands"
+          extra={<FileOutlined />}
           key="file-commands"
         >
           {render_file_commands()}
         </Panel>
         <Panel
-          header={
-            <>
-              <FolderOpenOutlined /> Directory commands
-            </>
-          }
+          header="Directory commands"
+          extra={<FolderOpenOutlined />}
           key="directory-commands"
         >
           {render_directory_commands()}
         </Panel>
-        <Panel
-          header={
-            <>
-              <Icon name="git" /> Git
-            </>
-          }
-          key="git"
-        >
+        <Panel header={"Git"} extra={<Icon name="git" />} key="git">
           {render_git()}
         </Panel>
         <Panel
-          header={
-            <>
-              <Icon name="file-archive" /> Archiving
-            </>
-          }
+          header="Archiving"
+          extra={<Icon name="file-archive" />}
           key="archiving-commands"
         >
           {render_archiving_commands()}
         </Panel>
         <Panel
-          header={
-            <>
-              <ControlOutlined /> System commands
-            </>
-          }
+          header={"System commands"}
+          extra={<ControlOutlined />}
           key="system-commands"
         >
           {render_system_commands()}
         </Panel>
-        <Panel
-          header={
-            <>
-              <Icon name="terminal" /> Bash
-            </>
-          }
-          key="bash"
-        >
+        <Panel header="Bash" extra={<Icon name="terminal" />} key="bash">
           {render_bash()}
         </Panel>
         <Panel
-          header={
-            <>
-              <Icon name="network-wired" /> Network
-            </>
-          }
+          header={"Network"}
+          extra={<Icon name="network-wired" />}
           key="network"
         >
           {render_network()}
         </Panel>
-        <Panel
-          header={
-            <>
-              <QuestionCircleOutlined /> Help
-            </>
-          }
-          key="help"
-        >
+        <Panel header="Help" extra={<QuestionCircleOutlined />} key="help">
           {render_help()}
         </Panel>
       </Collapse>

--- a/src/packages/frontend/frame-editors/terminal-editor/connected-terminal.ts
+++ b/src/packages/frontend/frame-editors/terminal-editor/connected-terminal.ts
@@ -549,6 +549,9 @@ export class Terminal<T extends CodeEditorState = CodeEditorState> {
     // but we still have to work around it.
     // The fix to https://github.com/sagemathinc/cocalc/issues/4140
     // might now prevent this bug.
+    //
+    // as of Jan 2022: if there isn't enough content yet (i.e. a new terminal)
+    // this doesn't resize properly.  This is probably a bug in xterm.js.
     try {
       this.terminal.resize(Math.floor(cols), Math.floor(rows));
     } catch (err) {

--- a/src/packages/frontend/frame-editors/terminal-editor/terminal.tsx
+++ b/src/packages/frontend/frame-editors/terminal-editor/terminal.tsx
@@ -78,7 +78,9 @@ export const TerminalFrame: React.FC<Props> = React.memo((props) => {
     }
   }, [props.is_current]);
 
-  useEffect(measure_size, [props.resize]);
+  useEffect(() => {
+    measure_size();
+  }, [props.resize]);
 
   function delete_terminal(): void {
     if (terminalRef.current == null) return; // already deleted or never created

--- a/src/packages/frontend/frame-editors/terminal-editor/terminal.tsx
+++ b/src/packages/frontend/frame-editors/terminal-editor/terminal.tsx
@@ -113,7 +113,7 @@ export const TerminalFrame: React.FC<Props> = React.memo((props) => {
     // NOTE: this would probably make sense in DOM mode instead of canvas mode;
     // if we switch, disable ..
     // Well, this context menu is still silly. Always disable it.
-    $(node).bind("contextmenu", function () {
+    $(node).on("contextmenu", function () {
       return false;
     });
 

--- a/src/packages/frontend/project/page/page.tsx
+++ b/src/packages/frontend/project/page/page.tsx
@@ -34,6 +34,7 @@ import {
   FIXED_PROJECT_TABS,
   FileTab,
 } from "./file-tab";
+
 const SortableFileTab = SortableElement(FileTab);
 
 const PAGE_STYLE: React.CSSProperties = {

--- a/src/packages/frontend/project_actions.ts
+++ b/src/packages/frontend/project_actions.ts
@@ -512,10 +512,14 @@ export class ProjectActions extends Actions<ProjectStoreState> {
             // of the component that displays this editor.  Otherwise, the user
             // would just see a spinner until they tab away and tab back.
             this.open_files.set(path, "component", { ...info });
+            // just like in the case where it is already loaded, we have to "show" it
+            // this is important, because e.g. the store has a "visible" field, which stays undefined
+            // which in turn causes e.g. https://github.com/sagemathinc/cocalc/issues/5398
+            this.show_file(path);
           })();
+        } else {
+          this.show_file(path);
         }
-
-        this.show_file(path);
     }
     this.setState(change);
   }


### PR DESCRIPTION
# Description

- fixes #5398 – well, not 100%, but still
- refactors this `FrameTree` to be a functional component … I initially thought this is the problem and with that I have more insight into what's happening. so, that's the meat of the PR now.
- but turns out, the real issue was the delayed initialization in `frontend/project_actions.ts`  … i.e. `show()` was never called, which in turn never set `visible` to true, and without being visible, no resize happens.
- while debugging this I was also thrown off by some other issue: if it is a new terminal (i.e. only a one line history) then calling `this.terminal.resize( ... )` in  `terminal-editor/connected-terminal.ts` doesn't do anything as well. I made a note that I think this is an upstream issue. The general symptom is that if you create a new terminal and split it vertically, then moving the divider around doesn't resize the terminals. After running `seq 100` to get enough lines, it resizes fine.
- finally, some cosmetics with the "guide" ... the icons are off and well, looks better if they're in their dedicated place in "extra"

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
