### PR TITLE
next: prioritize loading those images above the fold in "Content"

### DIFF
--- a/src/packages/next/components/landing/content.tsx
+++ b/src/packages/next/components/landing/content.tsx
@@ -91,6 +91,7 @@ export default function Content({
             <>
               <Image
                 src={image}
+                priority={true}
                 style={{ padding: "15px" }}
                 alt={alt ?? `Image illustrating ${title}`}
               />

--- a/src/packages/next/components/landing/image.tsx
+++ b/src/packages/next/components/landing/image.tsx
@@ -21,7 +21,14 @@ interface Props {
   height?: number;
 }
 
-export default function Image({ src, style, alt, width, height }: Props) {
+export default function Image({
+  src,
+  style,
+  alt,
+  width,
+  height,
+  priority = false,
+}: Props) {
   if (typeof src == "string") {
     return (
       <img
@@ -54,7 +61,13 @@ export default function Image({ src, style, alt, width, height }: Props) {
       }}
     >
       <div style={{ position: "relative", width: "100%" }}>
-        <NextImage src={src} alt={alt} layout="responsive" width={width} />
+        <NextImage
+          src={src}
+          alt={alt}
+          layout="responsive"
+          width={width}
+          priority={priority}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
# Description

it's complaint has a point, to avoid a flicker load of those larger images

> react_devtools_backend.js:4061 Image with src "..." was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.
> Read more: https://nextjs.org/docs/api-reference/next/image#priority

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
