### PR TITLE
account/avatar: get rid of scrollbars and 150px width limit

### DIFF
--- a/src/packages/frontend/account/profile-settings.tsx
+++ b/src/packages/frontend/account/profile-settings.tsx
@@ -65,7 +65,7 @@ class ProfileSettings extends Component<Props, State> {
         <LabeledRow label="Color">
           <ColorPicker
             color={this.props.profile.get("color")}
-            style={{ maxWidth: "150px" }}
+            justifyContent={"flex-start"}
             onChange={this.onColorChange}
           />
         </LabeledRow>

--- a/src/packages/frontend/components/color-picker.tsx
+++ b/src/packages/frontend/components/color-picker.tsx
@@ -37,6 +37,7 @@ interface Props {
   style?: CSSProperties;
   defaultPicker?: keyof typeof Pickers;
   toggle?: ReactNode;
+  justifyContent?: "flex-start" | "flex-end" | "center";
 }
 export default function ColorPicker({
   color,
@@ -44,6 +45,7 @@ export default function ColorPicker({
   style,
   defaultPicker,
   toggle,
+  justifyContent = "center",
 }: Props) {
   const [visible, setVisible] = useState<boolean>(!toggle);
   const [picker, setPicker] = useState<keyof typeof Pickers>(
@@ -78,8 +80,8 @@ export default function ColorPicker({
       <div
         style={{
           display: "flex",
-          justifyContent: "center",
-          overflowX: "scroll",
+          justifyContent,
+          overflowX: "auto",
         }}
       >
         <Picker


### PR DESCRIPTION
# Description

I opened the account settings and well, the color chooser is strange, especially on narrower pages. There is no need to always show a horizontal scrollbar, and I also don't understand the 150px width limit. What I added is an optional left alignment, to match the surrounding content.

Before:

![Screenshot from 2022-04-05 12-13-12](https://user-images.githubusercontent.com/207405/161733039-ac8f0230-d520-435b-90c9-4e3286f006df.png)

![Screenshot from 2022-04-05 12-12-36](https://user-images.githubusercontent.com/207405/161733042-520c6be1-7dd7-4dc1-befc-b08dba0af3d6.png)

After:

![Screenshot from 2022-04-05 12-20-47](https://user-images.githubusercontent.com/207405/161733306-7aa8aa31-f4ac-48b0-8c30-823343823c1e.png)


![Screenshot from 2022-04-05 12-17-33](https://user-images.githubusercontent.com/207405/161733092-5de16f4e-937b-46f4-b98c-297777d86071.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
