### PR TITLE
fix switching latex deps 

### DIFF
--- a/src/packages/frontend/frame-editors/code-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/code-editor/actions.ts
@@ -2510,7 +2510,7 @@ export class Actions<
       if (node == null) return id;
       if (node.get("path") == path) return id; // already done;
       // Change it --
-      this.set_frame_to_code_editor(id, path);
+      await this.set_frame_to_code_editor(id, path);
       return id;
     }
 

--- a/src/packages/frontend/frame-editors/code-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/code-editor/actions.ts
@@ -466,8 +466,8 @@ export class Actions<
     if (this._state == "closed") {
       return;
     }
-    window.removeEventListener("resize", this.set_resize);
     this._state = "closed";
+    window.removeEventListener("resize", this.set_resize);
     this.__save_local_view_state();
     // switch back to non-debounced version, in case called after this point.
     this._save_local_view_state = this.__save_local_view_state;
@@ -1383,7 +1383,9 @@ export class Actions<
   }
 
   syncstring_commit(): void {
-    if (this._state === "closed") return;
+    // We also skip if the syncstring hasn't yet been initialized.
+    // This happens in some cae
+    if (this._state === "closed" || this._syncstring.state != "ready") return;
     if (this._syncstring != null) {
       this._syncstring.commit();
     }
@@ -1410,7 +1412,10 @@ export class Actions<
   }
 
   private set_syncstring(value: string, do_not_exit_undo_mode?: boolean): void {
-    if (this._state === "closed") return;
+    // note -- we don't try to set the syncstring if actions are closed
+    // or the syncstring isn't initialized yet.  The latter case happens when
+    // switching the file that is being edited in a frame, e.g., for latex.
+    if (this._state === "closed" || this._syncstring.state != "ready") return;
     const cur = this._syncstring.to_str();
     if (cur === value) {
       // did not actually change.
@@ -2560,7 +2565,7 @@ export class Actions<
   }
 
   public async init_code_editor(id: string, path: string): Promise<void> {
-    this.code_editors.init_code_editor(id, path);
+    await this.code_editors.init_code_editor(id, path);
   }
 
   public get_matching_frame(obj: object): string | undefined {

--- a/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
@@ -285,8 +285,7 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
       // right now... We need to switch to something like we do with
       // CodeEditorManager.
       let is_subframe: boolean = false;
-      // TODO is there a function somewhere defining this `editor-X-Y` pattern?
-      let name_leaf = `editor-${project_id}-${desc.get("path", path)}`;
+      let name_leaf = name;
       let actions_leaf = actions;
       if (
         spec.name === "TimeTravel" &&

--- a/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
@@ -285,7 +285,8 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
       // right now... We need to switch to something like we do with
       // CodeEditorManager.
       let is_subframe: boolean = false;
-      let name_leaf = name;
+      // TODO is there a function somewhere defining this `editor-X-Y` pattern?
+      let name_leaf = `editor-${project_id}-${desc.get("path", path)}`;
       let actions_leaf = actions;
       if (
         spec.name === "TimeTravel" &&

--- a/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
@@ -21,29 +21,29 @@ const ERROR_STYLE: CSS = {
 } as const;
 
 interface Props {
+  actions: Actions;
+  active_id: string;
+  available_features: AvailableFeatures;
+  component: any; // ??
+  derived_file_types: Set<string>;
+  desc: NodeDesc;
+  editor_actions: Actions;
+  editor_settings?: AccountState["editor_settings"];
+  editor_state: EditorState;
+  font_size: number;
+  is_fullscreen: boolean;
+  is_public: boolean;
+  is_subframe: boolean;
+  local_view_state: Map<string, any>;
   name: string;
   path: string;
   project_id: string;
-  is_public: boolean;
-  font_size: number;
-  editor_state: EditorState;
-  active_id: string;
-  editor_settings?: AccountState["editor_settings"];
-  terminal?: Map<string, any>;
-  settings: Map<string, any>;
-  status: string;
-  derived_file_types: Set<string>;
-  available_features: AvailableFeatures;
-  resize: number;
-  actions: Actions;
-  component: any; // ??
-  spec: EditorDescription;
-  desc: NodeDesc;
-  editor_actions: Actions;
-  is_fullscreen: boolean;
   reload?: number;
-  is_subframe: boolean;
-  local_view_state: Map<string, any>;
+  resize: number;
+  settings: Map<string, any>;
+  spec: EditorDescription;
+  status: string;
+  terminal?: Map<string, any>;
   // is_visible: true if the entire frame tree is visible (i.e., the tab is shown);
   // knowing this can be critical for rendering certain types of editors, e.g.,
   // see https://github.com/sagemathinc/cocalc/issues/5133 where xterm.js would get
@@ -55,30 +55,30 @@ interface Props {
 
 export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
   const {
+    actions,
+    active_id,
+    available_features,
+    derived_file_types,
+    desc,
+    editor_actions,
+    editor_settings,
+    editor_state,
+    font_size,
+    is_fullscreen,
+    is_public,
+    is_subframe,
+    is_visible,
+    local_view_state,
     name,
     path,
     project_id,
-    is_public,
-    font_size,
-    editor_state,
-    active_id,
-    editor_settings,
-    terminal,
-    settings,
-    status,
-    derived_file_types,
-    available_features,
-    resize,
-    actions,
-    spec,
-    desc,
-    editor_actions,
-    is_fullscreen,
     reload,
-    is_subframe,
-    local_view_state,
-    is_visible,
+    resize,
+    settings,
+    spec,
+    status,
     tab_is_visible,
+    terminal,
   } = props;
 
   // Must be CamelCase
@@ -86,6 +86,7 @@ export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
 
   const read_only: boolean | undefined = useRedux(name, "read_only");
   const cursors: Map<string, any> | undefined = useRedux(name, "cursors");
+
   const value: string | undefined = useRedux(name, "value");
   const misspelled_words: Set<string> | undefined = useRedux(
     name,

--- a/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
@@ -21,6 +21,7 @@ const ERROR_STYLE: CSS = {
 } as const;
 
 interface Props {
+  name: string;
   actions: Actions;
   active_id: string;
   available_features: AvailableFeatures;
@@ -35,7 +36,6 @@ interface Props {
   is_public: boolean;
   is_subframe: boolean;
   local_view_state: Map<string, any>;
-  name: string;
   path: string;
   project_id: string;
   reload?: number;
@@ -69,7 +69,6 @@ export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
     is_subframe,
     is_visible,
     local_view_state,
-    name,
     path,
     project_id,
     reload,
@@ -80,6 +79,17 @@ export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
     tab_is_visible,
     terminal,
   } = props;
+
+  if (editor_actions == null) {
+    throw Error("bug -- editor_actions must not be null");
+  }
+
+  if (editor_actions.name == null) {
+    throw Error("bug -- editor_actions.name must not be null");
+  }
+
+  // for redux, not props.name!
+  const { name } = editor_actions;
 
   // Must be CamelCase
   const TheComponent = props.component as any;
@@ -100,21 +110,13 @@ export const FrameTreeLeaf: React.FC<Props> = React.memo((props: Props) => {
     "gutter_markers"
   );
 
-  if (editor_actions == null) {
-    throw Error("bug -- editor_actions must not be null");
-  }
-
-  if (editor_actions.name == null) {
-    throw Error("bug -- editor_actions.name must not be null");
-  }
-
   function render_leaf(): Rendered {
     if (!is_loaded) return <Loading theme="medium" />;
     if (TheComponent == null) throw Error("component must not be null");
     return (
       <TheComponent
         id={desc.get("id")}
-        name={name}
+        name={props.name}
         actions={actions}
         editor_actions={editor_actions}
         mode={spec.mode}

--- a/src/packages/frontend/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -7,6 +7,7 @@
 Show errors and warnings.
 */
 
+import { Alert } from "antd";
 import { sortBy } from "lodash";
 import { capitalize, is_different, path_split } from "@cocalc/util/misc";
 import { React, Rendered, useRedux } from "../../app-framework";
@@ -15,7 +16,7 @@ import { BuildLogs } from "./actions";
 import { Icon, IconName, Loading } from "@cocalc/frontend/components";
 import { COLORS } from "@cocalc/util/theme";
 import { use_build_logs } from "./hooks";
-import { EditorState } from "../frame-tree/types"
+import { EditorState } from "../frame-tree/types";
 
 function group_to_level(group: string): string {
   switch (group) {
@@ -182,21 +183,12 @@ function should_memoize(prev, next): boolean {
 // the function above is used for React.memo, see bottom
 export const ErrorsAndWarnings: React.FC<ErrorsAndWarningsProps> = React.memo(
   (props) => {
-    const {
-      /*id,*/
-      name,
-      actions,
-      /*editor_state,*/
-      /*is_fullscreen,*/
-      /*project_id,*/
-      /*path,*/
-      /*reload,*/
-      /*font_size,*/
-    } = props;
+    const { name, actions } = props;
 
     const build_logs: BuildLogs = use_build_logs(name);
     const status: string = useRedux([name, "status"]) ?? "";
     const knitr: boolean = useRedux([name, "knitr"]);
+    const includeError: string = useRedux([name, "includeError"]) ?? "";
 
     function render_status(): Rendered {
       if (status) {
@@ -315,6 +307,15 @@ export const ErrorsAndWarnings: React.FC<ErrorsAndWarningsProps> = React.memo(
           fontSize: "10pt",
         }}
       >
+        {includeError && (
+          <Alert
+            style={{ margin: "15px" }}
+            type="error"
+            showIcon
+            message={"\\include error -- ensure all included files exist"}
+            description={includeError.replace(/Error:/g, "")}
+          />
+        )}
         {render_hint()}
         {render_status()}
         {render_groups()}

--- a/src/packages/project/browser-websocket/api.ts
+++ b/src/packages/project/browser-websocket/api.ts
@@ -86,7 +86,7 @@ async function handle_api_call(data: Mesg, primus: any): Promise<any> {
     case "rename_file":
       return await rename_file(data.src, data.dest, winston);
     case "canonical_paths":
-      return canonical_paths(data.paths);
+      return await canonical_paths(data.paths);
     case "configuration":
       return await get_configuration(data.aspect, data.no_cache);
     case "prettier": // deprecated

--- a/src/packages/project/browser-websocket/canonical-path.ts
+++ b/src/packages/project/browser-websocket/canonical-path.ts
@@ -11,23 +11,28 @@
    be in the home directory.
 */
 
+import { realpath } from "fs/promises";
 import { resolve } from "path";
 
-export function canonical_paths(paths: string[]): string[] {
+export async function canonical_paths(paths: string[]): Promise<string[]> {
   const v: string[] = [];
 
-  const { HOME } = process.env;
-  if (HOME == null) {
+  const { HOME: HOME_ENV } = process.env;
+  if (HOME_ENV == null) {
     throw Error("HOME environment variable must be defined");
   }
 
+  // realpath is necessary, because in some circumstances the home dir is made up of a symlink
+  const HOME = await realpath(HOME_ENV);
+
   for (let path of paths) {
-    path = resolve(path);
+    path = await realpath(resolve(path));
     if (path.startsWith(HOME)) {
       v.push(path.slice(HOME.length + 1));
     } else {
       v.push(HOME + "/.smc/root" + path);
     }
   }
+
   return v;
 }


### PR DESCRIPTION
# Description

this is a half way attempt to fix #5779

The most important change I did is ```let name_leaf = `editor-${project_id}-${desc.get("path", path)}``` for the Leaf component, before that it was just the `name`. My main problem is, I have no idea what the real implications of changing any of these variables are. In this case the `CodeMirror` editor will get a different "value", and hence it starts showing a different content. At the same time it starts throwing errors: `Error: doc must be set  at SyncString.SyncDoc.to_str (sync-doc.ts ...)`.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
