### PR TITLE
jupyter: maybe fix a "TypeError: Cannot read properties of undefined 

### DIFF
--- a/src/packages/frontend/jupyter/output-messages/mime-types/register.ts
+++ b/src/packages/frontend/jupyter/output-messages/mime-types/register.ts
@@ -65,7 +65,8 @@ export function getHandler(type: string): Handler {
   if (h != null) return h.handler;
   for (const typeRegexp in HANDLERS) {
     if (type.match("^" + typeRegexp + "$")) {
-      return HANDLERS[typeRegexp].handler;
+      const hRegex = HANDLERS[typeRegexp];
+      if (hRegex != null) return hRegex.handler;
     }
   }
   return FallbackHandler;


### PR DESCRIPTION


# Description

There was a user reporting a `TypeError: Cannot read properties of undefined (reading 'handler')\n at HTMLDocument.eval`  … I don't now which document nor how to reproduce it, but just by going through the code I found this detail, which looks at least like a good idea to check.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
