### PR TITLE
fix license related issues

### DIFF
--- a/src/packages/database/postgres/site-license/sync-subscriptions.ts
+++ b/src/packages/database/postgres/site-license/sync-subscriptions.ts
@@ -51,7 +51,9 @@ type LicenseSubs = {
 
 // for each license_id, we want to know if/when it expires and if it is a trial -- trials are ignored
 type LicenseInfo = {
-  [license_id: string]: { expires: Date | undefined; trial: boolean };
+  [license_id: string]:
+    | { expires: Date | undefined; trial: boolean }
+    | undefined;
 };
 
 // Get all license expire times from database at once, so we don't
@@ -152,12 +154,13 @@ async function sync_subscriptions_to_licenses(
 ): Promise<number> {
   let n = 0;
   for (const { license_id, sub } of iter(subs)) {
-    if (licenses[license_id] == null) {
+    const license = licenses[license_id];
+    if (license == null) {
       L(
         `WARNING: no known license '${license_id}' for subscription '${sub.id}'`
       );
     }
-    const expires: Date | undefined = licenses[license_id].expires;
+    const expires: Date | undefined = license?.expires;
 
     // we check, if the given subscription of that license is still funding it
     if (is_funding(sub)) {
@@ -233,7 +236,7 @@ async function expire_cancelled_subscriptions(
     } else {
       const msg = `license_id '${license_id}' is not funded by any subscription`;
       // maybe trial without expiration?
-      if (licenses[license_id].trial) {
+      if (licenses[license_id]?.trial) {
         L(`${msg}, but it is a trial`);
       } else {
         L(`${msg}`);

--- a/src/packages/frontend/account/licenses/managed-licenses.tsx
+++ b/src/packages/frontend/account/licenses/managed-licenses.tsx
@@ -28,7 +28,7 @@ export const LICENSES_STYLE: CSS = {
 
 export const ManagedLicenses: React.FC = () => {
   const [error, setError] = useState<string | undefined>(undefined);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [show_all, set_show_all] = useState<boolean>(false);
   const actions = useActions("billing");
   const is_mounted_ref = useIsMountedRef();

--- a/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
+++ b/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
@@ -386,7 +386,10 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control} style={{ whiteSpace: "nowrap" }}>
-          <Select defaultValue={"short"} onChange={onIdleTimeoutChange}>
+          <Select
+            defaultValue={quota.idle_timeout ?? "short"}
+            onChange={onIdleTimeoutChange}
+          >
             {idleTimeoutUptimeOptions()}
           </Select>{" "}
           idle timeout

--- a/src/packages/frontend/site-licenses/site-license-public-info.tsx
+++ b/src/packages/frontend/site-licenses/site-license-public-info.tsx
@@ -136,6 +136,10 @@ export const SiteLicensePublicInfoTable: React.FC<PropsTable> = (
     if (isLicenseStatus(status_val)) {
       return status_val;
     } else {
+      // right after loading this the first time, the field is null.
+      if (v.expires == null) {
+        return "valid";
+      }
       if (new Date() >= v.expires) {
         return "expired";
       } else if (new Date() < v.activates) {

--- a/src/packages/next/components/licenses/license.tsx
+++ b/src/packages/next/components/licenses/license.tsx
@@ -8,6 +8,7 @@ import { EditableDescription, EditableTitle } from "./editable-license";
 import Timestamp from "components/misc/timestamp";
 import Copyable from "components/misc/copyable";
 import A from "components/misc/A";
+import { describe_quota } from "@cocalc/util/db-schema/site-licenses";
 
 interface Props {
   license_id: string;
@@ -148,39 +149,9 @@ export function Quota({ quota, upgrades }: { quota?: any; upgrades?: any }) {
       };
     }
   }
-  const v: ReactNode[] = [];
-  if (quota.user) {
-    v.push(capitalize(quota.user));
-  }
-  if (quota.cpu) {
-    v.push(`${quota.cpu} ${plural(quota.cpu, "shared CPU")}`);
-  }
-  if (quota.dedicated_cpu) {
-    v.push(
-      `${quota.dedicated_cpu} ${plural(quota.dedicated_cpu, "dedicated CPU")}`
-    );
-  }
-  if (quota.ram) {
-    v.push(`${quota.ram} ${plural(quota.ram, "GB")} shared RAM`);
-  }
-  if (quota.dedicated_ram) {
-    v.push(
-      `${quota.dedicated_ram} ${plural(
-        quota.dedicated_ram,
-        "GB"
-      )} dedicated RAM`
-    );
-  }
-  if (quota.disk) {
-    v.push(`${quota.disk} ${plural(quota.disk, "GB")} disk`);
-  }
-  if (quota.member) {
-    v.push("member hosting");
-  }
-  if (quota.always_running) {
-    v.push("always running");
-  }
-  return <span>{r_join(v)}</span>;
+
+  const info = describe_quota(quota, true);
+  return <span>{info}</span>;
 }
 
 export function DateRange({ activates, expires, info }) {

--- a/src/packages/util/db-schema/site-licenses.ts
+++ b/src/packages/util/db-schema/site-licenses.ts
@@ -27,6 +27,7 @@ import {
   untangleUptime,
   Uptime,
 } from "../consts/site-license";
+import { capitalize } from "lodash";
 
 export function describe_quota(
   quota: SiteLicenseQuota & { uptime?: Uptime },
@@ -42,10 +43,10 @@ export function describe_quota(
   }
 
   let desc: string = "";
-  if (!short) {
-    desc =
-      (quota.user == "business" ? "Business" : "Academic") +
-      " license providing ";
+  if (short) {
+    desc += `${capitalize(quota.user)}, `;
+  } else {
+    desc += `${capitalize(quota.user)} license providing `;
   }
   const v: string[] = [];
 


### PR DESCRIPTION
# Description

this is a rather simple PR

- backend/db: there is a check if a license doesn't exist during syncing it up. however, the code continues right after "WARNING: no known license '${license_id}' for subscription '${sub.id}".  … which obviously breaks right where `licenses[license_id].<any field>` is accessed. I've modified the typescript annotation to capture this, and then a few strategic questionmarks.
- code deduplication: using an existing function to generate the string describing a license instead of duplicating this. this was an issues, because there is no clause for the idle timeout upgrade
- editing a license as an admin resets the idle timeout. with this change, the default value for the dropdown is taken from the quota info
- frontend: when the managed licenses table  is shown, it is initially in the  loading state – not toggling around
- also, right after loading the table for listing managed licenses, a license is considered "valid" if there is no expiration info. that avoids flashing a red "expired" notice.
- frontend: react.fc-ing the admin / licenses dialog

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
