### PR TITLE
fix sagews modes()

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -4193,7 +4193,9 @@ def modes():
     for s in open(os.path.realpath(__file__), 'r'):
         s = s.strip()
         if s.startswith('%'):
-            mode_cmds.add(re.findall(r'%[a-zA-Z]+', s)[0])
+            sm = (re.findall(r'%[a-zA-Z]+', s))
+            if len(sm) > 0:
+                mode_cmds.add(sm[0])
     mode_cmds.discard('%s')
     for k, v in sage.interfaces.all.__dict__.items():
         if isinstance(v, sage.interfaces.expect.Expect):


### PR DESCRIPTION
# Description

Fixes "list index out of range" error in sagews modes().

To test:

1. See the bug before PR is applied. In current source tree:

```
$ cd ~/cocalc/src/smc_sagews
$ sage -python
...
>>> from smc_sagews import sage_salvus
>>> sage_salvus.modes()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/cocalc/src/smc_sagews/smc_sagews/sage_salvus.py", line 4196, in modes
    mode_cmds.add(re.findall(r'%[a-zA-Z]+', s)[0])
IndexError: list index out of range
```
  Kill the sage python process.

2. Apply the patch in the PR and repeat the above steps:
```
$ cd ~/cocalc/src/smc_sagews
$ sage -python
...
>>> from smc_sagews import sage_salvus
>>> sage_salvus.modes()
['%anaconda', '%auto', '%axiom', '%capture', '%coffeescript', '%command', '%cython', '%default', '%default_mode', '%exercise', '%file', '%fork', '%fortran', '%fricas', '%gap', '%gap3', '%giac', '%go', '%gp', '%hide', '%hideall', '%html', '%java', '%javascript', '%kash', '%lie', '%lisp', '%load', '%macaulay2', '%magma', '%maple', '%mathematica', '%matlab', '%maxima', '%md', '%mupad', '%mwrank', '%octave', '%pandoc', '%perl', '%polymake', '%prun', '%python', '%r', '%reset', '%ruby', '%runfile', '%sage0', '%scilab', '%script', '%sh', '%singular', '%time', '%timeit', '%typeset_mode', '%var', '%wiki']

```

