### PR TITLE
If we proxing cocalc with nginx http , we failed to set secure cookies

### DIFF
--- a/src/packages/hub/auth.ts
+++ b/src/packages/hub/auth.ts
@@ -498,9 +498,12 @@ export class PassportManager {
         const cookies = new Cookies(req, res);
         // to match @cocalc/frontend/client/password-reset
         const name = encodeURIComponent(`${base_path}PWRESET`);
+
+        const secure = (req.protocol === 'https');
+
         cookies.set(name, token, {
           maxAge: ms("5 minutes"),
-          secure: true,
+          secure: secure,
           overwrite: true,
           httpOnly: false,
         });


### PR DESCRIPTION
If we proxing cocalc with nginx http , we failed to set secure cookies, and it breaks for example password recovering.