### PR TITLE
jupyter/nbconvert: increase timeout

### DIFF
--- a/src/packages/project/jupyter/convert/index.ts
+++ b/src/packages/project/jupyter/convert/index.ts
@@ -22,7 +22,7 @@ export async function nbconvert(opts: NbconvertParams): Promise<void> {
   log.debug("start", opts);
   try {
     if (!opts.timeout) {
-      opts.timeout = 30;
+      opts.timeout = 60;
     }
 
     let { j, to } = parseTo(opts.args);


### PR DESCRIPTION
# Description

there was an problem reported about "pdf via latex" and I don't really understand what went wrong. in any case, this changes the default timeout to a minute. I don't know if there are other more specific timeouts …

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
