### PR TITLE
Join method from path module should not be used for joining URIs part…

### DIFF
--- a/src/packages/frontend/collaborators/project-invite-tokens.tsx
+++ b/src/packages/frontend/collaborators/project-invite-tokens.tsx
@@ -219,7 +219,7 @@ export const ProjectInviteTokens: React.FC<Props> = React.memo(
           <br />
           <br />
           <CopyToClipBoard
-            value={join(base, `app?${PROJECT_INVITE_QUERY_PARAM}=${token}`)}
+            value={`${base}app?${PROJECT_INVITE_QUERY_PARAM}=${token}`}
             style={{ width: "100%" }}
           />
           <br />


### PR DESCRIPTION
Join method from path module should not be used for joining URIs part, because it eats double slashes and make incorrect URI schema in URLs.

The bug that fixed here looks as 

![image](https://user-images.githubusercontent.com/1609739/159241135-a9ef5450-896e-4909-9ed0-5557f552b215.png)


