### PR TITLE
frontend/latex: add "no output dir" options and some fixes to sanitization functions

### DIFF
--- a/src/packages/frontend/frame-editors/latex-editor/build-command.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/build-command.tsx
@@ -15,17 +15,10 @@ import { Button } from "../../antd-bootstrap";
 import { SaveOutlined, DownOutlined } from "@ant-design/icons";
 import { React } from "../../app-framework";
 import { split } from "@cocalc/util/misc";
-import { Engine, build_command as latexmk_build_command } from "./latexmk";
+import { ENGINES, Engine, build_command as latexmk_build_command } from "./latexmk";
 import { Actions } from "./actions";
 import { COLORS } from "@cocalc/util/theme";
 
-const ENGINES: Engine[] = [
-  "PDFLaTeX",
-  "PDFLaTeX (shell-escape)",
-  "XeLaTeX",
-  "LuaTex",
-  "<disabled>",
-];
 
 // cmd could be undefined -- https://github.com/sagemathinc/cocalc/issues/3290
 function build_command_string(cmd: string | List<string>): string {
@@ -69,9 +62,8 @@ export const BuildCommand: React.FC<Props> = React.memo((props: Props) => {
     knitr,
     font_size,
   } = props;
-  const [build_command_prev, set_build_command_prev] = React.useState(
-    build_command_orig
-  );
+  const [build_command_prev, set_build_command_prev] =
+    React.useState(build_command_orig);
   const [build_command, set_build_command] = React.useState<string>(
     build_command_string(build_command_orig)
   );
@@ -91,7 +83,6 @@ export const BuildCommand: React.FC<Props> = React.memo((props: Props) => {
       actions.output_directory
     );
     actions.set_build_command(cmd);
-    set_build_command(build_command_string(fromJS(cmd)));
   }
 
   function render_engine_options(): JSX.Element {
@@ -198,7 +189,9 @@ export const BuildCommand: React.FC<Props> = React.memo((props: Props) => {
           <h4>Build Command</h4>
           Select a build engine from the menu at the right, or enter absolutely
           any custom build command line you want. Custom build commands are run
-          using bash, so you can separate multiple commands with a semicolon.  If there is no semicolon, then the command line must end with the filename (not including the directory).
+          using bash, so you can separate multiple commands with a semicolon. If
+          there is no semicolon, then the command line must end with the
+          filename (not including the directory).
         </div>
       </Alert>
     );

--- a/src/packages/frontend/frame-editors/latex-editor/util.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/util.ts
@@ -46,7 +46,11 @@ export function ensureTargetPathIsCorrect(
     // no single quotes at all -- old version.
     // replace the last argument with quoted version
     const j = cmd.lastIndexOf(" ");
-    return cmd.slice(0, j) + " " + quoted;
+    if (j == -1) {
+      return cmd; // we don't do anything, e.g. this could be just "false"
+    } else {
+      return cmd.slice(0, j) + " " + quoted;
+    }
   }
 
   // Get rid of whatever is between single quotes and put in the correct


### PR DESCRIPTION
# Description

- see #5910
- this also fixes nonsense sanitizations when someone selects "<disabled>" and similar issues


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
