### PR TITLE
Less intimidating trial banner

### DIFF
--- a/src/packages/frontend/project/settings/site-license.tsx
+++ b/src/packages/frontend/project/settings/site-license.tsx
@@ -23,25 +23,31 @@ interface Props {
   site_license?: Map<string, Map<string, number>>;
 }
 
+export async function applyLicense({
+  project_id,
+  license_id,
+}: {
+  project_id: string;
+  license_id: string;
+}): Promise<void> {
+  const actions = redux.getActions("projects");
+  // newly added licenses
+  try {
+    await actions.add_site_license_to_project(project_id, license_id);
+    await actions.restart_project(project_id);
+  } catch (err) {
+    alert_message({
+      type: "error",
+      message: `Unable to add license key -- ${err}`,
+    });
+    return;
+  }
+}
+
 export const SiteLicense: React.FC<Props> = (props: Props) => {
   const { project_id, site_license } = props;
 
   const [show_site_license, set_show_site_license] = useState<boolean>(false);
-
-  async function set_license(license_id: string): Promise<void> {
-    const actions = redux.getActions("projects");
-    // newly added licenses
-    try {
-      await actions.add_site_license_to_project(project_id, license_id);
-      await actions.restart_project(project_id);
-    } catch (err) {
-      alert_message({
-        type: "error",
-        message: `Unable to add license key -- ${err}`,
-      });
-      return;
-    }
-  }
 
   function render_site_license_text(): Rendered {
     if (!show_site_license) return;
@@ -60,7 +66,7 @@ export const SiteLicense: React.FC<Props> = (props: Props) => {
           exclude={site_license?.keySeq().toJS()}
           onSave={(license_id) => {
             set_show_site_license(false);
-            set_license(license_id);
+            applyLicense({ project_id, license_id });
           }}
           onCancel={() => set_show_site_license(false)}
         />

--- a/src/packages/frontend/project/trial-banner.tsx
+++ b/src/packages/frontend/project/trial-banner.tsx
@@ -7,15 +7,21 @@ import {
   CSS,
   React,
   redux,
+  useState,
   useMemo,
   useStore,
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { A, Icon } from "@cocalc/frontend/components";
 import { server_time } from "@cocalc/frontend/frame-editors/generic/client";
+import {
+  SiteLicenseInput,
+  useManagedLicenses,
+} from "@cocalc/frontend/site-licenses/input";
 import { Alert } from "antd";
 import humanizeList from "humanize-list";
 import { allow_project_to_run } from "./client-side-throttle";
+import { applyLicense } from "./settings/site-license";
 
 export const DOC_TRIAL = "https://doc.cocalc.com/trial.html";
 
@@ -35,7 +41,7 @@ const A_STYLE_ELEVATED: CSS = {
 const ALERT_STYLE: CSS = {
   padding: "5px 10px",
   marginBottom: 0,
-  fontSize: "12pt",
+  fontSize: "10pt",
   borderRadius: 0,
 } as const;
 
@@ -43,6 +49,7 @@ const ALERT_STYLE_ELEVATED: CSS = {
   ...ALERT_STYLE,
   color: "white",
   background: "red",
+  fontSize: "12pt",
 } as const;
 
 interface Props {
@@ -98,13 +105,19 @@ export const TrialBanner: React.FC<Props> = React.memo(({ project_id }) => {
     return null;
   }
 
-  const proj_created =
+  // timestamp, when this project was created. won't change over time.
+  const projCreatedTS =
     project_map?.getIn([project_id, "created"]) ?? new Date(0);
+
+  // list of all licenses applied to this project
+  const projectSiteLicenses =
+    project_map?.get(project_id)?.get("site_license")?.keySeq().toJS() ?? [];
 
   return (
     <TrialBannerComponent
       project_id={project_id}
-      proj_created={proj_created.getTime()}
+      projectSiteLicenses={projectSiteLicenses}
+      proj_created={projCreatedTS.getTime()}
       host={host}
       internet={internet}
     />
@@ -113,6 +126,7 @@ export const TrialBanner: React.FC<Props> = React.memo(({ project_id }) => {
 
 interface BannerProps {
   project_id: string;
+  projectSiteLicenses: string[];
   host: boolean;
   internet: boolean;
   proj_created: number; // timestamp when project started
@@ -121,22 +135,32 @@ interface BannerProps {
 // string and URLs
 const NO_INTERNET =
   "you can't install packages, clone from GitHub, or download datasets";
-const NO_HOST = ["expect VERY bad performance (e.g., 10 times slower!)"];
+const NO_HOST = ["expect VERY bad performance (up to several times slower!)"];
 const INET_QUOTA =
   "https://doc.cocalc.com/billing.html#what-exactly-is-the-internet-access-quota";
 const MEMBER_QUOTA =
   "https://doc.cocalc.com/billing.html#what-is-member-hosting";
-const ADD_LICENSE =
-  "https://doc.cocalc.com/project-settings.html#project-add-license";
+// const ADD_LICENSE = "https://doc.cocalc.com/project-settings.html#project-add-license";
 
 const TrialBannerComponent: React.FC<BannerProps> = React.memo(
   (props: BannerProps) => {
-    const { host, internet, project_id, proj_created } = props;
+    const { host, internet, project_id, proj_created, projectSiteLicenses } =
+      props;
+
+    const [showAddLicense, setShowAddLicense] = useState<boolean>(false);
+    const managedLicenses = useManagedLicenses();
 
     const age_ms: number = server_time().getTime() - proj_created;
     const ageDays = age_ms / (24 * 60 * 60 * 1000);
 
-    const elevated = ageDays >= ELEVATED_DAYS;
+    // when to show the more intimidating red banner:
+    // after $ELEVATED_DAYS days
+    // but not if there are already any licenses applied to the project
+    // and also if user manages at least one license
+    const elevated =
+      ageDays >= ELEVATED_DAYS &&
+      projectSiteLicenses.length === 0 &&
+      managedLicenses?.size === 0;
     const style = elevated ? ALERT_STYLE_ELEVATED : ALERT_STYLE;
     const a_style = elevated ? A_STYLE_ELEVATED : A_STYLE;
 
@@ -163,9 +187,9 @@ const TrialBannerComponent: React.FC<BannerProps> = React.memo(
             <u>buy a license</u> (starting at about $3/month)
           </a>{" "}
           and then{" "}
-          <A style={a_style} href={ADD_LICENSE}>
+          <a style={a_style} onClick={() => setShowAddLicense(true)}>
             <u>apply it to this project</u>
-          </A>
+          </a>
         </>
       );
 
@@ -229,6 +253,50 @@ const TrialBannerComponent: React.FC<BannerProps> = React.memo(
       );
     }
 
+    function renderApplySiteLicense() {
+      if (!showAddLicense) return;
+
+      // NOTE: we show this dialog even if user does not manage any licenses,
+      // because the user could have one via another channel and just wants to add it directly via copy/paste.
+      return (
+        <>
+          <br />
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              flex: "1 0 auto",
+            }}
+          >
+            <div
+              style={{
+                margin: "10px 10px 10px 0",
+                verticalAlign: "bottom",
+                display: "flex",
+                fontWeight: "bold",
+                whiteSpace: "nowrap",
+              }}
+            >
+              Select a license:
+            </div>
+            <SiteLicenseInput
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                flex: "1 0 auto",
+              }}
+              exclude={projectSiteLicenses}
+              onSave={(license_id) => {
+                setShowAddLicense(false);
+                applyLicense({ project_id, license_id });
+              }}
+              onCancel={() => setShowAddLicense(false)}
+            />
+          </div>
+        </>
+      );
+    }
+
     return (
       <Alert
         type="warning"
@@ -241,8 +309,10 @@ const TrialBannerComponent: React.FC<BannerProps> = React.memo(
         }
         description={
           <>
-            <Icon name="exclamation-triangle" /> {renderMessage()}{" "}
+            <Icon name="exclamation-triangle" />{" "}
+            <span style={{ fontSize: style.fontSize }}>{renderMessage()}</span>{" "}
             {renderLearnMore(style.color)}
+            {renderApplySiteLicense()}
           </>
         }
       />

--- a/src/packages/frontend/project/trial-banner.tsx
+++ b/src/packages/frontend/project/trial-banner.tsx
@@ -3,27 +3,47 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import humanizeList from "humanize-list";
-import { server_time } from "../frame-editors/generic/client";
 import {
   CSS,
   React,
   redux,
   useMemo,
-  useTypedRedux,
   useStore,
-} from "../app-framework";
-const { Alert } = require("react-bootstrap");
-import { Icon, A } from "../components";
-export const DOC_TRIAL = "https://doc.cocalc.com/trial.html";
+  useTypedRedux,
+} from "@cocalc/frontend/app-framework";
+import { A, Icon } from "@cocalc/frontend/components";
+import { server_time } from "@cocalc/frontend/frame-editors/generic/client";
+import { Alert } from "antd";
+import humanizeList from "humanize-list";
 import { allow_project_to_run } from "./client-side-throttle";
 
+export const DOC_TRIAL = "https://doc.cocalc.com/trial.html";
+
+const ELEVATED_DAYS = 10;
+
 // explains implications for having no internet and/or no member hosting
-const A_STYLE = {
+const A_STYLE: CSS = {
   cursor: "pointer",
-  color: "white",
   fontWeight: "bold",
-} as CSS;
+} as const;
+
+const A_STYLE_ELEVATED: CSS = {
+  ...A_STYLE,
+  color: "white",
+};
+
+const ALERT_STYLE: CSS = {
+  padding: "5px 10px",
+  marginBottom: 0,
+  fontSize: "12pt",
+  borderRadius: 0,
+} as const;
+
+const ALERT_STYLE_ELEVATED: CSS = {
+  ...ALERT_STYLE,
+  color: "white",
+  background: "red",
+} as const;
 
 interface Props {
   project_id: string;
@@ -50,107 +70,7 @@ export const TrialBanner: React.FC<Props> = React.memo(({ project_id }) => {
     "free_warning_closed"
   );
 
-  function message(host: boolean, internet: boolean): JSX.Element | undefined {
-    const allow_run = allow_project_to_run(project_id);
-
-    const proj_created =
-      project_map?.getIn([project_id, "created"]) ?? new Date(0);
-    const age_ms: number = server_time().getTime() - proj_created.getTime();
-    const age_days = age_ms / (24 * 60 * 60 * 1000);
-
-    const trial_project = (
-      <strong>
-        <A href={DOC_TRIAL} style={A_STYLE}>
-          Free Trial (Day {Math.floor(age_days)})
-        </A>
-      </strong>
-    );
-    const no_internet =
-      "you can't install packages, clone from GitHub, or download datasets";
-    const no_host = ["expect VERY bad performance (e.g., 10 times slower!)"];
-    const inetquota =
-      "https://doc.cocalc.com/billing.html#what-exactly-is-the-internet-access-quota";
-    const memberquota =
-      "https://doc.cocalc.com/billing.html#what-is-member-hosting";
-    const add_license =
-      "https://doc.cocalc.com/project-settings.html#project-add-license";
-    const buy_and_upgrade = (
-      <>
-        <a
-          style={A_STYLE}
-          onClick={() => {
-            redux.getActions("page").set_active_tab("account");
-            const account_actions = redux.getActions("account");
-            account_actions.set_show_purchase_form(true);
-            account_actions.set_active_tab("licenses");
-          }}
-        >
-          <u>buy a license</u> (starting at about $3/month)
-        </a>{" "}
-        and then{" "}
-        <A style={A_STYLE} href={add_license}>
-          <u>apply it to this project</u>
-        </A>
-      </>
-    );
-    if (!allow_run) {
-      return (
-        <span>
-          {trial_project} - There are too many free trial projects running right
-          now. Try again later or {buy_and_upgrade}.
-        </span>
-      );
-    }
-    if (host && internet) {
-      return (
-        <span>
-          {trial_project} – {buy_and_upgrade}.
-          <br />
-          Otherwise, {humanizeList([...no_host, no_internet])}
-          {"."}
-        </span>
-      );
-    } else if (host) {
-      return (
-        <span>
-          {trial_project} – upgrade to{" "}
-          <A href={memberquota} style={A_STYLE}>
-            <u>Member Hosting</u>
-          </A>{" "}
-          or {humanizeList(no_host)}
-          {"."}
-        </span>
-      );
-    } else if (internet) {
-      return (
-        <span>
-          <strong>No internet access</strong> – upgrade{" "}
-          <A href={inetquota} style={A_STYLE}>
-            <u>Internet Access</u>
-          </A>{" "}
-          or {no_internet}
-          {"."}
-        </span>
-      );
-    }
-  }
-
-  function render_learn_more(color): JSX.Element {
-    const style = {
-      ...A_STYLE,
-      ...{ fontWeight: "bold" as "bold", color: color },
-    };
-    return (
-      <>
-        {" – "}
-        <A href={DOC_TRIAL} style={style}>
-          <u>more info</u>
-        </A>
-        {"..."}
-      </>
-    );
-  }
-
+  // paying usres are allowed to have a setting to hide banner unconditionally
   if (other_settings?.get("no_free_warnings")) {
     return null;
   }
@@ -178,25 +98,154 @@ export const TrialBanner: React.FC<Props> = React.memo(({ project_id }) => {
     return null;
   }
 
-  const style = {
-    padding: "5px 10px",
-    marginBottom: 0,
-    fontSize: "12pt",
-    borderRadius: 0,
-    color: "white",
-    background: "red",
-  } as CSS;
-
-  const mesg = message(host, internet);
+  const proj_created =
+    project_map?.getIn([project_id, "created"]) ?? new Date(0);
 
   return (
-    <Alert bsStyle="warning" style={style}>
-      <Icon
-        name="exclamation-triangle"
-        style={{ float: "right", marginTop: "3px" }}
-      />
-      <Icon name="exclamation-triangle" /> {mesg}
-      {render_learn_more(style.color)}
-    </Alert>
+    <TrialBannerComponent
+      project_id={project_id}
+      proj_created={proj_created.getTime()}
+      host={host}
+      internet={internet}
+    />
   );
 });
+
+interface BannerProps {
+  project_id: string;
+  host: boolean;
+  internet: boolean;
+  proj_created: number; // timestamp when project started
+}
+
+// string and URLs
+const NO_INTERNET =
+  "you can't install packages, clone from GitHub, or download datasets";
+const NO_HOST = ["expect VERY bad performance (e.g., 10 times slower!)"];
+const INET_QUOTA =
+  "https://doc.cocalc.com/billing.html#what-exactly-is-the-internet-access-quota";
+const MEMBER_QUOTA =
+  "https://doc.cocalc.com/billing.html#what-is-member-hosting";
+const ADD_LICENSE =
+  "https://doc.cocalc.com/project-settings.html#project-add-license";
+
+const TrialBannerComponent: React.FC<BannerProps> = React.memo(
+  (props: BannerProps) => {
+    const { host, internet, project_id, proj_created } = props;
+
+    const age_ms: number = server_time().getTime() - proj_created;
+    const ageDays = age_ms / (24 * 60 * 60 * 1000);
+
+    const elevated = ageDays >= ELEVATED_DAYS;
+    const style = elevated ? ALERT_STYLE_ELEVATED : ALERT_STYLE;
+    const a_style = elevated ? A_STYLE_ELEVATED : A_STYLE;
+
+    const trial_project = (
+      <strong>
+        <A href={DOC_TRIAL} style={a_style}>
+          Free Trial (Day {Math.floor(ageDays)})
+        </A>
+      </strong>
+    );
+
+    function renderMessage(): JSX.Element | undefined {
+      const buy_and_upgrade = (
+        <>
+          <a
+            style={a_style}
+            onClick={() => {
+              redux.getActions("page").set_active_tab("account");
+              const account_actions = redux.getActions("account");
+              account_actions.set_show_purchase_form(true);
+              account_actions.set_active_tab("licenses");
+            }}
+          >
+            <u>buy a license</u> (starting at about $3/month)
+          </a>{" "}
+          and then{" "}
+          <A style={a_style} href={ADD_LICENSE}>
+            <u>apply it to this project</u>
+          </A>
+        </>
+      );
+
+      const allow_run = allow_project_to_run(project_id);
+      if (!allow_run) {
+        return (
+          <span>
+            {trial_project} - There are too many free trial projects running
+            right now. Try again later or {buy_and_upgrade}.
+          </span>
+        );
+      }
+
+      if (host && internet) {
+        return (
+          <span>
+            {trial_project} – {buy_and_upgrade}.
+            <br />
+            Otherwise, {humanizeList([...NO_HOST, NO_INTERNET])}
+            {"."}
+          </span>
+        );
+      } else if (host) {
+        return (
+          <span>
+            {trial_project} – upgrade to{" "}
+            <A href={MEMBER_QUOTA} style={a_style}>
+              <u>Member Hosting</u>
+            </A>{" "}
+            or {humanizeList(NO_HOST)}
+            {"."}
+          </span>
+        );
+      } else if (internet) {
+        return (
+          <span>
+            <strong>No internet access</strong> – upgrade{" "}
+            <A href={INET_QUOTA} style={a_style}>
+              <u>Internet Access</u>
+            </A>{" "}
+            or {NO_INTERNET}
+            {"."}
+          </span>
+        );
+      }
+    }
+
+    function renderLearnMore(color): JSX.Element {
+      const style = {
+        ...a_style,
+        ...{ fontWeight: "bold" as "bold", color: color },
+      };
+      return (
+        <>
+          {" – "}
+          <A href={DOC_TRIAL} style={style}>
+            <u>more info</u>
+          </A>
+          {"..."}
+        </>
+      );
+    }
+
+    return (
+      <Alert
+        type="warning"
+        style={style}
+        icon={
+          <Icon
+            name="exclamation-triangle"
+            style={{ float: "right", marginTop: "3px" }}
+          />
+        }
+        description={
+          <>
+            <Icon name="exclamation-triangle" /> {renderMessage()}{" "}
+            {renderLearnMore(style.color)}
+          </>
+        }
+      />
+    );
+  }
+);

--- a/src/packages/frontend/site-licenses/input.tsx
+++ b/src/packages/frontend/site-licenses/input.tsx
@@ -5,21 +5,37 @@
 
 // Inputing a site license, e.g., for a project, course, etc.
 
-import { redux, useTypedRedux, useEffect } from "../app-framework";
-import { Loading } from "../components";
+import {
+  React,
+  redux,
+  useTypedRedux,
+  useEffect,
+  CSS,
+} from "@cocalc/frontend/app-framework";
+import { Loading } from "@cocalc/frontend/components";
 import SelectLicense, { License } from "./select-license";
+
+export function useManagedLicenses() {
+  const managedLicenses = useTypedRedux("billing", "managed_licenses");
+
+  useEffect(() => {
+    redux.getActions("billing").update_managed_licenses();
+  }, []);
+
+  return managedLicenses;
+}
 
 interface Props {
   onSave: (licenseId: string) => void;
   onCancel: () => void;
   exclude?: string[];
+  style?: CSS;
 }
 
-export function SiteLicenseInput({ onSave, onCancel, exclude }: Props) {
-  const managedLicenses = useTypedRedux("billing", "managed_licenses");
-  useEffect(() => {
-    redux.getActions("billing").update_managed_licenses();
-  }, []);
+export const SiteLicenseInput: React.FC<Props> = (props: Props) => {
+  const { onSave, onCancel, exclude, style } = props;
+
+  const managedLicenses = useManagedLicenses();
 
   if (managedLicenses == null) return <Loading />;
 
@@ -30,6 +46,7 @@ export function SiteLicenseInput({ onSave, onCancel, exclude }: Props) {
       exclude={exclude}
       managedLicenses={managedLicenses.toJS() as { [id: string]: License }}
       confirmLabel={"Apply License"}
+      style={style}
     />
   );
-}
+};

--- a/src/packages/frontend/site-licenses/select-license.tsx
+++ b/src/packages/frontend/site-licenses/select-license.tsx
@@ -6,13 +6,14 @@ Component takes as input data that describes a licens.
 IMPORTANT: this component must work in *both* from nextjs and static.
 */
 
-import { ReactNode, useRef, useMemo, useState } from "react";
-import { Alert, Button, Checkbox, Select, Space } from "antd";
-const { Option } = Select;
-import { isValidUUID, days_ago as daysAgo, len } from "@cocalc/util/misc";
-import { describe_quota as describeQuota } from "@cocalc/util/db-schema/site-licenses";
-import { keys } from "lodash";
+import { CSS } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components/icon";
+import { describe_quota as describeQuota } from "@cocalc/util/db-schema/site-licenses";
+import { days_ago as daysAgo, isValidUUID, len } from "@cocalc/util/misc";
+import { Alert, Button, Checkbox, Select, Space } from "antd";
+import { keys } from "lodash";
+import { ReactNode, useMemo, useRef, useState } from "react";
+const { Option } = Select;
 
 export interface License {
   expires?: Date;
@@ -28,6 +29,7 @@ interface Props {
   managedLicenses: { [id: string]: License };
   defaultLicenseId?: string;
   confirmLabel?: ReactNode;
+  style?: CSS;
 }
 
 export default function SelectLicense({
@@ -38,6 +40,7 @@ export default function SelectLicense({
   exclude,
   managedLicenses,
   confirmLabel,
+  style,
 }: Props) {
   const isBlurredRef = useRef<boolean>(true);
   const [licenseId, setLicenseId] = useState<string>(defaultLicenseId ?? "");
@@ -92,7 +95,7 @@ export default function SelectLicense({
   const valid = isValidUUID(licenseId);
 
   return (
-    <div>
+    <div style={style}>
       <div style={{ width: "100%", display: "flex" }}>
         <Select
           style={{ margin: "5px 15px 10px 0", flex: 1 }}


### PR DESCRIPTION
# Description

This changes the trial banner in various ways:

* if you manage any license, never red
* in the first few days of the trial, also not red
* when you click "apply", the dropdown to select a license appears right there
* I've also split this up and got rid of react-bootstrap for the `Alert`

testing: there were a few edge cases, like, new project and no license, etc. … but I think I got them all.

deployment: this is frontend only

normal (with expanded dialog)

![Screenshot from 2022-03-16 16-07-17](https://user-images.githubusercontent.com/207405/158622790-aaf82227-96de-4707-85a6-9086c0638ee1.png)


severe:

![Screenshot from 2022-03-16 16-08-02](https://user-images.githubusercontent.com/207405/158623138-0658b879-3faa-4f02-9f49-c5fca0a0d40e.png)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
