### PR TITLE
smc_sagews: be explicit about not working with jupyter_client 7

### DIFF
--- a/src/smc_sagews/setup.py
+++ b/src/smc_sagews/setup.py
@@ -15,7 +15,13 @@ setup(
     author_email='office@sagemath.com',
     license='GPLv3+',
     packages=['smc_sagews'],
-    install_requires=['markdown2', 'ansi2html', 'ushlex', 'six'],
+    install_requires=[
+        'markdown2',
+        'ansi2html',
+        'ushlex',
+        'six',
+        'jupyter_client<7',  # not compatible, see https://github.com/sagemathinc/cocalc/issues/5715
+    ],
     zip_safe=False,
     classifiers=[
         'License :: OSI Approved :: GPLv3',


### PR DESCRIPTION
# Description

this just tells setuptools that this package does not work with the newest jupyter_client

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
