### PR TITLE
frontend: React.FC-ing FrameTree+Leaf+FormatBar

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/format-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/format-bar.tsx
@@ -7,19 +7,24 @@
 The format bar
 */
 
-const css_colors = require("css-color-names");
-
-import { Component, Rendered } from "../../app-framework";
-import { cmp } from "@cocalc/util/misc";
+import * as CSS_COLORS from "css-color-names";
+import { React, Rendered } from "../../app-framework";
 import { SetMap } from "./types";
 import { DropdownMenu, MenuItem } from "../../components";
 import { ButtonGroup, Button } from "../../antd-bootstrap";
 import { FONT_FACES } from "../../editors/editor-button-bar";
 import { Icon, isIconName, Space } from "@cocalc/frontend/components";
+import { sortBy } from "lodash";
 
-const FONT_SIZES = "xx-small x-small small medium large x-large xx-large".split(
-  " "
-);
+const FONT_SIZES = [
+  "xx-small",
+  "x-small",
+  "small",
+  "medium",
+  "large",
+  "x-large",
+  "xx-large",
+] as const;
 
 interface Props {
   actions: any; // type of file being edited, which impacts what buttons are shown.
@@ -27,12 +32,14 @@ interface Props {
   exclude?: SetMap; // exclude buttons with these names
 }
 
-export class FormatBar extends Component<Props, {}> {
-  shouldComponentUpdate(): boolean {
-    return false;
-  }
+function shouldMemoize() {
+  return true;
+}
 
-  render_button(
+export const FormatBar: React.FC<Props> = React.memo((props: Props) => {
+  const { actions, extension, exclude } = props;
+
+  function render_button(
     name: string,
     title: string,
     label?: string | Rendered, // if a string, the named icon; if a rendered
@@ -40,7 +47,7 @@ export class FormatBar extends Component<Props, {}> {
     // icon with given name.
     fontSize?: string
   ): Rendered {
-    if (this.props.exclude?.[name]) {
+    if (exclude?.[name]) {
       return;
     }
     if (label == null && isIconName(name)) {
@@ -53,7 +60,7 @@ export class FormatBar extends Component<Props, {}> {
       <Button
         key={name}
         title={title}
-        onClick={() => this.props.actions.format_action(name)}
+        onClick={() => actions.format_action(name)}
         style={{ maxHeight: "30px", fontSize }}
       >
         {label}
@@ -61,64 +68,48 @@ export class FormatBar extends Component<Props, {}> {
     );
   }
 
-  render_text_style_buttons(): Rendered {
+  function render_text_style_buttons(): Rendered {
     return (
       <ButtonGroup key={"text-style"}>
-        {this.render_button("bold", "Make selected text bold")}
-        {this.render_button("italic", "Make selected text italics")}
-        {this.render_button("underline", "Underline selected text")}
-        {this.render_button("strikethrough", "Strike through selected text")}
-        {this.render_button("code", "Format selected text as code")}
-        {this.render_button(
-          "sub",
-          "Make selected text a subscript",
-          "subscript"
-        )}
-        {this.render_button(
+        {render_button("bold", "Make selected text bold")}
+        {render_button("italic", "Make selected text italics")}
+        {render_button("underline", "Underline selected text")}
+        {render_button("strikethrough", "Strike through selected text")}
+        {render_button("code", "Format selected text as code")}
+        {render_button("sub", "Make selected text a subscript", "subscript")}
+        {render_button(
           "sup",
           "Make selected text a superscript",
           "superscript"
         )}
-        {this.render_button("comment", "Comment out selected text")}
+        {render_button("comment", "Comment out selected text")}
       </ButtonGroup>
     );
   }
 
-  render_insert_buttons(): Rendered {
+  function render_insert_buttons(): Rendered {
     return (
       <ButtonGroup key={"insert"}>
-        {this.render_button(
+        {render_button(
           "format_code",
           "Insert block of source code",
           "CodeOutlined"
         )}
-        {this.render_button(
-          "insertunorderedlist",
-          "Insert unordered list",
-          "list"
-        )}
-        {this.render_button(
-          "insertorderedlist",
-          "Insert ordered list",
-          "list-ol"
-        )}
-        {this.render_button(
-          "equation",
-          "Insert inline LaTeX math",
-          <span>$</span>
-        )}
-        {this.render_button(
+        {render_button("insertunorderedlist", "Insert unordered list", "list")}
+        {render_button("insertorderedlist", "Insert ordered list", "list-ol")}
+        {render_button("equation", "Insert inline LaTeX math", <span>$</span>)}
+        {render_button(
           "display_equation",
           "Insert displayed LaTeX math",
           <span>$$</span>
         )}
-        {this.render_button(
+        {render_button(
           "quote",
           "Make selected text into a quotation",
           "quote-left"
         )}
-        {this.render_button("table", "Insert table", "table")}
-        {this.render_button(
+        {render_button("table", "Insert table", "table")}
+        {render_button(
           "horizontalRule",
           "Insert horizontal rule",
           <span>&mdash;</span>
@@ -127,13 +118,13 @@ export class FormatBar extends Component<Props, {}> {
     );
   }
 
-  render_insert_dialog_buttons(): Rendered {
+  function render_insert_dialog_buttons(): Rendered {
     return (
       <ButtonGroup key={"insert-dialog"}>
-        {this.render_button("link", "Insert link", "link")}
-        {this.render_button("image", "Insert image", "image", "12pt")}
-        {this.props.extension !== "tex"
-          ? this.render_button(
+        {render_button("link", "Insert link", "link")}
+        {render_button("image", "Insert image", "image", "12pt")}
+        {extension !== "tex"
+          ? render_button(
               "SpecialChar",
               "Insert special character...",
               <span style={{ fontSize: "larger" }}>&Omega;</span>
@@ -143,35 +134,31 @@ export class FormatBar extends Component<Props, {}> {
     );
   }
 
-  render_format_buttons(): Rendered {
-    if (this.props.exclude?.["format_buttons"]) {
+  function render_format_buttons(): Rendered {
+    if (exclude?.["format_buttons"]) {
       return;
     }
     return (
       <>
         <Space />
         <ButtonGroup key={"format"}>
-          {this.render_button(
-            "format_code",
-            "Format selected text as code",
-            "code"
-          )}
-          {this.render_button(
+          {render_button("format_code", "Format selected text as code", "code")}
+          {render_button(
             "justifyleft",
             "Left justify current text",
             "align-left"
           )}
-          {this.render_button(
+          {render_button(
             "justifycenter",
             "Center current text",
             "align-center"
           )}
-          {this.render_button(
+          {render_button(
             "justifyright",
             "Right justify current text",
             "align-right"
           )}
-          {this.render_button(
+          {render_button(
             "justifyfull",
             "Fully justify current text",
             "align-justify"
@@ -179,7 +166,7 @@ export class FormatBar extends Component<Props, {}> {
         </ButtonGroup>
         <Space />
         <ButtonGroup key={"format2"}>
-          {this.render_button(
+          {render_button(
             "unformat",
             "Remove all formatting from selected text",
             "remove"
@@ -189,7 +176,7 @@ export class FormatBar extends Component<Props, {}> {
     );
   }
 
-  render_font_family_dropdown(): Rendered {
+  function render_font_family_dropdown(): Rendered {
     const items: Rendered[] = [];
     for (const family of FONT_FACES) {
       const item: Rendered = (
@@ -205,16 +192,14 @@ export class FormatBar extends Component<Props, {}> {
         title={<Icon name={"font"} />}
         key={"font-family"}
         id={"font-family"}
-        onClick={(family) =>
-          this.props.actions.format_action("font_family", family)
-        }
+        onClick={(family) => actions.format_action("font_family", family)}
       >
         {items}
       </DropdownMenu>
     );
   }
 
-  render_font_size_dropdown(): Rendered {
+  function render_font_size_dropdown(): Rendered {
     const items: Rendered[] = [];
     for (const size of FONT_SIZES) {
       const item: Rendered = (
@@ -232,49 +217,30 @@ export class FormatBar extends Component<Props, {}> {
         title={<Icon name={"text-height"} />}
         key={"font-size"}
         id={"font-size"}
-        onClick={(size) =>
-          this.props.actions.format_action("font_size_new", size)
-        }
+        onClick={(size) => actions.format_action("font_size_new", size)}
       >
         {items}
       </DropdownMenu>
     );
   }
 
-  render_heading_dropdown(): Rendered {
+  function heading_content(heading: number): JSX.Element {
+    const label = heading == 0 ? "Paragraph" : `Heading ${heading}`;
+    if (heading === 0) {
+      return <span>{label}</span>;
+    } else {
+      return React.createElement(`h${heading}`, {}, label);
+    }
+  }
+
+  function render_heading_dropdown(): Rendered {
     const items: Rendered[] = [];
     for (let heading = 0; heading <= 6; heading++) {
-      var c;
-      const label = heading == 0 ? "Paragraph" : `Heading ${heading}`;
-      switch (heading) {
-        case 0:
-          c = <span>{label}</span>;
-          break;
-        case 1:
-          c = <h1>{label}</h1>;
-          break;
-        case 2:
-          c = <h2>{label}</h2>;
-          break;
-        case 3:
-          c = <h3>{label}</h3>;
-          break;
-        case 4:
-          c = <h4>{label}</h4>;
-          break;
-        case 5:
-          c = <h5>{label}</h5>;
-          break;
-        case 6:
-          c = <h6>{label}</h6>;
-          break;
-      }
-      const item = (
+      items.push(
         <MenuItem key={heading} eventKey={heading}>
-          {c}
+          {heading_content(heading)}
         </MenuItem>
       );
-      items.push(item);
     }
     return (
       <DropdownMenu
@@ -283,7 +249,7 @@ export class FormatBar extends Component<Props, {}> {
         key={"heading"}
         id={"heading"}
         onClick={(heading) =>
-          this.props.actions.format_action(`format_heading_${heading}`)
+          actions.format_action(`format_heading_${heading}`)
         }
       >
         {items}
@@ -291,22 +257,13 @@ export class FormatBar extends Component<Props, {}> {
     );
   }
 
-  render_colors_dropdown(): Rendered {
-    let color, code;
-    const items: Rendered[] = [];
-    const v = (() => {
-      const result: any[] = [];
-      for (color in css_colors) {
-        code = css_colors[color];
-        result.push([color, code]);
-      }
-      return result;
-    })();
-    v.sort((a, b) => cmp(a.code, b.code));
-    for (const x of v) {
-      color = x[0];
-      code = x[1];
-      const item = (
+  function render_colors_dropdown(): Rendered {
+    // sort reversed by "code"
+    const cols = sortBy(Object.keys(CSS_COLORS), (color) => CSS_COLORS[color]);
+    cols.reverse();
+    const items = cols.map((color) => {
+      const code = CSS_COLORS[color];
+      return (
         <MenuItem key={color} eventKey={code}>
           <span style={{ background: code }}>
             <Space />
@@ -317,23 +274,23 @@ export class FormatBar extends Component<Props, {}> {
           {color}
         </MenuItem>
       );
-      items.push(item);
-    }
+    });
+
     return (
       <DropdownMenu
         button={true}
         title={<Icon name={"colors"} />}
         key={"font-color"}
         id={"font-color"}
-        onClick={(code) => this.props.actions.format_action("color", code)}
+        onClick={(code) => actions.format_action("color", code)}
       >
         {items}
       </DropdownMenu>
     );
   }
 
-  render_font_dropdowns(): Rendered {
-    if (this.props.exclude?.["font_dropdowns"]) {
+  function render_font_dropdowns(): Rendered {
+    if (exclude?.["font_dropdowns"]) {
       return;
     }
     return (
@@ -341,28 +298,26 @@ export class FormatBar extends Component<Props, {}> {
         key={"font-dropdowns"}
         style={{ float: "right", marginRight: "1px" }}
       >
-        {this.render_font_family_dropdown()}
-        {this.render_font_size_dropdown()}
-        {this.render_heading_dropdown()}
-        {this.render_colors_dropdown()}
+        {render_font_family_dropdown()}
+        {render_font_size_dropdown()}
+        {render_heading_dropdown()}
+        {render_colors_dropdown()}
       </ButtonGroup>
     );
   }
 
-  render(): Rendered {
-    return (
-      <div style={{ background: "#f8f8f8", margin: "0 1px" }}>
-        {this.render_font_dropdowns()}
-        <div className={"cc-frame-tree-format-bar"}>
-          {this.render_text_style_buttons()}
-          <Space />
-          {this.render_insert_buttons()}
-          <Space />
-          {this.render_insert_dialog_buttons()}
-          {this.render_format_buttons()}
-          <Space />
-        </div>
+  return (
+    <div style={{ background: "#f8f8f8", margin: "0 1px" }}>
+      {render_font_dropdowns()}
+      <div className={"cc-frame-tree-format-bar"}>
+        {render_text_style_buttons()}
+        <Space />
+        {render_insert_buttons()}
+        <Space />
+        {render_insert_dialog_buttons()}
+        {render_format_buttons()}
+        <Space />
       </div>
-    );
-  }
-}
+    </div>
+  );
+}, shouldMemoize);

--- a/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
@@ -40,9 +40,9 @@ import {
   Rendered,
   useState,
   useEffect,
-} from "../../app-framework";
-import { Loading } from "../../components";
-import { AvailableFeatures } from "../../project_configuration";
+} from "@cocalc/frontend/app-framework";
+import { Loading } from "@cocalc/frontend/components";
+import { AvailableFeatures } from "@cocalc/frontend/project_configuration";
 import { Actions } from "../code-editor/actions";
 import { cm as cm_spec } from "../code-editor/editor";
 import { is_safari } from "../generic/browser";
@@ -54,39 +54,40 @@ import { get_file_editor } from "./register";
 import { FrameTitleBar } from "./title-bar";
 import * as tree_ops from "./tree-ops";
 import { EditorDescription, EditorSpec, EditorState, NodeDesc } from "./types";
+import { AccountState } from "@cocalc/frontend/account/types";
 
 interface FrameTreeProps {
-  name: string; // just so editors (leaf nodes) can plug into reduxProps if they need to.
   actions: Actions;
-  path: string; // assumed to never change -- all frames in same project
-  project_id: string; // assumed to never change -- all frames in same project
   active_id: string;
-  full_id: string;
-  frame_tree: Map<string, any>;
+  available_features: AvailableFeatures;
+  complete: Map<string, any>;
+  cursors: Map<string, any>;
+  derived_file_types: Set<string>;
+  editor_settings?: AccountState["editor_settings"];
+  editor_spec: EditorSpec;
   editor_state: EditorState; // IMPORTANT: change does NOT cause re-render (uncontrolled); only used for full initial render, on purpose, i.e., setting scroll positions.
   font_size: number;
+  frame_tree: Map<string, any>;
+  full_id: string;
+  has_uncommitted_changes: boolean;
+  has_unsaved_changes: boolean;
   is_only: boolean;
-  cursors: Map<string, any>;
-  read_only: boolean; // if true, then whole document considered read only (individual frames can still be via desc)
   is_public: boolean;
-  value?: string;
-  editor_spec: EditorSpec;
+  is_saving: boolean;
+  is_visible: boolean;
+  local_view_state: Map<string, any>;
+  misspelled_words: Set<string>;
+  name: string; // just so editors (leaf nodes) can plug into reduxProps if they need to.
+  path: string; // assumed to never change -- all frames in same project
+  project_id: string; // assumed to never change -- all frames in same project
+  read_only: boolean; // if true, then whole document considered read only (individual frames can still be via desc)
   reload: Map<string, number>;
   resize: number; // if changes, means that frames have been resized, so may need refreshing; passed to leaf.
-  misspelled_words: Set<string>;
-  has_unsaved_changes: boolean;
-  has_uncommitted_changes: boolean;
-  is_saving: boolean;
-  editor_settings?: Map<string, any>;
-  terminal?: Map<string, any>; // terminal settings from account
-  status: string;
   settings: Map<string, any>;
-  complete: Map<string, any>;
-  derived_file_types: Set<string>;
-  available_features: AvailableFeatures;
-  local_view_state: Map<string, any>;
-  is_visible: boolean;
+  status: string;
   tab_is_visible: boolean;
+  terminal?: Map<string, any>; // terminal settings from account
+  value?: string;
 }
 
 function shouldMemoize(prev, next) {

--- a/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
@@ -4,12 +4,20 @@
  */
 
 import { Map, Set } from "immutable";
-import { Rendered, React, useRedux } from "../../app-framework";
-import { ErrorDisplay, Loading } from "../../components";
-import { AvailableFeatures } from "../../project_configuration";
+import { Rendered, React, useRedux, CSS } from "@cocalc/frontend/app-framework";
+import { ErrorDisplay, Loading } from "@cocalc/frontend/components";
+import { AvailableFeatures } from "@cocalc/frontend/project_configuration";
 
 import { Actions } from "../code-editor/actions";
 import { EditorDescription, EditorState, NodeDesc } from "./types";
+
+const ERROR_STYLE: CSS = {
+  maxWidth: "100%",
+  maxHeight: "30%",
+  fontFamily: "monospace",
+  fontSize: "85%",
+  whiteSpace: "pre-wrap",
+} as const;
 
 interface Props {
   name: string;
@@ -156,13 +164,7 @@ export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
         banner={true}
         error={error}
         onClose={() => editor_actions.set_error("")}
-        body_style={{
-          maxWidth: "100%",
-          maxHeight: "30%",
-          fontFamily: "monospace",
-          fontSize: "85%",
-          whiteSpace: "pre-wrap",
-        }}
+        body_style={ERROR_STYLE}
       />
     );
   }

--- a/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
@@ -10,6 +10,7 @@ import { AvailableFeatures } from "@cocalc/frontend/project_configuration";
 
 import { Actions } from "../code-editor/actions";
 import { EditorDescription, EditorState, NodeDesc } from "./types";
+import { AccountState } from "@cocalc/frontend/account/types";
 
 const ERROR_STYLE: CSS = {
   maxWidth: "100%",
@@ -27,7 +28,7 @@ interface Props {
   font_size: number;
   editor_state: EditorState;
   active_id: string;
-  editor_settings?: Map<string, any>;
+  editor_settings?: AccountState["editor_settings"];
   terminal?: Map<string, any>;
   settings: Map<string, any>;
   status: string;
@@ -80,6 +81,7 @@ export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
     tab_is_visible,
   } = props;
 
+  // Must be CamelCase
   const TheComponent = props.component as any;
 
   const read_only: boolean | undefined = useRedux(name, "read_only");

--- a/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
@@ -4,8 +4,7 @@
  */
 
 import { Map, Set } from "immutable";
-
-import { Component, Rendered, rclass, rtypes } from "../../app-framework";
+import { Rendered, React, useRedux } from "../../app-framework";
 import { ErrorDisplay, Loading } from "../../components";
 import { AvailableFeatures } from "../../project_configuration";
 
@@ -45,101 +44,108 @@ interface Props {
   tab_is_visible: boolean; // if that editor tab is active -- see page/page.tsx
 }
 
-interface ReduxProps {
-  read_only?: boolean;
-  cursors?: Map<string, any>;
-  value?: string;
-  misspelled_words?: Set<string>;
-  complete?: Map<string, any>;
-  is_loaded?: boolean;
-  error?: string;
-  gutter_markers?: Map<string, any>;
-}
+export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
+  const {
+    name,
+    path,
+    project_id,
+    is_public,
+    font_size,
+    editor_state,
+    active_id,
+    editor_settings,
+    terminal,
+    settings,
+    status,
+    derived_file_types,
+    available_features,
+    resize,
+    actions,
+    spec,
+    desc,
+    editor_actions,
+    is_fullscreen,
+    reload,
+    is_subframe,
+    local_view_state,
+    is_visible,
+    tab_is_visible,
+  } = props;
 
-class FrameTreeLeaf extends Component<Props & ReduxProps> {
-  static reduxProps({ editor_actions, is_subframe }): object {
-    if (editor_actions == null) {
-      throw Error("bug -- editor_actions must not be null");
-    }
-    const { name } = editor_actions;
-    if (name == null) {
-      throw Error("bug -- name must not be null");
-    }
-    const redux_props = {
-      read_only: rtypes.bool,
-      cursors: rtypes.immutable.Map,
-      value: rtypes.string,
-      misspelled_words: rtypes.immutable.Set,
-      complete: rtypes.immutable.Map,
-      is_loaded: rtypes.bool,
-      error: rtypes.string,
-      gutter_markers: rtypes.immutable.Map,
-    };
-    if (!is_subframe) {
-      // This is used for showing the error message right with this frame,
-      // since otherwise it wouldn't be visible at all.
-      delete redux_props.error;
-    }
-    return {
-      [name]: redux_props,
-    };
+  const TheComponent = props.component as any;
+
+  const read_only: boolean | undefined = useRedux(name, "read_only");
+  const cursors: Map<string, any> | undefined = useRedux(name, "cursors");
+  const value: string | undefined = useRedux(name, "value");
+  const misspelled_words: Set<string> | undefined = useRedux(
+    name,
+    "misspelled_words"
+  );
+  const complete: Map<string, any> | undefined = useRedux(name, "complete");
+  const is_loaded: boolean | undefined = useRedux(name, "is_loaded");
+  const error: string | undefined = useRedux(name, "error");
+  const gutter_markers: Map<string, any> | undefined = useRedux(
+    name,
+    "gutter_markers"
+  );
+
+  if (editor_actions == null) {
+    throw Error("bug -- editor_actions must not be null");
   }
 
-  private render_leaf(): Rendered {
-    if (!this.props.is_loaded) return <Loading theme="medium" />;
-    const { desc, component, spec } = this.props;
-    if (component == null) throw Error("component must not be null");
+  if (editor_actions.name == null) {
+    throw Error("bug -- editor_actions.name must not be null");
+  }
+
+  function render_leaf(): Rendered {
+    if (!is_loaded) return <Loading theme="medium" />;
+    if (TheComponent == null) throw Error("component must not be null");
     return (
-      <this.props.component
+      <TheComponent
         id={desc.get("id")}
-        name={this.props.name}
-        actions={this.props.actions}
-        editor_actions={this.props.editor_actions}
+        name={name}
+        actions={actions}
+        editor_actions={editor_actions}
         mode={spec.mode}
-        read_only={desc.get(
-          "read_only",
-          this.props.read_only || this.props.is_public
-        )}
-        is_public={this.props.is_public}
-        font_size={desc.get("font_size", this.props.font_size)}
-        path={this.props.path}
+        read_only={desc.get("read_only", read_only || is_public)}
+        is_public={is_public}
+        font_size={desc.get("font_size", font_size)}
+        path={path}
         fullscreen_style={spec.fullscreen_style}
-        project_id={this.props.project_id}
-        editor_state={this.props.editor_state.get(desc.get("id"), Map())}
-        is_current={desc.get("id") === this.props.active_id}
-        cursors={this.props.cursors}
-        value={this.props.value}
-        misspelled_words={this.props.misspelled_words}
-        is_fullscreen={this.props.is_fullscreen}
-        reload={this.props.reload}
-        resize={this.props.resize}
+        project_id={project_id}
+        editor_state={editor_state.get(desc.get("id"), Map())}
+        is_current={desc.get("id") === active_id}
+        cursors={cursors}
+        value={value}
+        misspelled_words={misspelled_words}
+        is_fullscreen={is_fullscreen}
+        reload={reload}
+        resize={resize}
         reload_images={!!spec.reload_images}
         gutters={spec.gutters != null ? spec.gutters : []}
-        gutter_markers={this.props.gutter_markers}
-        editor_settings={this.props.editor_settings}
-        terminal={this.props.terminal}
-        settings={this.props.settings}
-        status={this.props.status}
+        gutter_markers={gutter_markers}
+        editor_settings={editor_settings}
+        terminal={terminal}
+        settings={settings}
+        status={status}
         renderer={spec.renderer}
-        complete={
-          this.props.complete && this.props.complete.get(desc.get("id"))
-        }
-        derived_file_types={this.props.derived_file_types}
-        local_view_state={this.props.local_view_state}
+        complete={complete && complete.get(desc.get("id"))}
+        derived_file_types={derived_file_types}
+        local_view_state={local_view_state}
         desc={desc}
-        available_features={this.props.available_features}
-        is_subframe={this.props.is_subframe}
-        is_visible={this.props.is_visible}
-        tab_is_visible={this.props.tab_is_visible}
+        available_features={available_features}
+        is_subframe={is_subframe}
+        is_visible={is_visible}
+        tab_is_visible={tab_is_visible}
       />
     );
   }
 
-  private render_error(): Rendered {
-    if (
-      !this.props.error ||
-      this.props.desc.get("id") !== this.props.active_id
-    ) {
+  function render_error(): Rendered {
+    // This is used for showing the error message right with this frame,
+    // since otherwise it wouldn't be visible at all.
+    if (!is_subframe) return;
+    if (!error || desc.get("id") !== active_id) {
       // either no error or not the currently selected frame (otherwise,
       // it's cluttery and there could be a bunch of the same frame all
       // showing the same error.)
@@ -148,8 +154,8 @@ class FrameTreeLeaf extends Component<Props & ReduxProps> {
     return (
       <ErrorDisplay
         banner={true}
-        error={this.props.error}
-        onClose={() => this.props.editor_actions.set_error("")}
+        error={error}
+        onClose={() => editor_actions.set_error("")}
         body_style={{
           maxWidth: "100%",
           maxHeight: "30%",
@@ -161,19 +167,14 @@ class FrameTreeLeaf extends Component<Props & ReduxProps> {
     );
   }
 
-  public render(): Rendered {
-    return (
-      <div
-        id={`frame-${this.props.desc.get("id")}`}
-        className="smc-vfill"
-        style={{ background: "white", zIndex: 1 }}
-      >
-        {this.render_error()}
-        {this.render_leaf()}
-      </div>
-    );
-  }
-}
-
-const FrameTreeLeaf0 = rclass(FrameTreeLeaf);
-export { FrameTreeLeaf0 as FrameTreeLeaf };
+  return (
+    <div
+      id={`frame-${desc.get("id")}`}
+      className="smc-vfill"
+      style={{ background: "white", zIndex: 1 }}
+    >
+      {render_error()}
+      {render_leaf()}
+    </div>
+  );
+});


### PR DESCRIPTION
# Description

this gets rid of two components used widely, hence there is some chance to introduce a problem, but I wasn't able to find anything during testing. the only change in functionality is sorting of colors – the old code accessed the "`.code`" attribute, which doesn't exist. I stayed true to that intention and well, now the colors are sorted by color.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
