### PR TITLE
support NFS file watching by switching to chokidar

### DIFF
--- a/src/packages/database/package-lock.json
+++ b/src/packages/database/package-lock.json
@@ -15,9 +15,9 @@
         "../util"
       ],
       "dependencies": {
-        "@cocalc/backend": "^1.7.2",
-        "@cocalc/server": "^0.6.0",
-        "@cocalc/util": "^1.18.1",
+        "@cocalc/backend": "^1.10.0",
+        "@cocalc/server": "^0.12.0",
+        "@cocalc/util": "^1.24.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
         "@types/pg": "^8.6.1",
@@ -38,7 +38,7 @@
         "validator": "^13.6.0"
       },
       "devDependencies": {
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "coffeescript": "^2.5.1",
         "node-cjsx": "^2.0.0",
         "typescript": "^4.5.2"
@@ -46,7 +46,7 @@
     },
     "../backend": {
       "name": "@cocalc/backend",
-      "version": "1.7.2",
+      "version": "1.10.0",
       "license": "SEE LICENSE.md",
       "workspaces": [
         ".",
@@ -54,7 +54,7 @@
       ],
       "dependencies": {
         "@airbnb/node-memwatch": "^2.0.0",
-        "@cocalc/util": "^1.15.1",
+        "@cocalc/util": "^1.24.0",
         "@types/debug": "^4.1.7",
         "@types/lru-cache": "^5.1.1",
         "async": "^1.5.2",
@@ -80,7 +80,7 @@
     },
     "../server": {
       "name": "@cocalc/server",
-      "version": "0.6.0",
+      "version": "0.12.1",
       "license": "SEE LICENSE.md",
       "workspaces": [
         ".",
@@ -89,9 +89,9 @@
         "../util"
       ],
       "dependencies": {
-        "@cocalc/backend": "^1.7.2",
-        "@cocalc/database": "^0.8.0",
-        "@cocalc/util": "^1.18.1",
+        "@cocalc/backend": "^1.10.0",
+        "@cocalc/database": "^0.13.0",
+        "@cocalc/util": "^1.25.1",
         "@sendgrid/mail": "^7.5.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
@@ -109,13 +109,13 @@
         "stripe": "^8.78.0"
       },
       "devDependencies": {
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "typescript": "^4.5.2"
       }
     },
     "../util": {
       "name": "@cocalc/util",
-      "version": "1.18.1",
+      "version": "1.25.1",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "."
@@ -139,7 +139,7 @@
         "@types/jest": "^26.0.23",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.176",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "coffee-cache": "^1.0.2",
         "coffee-coverage": "^3.0.1",
         "coffeelint": "^2.1.0",
@@ -1836,9 +1836,9 @@
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -3907,7 +3907,7 @@
       "version": "file:../backend",
       "requires": {
         "@airbnb/node-memwatch": "^2.0.0",
-        "@cocalc/util": "^1.15.1",
+        "@cocalc/util": "^1.24.0",
         "@types/debug": "^4.1.7",
         "@types/lru-cache": "^5.1.1",
         "async": "^1.5.2",
@@ -5061,7 +5061,7 @@
           "version": "file:../backend",
           "requires": {
             "@airbnb/node-memwatch": "^2.0.0",
-            "@cocalc/util": "^1.15.1",
+            "@cocalc/util": "^1.24.0",
             "@types/debug": "^4.1.7",
             "@types/lru-cache": "^5.1.1",
             "async": "^1.5.2",
@@ -5086,13 +5086,13 @@
         "@cocalc/server": {
           "version": "file:../server",
           "requires": {
-            "@cocalc/backend": "^1.7.2",
-            "@cocalc/database": "^0.8.0",
-            "@cocalc/util": "^1.18.1",
+            "@cocalc/backend": "^1.10.0",
+            "@cocalc/database": "^0.13.0",
+            "@cocalc/util": "^1.25.1",
             "@sendgrid/mail": "^7.5.0",
             "@types/lodash": "^4.14.176",
             "@types/lru-cache": "^5.1.1",
-            "@types/node": "^14.17.32",
+            "@types/node": "^14.18.10",
             "@types/node-zendesk": "^2.0.4",
             "@types/nodemailer": "^6.4.4",
             "async-await-utils": "^3.0.1",
@@ -5114,7 +5114,7 @@
             "@types/jest": "^26.0.23",
             "@types/json-stable-stringify": "^1.0.32",
             "@types/lodash": "^4.14.176",
-            "@types/node": "^14.17.32",
+            "@types/node": "^14.18.10",
             "@types/uuid": "^8.3.1",
             "async": "^1.5.2",
             "async-await-utils": "^3.0.1",
@@ -5155,9 +5155,9 @@
           "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
         },
         "@types/node": {
-          "version": "14.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-          "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+          "version": "14.18.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+          "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
         },
         "@types/pg": {
           "version": "8.6.1",
@@ -5880,13 +5880,13 @@
     "@cocalc/server": {
       "version": "file:../server",
       "requires": {
-        "@cocalc/backend": "^1.7.2",
-        "@cocalc/database": "^0.8.0",
-        "@cocalc/util": "^1.18.1",
+        "@cocalc/backend": "^1.10.0",
+        "@cocalc/database": "^0.13.0",
+        "@cocalc/util": "^1.25.1",
         "@sendgrid/mail": "^7.5.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/node-zendesk": "^2.0.4",
         "@types/nodemailer": "^6.4.4",
         "async-await-utils": "^3.0.1",
@@ -5908,7 +5908,7 @@
         "@types/jest": "^26.0.23",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.176",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/uuid": "^8.3.1",
         "async": "^1.5.2",
         "async-await-utils": "^3.0.1",
@@ -5949,9 +5949,9 @@
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "@types/pg": {
       "version": "8.6.1",

--- a/src/packages/database/package.json
+++ b/src/packages/database/package.json
@@ -41,7 +41,7 @@
     "validator": "^13.6.0"
   },
   "devDependencies": {
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.10",
     "coffeescript": "^2.5.1",
     "node-cjsx": "^2.0.0",
     "typescript": "^4.5.2"

--- a/src/packages/hub/package-lock.json
+++ b/src/packages/hub/package-lock.json
@@ -25,11 +25,11 @@
         "@cocalc/backend": "^1.10.0",
         "@cocalc/cdn": "^1.8.2",
         "@cocalc/database": "^0.13.0",
-        "@cocalc/frontend": "^1.29.0",
-        "@cocalc/next": "^0.30.2",
-        "@cocalc/server": "^0.12.0",
-        "@cocalc/static": "^1.62.0",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/frontend": "^1.30.0",
+        "@cocalc/next": "^0.30.3",
+        "@cocalc/server": "^0.12.1",
+        "@cocalc/static": "^1.63.0",
+        "@cocalc/util": "^1.25.1",
         "@passport-next/passport-google-oauth2": "^1.0.0",
         "@passport-next/passport-oauth2": "^2.1.1",
         "@sendgrid/client": "^7.4.6",
@@ -109,7 +109,7 @@
       "devDependencies": {
         "@types/http-proxy": "^1.17.6",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/passport": "^1.0.3",
         "@types/react-dom": "^17.0.0",
         "@types/sanitize-html": "^2.3.1",
@@ -232,7 +232,7 @@
     },
     "../frontend": {
       "name": "@cocalc/frontend",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "./",
@@ -247,11 +247,11 @@
         "@ant-design/icons": "^4.3.0",
         "@cocalc/assets": "^1.5.1",
         "@cocalc/cdn": "^1.8.2",
-        "@cocalc/hub": "^1.38.0",
+        "@cocalc/hub": "^1.38.2",
         "@cocalc/local-storage-lru": "^2.1.1",
         "@cocalc/project": "^1.13.4",
         "@cocalc/sync": "^0.2.3",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/util": "^1.25.1",
         "@jupyter-widgets/base": "^1.2.3",
         "@jupyter-widgets/controls": "^1.4.3",
         "@jupyter-widgets/output": "^1.1.2",
@@ -415,7 +415,7 @@
     },
     "../next": {
       "name": "@cocalc/next",
-      "version": "0.30.1",
+      "version": "0.30.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
         "../assets",
@@ -431,9 +431,9 @@
         "@cocalc/backend": "^1.10.0",
         "@cocalc/cdn": "^1.8.2",
         "@cocalc/database": "^0.13.0",
-        "@cocalc/frontend": "^1.29.0",
-        "@cocalc/server": "^0.12.0",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/frontend": "^1.30.0",
+        "@cocalc/server": "^0.12.1",
+        "@cocalc/util": "^1.25.1",
         "@types/express": "^4.17.13",
         "@types/react": "^17.0.33",
         "antd": "^4.18.2",
@@ -463,7 +463,7 @@
     },
     "../server": {
       "name": "@cocalc/server",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "SEE LICENSE.md",
       "workspaces": [
         ".",
@@ -474,7 +474,7 @@
       "dependencies": {
         "@cocalc/backend": "^1.10.0",
         "@cocalc/database": "^0.13.0",
-        "@cocalc/util": "^1.24.0",
+        "@cocalc/util": "^1.25.1",
         "@sendgrid/mail": "^7.5.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
@@ -492,7 +492,7 @@
         "stripe": "^8.78.0"
       },
       "devDependencies": {
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "typescript": "^4.5.2"
       }
     },
@@ -534,7 +534,7 @@
     },
     "../static": {
       "name": "@cocalc/static",
-      "version": "1.62.0",
+      "version": "1.63.0",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "../assets",
@@ -547,8 +547,8 @@
         "@cocalc/assets": "^1.5.1",
         "@cocalc/backend": "^1.10.0",
         "@cocalc/cdn": "^1.8.2",
-        "@cocalc/frontend": "^1.29.0",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/frontend": "^1.30.0",
+        "@cocalc/util": "^1.25.1",
         "@types/enzyme": "^3.10.8",
         "@types/jest": "^26.0.23",
         "@types/jquery": "^3.5.5",
@@ -626,7 +626,7 @@
     },
     "../util": {
       "name": "@cocalc/util",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "."
@@ -2902,9 +2902,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "node_modules/@types/nodemailer": {
       "version": "6.4.4",
@@ -11949,11 +11949,11 @@
         "@ant-design/icons": "^4.3.0",
         "@cocalc/assets": "^1.5.1",
         "@cocalc/cdn": "^1.8.2",
-        "@cocalc/hub": "^1.38.0",
+        "@cocalc/hub": "^1.38.2",
         "@cocalc/local-storage-lru": "^2.1.1",
         "@cocalc/project": "^1.13.4",
         "@cocalc/sync": "^0.2.3",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/util": "^1.25.1",
         "@jupyter-widgets/base": "^1.2.3",
         "@jupyter-widgets/controls": "^1.4.3",
         "@jupyter-widgets/output": "^1.1.2",
@@ -13366,11 +13366,11 @@
             "@ant-design/icons": "^4.3.0",
             "@cocalc/assets": "^1.5.1",
             "@cocalc/cdn": "^1.8.2",
-            "@cocalc/hub": "^1.38.0",
+            "@cocalc/hub": "^1.38.2",
             "@cocalc/local-storage-lru": "^2.1.1",
             "@cocalc/project": "^1.13.4",
             "@cocalc/sync": "^0.2.3",
-            "@cocalc/util": "^1.25.0",
+            "@cocalc/util": "^1.25.1",
             "@jupyter-widgets/base": "^1.2.3",
             "@jupyter-widgets/controls": "^1.4.3",
             "@jupyter-widgets/output": "^1.1.2",
@@ -13513,9 +13513,9 @@
             "@cocalc/backend": "^1.10.0",
             "@cocalc/cdn": "^1.8.2",
             "@cocalc/database": "^0.13.0",
-            "@cocalc/frontend": "^1.29.0",
-            "@cocalc/server": "^0.12.0",
-            "@cocalc/util": "^1.25.0",
+            "@cocalc/frontend": "^1.30.0",
+            "@cocalc/server": "^0.12.1",
+            "@cocalc/util": "^1.25.1",
             "@types/express": "^4.17.13",
             "@types/react": "^17.0.33",
             "antd": "^4.18.2",
@@ -13546,11 +13546,11 @@
           "requires": {
             "@cocalc/backend": "^1.10.0",
             "@cocalc/database": "^0.13.0",
-            "@cocalc/util": "^1.24.0",
+            "@cocalc/util": "^1.25.1",
             "@sendgrid/mail": "^7.5.0",
             "@types/lodash": "^4.14.176",
             "@types/lru-cache": "^5.1.1",
-            "@types/node": "^14.17.32",
+            "@types/node": "^14.18.10",
             "@types/node-zendesk": "^2.0.4",
             "@types/nodemailer": "^6.4.4",
             "async-await-utils": "^3.0.1",
@@ -13572,8 +13572,8 @@
             "@cocalc/assets": "^1.5.1",
             "@cocalc/backend": "^1.10.0",
             "@cocalc/cdn": "^1.8.2",
-            "@cocalc/frontend": "^1.29.0",
-            "@cocalc/util": "^1.25.0",
+            "@cocalc/frontend": "^1.30.0",
+            "@cocalc/util": "^1.25.1",
             "@types/enzyme": "^3.10.8",
             "@types/jest": "^26.0.23",
             "@types/jquery": "^3.5.5",
@@ -14065,9 +14065,9 @@
           "dev": true
         },
         "@types/node": {
-          "version": "14.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-          "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+          "version": "14.18.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+          "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
         },
         "@types/nodemailer": {
           "version": "6.4.4",
@@ -20238,9 +20238,9 @@
         "@cocalc/backend": "^1.10.0",
         "@cocalc/cdn": "^1.8.2",
         "@cocalc/database": "^0.13.0",
-        "@cocalc/frontend": "^1.29.0",
-        "@cocalc/server": "^0.12.0",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/frontend": "^1.30.0",
+        "@cocalc/server": "^0.12.1",
+        "@cocalc/util": "^1.25.1",
         "@types/express": "^4.17.13",
         "@types/react": "^17.0.33",
         "antd": "^4.18.2",
@@ -20271,11 +20271,11 @@
       "requires": {
         "@cocalc/backend": "^1.10.0",
         "@cocalc/database": "^0.13.0",
-        "@cocalc/util": "^1.24.0",
+        "@cocalc/util": "^1.25.1",
         "@sendgrid/mail": "^7.5.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/node-zendesk": "^2.0.4",
         "@types/nodemailer": "^6.4.4",
         "async-await-utils": "^3.0.1",
@@ -20297,8 +20297,8 @@
         "@cocalc/assets": "^1.5.1",
         "@cocalc/backend": "^1.10.0",
         "@cocalc/cdn": "^1.8.2",
-        "@cocalc/frontend": "^1.29.0",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/frontend": "^1.30.0",
+        "@cocalc/util": "^1.25.1",
         "@types/enzyme": "^3.10.8",
         "@types/jest": "^26.0.23",
         "@types/jquery": "^3.5.5",
@@ -20790,9 +20790,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "@types/nodemailer": {
       "version": "6.4.4",

--- a/src/packages/hub/package.json
+++ b/src/packages/hub/package.json
@@ -98,7 +98,7 @@
   "devDependencies": {
     "@types/http-proxy": "^1.17.6",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.10",
     "@types/passport": "^1.0.3",
     "@types/react-dom": "^17.0.0",
     "@types/sanitize-html": "^2.3.1",

--- a/src/packages/project/package-lock.json
+++ b/src/packages/project/package-lock.json
@@ -27,6 +27,7 @@
         "awaiting": "^3.0.0",
         "better-sqlite3": "^7.1.0",
         "body-parser": "^1.19.0",
+        "chokidar": "^3.5.3",
         "commander": "^7.2.0",
         "compression": "^1.7.4",
         "daemonize-process": "^3.0.0",
@@ -77,7 +78,7 @@
         "@types/express": "^4.17.13",
         "@types/jquery": "^3.5.5",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "coffeelint": "^2.1.0",
         "coffeescript": "^2.5.1",
         "typescript": "^4.5.2"
@@ -2232,9 +2233,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -2785,23 +2786,29 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -4928,6 +4935,26 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
     "node_modules/mocha/node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -5001,6 +5028,17 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/mocha/node_modules/strip-json-comments": {
@@ -5672,9 +5710,9 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -8064,13 +8102,14 @@
         "@types/jquery": "^3.5.5",
         "@types/lru-cache": "^5.1.1",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/uuid": "^8.3.1",
         "async": "^1.5.2",
         "async-await-utils": "^3.0.1",
         "awaiting": "^3.0.0",
         "better-sqlite3": "^7.1.0",
         "body-parser": "^1.19.0",
+        "chokidar": "*",
         "coffeelint": "^2.1.0",
         "coffeescript": "^2.5.1",
         "commander": "^7.2.0",
@@ -9631,9 +9670,9 @@
           "dev": true
         },
         "@types/node": {
-          "version": "14.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-          "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+          "version": "14.18.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+          "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
         },
         "@types/qs": {
           "version": "6.9.7",
@@ -10076,18 +10115,18 @@
           }
         },
         "chokidar": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+          "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
           "requires": {
-            "anymatch": "~3.1.1",
+            "anymatch": "~3.1.2",
             "braces": "~3.0.2",
-            "fsevents": "~2.3.1",
-            "glob-parent": "~5.1.0",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.5.0"
+            "readdirp": "~3.6.0"
           }
         },
         "chownr": {
@@ -11724,6 +11763,21 @@
             "yargs-unparser": "2.0.0"
           },
           "dependencies": {
+            "chokidar": {
+              "version": "3.5.1",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+              "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+              "requires": {
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.1",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.5.0"
+              }
+            },
             "debug": {
               "version": "4.3.1",
               "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -11771,6 +11825,14 @@
               "version": "3.1.20",
               "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
               "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
+            },
+            "readdirp": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+              "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+              "requires": {
+                "picomatch": "^2.2.1"
+              }
             },
             "strip-json-comments": {
               "version": "3.1.1",
@@ -12286,9 +12348,9 @@
           }
         },
         "readdirp": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
           "requires": {
             "picomatch": "^2.2.1"
           }
@@ -13406,9 +13468,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -13851,18 +13913,18 @@
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
@@ -15499,6 +15561,21 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "chokidar": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -15546,6 +15623,14 @@
           "version": "3.1.20",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
           "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
         },
         "strip-json-comments": {
           "version": "3.1.1",
@@ -16061,9 +16146,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
       }

--- a/src/packages/project/package.json
+++ b/src/packages/project/package.json
@@ -36,6 +36,7 @@
     "awaiting": "^3.0.0",
     "better-sqlite3": "^7.1.0",
     "body-parser": "^1.19.0",
+    "chokidar": "^3.5.3",
     "commander": "^7.2.0",
     "compression": "^1.7.4",
     "daemonize-process": "^3.0.0",
@@ -83,7 +84,7 @@
     "@types/express": "^4.17.13",
     "@types/jquery": "^3.5.5",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.10",
     "coffeelint": "^2.1.0",
     "coffeescript": "^2.5.1",
     "typescript": "^4.5.2"

--- a/src/packages/project/sync/path-watcher.ts
+++ b/src/packages/project/sync/path-watcher.ts
@@ -20,7 +20,8 @@ The code below deals with two very different cases:
  - when the path does exist: use fs.watch (hence inotify) on the path itself to report when it changes
 
 NOTE: if you are running on a filesystem like NFS, inotify won't work well or not at all.
-In that case, set the env variable COCALC_FS_WATCHER=poll to use fs.watchFile instead.
+In that case, set the env variable COCALC_FS_WATCHER=poll to use polling instead.
+You can configure the poll interval by setting COCALC_FS_WATCHER_POLL_INTERVAL_MS.
 */
 
 import { watch, WatchOptions } from "chokidar";
@@ -117,11 +118,9 @@ export class Watcher extends EventEmitter {
     } else if (this.exists && !e) {
       // it got deleted
       this.exists = e;
-      for (const w in ["watchContentsInotify", "watchContentsPoll"]) {
-        if (this[w] != null) {
-          this[w].close();
-          delete this[w];
-        }
+      if (this.watchContents != null) {
+        this.watchContents.close();
+        delete this.watchContents;
       }
 
       this.change();

--- a/src/packages/project/sync/path-watcher.ts
+++ b/src/packages/project/sync/path-watcher.ts
@@ -18,87 +18,123 @@ The code below deals with two very different cases:
  - when that path doesn't exist: use fs.watch on the parent directory.
         NOTE: this case can't happen when path='', which exists, so we can assume to have read perms on parent.
  - when the path does exist: use fs.watch (hence inotify) on the path itself to report when it changes
+
+NOTE: if you are running on a filesystem like NFS, inotify won't work well or not at all.
+In that case, set the env variable COCALC_FS_WATCHER=poll to use fs.watchFile instead.
 */
 
-import { watch, FSWatcher } from "fs";
+import { watch, WatchOptions } from "chokidar";
+import { FSWatcher } from "fs";
 import { join } from "path";
 import { EventEmitter } from "events";
 import { debounce } from "lodash";
 import { exists } from "../jupyter/async-utils-node";
 import { close, path_split } from "@cocalc/util/misc";
+import { getLogger } from "@cocalc/project/logger";
+const L = getLogger("fs-watcher");
+
+const COCALC_FS_WATCHER = process.env.COCALC_FS_WATCHER ?? "inotify";
+if (!["inotify", "poll"].includes(COCALC_FS_WATCHER)) {
+  throw new Error(
+    `$COCALC_FS_WATCHER=${COCALC_FS_WATCHER} -- must be "inotify" or "poll"`
+  );
+}
+const POLLING = COCALC_FS_WATCHER === "poll";
+
+const DEFAULT_POLL_MS = parseInt(
+  process.env.COCALC_FS_WATCHER_POLL_INTERVAL_MS ?? "2000"
+);
+
+const ChokidarOpts: WatchOptions = {
+  persistent: true, // otherwise won't work
+  followSymlinks: false, // don't wander about
+  disableGlobbing: true, // watch the path as it is, that's it
+  usePolling: POLLING,
+  interval: DEFAULT_POLL_MS,
+  binaryInterval: DEFAULT_POLL_MS,
+  depth: 0, // we only care about the explicitly mentioned path – there could be a lot of files and sub-dirs!
+  // maybe some day we want this:
+  // awaitWriteFinish: {
+  //   stabilityThreshold: 100,
+  //   pollInterval: 50,
+  // },
+  ignorePermissionErrors: true,
+} as const;
 
 export class Watcher extends EventEmitter {
   private path: string;
   private exists: boolean;
-  private watch_contents?: FSWatcher;
-  private watch_existence?: FSWatcher;
+  private watchContents?: FSWatcher;
+  private watchExistence?: FSWatcher;
   private debounce_ms: number;
+  private debouncedChange: any;
   private log: Function;
 
-  constructor(path: string, debounce_ms: number, log: Function) {
+  constructor(path: string, debounce_ms: number) {
     super();
-    this.debounce_ms = debounce_ms;
-    this.log = log;
-    this.log(`Watcher("${path}")`);
+    this.log = L.extend(path).debug;
+    this.log(`initalizing: poll=${POLLING}`);
     if (process.env.HOME == null) throw Error("bug -- HOME must be defined");
     this.path = join(process.env.HOME, path);
+    this.debounce_ms = debounce_ms;
+    this.debouncedChange = debounce(this.change.bind(this), this.debounce_ms, {
+      leading: true,
+      trailing: true,
+    }).bind(this);
     this.init();
   }
 
   private async init(): Promise<void> {
     this.exists = await exists(this.path);
     if (this.path != "") {
-      this.init_watch_existence();
+      this.initWatchExistence();
     }
     if (this.exists) {
-      this.init_watch_contents();
+      this.initWatchContents();
     }
   }
 
-  private init_watch_contents(): void {
-    this.watch_contents = watch(
-      this.path,
-      debounce(this.change.bind(this), this.debounce_ms, {
-        leading: true,
-        trailing: true,
-      })
-    );
+  private initWatchContents(): void {
+    this.watchContents = watch(this.path, ChokidarOpts);
+    this.watchContents.on("all", this.debouncedChange);
   }
 
-  private async init_watch_existence(): Promise<void> {
+  private async initWatchExistence(): Promise<void> {
     const containing_path = path_split(this.path).head;
-    this.watch_existence = watch(containing_path, async (_, filename) => {
-      const path = join(containing_path, filename);
-      if (path != this.path) return;
-      const e = await exists(this.path);
-      if (!this.exists && e) {
-        // it sprung into existence
-        this.exists = e;
-        this.init_watch_contents();
-        this.change();
-      } else if (this.exists && !e) {
-        // it got deleted
-        this.exists = e;
-        if (this.watch_contents != null) {
-          this.watch_contents.close();
-          delete this.watch_contents;
-        }
-        this.change();
-      }
-    });
+    this.watchExistence = watch(containing_path, ChokidarOpts);
+    this.watchExistence.on("all", this.watchExistenceChange(containing_path));
   }
+
+  private watchExistenceChange = (containing_path) => async (_, filename) => {
+    const path = join(containing_path, filename);
+    if (path != this.path) return;
+    const e = await exists(this.path);
+    if (!this.exists && e) {
+      // it sprung into existence
+      this.exists = e;
+      this.initWatchContents();
+      this.change();
+    } else if (this.exists && !e) {
+      // it got deleted
+      this.exists = e;
+      for (const w in ["watchContentsInotify", "watchContentsPoll"]) {
+        if (this[w] != null) {
+          this[w].close();
+          delete this[w];
+        }
+      }
+
+      this.change();
+    }
+  };
 
   private change(): void {
     this.emit("change");
   }
 
   public close(): void {
-    if (this.watch_contents != null) {
-      this.watch_contents.close();
-    }
-    if (this.watch_existence != null) {
-      this.watch_existence.close();
-    }
+    this.watchExistence?.close();
+    this.watchContents?.close();
     close(this);
   }
 }

--- a/src/packages/server/package-lock.json
+++ b/src/packages/server/package-lock.json
@@ -15,9 +15,9 @@
         "../util"
       ],
       "dependencies": {
-        "@cocalc/backend": "^1.7.2",
-        "@cocalc/database": "^0.7.0",
-        "@cocalc/util": "^1.18.0",
+        "@cocalc/backend": "^1.10.0",
+        "@cocalc/database": "^0.13.0",
+        "@cocalc/util": "^1.25.1",
         "@sendgrid/mail": "^7.5.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
@@ -35,13 +35,13 @@
         "stripe": "^8.78.0"
       },
       "devDependencies": {
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "typescript": "^4.5.2"
       }
     },
     "../backend": {
       "name": "@cocalc/backend",
-      "version": "1.7.2",
+      "version": "1.10.0",
       "license": "SEE LICENSE.md",
       "workspaces": [
         ".",
@@ -49,7 +49,7 @@
       ],
       "dependencies": {
         "@airbnb/node-memwatch": "^2.0.0",
-        "@cocalc/util": "^1.15.1",
+        "@cocalc/util": "^1.24.0",
         "@types/debug": "^4.1.7",
         "@types/lru-cache": "^5.1.1",
         "async": "^1.5.2",
@@ -75,7 +75,7 @@
     },
     "../database": {
       "name": "@cocalc/database",
-      "version": "0.7.0",
+      "version": "0.13.0",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "./",
@@ -84,9 +84,9 @@
         "../util"
       ],
       "dependencies": {
-        "@cocalc/backend": "^1.7.2",
-        "@cocalc/server": "^0.5.0",
-        "@cocalc/util": "^1.18.0",
+        "@cocalc/backend": "^1.10.0",
+        "@cocalc/server": "^0.12.0",
+        "@cocalc/util": "^1.24.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
         "@types/pg": "^8.6.1",
@@ -115,7 +115,7 @@
     },
     "../util": {
       "name": "@cocalc/util",
-      "version": "1.18.1",
+      "version": "1.25.1",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "."
@@ -1886,9 +1886,9 @@
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "node_modules/@types/node-zendesk": {
       "version": "2.0.4",
@@ -4521,7 +4521,7 @@
       "version": "file:../backend",
       "requires": {
         "@airbnb/node-memwatch": "^2.0.0",
-        "@cocalc/util": "^1.15.1",
+        "@cocalc/util": "^1.24.0",
         "@types/debug": "^4.1.7",
         "@types/lru-cache": "^5.1.1",
         "async": "^1.5.2",
@@ -4546,9 +4546,9 @@
     "@cocalc/database": {
       "version": "file:../database",
       "requires": {
-        "@cocalc/backend": "^1.7.2",
-        "@cocalc/server": "^0.5.0",
-        "@cocalc/util": "^1.18.0",
+        "@cocalc/backend": "^1.10.0",
+        "@cocalc/server": "^0.12.0",
+        "@cocalc/util": "^1.24.0",
         "@types/lodash": "^4.14.176",
         "@types/lru-cache": "^5.1.1",
         "@types/node": "^14.17.32",
@@ -4595,7 +4595,7 @@
         "nodemailer": "^6.7.0",
         "parse-domain": "^4.1.0",
         "random-key": "^0.3.2",
-        "stripe": "8.78.0",
+        "stripe": "^8.78.0",
         "typescript": "^4.5.2"
       },
       "dependencies": {
@@ -5709,7 +5709,7 @@
           "version": "file:../backend",
           "requires": {
             "@airbnb/node-memwatch": "^2.0.0",
-            "@cocalc/util": "^1.15.1",
+            "@cocalc/util": "^1.24.0",
             "@types/debug": "^4.1.7",
             "@types/lru-cache": "^5.1.1",
             "async": "^1.5.2",
@@ -5734,9 +5734,9 @@
         "@cocalc/database": {
           "version": "file:../database",
           "requires": {
-            "@cocalc/backend": "^1.7.2",
-            "@cocalc/server": "^0.5.0",
-            "@cocalc/util": "^1.18.0",
+            "@cocalc/backend": "^1.10.0",
+            "@cocalc/server": "^0.12.0",
+            "@cocalc/util": "^1.24.0",
             "@types/lodash": "^4.14.176",
             "@types/lru-cache": "^5.1.1",
             "@types/node": "^14.17.32",
@@ -5834,9 +5834,9 @@
           "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
         },
         "@types/node": {
-          "version": "14.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-          "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+          "version": "14.18.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+          "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
         },
         "@types/node-zendesk": {
           "version": "2.0.4",
@@ -7046,9 +7046,9 @@
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
     },
     "@types/node-zendesk": {
       "version": "2.0.4",

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -60,7 +60,7 @@
     "url": "https://github.com/sagemathinc/cocalc"
   },
   "devDependencies": {
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.10",
     "typescript": "^4.5.2"
   }
 }

--- a/src/packages/static/package-lock.json
+++ b/src/packages/static/package-lock.json
@@ -19,12 +19,12 @@
         "@cocalc/assets": "^1.5.1",
         "@cocalc/backend": "^1.10.0",
         "@cocalc/cdn": "^1.8.2",
-        "@cocalc/frontend": "^1.29.0",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/frontend": "^1.30.0",
+        "@cocalc/util": "^1.25.1",
         "@types/enzyme": "^3.10.8",
         "@types/jest": "^26.0.23",
         "@types/jquery": "^3.5.5",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/react": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^4.24.0",
         "@typescript-eslint/parser": "^4.24.0",
@@ -161,7 +161,7 @@
     },
     "../frontend": {
       "name": "@cocalc/frontend",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "./",
@@ -176,11 +176,11 @@
         "@ant-design/icons": "^4.3.0",
         "@cocalc/assets": "^1.5.1",
         "@cocalc/cdn": "^1.8.2",
-        "@cocalc/hub": "^1.38.0",
+        "@cocalc/hub": "^1.38.2",
         "@cocalc/local-storage-lru": "^2.1.1",
         "@cocalc/project": "^1.13.4",
         "@cocalc/sync": "^0.2.3",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/util": "^1.25.1",
         "@jupyter-widgets/base": "^1.2.3",
         "@jupyter-widgets/controls": "^1.4.3",
         "@jupyter-widgets/output": "^1.1.2",
@@ -320,7 +320,7 @@
     },
     "../util": {
       "name": "@cocalc/util",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "."
@@ -344,7 +344,7 @@
         "@types/jest": "^26.0.23",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.176",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "coffee-cache": "^1.0.2",
         "coffee-coverage": "^3.0.1",
         "coffeelint": "^2.1.0",
@@ -1840,9 +1840,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -18224,11 +18224,11 @@
         "@ant-design/icons": "^4.3.0",
         "@cocalc/assets": "^1.5.1",
         "@cocalc/cdn": "^1.8.2",
-        "@cocalc/hub": "^1.38.0",
+        "@cocalc/hub": "^1.38.2",
         "@cocalc/local-storage-lru": "^2.1.1",
         "@cocalc/project": "^1.13.4",
         "@cocalc/sync": "^0.2.3",
-        "@cocalc/util": "^1.25.0",
+        "@cocalc/util": "^1.25.1",
         "@jupyter-widgets/base": "^1.2.3",
         "@jupyter-widgets/controls": "^1.4.3",
         "@jupyter-widgets/output": "^1.1.2",
@@ -18370,7 +18370,7 @@
         "@types/jest": "^26.0.23",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.176",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/uuid": "^8.3.1",
         "async": "^1.5.2",
         "async-await-utils": "^3.0.1",
@@ -19081,9 +19081,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/src/packages/static/package.json
+++ b/src/packages/static/package.json
@@ -56,7 +56,7 @@
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^26.0.23",
     "@types/jquery": "^3.5.5",
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.10",
     "@types/react": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",

--- a/src/packages/sync/package-lock.json
+++ b/src/packages/sync/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@types/jest": "^26.0.23",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "jest": "^26.6.3",
         "ts-jest": "^26.5.6",
         "typescript": "^4.5.2"
@@ -30,7 +30,7 @@
     },
     "../util": {
       "name": "@cocalc/util",
-      "version": "1.18.1",
+      "version": "1.25.1",
       "license": "SEE LICENSE.md",
       "workspaces": [
         "."
@@ -54,7 +54,7 @@
         "@types/jest": "^26.0.23",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.176",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "coffee-cache": "^1.0.2",
         "coffee-coverage": "^3.0.1",
         "coffeelint": "^2.1.0",
@@ -2262,9 +2262,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.17.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
-      "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -8915,7 +8915,7 @@
         "jest": "^26.6.3",
         "json-stable-stringify": "^1.0.1",
         "ts-jest": "^26.5.6",
-        "typescript": "4.5.2"
+        "typescript": "^4.5.2"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -10120,7 +10120,7 @@
             "@types/jest": "^26.0.23",
             "@types/json-stable-stringify": "^1.0.32",
             "@types/lodash": "^4.14.176",
-            "@types/node": "^14.17.32",
+            "@types/node": "^14.18.10",
             "@types/uuid": "^8.3.1",
             "async": "^1.5.2",
             "async-await-utils": "^3.0.1",
@@ -10498,9 +10498,9 @@
           }
         },
         "@types/node": {
-          "version": "14.17.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
-          "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
+          "version": "14.18.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+          "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
           "dev": true
         },
         "@types/normalize-package-data": {
@@ -14759,7 +14759,7 @@
         "@types/jest": "^26.0.23",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.176",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "@types/uuid": "^8.3.1",
         "async": "^1.5.2",
         "async-await-utils": "^3.0.1",
@@ -15137,9 +15137,9 @@
       }
     },
     "@types/node": {
-      "version": "14.17.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
-      "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/src/packages/sync/package.json
+++ b/src/packages/sync/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.10",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",
     "typescript": "^4.5.2"

--- a/src/packages/util/package-lock.json
+++ b/src/packages/util/package-lock.json
@@ -30,7 +30,7 @@
         "@types/jest": "^26.0.23",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.176",
-        "@types/node": "^14.17.32",
+        "@types/node": "^14.18.10",
         "coffee-cache": "^1.0.2",
         "coffee-coverage": "^3.0.1",
         "coffeelint": "^2.1.0",
@@ -2601,9 +2601,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -14784,9 +14784,9 @@
           "dev": true
         },
         "@types/node": {
-          "version": "14.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-          "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+          "version": "14.18.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+          "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
           "dev": true
         },
         "@types/normalize-package-data": {
@@ -22559,9 +22559,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/src/packages/util/package.json
+++ b/src/packages/util/package.json
@@ -53,7 +53,7 @@
     "@types/jest": "^26.0.23",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash": "^4.14.176",
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.10",
     "coffee-cache": "^1.0.2",
     "coffee-coverage": "^3.0.1",
     "coffeelint": "^2.1.0",


### PR DESCRIPTION
# Description

cocalc onprem setups using NFS do not watch the files reliably. there is a package "chokidar", which uses inotify or polling, and also claims to be more robust. it's used by vscode and others, so I think it's fine to add it as a dependency. I also configured it in such a way that it doesn't watch/poll for all the subdirectories – it's should be the same overall mechanism as before.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
