### PR TITLE
frontend: fix %20 in filenames 

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/util.ts
+++ b/src/packages/frontend/frame-editors/frame-tree/util.ts
@@ -8,6 +8,7 @@ Utility functions useful for frame-tree editors.
 */
 
 import { path_split, separate_file_extension } from "@cocalc/util/misc";
+import { encode_path } from "@cocalc/util/misc";
 import { join } from "path";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 
@@ -22,5 +23,9 @@ export function parse_path(path: string): {
 }
 
 export function raw_url(project_id: string, path: string): string {
-  return join(appBasePath, project_id, "raw", path);
+  // we have to encode the path, since we query this raw server. see
+  // https://github.com/sagemathinc/cocalc/issues/5542
+  // but actually, this is a problem for types of files, not just PDF
+  const path_enc = encode_path(path);
+  return join(appBasePath, project_id, "raw", path_enc);
 }

--- a/src/packages/frontend/frame-editors/html-editor/iframe-html.tsx
+++ b/src/packages/frontend/frame-editors/html-editor/iframe-html.tsx
@@ -27,8 +27,7 @@ import { debounce } from "lodash";
 import { React, ReactDOM, Rendered, CSS } from "../../app-framework";
 import { use_font_size_scaling } from "../frame-tree/hooks";
 import { EditorState } from "../frame-tree/types";
-import { join } from "path";
-import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { raw_url } from "../frame-tree/util";
 
 interface Props {
   id: string;
@@ -171,12 +170,7 @@ export const IFrameHTML: React.FC<Props> = React.memo((props: Props) => {
     }
 
     // param below is just to avoid caching.
-    const src = join(
-      appBasePath,
-      project_id,
-      "raw",
-      `${actual_path}?param=${reload}`
-    );
+    const src = `${raw_url(project_id, actual_path)}?param=${reload}`;
 
     return (
       <iframe

--- a/src/packages/frontend/frame-editors/latex-editor/pdfjs-doc-cache.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/pdfjs-doc-cache.ts
@@ -37,7 +37,6 @@ import type { PDFDocumentProxy } from "pdfjs-dist/webpack";
 
 import { raw_url } from "../frame-tree/util";
 import { pdf_path } from "./util";
-import { encode_path } from "@cocalc/util/misc";
 
 const options = {
   max: MAX_PAGES,
@@ -51,7 +50,7 @@ export function url_to_pdf(
   path: string,
   reload: number
 ): string {
-  const url = raw_url(project_id, encode_path(pdf_path(path)));
+  const url = raw_url(project_id, pdf_path(path));
   return `${url}?param=${reload}`;
 }
 

--- a/src/packages/frontend/frame-editors/pdf-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/pdf-editor/actions.ts
@@ -8,7 +8,10 @@ PDF Editor Actions
 */
 
 import { FrameTree } from "../frame-tree/types";
-import { Actions as BaseActions, CodeEditorState } from "../code-editor/actions";
+import {
+  Actions as BaseActions,
+  CodeEditorState,
+} from "../code-editor/actions";
 import { print_html } from "../frame-tree/print";
 import { raw_url } from "../frame-tree/util";
 

--- a/src/packages/util/misc.ts
+++ b/src/packages/util/misc.ts
@@ -63,7 +63,6 @@ export {
   YEAR,
 } from "./relative-time";
 
-
 import sha1 from "sha1";
 export { sha1 };
 


### PR DESCRIPTION

# Description


- see #5542
- this is an issue for for pdf native, rst, iframe/html, ipynb reveal.js slideshow and .wiki files 
- I probably also fixed this for the latex editor, but %20 is forbidden in filenames anyways

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
