### PR TITLE
backend only aspect of #5723

### DIFF
--- a/src/packages/util/consts/site-license.ts
+++ b/src/packages/util/consts/site-license.ts
@@ -1,0 +1,59 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { sortBy } from "lodash";
+import { SiteLicenseQuota } from "../types/site-licenses";
+
+type Keys = NonNullable<SiteLicenseQuota["idle_timeout"]>;
+
+// Site Licenses related constants
+// the license timeouts combined with the default quota (either hardcoded or the one from the site_settings)
+// hence 30 minutes + 30 minutes default result in 30 minutes, and the same for "medium" and "day"
+// @see DEFAULT_QUOTAS.mintime in src/packages/util/upgrade-spec.js
+// medium and day imply member hosting
+export const LicenseIdleTimeouts: {
+  [key in Keys]: {
+    mins: number;
+    label: string;
+    priceFactor: number;
+    requireMemberhosting?: boolean; // if true, require member hosting
+  };
+} = {
+  short: {
+    mins: 30,
+    label: "30 minutes",
+    priceFactor: 1,
+  },
+  medium: { mins: 2 * 60, label: "2 hours", priceFactor: 2 },
+  day: {
+    mins: 24 * 60,
+    label: "1 day",
+    priceFactor: 4,
+    requireMemberhosting: true,
+  },
+} as const;
+
+export const LicenseIdleTimeoutsKeysOrdered = sortBy(
+  Object.keys(LicenseIdleTimeouts),
+  (v) => LicenseIdleTimeouts[v].mins
+) as Readonly<Keys[]>;
+
+export function requiresMemberhosting(key?: Uptime | string): boolean {
+  if (key == null) return false;
+  if (key == "always_running") return true;
+  return LicenseIdleTimeouts[key]?.requireMemberhosting ?? false;
+}
+
+export type Uptime = keyof typeof LicenseIdleTimeouts | "always_running";
+
+export function untangleUptime(uptime: Uptime): {
+  always_running: boolean;
+  idle_timeout: Keys;
+} {
+  if (uptime == "always_running") {
+    return { always_running: true, idle_timeout: "day" };
+  }
+  return { always_running: false, idle_timeout: uptime };
+}

--- a/src/packages/util/test/quota.test.ts
+++ b/src/packages/util/test/quota.test.ts
@@ -6,7 +6,7 @@
 // this tests kucalc's quota function
 //
 // after any change to quota.ts, be a good citizen and run this test or even extend it
-// ~/src/@cocalc/hub/test$ SMC_DB_RESET=true SMC_TEST=true npx jest kucalc/quota.test.ts
+// …/packages/util/test$ SMC_DB_RESET=true SMC_TEST=true npx jest quota.test.ts
 
 // import * as init from "./init";
 //let db = undefined;
@@ -1504,15 +1504,6 @@ describe("default quota", () => {
     expect(LicenseIdleTimeoutsKeysOrdered).toEqual(["short", "medium", "day"]);
   });
 
