### PR TITLE
frontend: more React.FC

### DIFF
--- a/src/packages/frontend/account/editor-settings/color-schemes.tsx
+++ b/src/packages/frontend/account/editor-settings/color-schemes.tsx
@@ -37,6 +37,7 @@ export function EditorSettingsColorScheme(props: Props): JSX.Element {
           options={EDITOR_COLOR_SCHEMES}
           selected={props.theme}
           on_change={props.on_change}
+          showSearch={true}
         />
       </LabeledRow>
       <CodeMirrorPreview

--- a/src/packages/frontend/account/editor-settings/x11-keyboard.tsx
+++ b/src/packages/frontend/account/editor-settings/x11-keyboard.tsx
@@ -24,6 +24,7 @@ export function EditorSettingsPhysicalKeyboard(
           options={PHYSICAL_KEYBOARDS}
           selected={props.physical_keyboard}
           on_change={props.on_change}
+          showSearch={true}
         />
       </LabeledRow>
     );
@@ -48,6 +49,7 @@ export function EditorSettingsKeyboardVariant(
           options={props.keyboard_variant_options}
           selected={props.keyboard_variant}
           on_change={props.on_change}
+          showSearch={true}
         />
       </LabeledRow>
     );

--- a/src/packages/frontend/account/sign-out.tsx
+++ b/src/packages/frontend/account/sign-out.tsx
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Component, React, Rendered, redux } from "../app-framework";
+import { React, Rendered, redux } from "../app-framework";
 import { Button, Popconfirm } from "antd";
 import { LogoutOutlined } from "@ant-design/icons";
 
@@ -14,57 +14,57 @@ interface Props {
   style?: React.CSSProperties;
 }
 
