### PR TITLE
x11 editor: functional components

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -462,7 +462,7 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
       return;
     }
 
-    const items: Rendered[] = [100, 125, 150, 200].map((zoom) => {
+    const items: Rendered[] = [85, 100, 115, 125, 150, 200].map((zoom) => {
       return <MenuItem key={zoom}>{`${zoom}%`}</MenuItem>;
     });
 

--- a/src/packages/frontend/frame-editors/x11-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/actions.ts
@@ -100,11 +100,6 @@ export class Actions extends BaseActions<X11EditorState> {
     this.setState({ disabled: !ok, config_unknown, x11_apps });
   }
 
-  /*
-  _raw_default_frame_tree(): FrameTree {
-    return { type: "x11" };
-  }
-  */
   _raw_default_frame_tree(): FrameTree {
     return {
       direction: "col",

--- a/src/packages/frontend/frame-editors/x11-editor/launcher.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/launcher.tsx
@@ -7,7 +7,7 @@
 X11 Window frame.
 */
 
-import { React, Rendered, useRedux } from "../../app-framework";
+import { React, Rendered, TypedMap, useRedux } from "../../app-framework";
 import { Button } from "@cocalc/frontend/antd-bootstrap";
 import { Icon } from "../../components";
 import { APPS } from "./apps";
@@ -38,7 +38,10 @@ function isSame(prev, next) {
 export const Launcher: React.FC<Props> = React.memo((props: Props) => {
   const { actions, name } = props;
 
-  const x11_apps: Readonly<Capabilities> = useRedux(name, "x11_apps");
+  const x11_apps: TypedMap<Capabilities> | undefined = useRedux(
+    name,
+    "x11_apps"
+  );
 
   const launch = debounce(_launch, 500, { leading: true, trailing: false });
 
@@ -78,7 +81,7 @@ export const Launcher: React.FC<Props> = React.memo((props: Props) => {
     if (available == null) return [];
     // hide those apps, where certainly know they're not available
     return APP_KEYS.filter((app) => {
-      const avail = available[app];
+      const avail = available.get(app);
       return avail !== false;
     }).map(render_launcher);
   }

--- a/src/packages/frontend/frame-editors/x11-editor/launcher.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/launcher.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 function isSame(prev, next) {
-  return !is_different(prev, next, ["x11_apps"]);
+  return true;
 }
 
 export const Launcher: React.FC<Props> = React.memo((props: Props) => {
@@ -43,13 +43,11 @@ export const Launcher: React.FC<Props> = React.memo((props: Props) => {
     "x11_apps"
   );
 
-  const launch = debounce(_launch, 500, { leading: true, trailing: false });
+  const launch = debounce(_launch, 1000, { leading: true, trailing: false });
 
   function _launch(app: string): void {
     const desc = APPS[app];
-    if (desc == null) {
-      return;
-    }
+    if (desc == null) return;
     actions.launch(desc.command ? desc.command : app, desc.args);
   }
 
@@ -79,7 +77,7 @@ export const Launcher: React.FC<Props> = React.memo((props: Props) => {
     // i.e. wait until we know which apps exist …
     const available = x11_apps;
     if (available == null) return [];
-    // hide those apps, where certainly know they're not available
+    // hide those apps, where we know for certain they're not available
     return APP_KEYS.filter((app) => {
       const avail = available.get(app);
       return avail !== false;

--- a/src/packages/frontend/frame-editors/x11-editor/launcher.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/launcher.tsx
@@ -7,14 +7,14 @@
 X11 Window frame.
 */
 
-import { Component, Rendered, rclass, rtypes } from "../../app-framework";
-import { debounce, keys, sortBy } from "underscore";
-const { Button } = require("react-bootstrap");
+import { React, Rendered, useRedux } from "../../app-framework";
+import { Button } from "@cocalc/frontend/antd-bootstrap";
 import { Icon } from "../../components";
 import { APPS } from "./apps";
 import { is_different } from "@cocalc/util/misc";
 import { Actions } from "./actions";
 import { Capabilities } from "../../project_configuration";
+import { debounce, keys, sortBy } from "lodash";
 
 function sort_apps(k): string {
   const label = APPS[k].label;
@@ -28,39 +28,29 @@ const APP_KEYS: ReadonlyArray<string> = Object.freeze(
 
 interface Props {
   actions: Actions;
-  x11_apps?: Readonly<Capabilities>;
+  name: string;
 }
 
-export class LauncherComponent extends Component<Props, {}> {
-  static displayName = "X11 Launcher";
+function isSame(prev, next) {
+  return !is_different(prev, next, ["x11_apps"]);
+}
 
-  constructor(props) {
-    super(props);
-    this.launch = debounce(this.launch.bind(this), 500, true);
-    this.render_launcher = this.render_launcher.bind(this);
-  }
+export const Launcher: React.FC<Props> = React.memo((props: Props) => {
+  const { actions, name } = props;
 
-  static reduxProps({ name }) {
-    return {
-      [name]: {
-        x11_apps: rtypes.object,
-      },
-    };
-  }
+  const x11_apps: Readonly<Capabilities> = useRedux(name, "x11_apps");
 
-  shouldComponentUpdate(next): boolean {
-    return is_different(this.props, next, ["x11_apps"]);
-  }
+  const launch = debounce(_launch, 500, { leading: true, trailing: false });
 
-  launch(app: string): void {
+  function _launch(app: string): void {
     const desc = APPS[app];
     if (desc == null) {
       return;
     }
-    this.props.actions.launch(desc.command ? desc.command : app, desc.args);
+    actions.launch(desc.command ? desc.command : app, desc.args);
   }
 
-  render_launcher(app: string): Rendered {
+  function render_launcher(app: string): Rendered {
     const desc = APPS[app];
     if (desc == null) return;
 
@@ -72,7 +62,7 @@ export class LauncherComponent extends Component<Props, {}> {
     return (
       <Button
         key={app}
-        onClick={() => this.launch(app)}
+        onClick={() => launch(app)}
         title={desc.desc}
         style={{ margin: "5px" }}
       >
@@ -82,24 +72,20 @@ export class LauncherComponent extends Component<Props, {}> {
     );
   }
 
-  render_launchers(): Rendered[] {
+  function render_launchers(): Rendered[] {
     // i.e. wait until we know which apps exist …
-    const available = this.props.x11_apps;
+    const available = x11_apps;
     if (available == null) return [];
     // hide those apps, where certainly know they're not available
     return APP_KEYS.filter((app) => {
       const avail = available[app];
       return avail !== false;
-    }).map(this.render_launcher);
+    }).map(render_launcher);
   }
 
-  render(): Rendered {
-    return (
-      <div style={{ overflowY: "auto", padding: "5px" }}>
-        {this.render_launchers()}
-      </div>
-    );
-  }
-}
-
-export const Launcher = rclass(LauncherComponent);
+  return (
+    <div style={{ overflowY: "auto", padding: "5px" }}>
+      {render_launchers()}
+    </div>
+  );
+}, isSame);

--- a/src/packages/frontend/frame-editors/x11-editor/window-tab.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/window-tab.tsx
@@ -8,15 +8,10 @@ X11 Window frame.
 */
 
 import { Icon } from "@cocalc/frontend/components";
-
 import { Map } from "immutable";
-
-import { Component, Rendered } from "../../app-framework";
-
+import { React, Rendered } from "../../app-framework";
 import { Actions } from "./actions";
-
 import { TAB_BAR_GREY, TAB_BAR_BLUE } from "./theme";
-
 import { delay } from "awaiting";
 
 interface Props {
@@ -26,32 +21,29 @@ interface Props {
   is_current: boolean;
 }
 
-export class WindowTab extends Component<Props, {}> {
-  static displayName = "X11-WindowTab";
+function isSame(prev, next) {
+  return prev.info.equals(next.info) && prev.is_current == next.is_current;
+}
 
-  shouldComponentUpdate(next): boolean {
-    return (
-      !this.props.info.equals(next.info) ||
-      this.props.is_current != next.is_current
-    );
-  }
+export const WindowTab: React.FC<Props> = React.memo((props: Props) => {
+  const { id, info, actions, is_current } = props;
 
-  render_icon(): Rendered {
-    if (this.props.info.get("icon")) {
+  function render_icon(): Rendered {
+    if (info.get("icon")) {
       return (
         <img
           height={"20px"}
           style={{ paddingRight: "5px" }}
-          src={this.props.info.get("icon")}
+          src={info.get("icon")}
         />
       );
     }
     return <Icon name="file" style={{ height: "20px", paddingRight: "5px" }} />;
   }
 
-  render_close_button(): Rendered {
-    const color = this.props.is_current ? TAB_BAR_GREY : TAB_BAR_BLUE;
-    const backgroundColor = this.props.is_current ? TAB_BAR_BLUE : TAB_BAR_GREY;
+  function render_close_button(): Rendered {
+    const color = is_current ? TAB_BAR_GREY : TAB_BAR_BLUE;
+    const backgroundColor = is_current ? TAB_BAR_BLUE : TAB_BAR_GREY;
     return (
       <div
         style={{
@@ -62,14 +54,14 @@ export class WindowTab extends Component<Props, {}> {
           padding: "0 5px",
         }}
         onClick={async (evt) => {
-          const wid = this.props.info.get("wid");
-          this.props.actions.close_window(this.props.id, wid);
+          const wid = info.get("wid");
+          actions.close_window(id, wid);
           evt.stopPropagation();
 
           // focus this frame in the next event loop.
           await delay(0);
           try {
-            this.props.actions.focus(this.props.id);
+            actions.focus(id);
           } catch (e) {
             // ignore - already closed.
           }
@@ -80,36 +72,31 @@ export class WindowTab extends Component<Props, {}> {
     );
   }
 
-  render(): Rendered {
-    return (
-      <div
-        onClick={(evt) => {
-          // FIRST set the active frame to the one we just clicked on!
-          this.props.actions.set_active_id(this.props.id);
-          // SECOND make this particular tab focused.
-          this.props.actions.set_focused_window_in_frame(
-            this.props.id,
-            this.props.info.get("wid")
-          );
-          this.props.actions.client?.focus();
-          evt.stopPropagation();
-        }}
-        style={{
-          display: "inline-block",
-          width: "250px",
-          overflow: "hidden",
-          whiteSpace: "nowrap",
-          cursor: "pointer",
-          margin: "5px 0 5px 5px",
-          borderRight: "1px solid #aaa",
-          background: this.props.is_current ? TAB_BAR_BLUE : TAB_BAR_GREY,
-          color: this.props.is_current ? TAB_BAR_GREY : TAB_BAR_BLUE,
-        }}
-      >
-        {this.render_close_button()}
-        {this.render_icon()}
-        {this.props.info.get("title")}
-      </div>
-    );
-  }
-}
+  return (
+    <div
+      onClick={(evt) => {
+        // FIRST set the active frame to the one we just clicked on!
+        actions.set_active_id(id);
+        // SECOND make this particular tab focused.
+        actions.set_focused_window_in_frame(id, info.get("wid"));
+        actions.client?.focus();
+        evt.stopPropagation();
+      }}
+      style={{
+        display: "inline-block",
+        width: "250px",
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        cursor: "pointer",
+        margin: "5px 0 5px 5px",
+        borderRight: "1px solid #aaa",
+        background: is_current ? TAB_BAR_BLUE : TAB_BAR_GREY,
+        color: is_current ? TAB_BAR_GREY : TAB_BAR_BLUE,
+      }}
+    >
+      {render_close_button()}
+      {render_icon()}
+      {info.get("title")}
+    </div>
+  );
+}, isSame);

--- a/src/packages/frontend/frame-editors/x11-editor/window-tab.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/window-tab.tsx
@@ -22,7 +22,11 @@ interface Props {
 }
 
 function isSame(prev, next) {
-  return prev.info.equals(next.info) && prev.is_current == next.is_current;
+  return (
+    prev.info.equals(next.info) &&
+    prev.is_current === next.is_current &&
+    prev.id === next.id
+  );
 }
 
 export const WindowTab: React.FC<Props> = React.memo((props: Props) => {

--- a/src/packages/frontend/frame-editors/x11-editor/window-tab.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/window-tab.tsx
@@ -45,6 +45,24 @@ export const WindowTab: React.FC<Props> = React.memo((props: Props) => {
     return <Icon name="file" style={{ height: "20px", paddingRight: "5px" }} />;
   }
 
+  async function onClose(evt) {
+    // we have to focus on close as well, because there could be a modal dialog (e.g. asking upon closing)
+    onFocus(evt);
+
+    const wid = info.get("wid");
+    actions.close_window(id, wid);
+    evt.stopPropagation();
+  }
+
+  async function onFocus(evt) {
+    // FIRST set the active frame to the one we just clicked on!
+    actions.set_active_id(id);
+    // SECOND make this particular tab focused.
+    actions.set_focused_window_in_frame(id, info.get("wid"));
+    actions.client?.focus();
+    evt.stopPropagation();
+  }
+
   function render_close_button(): Rendered {
     const color = is_current ? TAB_BAR_GREY : TAB_BAR_BLUE;
     const backgroundColor = is_current ? TAB_BAR_BLUE : TAB_BAR_GREY;
@@ -57,19 +75,7 @@ export const WindowTab: React.FC<Props> = React.memo((props: Props) => {
           position: "relative",
           padding: "0 5px",
         }}
-        onClick={async (evt) => {
-          const wid = info.get("wid");
-          actions.close_window(id, wid);
-          evt.stopPropagation();
-
-          // focus this frame in the next event loop.
-          await delay(0);
-          try {
-            actions.focus(id);
-          } catch (e) {
-            // ignore - already closed.
-          }
-        }}
+        onClick={onClose}
       >
         <Icon name="times" />
       </div>
@@ -78,14 +84,7 @@ export const WindowTab: React.FC<Props> = React.memo((props: Props) => {
 
   return (
     <div
-      onClick={(evt) => {
-        // FIRST set the active frame to the one we just clicked on!
-        actions.set_active_id(id);
-        // SECOND make this particular tab focused.
-        actions.set_focused_window_in_frame(id, info.get("wid"));
-        actions.client?.focus();
-        evt.stopPropagation();
-      }}
+      onClick={onFocus}
       style={{
         display: "inline-block",
         width: "250px",

--- a/src/packages/frontend/frame-editors/x11-editor/x11.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/x11.tsx
@@ -17,6 +17,7 @@ import {
   useIsMountedRef,
   useRef,
   useRedux,
+  useTypedRedux,
   usePrevious,
   useMemo,
 } from "../../app-framework";
@@ -77,6 +78,7 @@ export const X11: React.FC<Props> = React.memo((props: Props) => {
   const windowRef = useRef<HTMLDivElement>(null);
   const focusRef = useRef<HTMLTextAreaElement>(null);
 
+  const default_font_size = useTypedRedux("account", "font_size") ?? 14;
   const windows: Map<string, any> = useRedux(name, "windows");
   const x11_is_idle: boolean = useRedux(name, "x11_is_idle");
   const disabled: boolean = useRedux(name, "disabled");
@@ -243,7 +245,7 @@ export const X11: React.FC<Props> = React.memo((props: Props) => {
     if (width == null || height == null) {
       return;
     }
-    const frame_scale = myProps.font_size / 14;
+    const frame_scale = myProps.font_size / default_font_size;
     client.resize_window(wid, width, height, frame_scale);
   }
 

--- a/src/packages/frontend/frame-editors/x11-editor/x11.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/x11.tsx
@@ -42,14 +42,21 @@ interface Props {
 
 function isSame(prev, next): boolean {
   // another other change causes re-render (e.g., of tab titles).
-  return !is_different(prev, next, [
-    "id",
-    "windows",
-    "is_current",
-    "x11_is_idle",
-    "disabled",
-    "config_unknown",
-  ]);
+  return (
+    !is_different(prev, next, [
+      "id",
+      "desc",
+      "windows",
+      "is_current",
+      "resize",
+      "reload",
+    ]) &&
+    prev.editor_settings.get("physical_keyboard") ==
+      next.editor_settings.get("physical_keyboard") &&
+    prev.editor_settings.get("keyboard_variant") ==
+      next.editor_settings.get("keyboard_variant") &&
+    prev.desc.get("font_size") == next.desc.get("font_size")
+  );
 }
 
 export const X11: React.FC<Props> = React.memo((props: Props) => {

--- a/src/packages/frontend/frame-editors/x11-editor/x11.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/x11.tsx
@@ -10,11 +10,15 @@ X11 Window frame.
 import { Map, Set } from "immutable";
 import { delay } from "awaiting";
 import {
-  Component,
   ReactDOM,
   Rendered,
-  rclass,
-  rtypes,
+  React,
+  useEffect,
+  useIsMountedRef,
+  useRef,
+  useRedux,
+  usePrevious,
+  useMemo,
 } from "../../app-framework";
 import { debounce } from "underscore";
 import { cmp, is_different } from "@cocalc/util/misc";
@@ -26,6 +30,7 @@ import { retry_until_success } from "@cocalc/util/async-utils";
 
 interface Props {
   actions: Actions;
+  name: string;
   id: string;
   desc: Map<string, any>;
   is_current: boolean;
@@ -33,138 +38,141 @@ interface Props {
   reload: string;
   editor_settings: Map<string, any>;
   resize: number;
-  // reduxProps:
-  windows: Map<string, any>;
-  x11_is_idle: boolean;
-  disabled: boolean;
-  config_unknown: boolean;
 }
 
-class X11Component extends Component<Props, {}> {
-  private is_mounted: boolean = false;
-  private is_loaded: boolean = false;
-  private measure_size: Function;
+function isSame(prev, next): boolean {
+  // another other change causes re-render (e.g., of tab titles).
+  return !is_different(prev, next, [
+    "id",
+    "windows",
+    "is_current",
+    "x11_is_idle",
+    "disabled",
+    "config_unknown",
+  ]);
+}
 
-  static displayName = "X11";
+export const X11: React.FC<Props> = React.memo((props: Props) => {
+  const {
+    actions,
+    name,
+    id,
+    desc,
+    is_current,
+    // font_size,
+    reload,
+    editor_settings,
+    resize,
+  } = props;
 
-  static reduxProps({ name }) {
-    return {
-      [name]: {
-        windows: rtypes.immutable.Map,
-        x11_is_idle: rtypes.bool,
-        disabled: rtypes.bool,
-        config_unknown: rtypes.bool,
-      },
-    };
-  }
+  const is_mounted = useIsMountedRef();
+  const is_loaded = useRef<boolean>(false);
+  const windowRef = useRef<HTMLDivElement>(null);
+  const focusRef = useRef<HTMLTextAreaElement>(null);
 
-  componentWillReceiveProps(next: Props): void {
-    if (this.props.resize != next.resize) {
-      this.measure_size();
+  const windows: Map<string, any> = useRedux(name, "windows");
+  const x11_is_idle: boolean = useRedux(name, "x11_is_idle");
+  const disabled: boolean = useRedux(name, "disabled");
+  const config_unknown: boolean = useRedux(name, "config_unknown");
+
+  const measure_size = debounce(_measure_size, 500);
+
+  useEffect(() => {
+    measure_size();
+  }, [resize]);
+
+  useEffect(() => {
+    // keyboard layout change
+    actions.set_physical_keyboard(
+      editor_settings.get("physical_keyboard"),
+      editor_settings.get("keyboard_variant")
+    );
+  }, [
+    editor_settings.get("physical_keyboard"),
+    editor_settings.get("keyboard_variant"),
+  ]);
+
+  useEffect(() => {
+    if (is_current) focus_textarea();
+  }, [is_current]);
+
+  // tab change (so different wid)
+  useEffect(() => {
+    insert_window_in_dom(props);
+  }, [desc.get("wid")]);
+
+  // just got loaded?
+  useEffect(() => {
+    if (!is_loaded.current && desc.get("wid") != null) {
+      insert_window_in_dom(props);
     }
-  }
+  }, [desc.get("wid")]);
 
-  shouldComponentUpdate(next): boolean {
-    if (
-      this.props.editor_settings.get("physical_keyboard") !==
-        next.editor_settings.get("physical_keyboard") ||
-      this.props.editor_settings.get("keyboard_variant") !==
-        next.editor_settings.get("keyboard_variant")
-    ) {
-      // keyboard layout change
-      this.props.actions.set_physical_keyboard(
-        next.editor_settings.get("physical_keyboard"),
-        next.editor_settings.get("keyboard_variant")
-      );
+  // children changed?
+  const children = useMemo(() => {
+    if (windows == null) return;
+    const wid: number = desc.get("wid");
+    return windows.getIn([wid, "children"], Set());
+  }, [windows]);
+
+  const prevChildren = usePrevious(children);
+
+  useEffect(() => {
+    if (is_loaded.current && !children.equals(prevChildren)) {
+      insert_children_in_dom(children.subtract(prevChildren));
     }
+  }, [prevChildren, children]);
 
-    // focused on a frame
-    if (!this.props.is_current && next.is_current) {
-      this.focus_textarea();
-    }
+  // reload or font size change -- measure and resize again.
 
-    // tab change (so different wid)
-    if (this.props.desc.get("wid") != next.desc.get("wid")) {
-      this.insert_window_in_dom(next);
-      return true;
-    }
+  useEffect(() => {
+    measure_size(props);
+  }, [desc.get("font_size"), reload]);
 
-    // just got loaded?
-    if (!this.is_loaded && next.desc.get("wid") != null) {
-      this.insert_window_in_dom(next);
-    }
-
-    // children changed?
-    if (this.props.windows != null && this.props.windows !== next.windows) {
-      const wid: number = next.desc.get("wid");
-      const children = this.props.windows.getIn([wid, "children"], Set());
-      const next_children = next.windows.getIn([wid, "children"], Set());
-      if (this.is_loaded && !children.equals(next_children)) {
-        this.insert_children_in_dom(next_children.subtract(children));
-      }
-    }
-
-    // reload or font size change -- measure and resize again.
-    if (
-      this.props.desc.get("font_size") != next.desc.get("font_size") ||
-      this.props.reload != next.reload
-    ) {
-      this.measure_size(next);
-      return true;
-    }
-
-    // another other change causes re-render (e.g., of tab titles).
-    return is_different(this.props, next, [
-      "id",
-      "windows",
-      "is_current",
-      "x11_is_idle",
-      "disabled",
-      "config_unknown",
-    ]);
-  }
-
-  async componentDidMount(): Promise<void> {
-    this.measure_size = debounce(this._measure_size.bind(this), 500);
-    this.is_mounted = true;
-
+  useEffect(() => {
     // "wait" until window node is available
-    await retry_until_success({
-      f: async () => {
-        const node: any = ReactDOM.findDOMNode(this.refs.window);
-        if (node == null) {
-          throw new Error("x11 window node not yet available");
-        }
-      },
-      max_time: 60000,
-      max_delay: 150,
-    });
-    this.insert_window_in_dom(this.props);
-    this.disable_browser_context_menu();
+    const load = async () =>
+      retry_until_success({
+        f: async () => {
+          const node: any = ReactDOM.findDOMNode(windowRef.current);
+          if (node == null) {
+            throw new Error("x11 window node not yet available");
+          }
+        },
+        max_time: 60000,
+        max_delay: 150,
+      });
+    load();
+    insert_window_in_dom(props);
+    disable_browser_context_menu();
 
     // set keyboard layout
-    this.props.actions.set_physical_keyboard(
-      this.props.editor_settings.get("physical_keyboard"),
-      this.props.editor_settings.get("keyboard_variant")
+    actions.set_physical_keyboard(
+      editor_settings.get("physical_keyboard"),
+      editor_settings.get("keyboard_variant")
     );
-  }
 
-  disable_browser_context_menu(): void {
-    const node: any = ReactDOM.findDOMNode(this.refs.window);
+    return () => {
+      is_loaded.current = false;
+    };
+  }, []);
+
+  function disable_browser_context_menu(): void {
+    const node: any = ReactDOM.findDOMNode(windowRef.current);
     // Get rid of browser context menu, which makes no sense on a canvas.
     // See https://stackoverflow.com/questions/10864249/disabling-right-click-context-menu-on-a-html-canvas
     // NOTE: this would probably make sense in DOM mode instead of canvas mode;
     // if we switch, disable this...
-    $(node).bind("contextmenu", function () {
+    $(node).on("contextmenu", function () {
       return false;
     });
   }
 
-  async insert_window_in_dom(props: Props): Promise<void> {
-    if (!this.is_mounted) {
+  async function insert_window_in_dom(props: Props): Promise<void> {
+    if (!is_mounted.current) {
       return;
     }
-    const node: any = ReactDOM.findDOMNode(this.refs.window);
+    const node: any = ReactDOM.findDOMNode(windowRef.current);
     const client = props.actions.client;
     if (client == null) {
       // will never happen -- to satisfy typescript
@@ -172,7 +180,7 @@ class X11Component extends Component<Props, {}> {
     }
     const wid = props.desc.get("wid");
     if (wid == null) {
-      this.is_loaded = false;
+      is_loaded.current = false;
       $(node).empty();
       return;
     }
@@ -180,25 +188,25 @@ class X11Component extends Component<Props, {}> {
       client.insert_window_in_dom(wid, node);
     } catch (err) {
       // window not available right now.
-      this.is_loaded = false;
+      is_loaded.current = false;
       $(node).empty();
       return;
     }
-    this.is_loaded = true;
-    this.insert_children_in_dom(props.windows.getIn([wid, "children"], Set()));
-    this._measure_size();
+    is_loaded.current = true;
+    insert_children_in_dom(windows.getIn([wid, "children"], Set()));
+    _measure_size();
     await delay(0);
-    if (!this.is_mounted || wid !== props.desc.get("wid")) {
+    if (!is_mounted.current || wid !== props.desc.get("wid")) {
       return;
     }
-    this._measure_size();
+    _measure_size();
     if (props.is_current) {
       client.focus_window(wid);
     }
   }
 
-  insert_children_in_dom(wids: Set<number>): void {
-    const client = this.props.actions.client;
+  function insert_children_in_dom(wids: Set<number>): void {
+    const client = actions.client;
     if (client == null) {
       // will never happen -- to satisfy typescript
       return;
@@ -206,63 +214,58 @@ class X11Component extends Component<Props, {}> {
     wids.forEach((wid) => {
       client.insert_child_in_dom(wid);
     });
-    this.measure_size();
+    measure_size();
   }
 
-  _measure_size(props?: Props): void {
-    if (props == null) {
-      props = this.props;
+  function _measure_size(myProps?: Props): void {
+    if (myProps == null) {
+      myProps = props;
     }
-    const client = props.actions.client;
+    const client = myProps.actions.client;
     if (client == null) {
       // to satisfy typescript
       return;
     }
-    const wid = props.desc.get("wid");
+    const wid = myProps.desc.get("wid");
     if (wid == null) {
       return;
     }
-    const node = $(ReactDOM.findDOMNode(this.refs.window));
+    const node = $(ReactDOM.findDOMNode(windowRef.current));
     const width = node.width(),
       height = node.height();
     if (width == null || height == null) {
       return;
     }
-    const frame_scale = props.font_size / 14;
+    const frame_scale = myProps.font_size / 14;
     client.resize_window(wid, width, height, frame_scale);
   }
 
-  componentWillUnmount(): void {
-    this.is_mounted = false;
-    this.is_loaded = false;
-  }
-
-  render_window_tabs(): Rendered[] {
+  function render_window_tabs(): Rendered[] {
     const v: Rendered[] = [];
-    if (this.props.windows == null) {
+    if (windows == null) {
       return v;
     }
-    const wids = this.props.windows.keySeq().toJS();
+    const wids = windows.keySeq().toJS();
     wids.sort(cmp); // since sort uses string cmp by default
     for (const wid of wids) {
-      if (this.props.windows.getIn([wid, "parent"])) {
+      if (windows.getIn([wid, "parent"])) {
         // don't render a tab for modal dialogs (or windows on top of others that block them).
         continue;
       }
       v.push(
         <WindowTab
-          id={this.props.id}
+          id={id}
           key={wid}
-          is_current={wid === this.props.desc.get("wid")}
-          info={this.props.windows.get(wid)}
-          actions={this.props.actions}
+          is_current={wid === desc.get("wid")}
+          info={windows.get(wid)}
+          actions={actions}
         />
       );
     }
     return v;
   }
 
-  render_tab_bar(): Rendered {
+  function render_tab_bar(): Rendered {
     return (
       <div
         style={{
@@ -271,52 +274,52 @@ class X11Component extends Component<Props, {}> {
           display: "inline-flex",
         }}
       >
-        {this.render_window_tabs()}
+        {render_window_tabs()}
       </div>
     );
   }
 
-  render_window_div(): Rendered {
+  function render_window_div(): Rendered {
     return (
       <div
         className="smc-vfill"
-        ref="window"
+        ref={windowRef}
         style={{ position: "relative" }}
         onClick={() => {
-          this.focus_textarea();
+          focus_textarea();
           // TODO:
-          // const client = this.props.actions.client;
+          // const client = actions.client;
           // (client as any).client.mouse_inject(ev);
         }}
       />
     );
   }
 
-  focus_textarea(): void {
-    const node: any = ReactDOM.findDOMNode(this.refs.focus);
-    $(node).focus();
-    const client = this.props.actions.client;
+  function focus_textarea(): void {
+    const node: any = ReactDOM.findDOMNode(focusRef.current);
+    $(node).trigger("focus");
+    const client = actions.client;
     if (client == null) {
       return;
     }
     client.focus();
   }
 
-  textarea_blur(): void {
-    const client = this.props.actions.client;
+  function textarea_blur(): void {
+    const client = actions.client;
     if (client == null) {
       return;
     }
     client.blur();
   }
 
-  on_paste(e): boolean {
+  function on_paste(e): boolean {
     const value: string = e.clipboardData.getData("Text");
-    this.props.actions.paste(this.props.id, value);
+    actions.paste(id, value);
     return false;
   }
 
-  render_hidden_textarea(): Rendered {
+  function render_hidden_textarea(): Rendered {
     return (
       <textarea
         style={{
@@ -331,24 +334,24 @@ class X11Component extends Component<Props, {}> {
         autoCapitalize="off"
         spellCheck={false}
         tabIndex={0}
-        ref="focus"
-        onBlur={() => this.textarea_blur()}
-        onPaste={(e) => this.on_paste(e)}
+        ref={focusRef}
+        onBlur={() => textarea_blur()}
+        onPaste={(e) => on_paste(e)}
       />
     );
   }
 
-  not_idle(): void {
-    this.props.actions.x11_not_idle();
+  function not_idle(): void {
+    actions.x11_not_idle();
   }
 
-  render_idle(): Rendered {
-    if (!this.props.x11_is_idle) {
+  function render_idle(): Rendered {
+    if (!x11_is_idle) {
       return;
     }
     return (
       <div
-        onClick={this.not_idle.bind(this)}
+        onClick={not_idle}
         style={{
           position: "absolute",
           fontSize: "36pt",
@@ -369,30 +372,25 @@ class X11Component extends Component<Props, {}> {
     );
   }
 
-  render(): Rendered {
-    if (this.props.disabled == null || this.props.config_unknown == null)
-      return <Loading />;
+  if (disabled == null || config_unknown == null) return <Loading />;
 
-    if (this.props.disabled) {
-      const no_info = this.props.config_unknown
-        ? "There is no X11 configuration information available. You might have to restart this project"
-        : "";
-      return (
-        <div className="smc-vfill" style={{ padding: "100px auto auto auto" }}>
-          X11 is not available for this project. {no_info}
-        </div>
-      );
-    }
+  if (disabled) {
+    const no_info = config_unknown
+      ? "There is no X11 configuration information available. You might have to restart this project"
+      : "";
     return (
-      <div className="smc-vfill" style={{ position: "relative" }}>
-        {this.render_idle()}
-        {this.render_tab_bar()}
-        {this.render_hidden_textarea()}
-        {this.render_window_div()}
+      <div className="smc-vfill" style={{ padding: "100px auto auto auto" }}>
+        X11 is not available for this project. {no_info}
       </div>
     );
   }
-}
 
-const X110 = rclass(X11Component);
-export { X110 as X11 };
+  return (
+    <div className="smc-vfill" style={{ position: "relative" }}>
+      {render_idle()}
+      {render_tab_bar()}
+      {render_hidden_textarea()}
+      {render_window_div()}
+    </div>
+  );
+}, isSame);


### PR DESCRIPTION
# Description

actually, the main change is to add more zoom levels, and switching to lodash, ... everything else should be the same. what I tested:
- opening two or more apps, tabbing between them
- refreshing the entire page, and after a few secs of reconnecting to the websocket stream, I'm able to continue working with the apps
   - this is the only problem left, somehow it either doesn't update or information is lost. or well, maybe this is a bug in the current version as well, not sure. 
   - ok, got it, the initialization works a bit differently now
- split the x11 area in two, have two apps open at the same time, and well, it switches between them as before
- I also took care to preserve all those memoizations
- zoom/font-size: changes size and re-measures everything
- same for resizing the frames

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