-  it("licensed idle timeout / non members are always short", () => {
-    const q0 = quota(
-      {},
-      {},
-      { l: { quota: { idle_timeout: "day", member: false } } }
-    );
-    expect(q0.idle_timeout).toBe(30 * 60); // short
-  });
-
   it("licensed idle timeout / priority", () => {
     const site_licenses: SiteLicenses = {
       a: {
@@ -1584,7 +1575,7 @@ describe("default quota", () => {
     expect(q.memory_limit).toBe(5000);
   });
 
-  it("licensed idle timeout / short is automatically member, unless set to false", () => {
+  it("licensed idle timeout / short (automatically member)", () => {
     const q0 = quota(
       {},
       {},
@@ -1593,13 +1584,19 @@ describe("default quota", () => {
     expect(q0.idle_timeout).toBe(30 * 60); // short
     expect(q0.member_host).toBe(false);
 
-    const q1 = quota(
-      {},
-      {},
-      { l: { quota: { idle_timeout: "short", member: true } } }
-    );
+    const q1 = quota({}, {}, { l: { quota: { idle_timeout: "short" } } });
     expect(q1.idle_timeout).toBe(30 * 60); // short
     expect(q1.member_host).toBe(true);
+  });
+
+  it("licensed idle timeout / non member hosting medium", () => {
+    const q0 = quota(
+      {},
+      {},
+      { l: { quota: { idle_timeout: "medium", member: false } } }
+    );
+    expect(q0.idle_timeout).toBe(2 * 60 * 60); // medium
+    expect(q0.member_host).toBe(false);
   });
 
   it("licensed idle timeout / mixed with user upgrades", () => {

--- a/src/packages/util/types/site-licenses.ts
+++ b/src/packages/util/types/site-licenses.ts
@@ -1,0 +1,39 @@
+import { Upgrades } from "../upgrades/types";
+import { DedicatedDisk, DedicatedVM } from "./dedicated";
+
+export interface SiteLicenseQuota {
+  ram?: number;
+  dedicated_ram?: number;
+  cpu?: number;
+  dedicated_cpu?: number;
+  disk?: number;
+  always_running?: boolean;
+  member?: boolean;
+  user?: "academic" | "business";
+  dedicated_vm?: DedicatedVM | boolean;
+  dedicated_disk?: DedicatedDisk;
+  // idle_timeouts came later:
+  // 1. they don't mix, just like member/free and always_running does not mix
+  // 2. we define the timeout spans indirectly, gives us a bit of room to modify this later on.
+  idle_timeout?: "short" | "medium" | "day";
+}
+
+// For typescript use of these from user side, we make this available:
+export interface SiteLicense {
+  id: string;
+  title?: string;
+  description?: string;
+  info?: { [key: string]: any };
+  expires?: Date;
+  activates?: Date;
+  created?: Date;
+  last_used?: Date;
+  managers?: string[];
+  restricted?: boolean;
+  upgrades?: Upgrades;
+  quota?: SiteLicenseQuota;
+  run_limit?: number;
+  apply_limit?: number;
+}
+
+export type SiteLicenses = { [uuid: string]: SiteLicense };

--- a/src/packages/util/upgrades/quota.ts
+++ b/src/packages/util/upgrades/quota.ts
@@ -331,10 +331,6 @@ function prepareSiteLicenses(site_licenses?: SiteLicenses): SiteLicenses {
     if (!isSiteLicenseQuotaSetting(sl)) continue;
     const slq = sl.quota;
     const validIdleTimeouts = Object.keys(LicenseIdleTimeouts);
-    // preempts are always short!
-    if (slq.member === false) {
-      slq.idle_timeout = "short";
-    }
     if (slq.idle_timeout != null) {
       // reset idle_timeouts we don't know
       if (!validIdleTimeouts.includes(slq.idle_timeout)) {

--- a/src/packages/util/upgrades/quota.ts
+++ b/src/packages/util/upgrades/quota.ts
@@ -38,10 +38,15 @@ costs add).
 
 import { isEmpty } from "lodash";
 import { DEFAULT_QUOTAS, upgrades } from "../upgrade-spec";
-import { Quota as SiteLicenseQuota } from "../db-schema/site-licenses";
+
 import { DedicatedDisk, DedicatedVM } from "@cocalc/util/types/dedicated";
 import { len } from "../misc";
 import { VMS } from "@cocalc/util/upgrades/dedicated";
+import { SiteLicenseQuota } from "../types/site-licenses";
+import {
+  LicenseIdleTimeouts,
+  LicenseIdleTimeoutsKeysOrdered,
+} from "../consts/site-license";
 // TODO how to use the logger ?
 //import { getLogger } from "@cocalc/backend/logger";
 //const L = getLogger("upgrades:quota");
@@ -231,7 +236,7 @@ function sanitize_overcommit(oc: number | undefined): number | undefined {
 }
 
 // the quota calculation starts with certain base quotas, which could be modified by the site_settings
-function calc_default_quotas(site_settings?: SiteSettingsQuotas): Quota {
+function calcDefaultQuotas(site_settings?: SiteSettingsQuotas): Quota {
   const quota: Quota = { ...BASE_QUOTAS };
 
   // overwrite/set extras for any set default quota in the site setting
@@ -316,67 +321,130 @@ function select_dedicated_disks(site_licenses: SiteLicenses): DedicatedDisk[] {
   return dedicated_disks;
 }
 
+/**
+ * We imply/normalize some settings in order to make the remaining processing easier.
+ */
+function prepareSiteLicenses(site_licenses?: SiteLicenses): SiteLicenses {
+  if (site_licenses == null || isEmpty(site_licenses)) return {};
+
+  for (const sl of Object.values(site_licenses)) {
+    if (!isSiteLicenseQuotaSetting(sl)) continue;
+    const slq = sl.quota;
+    const validIdleTimeouts = Object.keys(LicenseIdleTimeouts);
+    // preempts are always short!
+    if (slq.member === false) {
+      slq.idle_timeout = "short";
+    }
+    if (slq.idle_timeout != null) {
+      // reset idle_timeouts we don't know
+      if (!validIdleTimeouts.includes(slq.idle_timeout)) {
+        slq.idle_timeout = "short";
+      }
+      // every license with an idle_timeout gets member hosting – unless explicitly disabled (shouldn't be the case)
+      if (slq.member !== false) slq.member = true;
+    } else {
+      // if there is no idle_timeout set, we default to "short"
+      slq.idle_timeout = "short";
+    }
+  }
+
+  return site_licenses;
+}
+
+// this is used below to map the various types of site license upgrades into unique groups
+// key is <member:0/1>-<always_running:0/1>-<idle_timeout>
+function makeSiteLicenseGroupKey(params: {
+  always_running: "0" | "1";
+  member_hosting: "0" | "1";
+  idle_timeout: NonNullable<SiteLicenseQuota["idle_timeout"]>;
+}): string {
+  const { always_running: ar, member_hosting: mh, idle_timeout: it } = params;
+  return `${ar}-${mh}-${it}`;
+}
+
+// return all possible key combinations,
+// where the order is from highest to lowest priority
+function* siteLicenseSelectionKeys() {
+  const ltkeys = LicenseIdleTimeoutsKeysOrdered.slice(0);
+  // reversing a copy of ordered keys
+  ltkeys.reverse();
+  // one first, higher priority
+  const oneZero = ["1", "0"] as const;
+  // always running
+  for (const ar of oneZero) {
+    // member hosting
+    for (const mh of oneZero) {
+      for (const it of ltkeys) {
+        const k = makeSiteLicenseGroupKey({
+          always_running: ar,
+          member_hosting: mh,
+          idle_timeout: it,
+        });
+        yield k;
+      }
+    }
+  }
+}
+
 // some site licenses do not mix.
 // e.g. always_running==true can't upgrade another (especially large) one not having always_running set.
 // also preempt upgrades shouldn't uprade member hosting upgades.
 //
 // this heuristic groups all licenses by always_running and member hosting, and then picks the first nonempty group.
-// TODO: once we have a license with an extended uptime (hours instead of ~30 mins), we introduce that as a third dimension.
+// 2022-02: introducing a third dimension for "idle_timeout" license quota upgrades.
 //
 // Fall 2021: on top of that, "dedicted resources" are treated in a special way
 // * VMs: do not mix with any other upgrades, only one per project
 // * disks: orthogonal to VMs, more than one per project is possible
-function select_site_licenses(site_licenses?: SiteLicenses): {
+function selectSiteLicenses(site_licenses: SiteLicenses): {
   site_licenses: SiteLicenses;
   dedicated_disks?: DedicatedDisk[];
   dedicated_vm?: DedicatedVM;
 } {
-  if (site_licenses == null || isEmpty(site_licenses))
-    return { site_licenses: {} };
-
   // this "extracts" all dedicated disk upgrades from the site_licenses map
   const dedicated_disks = select_dedicated_disks(site_licenses);
 
   const dedicated_vm: DedicatedVM | null = select_dedicated_vm(site_licenses);
 
+  // if there is a dedicated VM, we ignore all site licenses.
   if (dedicated_vm != null) {
     return { site_licenses: {}, dedicated_disks, dedicated_vm };
   }
 
-  // key is <member>-<always_running> as 0/1 numbers
-  const groups = {
-    "0-0": [],
-    "0-1": [],
-    "1-0": [],
-    "1-1": [],
-  } as { [key: string]: string[] };
-
-  // classification
+  // classification: each group is a list of licenses, and only the group
+  // with the higest priority is considered for license upgrades.
+  const groups: { [key: string]: string[] | null } = {};
   for (const [key, val] of Object.entries(site_licenses)) {
     if (val == null) continue;
 
-    const is_ar = isSiteLicenseQuotaSetting(val)
+    const isAR = isSiteLicenseQuotaSetting(val)
       ? val.quota.always_running === true
       : ((val as Upgrades).always_running ?? 0) >= 1;
 
-    const is_member = isSiteLicenseQuotaSetting(val)
+    const isMember = isSiteLicenseQuotaSetting(val)
       ? val.quota.member === true
       : ((val as Upgrades).member_host ?? 0) >= 1;
 
-    groups[`${is_member ? "1" : "0"}-${is_ar ? "1" : "0"}`].push(key);
+    // prepareSiteLicenses() takes care about always defining quota.idle_timeout (still, TS needs to know)
+    const idle_timeout =
+      (isSiteLicenseQuotaSetting(val) ? val.quota.idle_timeout : "short") ??
+      "short";
+
+    const groupKey = makeSiteLicenseGroupKey({
+      always_running: isAR ? "1" : "0",
+      member_hosting: isMember ? "1" : "0",
+      idle_timeout,
+    });
+
+    const curGrp = groups[groupKey];
+    groups[groupKey] = curGrp == null ? [key] : [...curGrp, key];
   }
 
   // selection -- always_running comes first, then member hosting
   const selected: string[] | undefined = (function () {
-    for (const ar of ["1", "0"]) {
-      // always running
-      for (const mh of ["1", "0"]) {
-        // member hosting
-        const k = `${mh}-${ar}`;
-        if (groups[k].length > 0) {
-          return groups[k];
-        }
-      }
+    for (const k of siteLicenseSelectionKeys()) {
+      const grp = groups[k];
+      if (grp != null && grp.length > 0) return grp;
     }
   })();
 
@@ -388,6 +456,19 @@ function select_site_licenses(site_licenses?: SiteLicenses): {
   }, {});
 
   return { site_licenses: selected_licenses, dedicated_disks };
+}
+
+// idle_timeouts aren't added up. All are assumed to have the *same* idle_timeout
+// so we just take the first one. @see selectSiteLicense.
+// the basic unit is seconds!
+function calcSiteLicenseQuotaIdleTimeout(
+  site_licenses?: SiteLicenseQuotaSetting[]
+): number {
+  if (site_licenses == null || site_licenses.length === 0) return 0;
+  const sl = site_licenses[0];
+  const it = sl.quota.idle_timeout;
+  if (it == null) return 0;
+  return LicenseIdleTimeouts[it].mins * 60;
 }
 
 // there is an old schema, inherited from SageMathCloud, etc. and newer iterations.
@@ -425,7 +506,7 @@ function license2quota(q: Partial<SiteLicenseQuota>): RQuota {
     cpu_limit: (q.cpu ?? 0) + (q.dedicated_cpu ?? 0),
     cpu_request: q.dedicated_cpu ?? 0,
     privileged: false,
-    idle_timeout: 0, // always zero, until we have an upgrade schema in place
+    idle_timeout: 0, // idle_timeout is set AFTER summing up all licenses, they're not additive
     dedicated_vm: q.dedicated_vm ?? false,
     dedicated_disks: [] as DedicatedDisk[],
   };
@@ -582,11 +663,20 @@ function quota_v2(opts: OptsV2): Quota {
     ...Object.values(site_licenses).filter(isSettingsQuota).map(upgrade2quota)
   );
 
+  // those site licenses, which have a {quota : ...} set
+  const site_license_quota_settings = Object.values(site_licenses).filter(
+    isSiteLicenseQuotaSetting
+  );
+
   // v2 of licenses, indirectly via {quota: {…}} objects, introducing yet another schema.
   const license_quota_sum = sum_quotas(
-    ...Object.values(site_licenses)
-      .filter(isSiteLicenseQuotaSetting)
-      .map((l: SiteLicenseQuotaSetting) => license2quota(l.quota))
+    ...site_license_quota_settings.map((l: SiteLicenseQuotaSetting) =>
+      license2quota(l.quota)
+    )
+  );
+
+  license_quota_sum.idle_timeout = calcSiteLicenseQuotaIdleTimeout(
+    site_license_quota_settings
   );
 
   // the main idea is old upgrades and licenses quotas only complement each other – not add up.
@@ -638,7 +728,7 @@ export function quota(
   site_settings = Object.freeze(site_settings);
 
   // new quota object, we modify it in-place below and return it.
-  let quota: Quota = calc_default_quotas(site_settings);
+  let quota: Quota = calcDefaultQuotas(site_settings);
 
   // site settings max quotas overwrite the hardcoded values
   const max_upgrades: Upgrades = Object.freeze({
@@ -646,12 +736,15 @@ export function quota(
     ...(site_settings?.max_upgrades ?? {}),
   });
 
+  // site_licenses will at least be an empty dict object
+  site_licenses = prepareSiteLicenses(site_licenses);
+
   // we might not consider all of them!
   const {
     site_licenses: site_licenses_selected,
     dedicated_disks = [],
     dedicated_vm = false,
-  } = select_site_licenses(site_licenses);
+  } = selectSiteLicenses(site_licenses);
 
   site_licenses = Object.freeze(site_licenses_selected);
 
@@ -712,7 +805,7 @@ export function site_license_quota(
 ): Quota {
   // we filter here as well, b/c this function is used elsewhere
   const { site_licenses: site_licenses_selected, dedicated_vm = false } =
-    select_site_licenses(site_licenses);
+    selectSiteLicenses(site_licenses);
   site_licenses = Object.freeze(site_licenses_selected);
   // a fallback, should take site settings into account here as well
   const max_upgrades: Upgrades = max_upgrades_param ?? MAX_UPGRADES;


### PR DESCRIPTION
# Description

This is the a first phase of #5723, such that we can update the backend services first and then do the frontend related part.

this is ready to be merged. the main detail about all this is that all previous quota tests weren't touched and they still pass. so, no impact for the existing functionality. `util/consts/site-license.ts` defines the new upgrade types. once this is in, I'll deploy it on the backend and will test it with manually created licenses. then we can fine tune the frontend part.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
