### PR TITLE
next/status: show whiteboard stats

### DIFF
--- a/src/packages/next/components/statistics/opened-files.tsx
+++ b/src/packages/next/components/statistics/opened-files.tsx
@@ -88,7 +88,8 @@ const extensionToInfo: { [ext: string]: { desc: string; link?: string } } = {
     link: "https://doc.cocalc.com/sagews.html",
   },
   "sage-chat": { desc: "Chatroom" },
-};
+  board: { desc: "Whiteboard", link: "/features/whiteboard" },
+} as const;
 
 function processFilesOpened(
   filesOpened,


### PR DESCRIPTION
# Description

I just noticed it's recorded, but not shown.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
