### PR TITLE
frontend/x11: change spyder icon to the one for python

### DIFF
--- a/src/packages/frontend/frame-editors/x11-editor/apps.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/apps.ts
@@ -156,7 +156,7 @@ export const APPS: Readonly<APPS_Interface> = Object.freeze({
   spyder: {
     command: "spyder",
     desc: "Spyder is a powerful scientific environment written in Python, for Python, and designed by and for scientists, engineers and data analysts.",
-    icon: "calculator",
+    icon: "python",
     label: "Spyder",
   },
   gchempaint: {


### PR DESCRIPTION
# Description

just a trivial change

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
