### PR TITLE
latex: introduce support for !TeX cocalc = hardcoded command

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -71,6 +71,7 @@ interface FrameActions extends Actions {
 interface EditorActions extends Actions {
   download?: (id: string) => void;
   restart?: () => void;
+  rescan_latex_directive?: () => void;
 }
 
 import { AvailableFeatures } from "../../project_configuration";
@@ -1106,6 +1107,21 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
     );
   }
 
+  function render_rescan_latex_directives(): Rendered {
+    if (!is_visible("rescan_latex_directive", true)) return;
+    return (
+      <Button
+        key={"rescan-latex-directive"}
+        disabled={!!props.status}
+        bsSize={button_size()}
+        onClick={() => props.editor_actions.rescan_latex_directive?.()}
+        title={"Rescan document for build directive"}
+      >
+        <Icon name={"reload"} /> <VisibleMDLG>Directive</VisibleMDLG>
+      </Button>
+    );
+  }
+
   function render_clean(): Rendered {
     if (!is_visible("clean", true)) {
       return;
@@ -1364,6 +1380,7 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
     v.push(render_switch_to_file());
     v.push(render_clean());
     v.push(render_zoom_group());
+    v.push(render_rescan_latex_directives());
     if (!is_public) {
       v.push(render_undo_redo_group());
     }
@@ -1544,7 +1561,7 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
               max={props.pages}
               value={props.page}
               onChange={(page) => {
-                if(!page) return;
+                if (!page) return;
                 props.actions.setPage(props.id, page);
               }}
             />{" "}

--- a/src/packages/frontend/frame-editors/latex-editor/build.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/build.tsx
@@ -99,6 +99,8 @@ export const Build: React.FC<Props> = React.memo((props) => {
   const font_size = 0.8 * font_size_orig;
   const build_logs: BuildLogs = use_build_logs(name);
   const build_command = useRedux([name, "build_command"]);
+  const build_command_hardcoded =
+    useRedux([name, "build_command_hardcoded"]) ?? false;
   const knitr: boolean = useRedux([name, "knitr"]);
   const [active_tab, set_active_tab] = React.useState<string>(
     BUILD_SPECS.latex.label
@@ -191,6 +193,7 @@ export const Build: React.FC<Props> = React.memo((props) => {
         actions={actions}
         build_command={build_command}
         knitr={knitr}
+        build_command_hardcoded={build_command_hardcoded}
       />
     );
   }

--- a/src/packages/frontend/frame-editors/latex-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/editor.ts
@@ -91,6 +91,7 @@ const EDITOR_SPEC = {
       "clean",
       "decrease_font_size",
       "increase_font_size",
+      "rescan_latex_directive",
     ]),
   } as EditorDescription,
 
@@ -107,7 +108,6 @@ const EDITOR_SPEC = {
   settings: SETTINGS_SPEC,
 
   time_travel,
-
 };
 
 // See https://github.com/sagemathinc/cocalc/issues/5114

--- a/src/packages/frontend/frame-editors/latex-editor/latexmk.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/latexmk.ts
@@ -89,6 +89,7 @@ export function get_engine_from_config(config: string): Engine | null {
 
     case "lua":
     case "luatex":
+    case "lualatex":
       return "LuaTex";
   }
   return null;


### PR DESCRIPTION
# Description

While working on software updates, I did this. It's a cocalc specific extension to these `!TeX` build directives. The main use case is to hardcode the build instruction in the document, such that CoCalc will always set the build command based on the file's content. It's 100% optional, and the content isn't automatically changed.

The existing support for selecting the engine is enhanced, e.g. more flexible whitespace and case insensitiveness.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
