### PR TITLE
frontend/frame-editor: get rid of inconsistencies in buttons

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -23,7 +23,11 @@ import { Popconfirm } from "antd";
 import { SaveButton } from "./save-button";
 
 const { debounce } = require("underscore");
-import { ButtonGroup, Button, ButtonStyle } from "../../antd-bootstrap";
+import {
+  ButtonGroup,
+  Button as AntdBootstrapButton,
+  ButtonStyle,
+} from "../../antd-bootstrap";
 
 import { get_default_font_size } from "../generic/client";
 
@@ -216,10 +220,14 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
 
   function StyledButton(props) {
     return (
-      <Button {...props} style={button_style(props.style)}>
+      <AntdBootstrapButton {...props} style={button_style(props.style)}>
         {props.children}
-      </Button>
+      </AntdBootstrapButton>
     );
+  }
+
+  function Button(props) {
+    return <StyledButton {...props}>{props.children}</StyledButton>;
   }
 
   function is_visible(action_name: string, explicit?: boolean): boolean {


### PR DESCRIPTION
# Description

simple idea: wrap that button just like the "styled" buttons, because with the same styling they'll look the same 🤷🏻 

before:

![Screenshot from 2022-02-17 16-13-43](https://user-images.githubusercontent.com/207405/154511288-3325768d-7ac5-442b-8f29-1bf900ad731a.png)


after:

![Screenshot from 2022-02-17 16-13-59](https://user-images.githubusercontent.com/207405/154511591-bbebdc25-8550-4ec8-9594-34c8b258fe9c.png)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