-export class SignOut extends Component<Props> {
-  private sign_out(): void {
+export const SignOut: React.FC<Props> = (props: Props) => {
+  const { everywhere, sign_in, highlight, style } = props;
+
+  function sign_out(): void {
     const account = redux.getActions("account");
     if (account != null) {
-      account.sign_out(!!this.props.everywhere, !!this.props.sign_in);
+      account.sign_out(!!everywhere, !!sign_in);
     }
   }
 
-  private render_body(): Rendered {
-    if (this.props.sign_in) {
+  function render_body(): Rendered {
+    if (sign_in) {
       return <span>Sign in to your account...</span>;
     } else {
-      return (
-        <span>Sign out{this.props.everywhere ? " everywhere" : ""}...</span>
-      );
+      return <span>Sign out{everywhere ? " everywhere" : ""}...</span>;
     }
   }
-  public render(): Rendered {
-    // I think not using reduxProps is fine for this, since it's only rendered once
-    // you are signed in, and falling back to "your account" isn't bad.
-    const store = redux.getStore("account");
-    let account: string | undefined = store.get("email_address");
-    if (!account) {
-      account = "your account";
-    }
-    let title: string = `Are you sure you want to sign ${account} out `;
-    if (this.props.everywhere) {
-      title +=
-        "on all web browsers? Every web browser will have to reauthenticate before using this account again.";
-    } else {
-      title += "on this web browser?";
-    }
-    if (store.get("is_anonymous")) {
-      title +=
-        "\n Everything you have done using this TEMPORARY ACCOUNT will be immediately deleted!  If you would like to save your work to a new account, click cancel and sign up below.";
-    }
-    return (
-      <Popconfirm
-        title={<div style={{ maxWidth: "60ex" }}>{title}</div>}
-        onConfirm={this.sign_out.bind(this)}
-        okText={`Yes, sign out${this.props.everywhere ? " everywhere" : ""}`}
-        cancelText={"Cancel"}
+
+  // I think not using reduxProps is fine for this, since it's only rendered once
+  // you are signed in, and falling back to "your account" isn't bad.
+  const store = redux.getStore("account");
+  const account: string = store.get("email_address") ?? "your account";
+
+  let title: string = `Are you sure you want to sign ${account} out `;
+
+  if (everywhere) {
+    title +=
+      "on all web browsers? Every web browser will have to reauthenticate before using this account again.";
+  } else {
+    title += "on this web browser?";
+  }
+
+  if (store.get("is_anonymous")) {
+    title +=
+      "\n Everything you have done using this TEMPORARY ACCOUNT will be immediately deleted!  If you would like to save your work to a new account, click cancel and sign up below.";
+  }
+
+  return (
+    <Popconfirm
+      title={<div style={{ maxWidth: "60ex" }}>{title}</div>}
+      onConfirm={sign_out}
+      okText={`Yes, sign out${everywhere ? " everywhere" : ""}`}
+      cancelText={"Cancel"}
+    >
+      <Button
+        icon={<LogoutOutlined />}
+        type={highlight ? "primary" : undefined}
+        style={style}
       >
-        <Button
-          icon={<LogoutOutlined />}
-          type={this.props.highlight ? "primary" : undefined}
-          style={this.props.style}
-        >
-          {this.render_body()}
-        </Button>
-      </Popconfirm>
-    );
-  }
-}
+        {render_body()}
+      </Button>
+    </Popconfirm>
+  );
+};

--- a/src/packages/frontend/components/close-x2.tsx
+++ b/src/packages/frontend/components/close-x2.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from "react";
+import { CSS } from "@cocalc/frontend/app-framework";
 import { Icon } from "./icon";
 
 interface Props {
@@ -11,29 +12,28 @@ interface Props {
   close?: () => void;
 }
 
-export class CloseX2 extends React.Component<Props> {
-  static defaultProps = {
-    close: undefined,
-    style: {
-      cursor: "pointer",
-      fontSize: "13pt",
-    },
-  };
+const DEFAULT_STYLE: CSS = {
+  cursor: "pointer",
+  fontSize: "13pt",
+};
 
-  shouldComponentUpdate(next) {
-    return this.props.close != next.close;
+function isSame(prev, next) {
+  if (prev == null || next == null) {
+    return false;
   }
+  return prev.close != next.close;
+}
 
-  render() {
-    if (!this.props.close) return undefined;
+export const CloseX2: React.FC<Props> = React.memo((props: Props) => {
+  const { close = undefined, style = DEFAULT_STYLE } = props;
+
+  if (!close) {
+    return null;
+  } else {
     return (
-      <div
-        className={"pull-right lighten"}
-        style={this.props.style}
-        onClick={this.props.close}
-      >
+      <div className={"pull-right lighten"} style={style} onClick={close}>
         <Icon name={"times"} />
       </div>
     );
   }
-}
+}, isSame);

--- a/src/packages/frontend/course/nbgrader/scores.tsx
+++ b/src/packages/frontend/course/nbgrader/scores.tsx
@@ -9,7 +9,7 @@ Component that shows all the scores for all problems and notebooks in a given as
 
 import { Alert, Card } from "antd";
 import { Icon } from "../../components";
-import { Rendered, Component, redux } from "../../app-framework";
+import { Rendered, redux, useState } from "../../app-framework";
 import { NotebookScores, Score } from "../../jupyter/nbgrader/autograde";
 import { get_nbgrader_score } from "../store";
 import { CourseActions } from "../actions";
@@ -26,69 +26,71 @@ interface Props {
 }
 
 interface State {
-  editing_score_filename?: string;
-  editing_score_id?: string;
+  filename?: string;
+  id?: string;
 }
 
-export class NbgraderScores extends Component<Props, State> {
-  constructor(props, state) {
-    super(props, state);
-    this.state = {};
+export const NbgraderScores: React.FC<Props> = (props: Props) => {
+  const {
+    nbgrader_scores,
+    nbgrader_score_ids,
+    assignment_id,
+    student_id,
+    name,
+    show_all,
+    set_show_all,
+  } = props;
+
+  const [editingScore, setEditingScore] = useState<State>({});
+
+  function get_actions(): CourseActions {
+    return redux.getActions(name);
   }
 
-  private get_actions(): CourseActions {
-    return redux.getActions(this.props.name);
-  }
-
-  private render_show_all(): Rendered {
-    if (!this.props.show_all) return;
+  function render_show_all(): Rendered {
+    if (!show_all) return;
     const v: Rendered[] = [];
-    for (const filename in this.props.nbgrader_scores) {
-      v.push(
-        this.render_info_for_file(
-          filename,
-          this.props.nbgrader_scores[filename]
-        )
-      );
+    for (const filename in nbgrader_scores) {
+      v.push(render_info_for_file(filename, nbgrader_scores[filename]));
     }
     return <div>{v}</div>;
   }
 
-  private render_info_for_file(
+  function render_info_for_file(
     filename: string,
     scores: NotebookScores | string
   ): Rendered {
     return (
       <div key={filename} style={{ marginBottom: "5px" }}>
-        {this.render_filename_links(filename)}
-        {this.render_scores_for_file(filename, scores)}
+        {render_filename_links(filename)}
+        {render_scores_for_file(filename, scores)}
       </div>
     );
   }
 
-  private open_filename(filename: string): void {
-    const actions = this.get_actions();
+  function open_filename(filename: string): void {
+    const actions = get_actions();
     actions.assignments.open_file_in_collected_assignment(
-      this.props.assignment_id,
-      this.props.student_id,
+      assignment_id,
+      student_id,
       filename
     );
   }
 
-  private render_filename_links(filename: string): Rendered {
+  function render_filename_links(filename: string): Rendered {
     const filename2 = autograded_filename(filename);
     return (
       <div style={{ fontSize: "12px" }}>
         <a
           style={{ fontFamily: "monospace" }}
-          onClick={() => this.open_filename(filename)}
+          onClick={() => open_filename(filename)}
         >
           {filename}
         </a>
         <br />
         <a
           style={{ fontFamily: "monospace" }}
-          onClick={() => this.open_filename(filename2)}
+          onClick={() => open_filename(filename2)}
         >
           {filename2}
         </a>
@@ -96,7 +98,7 @@ export class NbgraderScores extends Component<Props, State> {
     );
   }
 
-  private render_scores_for_file(
+  function render_scores_for_file(
     filename: string,
     scores: NotebookScores | string
   ): Rendered {
@@ -110,7 +112,7 @@ export class NbgraderScores extends Component<Props, State> {
     }
     const v: Rendered[] = [];
 
-    const ids: string[] = this.props.nbgrader_score_ids?.[filename] ?? [];
+    const ids: string[] = nbgrader_score_ids?.[filename] ?? [];
     for (const id in scores) {
       if (!ids.includes(id)) {
         ids.push(id);
@@ -119,7 +121,7 @@ export class NbgraderScores extends Component<Props, State> {
 
     for (const id of ids) {
       if (scores[id] != null) {
-        v.push(this.render_score(filename, id, scores[id]));
+        v.push(render_score(filename, id, scores[id]));
       }
     }
 
@@ -144,14 +146,14 @@ export class NbgraderScores extends Component<Props, State> {
     );
   }
 
-  private set_score(filename: string, id: string, value: string): void {
+  function set_score(filename: string, id: string, value: string): void {
     const score = parseFloat(value);
     if (isNaN(score) || !isFinite(score)) {
       return; // invalid scores gets thrown away
     }
-    this.get_actions().assignments.set_specific_nbgrader_score(
-      this.props.assignment_id,
-      this.props.student_id,
+    get_actions().assignments.set_specific_nbgrader_score(
+      assignment_id,
+      student_id,
       filename,
       id,
       score,
@@ -159,7 +161,7 @@ export class NbgraderScores extends Component<Props, State> {
     );
   }
 
-  private render_assigned_score(
+  function render_assigned_score(
     filename: string,
     id: string,
     score: Score
@@ -177,69 +179,51 @@ export class NbgraderScores extends Component<Props, State> {
       display: "inline-block",
       padding: "1px",
     };
-    if (
-      this.state.editing_score_filename == filename &&
-      this.state.editing_score_id == id
-    ) {
+    if (editingScore.filename == filename && editingScore.id == id) {
       return (
         <input
           spellCheck={false}
           autoFocus
           type="input"
           defaultValue={value}
-          onBlur={(e) => this.stop_editing_score((e.target as any).value)}
+          onBlur={(e) => stop_editing_score((e.target as any).value)}
           style={style}
         />
       );
     } else {
       return (
-        <span
-          style={style}
-          onClick={() =>
-            this.setState({
-              editing_score_filename: filename,
-              editing_score_id: id,
-            })
-          }
-        >
+        <span style={style} onClick={() => setEditingScore({ filename, id })}>
           {value ? value : "-"}
         </span>
       );
     }
   }
 
-  private stop_editing_score(value: string): void {
-    if (
-      this.state.editing_score_id != null &&
-      this.state.editing_score_filename != null
-    ) {
-      this.set_score(
-        this.state.editing_score_filename,
-        this.state.editing_score_id,
-        value
-      );
+  function stop_editing_score(value: string): void {
+    if (editingScore.id != null && editingScore.filename != null) {
+      set_score(editingScore.filename, editingScore.id, value);
     }
-    this.setState({
-      editing_score_filename: undefined,
-      editing_score_id: undefined,
+    setEditingScore({
+      filename: undefined,
+      id: undefined,
     });
   }
 
-  private render_score(filename: string, id: string, score: Score): Rendered {
+  function render_score(filename: string, id: string, score: Score): Rendered {
     const backgroundColor = score.score == null ? "#fff1f0" : undefined;
     const style = { padding: "5px", backgroundColor };
     return (
       <tr key={id}>
         <td style={style}>{id}</td>
         <td style={style}>
-          {this.render_assigned_score(filename, id, score)} / {score.points}
-          {this.render_needs_score(score)}
+          {render_assigned_score(filename, id, score)} / {score.points}
+          {render_needs_score(score)}
         </td>
       </tr>
     );
   }
 
-  private render_needs_score(score: Score): Rendered {
+  function render_needs_score(score: Score): Rendered {
     if (!score.manual || score.score != null) return;
     return (
       <div>
@@ -248,20 +232,20 @@ export class NbgraderScores extends Component<Props, State> {
     );
   }
 
-  private render_more_toggle(action_required: boolean): Rendered {
+  function render_more_toggle(action_required: boolean): Rendered {
     return (
-      <a onClick={() => this.props.set_show_all?.()}>
+      <a onClick={() => set_show_all?.()}>
         {action_required ? (
           <>
             <Icon name="exclamation-triangle" />{" "}
           </>
         ) : undefined}
-        {this.props.show_all ? "" : "Edit..."}
+        {show_all ? "" : "Edit..."}
       </a>
     );
   }
 
-  private render_title(score, points, error): Rendered {
+  function render_title(score, points, error): Rendered {
     return (
       <span>
         <b>nbgrader:</b> {error ? "error" : `${score}/${points}`}
@@ -269,25 +253,22 @@ export class NbgraderScores extends Component<Props, State> {
     );
   }
 
-  public render(): Rendered {
-    const { score, points, error, manual_needed } = get_nbgrader_score(
-      this.props.nbgrader_scores
-    );
-    const action_required: boolean = !!(
-      !this.props.show_all &&
-      (manual_needed || error)
-    );
-    const backgroundColor = action_required ? "#fff1f0" : undefined;
-    return (
-      <Card
-        size="small"
-        style={{ marginTop: "5px", backgroundColor }}
-        extra={this.render_more_toggle(action_required)}
-        title={this.render_title(score, points, error)}
-        bodyStyle={this.props.show_all ? {} : { padding: 0 }}
-      >
-        {this.render_show_all()}
-      </Card>
-    );
-  }
-}
+  const { score, points, error, manual_needed } =
+    get_nbgrader_score(nbgrader_scores);
+
+  const action_required: boolean = !!(!show_all && (manual_needed || error));
+
+  const backgroundColor = action_required ? "#fff1f0" : undefined;
+
+  return (
+    <Card
+      size="small"
+      style={{ marginTop: "5px", backgroundColor }}
+      extra={render_more_toggle(action_required)}
+      title={render_title(score, points, error)}
+      bodyStyle={show_all ? {} : { padding: 0 }}
+    >
+      {render_show_all()}
+    </Card>
+  );
+};

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -24,6 +24,7 @@ import {
   build_date,
   smc_git_rev,
   UNIT,
+  r_join,
 } from "./components";
 import { callback2, retry_until_success } from "@cocalc/util/async-utils";
 import { dict, YEAR } from "@cocalc/util/misc";
@@ -381,6 +382,7 @@ const AccountCreationEmailInstructions0 = rclass<{}>(
   }
 );
 
+// TODO is this used?
 export function AccountCreationEmailInstructions() {
   return (
     <Redux>
@@ -389,59 +391,41 @@ export function AccountCreationEmailInstructions() {
   );
 }
 
-interface FooterRedux {
-  site_name: string;
-  organization_name: string;
-  terms_of_service_url: string;
-}
+export const Footer: React.FC = React.memo(() => {
+  const on = useTypedRedux("customize", "organization_name");
+  const tos = useTypedRedux("customize", "terms_of_service_url");
 
-const FooterElement = rclass<{}>(
-  class FooterComponent extends React.Component<FooterRedux> {
-    public static reduxProps = () => {
-      return {
-        customize: {
-          site_name: rtypes.string,
-          organization_name: rtypes.string,
-          terms_of_service_url: rtypes.string,
-        },
-      };
-    };
-    render() {
-      const on = this.props.organization_name;
-      const orga = on.length > 0 ? on : theme.COMPANY_NAME;
-      const tos = this.props.terms_of_service_url;
-      const TOSurl = tos.length > 0 ? tos : PolicyTOSPageUrl;
-      const yt =
-        `Version ${smc_version} @ ${build_date}` +
-        ` | ${smc_git_rev.slice(0, 8)}`;
-      const style: React.CSSProperties = {
-        color: "gray",
-        textAlign: "center",
-        paddingBottom: `${UNIT}px`,
-      };
-      return (
-        <footer style={style}>
-          <hr />
-          <Space />
-          <A href={appBasePath}>
-            <SiteName /> by {orga} &middot;{" "}
-          </A>
-          <A href={join(appBasePath, "info/status")}>System Status &middot; </A>
-          <A href={TOSurl}>Terms of Service</A> &middot; <HelpEmailLink />{" "}
-          &middot; <span title={yt}>&copy; {YEAR}</span>
-        </footer>
-      );
-    }
+  const organizationName = on.length > 0 ? on : theme.COMPANY_NAME;
+  const TOSurl = tos.length > 0 ? tos : PolicyTOSPageUrl;
+  const webappVersionInfo =
+    `Version ${smc_version} @ ${build_date}` + ` | ${smc_git_rev.slice(0, 8)}`;
+  const style: React.CSSProperties = {
+    color: "gray",
+    textAlign: "center",
+    paddingBottom: `${UNIT}px`,
+  };
+
+  function contents() {
+    const elements = [
+      <A href={appBasePath}>
+        <SiteName /> by {organizationName}
+      </A>,
+      <A href={SystemStatusUrl}>System Status</A>,
+      <A href={TOSurl}>Terms of Service</A>,
+      <HelpEmailLink />,
+      <span title={webappVersionInfo}>&copy; {YEAR}</span>,
+    ];
+    return r_join(elements, <> &middot; </>);
   }
-);
 
-export function Footer() {
   return (
-    <Redux>
-      <FooterElement />
-    </Redux>
+    <footer style={style}>
+      <hr />
+      <Space />
+      {contents()}
+    </footer>
   );
-}
+});
 
 // first step of centralizing these URLs in one place → collecting all such pages into one
 // react-class with a 'type' prop is the next step (TODO)
@@ -452,6 +436,7 @@ export const PolicyPricingPageUrl = join(appBasePath, "pricing");
 export const PolicyPrivacyPageUrl = join(appBasePath, "policies/privacy");
 export const PolicyCopyrightPageUrl = join(appBasePath, "policies/copyright");
 export const PolicyTOSPageUrl = join(appBasePath, "policies/terms");
+export const SystemStatusUrl = join(appBasePath, "info/status");
 
 import { gtag_id } from "@cocalc/util/theme";
 async function init_analytics() {

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -6,7 +6,15 @@
 // Site Customize -- dynamically customize the look of CoCalc for the client.
 
 import { List } from "immutable";
-import { redux, Redux, rclass, rtypes, Store, Actions } from "./app-framework";
+import {
+  redux,
+  Redux,
+  rclass,
+  rtypes,
+  Store,
+  Actions,
+  useTypedRedux,
+} from "./app-framework";
 import React from "react";
 import {
   A,
@@ -191,102 +199,54 @@ export function set_customize(obj) {
   actions.setState(obj);
 }
 
-interface Props0 {
-  text: React.ReactNode;
-  color?: string;
-}
-
-interface ReduxProps {
-  help_email: string;
-  _is_configured: boolean;
-}
-
-const HelpEmailLink0 = rclass<Props0>(
-  class HelpEmailLink extends React.Component<Props0 & ReduxProps> {
-    public static reduxProps() {
-      return {
-        customize: {
-          help_email: rtypes.string,
-          _is_configured: rtypes.bool,
-        },
-      };
-    }
-
-    public render() {
-      const style: React.CSSProperties = {};
-      if (this.props.color != undefined) {
-        style.color = this.props.color;
-      }
-
-      if (this.props._is_configured) {
-        if (this.props.help_email?.length > 0) {
-          return (
-            <A href={`mailto:${this.props.help_email}`} style={style}>
-              {this.props.text != undefined
-                ? this.props.text
-                : this.props.help_email}
-            </A>
-          );
-        } else {
-          return (
-            <span>
-              <em>
-                {"["}not configured{"]"}
-              </em>
-            </span>
-          );
-        }
-      } else {
-        return <Loading style={{ display: "inline" }} />;
-      }
-    }
-  }
-);
-
 interface HelpEmailLink {
   text?: React.ReactNode;
   color?: string;
 }
 
-export function HelpEmailLink(props: HelpEmailLink) {
-  return (
-    <Redux>
-      <HelpEmailLink0 text={props.text} color={props.color} />
-    </Redux>
-  );
-}
+export const HelpEmailLink: React.FC<HelpEmailLink> = React.memo(
+  (props: HelpEmailLink) => {
+    const { text, color } = props;
 
-interface SiteNameProps {
-  site_name: string;
-}
+    const help_email = useTypedRedux("customize", "help_email");
+    const _is_configured = useTypedRedux("customize", "_is_configured");
 
-const SiteName0 = rclass<{}>(
-  class SiteName extends React.Component<SiteNameProps> {
-    public static reduxProps() {
-      return {
-        customize: {
-          site_name: rtypes.string,
-        },
-      };
+    const style: React.CSSProperties = {};
+    if (color != null) {
+      style.color = color;
     }
 
-    public render(): JSX.Element {
-      if (this.props.site_name) {
-        return <span>{this.props.site_name}</span>;
+    if (_is_configured) {
+      if (help_email?.length > 0) {
+        return (
+          <A href={`mailto:${help_email}`} style={style}>
+            {text ?? help_email}
+          </A>
+        );
       } else {
-        return <Loading style={{ display: "inline" }} />;
+        return (
+          <span>
+            <em>
+              {"["}not configured{"]"}
+            </em>
+          </span>
+        );
       }
+    } else {
+      return <Loading style={{ display: "inline" }} />;
     }
   }
 );
 
-export function SiteName() {
-  return (
-    <Redux>
-      <SiteName0 />
-    </Redux>
-  );
-}
+export const SiteName: React.FC = React.memo(() => {
+  const site_name = useTypedRedux("customize", "site_name");
+
+  if (site_name != null) {
+    return <span>{site_name}</span>;
+  } else {
+    return <Loading style={{ display: "inline" }} />;
+  }
+});
 
 interface SiteDescriptionProps {
   style?: React.CSSProperties;
@@ -317,6 +277,7 @@ const SiteDescription0 = rclass<{ style?: React.CSSProperties }>(
   }
 );
 
+// TODO: not used?
 export function SiteDescription({ style }: { style?: React.CSSProperties }) {
   return (
     <Redux>
@@ -382,6 +343,7 @@ const CustomizeStringElement = rclass<CustomizeStringProps>(
   }
 );
 
+// TODO: not used?
 export function CustomizeString({ name }: CustomizeStringProps) {
   return (
     <Redux>

--- a/src/packages/frontend/project/utils.ts
+++ b/src/packages/frontend/project/utils.ts
@@ -33,9 +33,7 @@ export type NewFilenameTypes =
   | "semantic"
   | "ymd_semantic";
 
-export const NewFilenameFamilies = Object.freeze<
-  { [name in NewFilenameTypes]: string }
->({
+export const NewFilenameFamilies: { [name in NewFilenameTypes]: string } = {
   iso: "Current time",
   heroku: "Heroku-like",
   ymd_heroku: "Heroku-like (prefix today)",
@@ -43,7 +41,7 @@ export const NewFilenameFamilies = Object.freeze<
   ymd_pet: "Pet names (prefix today)",
   semantic: "Semantic",
   ymd_semantic: "Semantic (prefix today) ",
-});
+} as const;
 
 export class NewFilenames {
   // TODO iso is the "old way". Change it to "semantic" after a week or two…


### PR DESCRIPTION
# Description

- close-x2 cross
- TextInput: FC component and no bootstrap any more
- the "nbgrader scores" table in a student assignment row
- time elapsed (e.g. used in the project settings/control)
- getting rid of a bit of bootstrap usage in textinput
- SelectorInput: now also searchable, e.g. keyboard language
- SiteName, HelpEmailLink, Footer, ...
- SignOut button
- and well, I looked at that windowed list, and the row itself is easy, but the windowed list makes its internal state directly accessible and that must be done differently, with a callback or whatnot?, since functional components do not have an internal state


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
