### PR TITLE
server/single-mode: record start_ts and session_id in project status

### DIFF
--- a/src/packages/frontend/project/settings/project-control.tsx
+++ b/src/packages/frontend/project/settings/project-control.tsx
@@ -171,9 +171,7 @@ export const ProjectControl: React.FC<ReactProps> = (props: ReactProps) => {
   function render_uptime() {
     // start_ts is e.g. 1508576664416
     const start_ts = project.getIn(["status", "start_ts"]);
-    if (start_ts == undefined) {
-      return;
-    }
+    if (start_ts == undefined) return;
     if (project.getIn(["state", "state"]) !== "running") {
       return;
     }

--- a/src/packages/project/consts.ts
+++ b/src/packages/project/consts.ts
@@ -1,0 +1,14 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// static values for monitoring and project information
+
+import { uuid } from "@cocalc/util/misc";
+
+// uniquely identify this instance of the local hub
+export const session_id = uuid();
+
+// record when this instance started
+export const start_ts = Date.now();

--- a/src/packages/project/data.ts
+++ b/src/packages/project/data.ts
@@ -1,4 +1,9 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
 Paths to temporary files used by the project.
 */
 
@@ -12,6 +17,8 @@ export const hubPortFile = join(data, "hub-server.port");
 export const apiServerPortFile = join(data, "api-server.port");
 export const browserPortFile = join(data, "browser-server.port");
 export const projectPidFile = join(data, "project.pid");
+export const startTimestampFile = join(data, "start-timestamp.txt");
+export const sessionIDFile = join(data, "session-id.txt");
 export const rootSymlink = join(data, "root");
 export const secretToken =
   process.env.COCALC_SECRET_TOKEN ?? join(data, "secret_token");

--- a/src/packages/project/init-kucalc.ts
+++ b/src/packages/project/init-kucalc.ts
@@ -1,3 +1,8 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { options } from "./init-program";
 const kucalc = require("./kucalc");
 import * as projectSetup from "./project-setup";

--- a/src/packages/project/kucalc.coffee
+++ b/src/packages/project/kucalc.coffee
@@ -17,6 +17,8 @@ path       = require('path')
 {execSync} = require('child_process')
 {defaults} = misc = require('@cocalc/util/misc')
 
+{start_ts, session_id} = require('./consts')
+
 # global variable
 PROJECT_ID = undefined
 PREFIX = 'cocalc_project_'
@@ -39,16 +41,10 @@ prom_client.collectDefaultMetrics(timeout: 10 * 1000)
 
 # --- end prometheus setup
 
-
 # This gets **changed** to true, if a certain
 # command line flag is passed in.
 exports.IN_KUCALC = false
 
-# static values for monitoring and project information
-# uniquely identifies this instance of the local hub
-session_id = misc.uuid()
-# record when this instance started
-start_ts   = (new Date()).getTime()
 # status information
 current_status = {}
 
@@ -81,12 +77,13 @@ update_project_status = (client, cb) ->
 
 exports.compute_status = compute_status = (cb) ->
     status =
-        time      : (new Date()).getTime()
-        memory    : {rss: 0}
-        disk_MB   : 0
-        cpu       : {}
-        start_ts  : start_ts
-        processes : {}
+        time       : (new Date()).getTime()
+        memory     : {rss: 0}
+        disk_MB    : 0
+        cpu        : {}
+        start_ts   : start_ts
+        session_id : session_id
+        processes  : {}
     async.parallel([
         (cb) ->
             compute_status_disk(status, cb)

--- a/src/packages/project/servers/browser/http-server.ts
+++ b/src/packages/project/servers/browser/http-server.ts
@@ -1,4 +1,9 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
 This is an express http server that is meant to receive connections
 only from web browser clients that signed in as collaborators on
 this projects.  It serves both HTTP and websocket connections, which

--- a/src/packages/project/servers/init.ts
+++ b/src/packages/project/servers/init.ts
@@ -1,3 +1,8 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 /* Initialize both the hub and browser servers. */
 
 import { getLogger } from "@cocalc/project/logger";

--- a/src/packages/project/servers/pid-file.ts
+++ b/src/packages/project/servers/pid-file.ts
@@ -1,8 +1,22 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { writeFile } from "fs";
 import { callback } from "awaiting";
 
-import { projectPidFile } from "@cocalc/project/data";
+import {
+  projectPidFile,
+  startTimestampFile,
+  sessionIDFile,
+} from "@cocalc/project/data";
+import { session_id, start_ts } from "@cocalc/project/consts";
 
 export default async function init() {
-  await callback(writeFile, projectPidFile, `${process.pid}`);
+  await Promise.all([
+    callback(writeFile, projectPidFile, `${process.pid}`),
+    callback(writeFile, startTimestampFile, `${start_ts}`),
+    callback(writeFile, sessionIDFile, `${session_id}`),
+  ]);
 }

--- a/src/packages/project/servers/secret-token.ts
+++ b/src/packages/project/servers/secret-token.ts
@@ -1,4 +1,9 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
 Generate the "secret_token" file if it does not already exist.
 */
 

--- a/src/packages/server/projects/control/base.ts
+++ b/src/packages/server/projects/control/base.ts
@@ -1,4 +1,9 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
 Project control abstract base class.
 
 The hub uses this to get information about a project and do some basic tasks.
@@ -215,4 +220,3 @@ export interface CopyOptions {
   public?: boolean; // kucalc only: if true, may use the share server files rather than start the source project running
   exclude?: string[]; // options passed to rsync via --exclude
 }
-

--- a/src/packages/server/projects/control/single-user.ts
+++ b/src/packages/server/projects/control/single-user.ts
@@ -1,4 +1,9 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
 This is meant to run on a multi-user system, but where the hub
 runs as a single user and all projects also run as that same
 user, but with there own HOME directories.  There is thus no
@@ -64,7 +69,7 @@ class Project extends BaseProject {
     winston.debug(
       `got status of ${this.project_id} = ${JSON.stringify(status)}`
     );
-    this.saveStatusToDatabase(status);
+    await this.saveStatusToDatabase(status);
     return status;
   }
 

--- a/src/packages/server/projects/control/util.ts
+++ b/src/packages/server/projects/control/util.ts
@@ -228,6 +228,8 @@ export async function getStatus(HOME: string): Promise<ProjectStatus> {
     "sage_server.port",
     "sage_server.pid",
     "secret_token",
+    "start-timestamp.txt",
+    "session-id.txt",
   ]) {
     try {
       const val = (await readFile(join(data, path))).toString().trim();
@@ -236,6 +238,10 @@ export async function getStatus(HOME: string): Promise<ProjectStatus> {
         if (pidIsRunning(pid)) {
           status[path] = pid;
         }
+      } else if (path == "start-timestamp.txt") {
+        status.start_ts = parseInt(val)
+      } else if (path == "session-id.txt") {
+        status.session_id = val;
       } else if (path.endsWith(".port")) {
         status[path] = parseInt(val);
       } else {

--- a/src/packages/util/db-schema/projects.ts
+++ b/src/packages/util/db-schema/projects.ts
@@ -469,6 +469,8 @@ export interface ProjectStatus {
   "browser-server.port"?: number; // port listening for http/websocket conn from browser client
   "sage_server.port"?: number; // port where sage server is listening.
   "sage_server.pid"?: number; // pid of sage server process
+  start_ts?: number; // timestamp, when project server started
+  session_id?: string; // unique identifyer
   secret_token?: string; // long random secret token that is needed to communicate with local_hub
   version?: number; // version number of project code
   disk_MB?: number; // MB of used disk


### PR DESCRIPTION

# Description

this is mainly to have the `start_ts` timestamp available in development mode as well. I'm also adding the `session_id`, might be useful at some point.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
