### PR TITLE
cleaning up purchase options page

### DIFF
--- a/src/packages/frontend/account/upgrades/upgrades-page.tsx
+++ b/src/packages/frontend/account/upgrades/upgrades-page.tsx
@@ -3,18 +3,24 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import "./project-upgrades-table";
-import { Map } from "immutable";
-import { round1, plural } from "@cocalc/util/misc";
-import { redux, rclass, rtypes, Component } from "../../app-framework";
-import { A, Icon, Loading, Space } from "../../components";
-import { SiteName, PolicyPricingPageUrl, Footer } from "../../customize";
+import { Col, Panel, Row } from "@cocalc/frontend/antd-bootstrap";
+import {
+  Component,
+  rclass,
+  redux,
+  rtypes,
+} from "@cocalc/frontend/app-framework";
+import { A, Icon, Loading, Space } from "@cocalc/frontend/components";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { plural, round1 } from "@cocalc/util/misc";
 import { PROJECT_UPGRADES } from "@cocalc/util/schema";
 import { Progress } from "antd";
-import { Row, Col, Panel } from "../../antd-bootstrap";
-import { ProjectUpgradesTable } from "./project-upgrades-table";
-import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { Map } from "immutable";
 import { join } from "path";
+import { Footer, PolicyPricingPageUrl, SiteName } from "../../customize";
+import "./project-upgrades-table";
+import { ProjectUpgradesTable } from "./project-upgrades-table";
+export { tmp as UpgradesPage };
 
 interface reduxProps {
   stripe_customer?: Map<string, any>;
@@ -52,14 +58,20 @@ class UpgradesPage extends Component<reduxProps> {
         <h3>
           Thank you for supporting <SiteName />
         </h3>
-        <span style={{ color: "#666" }}>
-          We offer many{" "}
-          <A href={PolicyPricingPageUrl}> pricing and subscription options</A>,
-          which you can subscribe to in the Billing tab. Your upgrades are
-          listed below, along with how you have applied them to projects. You
-          can adjust your project upgrades from the settings page in any
-          project.
-        </span>
+        <div style={{ color: "#666" }}>
+          <p>
+            You have some now deprecated "quota upgrades". They are listed
+            below, along with how you have applied them to projects. You can
+            adjust your project upgrade contribution from the settings page in
+            any project.
+          </p>
+          <p>
+            Going forward, we offer many{" "}
+            <A href={PolicyPricingPageUrl}> pricing and subscription options</A>
+            , which you can subscribe to in the{" "}
+            <A href={join(appBasePath, "store")}>Store</A>.
+          </p>
+        </div>
         <Space />
       </div>
     );
@@ -182,4 +194,3 @@ class UpgradesPage extends Component<reduxProps> {
 }
 
 const tmp = rclass(UpgradesPage);
-export { tmp as UpgradesPage };

--- a/src/packages/frontend/billing/billing-page.tsx
+++ b/src/packages/frontend/billing/billing-page.tsx
@@ -6,26 +6,30 @@
 // Ensure the billing Actions and Store are created:
 require("./actions");
 
-import { Component, Rendered, redux, rtypes, rclass } from "../app-framework";
-import { AppliedCoupons, Customer, InvoicesMap } from "./types";
-import { Map } from "immutable";
+import {
+  Component,
+  rclass,
+  redux,
+  Rendered,
+  rtypes,
+} from "@cocalc/frontend/app-framework";
 import {
   A,
   ActivityDisplay,
   ErrorDisplay,
-  Icon,
   Loading,
-  Space,
-} from "../components";
-import { HelpEmailLink, PolicyPricingPageUrl, Footer } from "../customize";
-import { SubscriptionList } from "./subscription-list";
-import { PaymentMethods } from "./payment-methods";
-import { AddSubscription } from "./add-subscription";
-const { Panel } = require("react-bootstrap");
-import InvoiceHistory from "./invoice-history";
+} from "@cocalc/frontend/components";
+import {
+  Footer,
+  HelpEmailLink,
+  PolicyPricingPageUrl,
+} from "@cocalc/frontend/customize";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
-import { join } from "path";
 import { Alert } from "antd";
+import { Map } from "immutable";
+import { join } from "path";
+import { PaymentMethods } from "./payment-methods";
+import { Customer, InvoicesMap } from "./types";
 
 interface ReactProps {
   is_simplified?: boolean;
@@ -40,9 +44,6 @@ interface ReduxProps {
   loaded?: boolean;
   no_stripe?: boolean; // if true, stripe definitely isn't configured on the server
   selected_plan: string;
-  applied_coupons: AppliedCoupons;
-  coupon_error?: string;
-  continue_first_purchase?: boolean;
   project_map: Map<string, any>; // used, e.g., for course project payments; also computing available upgrades
   stripe_customer: Map<string, any>; // to get total upgrades user has available
 }
@@ -59,9 +60,6 @@ export const BillingPage = rclass<ReactProps>(
           loaded: rtypes.bool,
           no_stripe: rtypes.bool, // if true, stripe definitely isn't configured on the server
           selected_plan: rtypes.string,
-          applied_coupons: rtypes.immutable.Map,
-          coupon_error: rtypes.string,
-          continue_first_purchase: rtypes.bool,
         },
         projects: {
           project_map: rtypes.immutable, // used, e.g., for course project payments; also computing available upgrades
@@ -98,7 +96,6 @@ export const BillingPage = rclass<ReactProps>(
     private render_enterprise_support(): Rendered {
       return (
         <p>
-          <br />
           <b>Enterprise Support:</b> Contact us at <HelpEmailLink /> for{" "}
           <i>enterprise support</i>, including customized course packages,
           modified terms of service, additional legal agreements, purchase
@@ -121,22 +118,24 @@ export const BillingPage = rclass<ReactProps>(
 
     private render_help_suggestion(): Rendered {
       return (
-        <span>
-          <Space /> If you have any questions at all, read the{" "}
-          <A href={"https://doc.cocalc.com/billing.html"}>
-            Billing{"/"}Upgrades FAQ
-          </A>{" "}
-          or email <HelpEmailLink /> immediately.
-          <b>
-            <Space />
+        <>
+          <p>
+            <b>Questions: </b>
+            If you have any questions at all, read the{" "}
+            <A href={"https://doc.cocalc.com/billing.html"}>
+              Billing{"/"}Upgrades FAQ
+            </A>{" "}
+            or email <HelpEmailLink /> immediately.
+          </p>
+          <p>
+            <b>Teaching:</b>{" "}
             <HelpEmailLink text={<span>Contact&nbsp;us</span>} /> if you are
             considering purchasing a course subscription and need a short
             evaluation trial.
-            <Space />
-          </b>
+          </p>
           {this.render_enterprise_support()}
           {this.render_on_prem()}
-        </span>
+        </>
       );
     }
 
@@ -147,118 +146,8 @@ export const BillingPage = rclass<ReactProps>(
       return { cards, subs, invoices };
     }
 
-    private render_suggested_next_step(): Rendered {
-      const { cards, subs, invoices } = this.counts();
-      const help = this.render_help_suggestion();
-
-      if (cards === 0) {
-        if (subs === 0) {
-          // no payment sources yet; no subscriptions either: a new user (probably)
-          return (
-            <span>
-              If you are{" "}
-              <A href={"https://doc.cocalc.com/teaching-instructors.html"}>
-                teaching a course
-              </A>
-              , choose one of the course packages. If you need to upgrade your
-              personal projects, choose a recurring subscription. You will{" "}
-              <b>not be charged</b> until you explicitly click "Add Subscription
-              or Course Package".
-              {help}
-            </span>
-          );
-        } else {
-          // subscriptions but they deleted their card.
-          return (
-            <span>
-              Click "Add payment method..." to add a credit card so you can
-              purchase or renew your subscriptions. Without a credit card any
-              current subscriptions will run to completion, but will not renew.
-              If you have any questions about subscriptions or billing (e.g.,
-              about purchase orders, using PayPal or wire transfers for
-              non-recurring subscriptions above $50) please email{" "}
-              <HelpEmailLink /> immediately.
-              {this.render_enterprise_support()}
-            </span>
-          );
-        }
-      } else if (subs === 0) {
-        // have a payment source, but no subscriptions
-        return (
-          <span>
-            Click "Add Subscription or Course Package...". If you are{" "}
-            <A href={"https://doc.cocalc.com/teaching-instructors.html"}>
-              teaching a course,
-            </A>
-            choose one of the course packages. If you need to upgrade your
-            personal projects, choose a recurring subscription. You will be
-            charged only after you select a specific subscription and click "Add
-            Subscription or Course Package".
-            {help}
-          </span>
-        );
-      } else if (invoices === 0) {
-        // have payment source, subscription, but no invoices yet
-        return (
-          <span>
-            You may sign up for the same subscription package more than once to
-            increase the number of upgrades that you can use.
-            {help}
-          </span>
-        );
-      } else {
-        // have payment source, subscription, and at least one invoice
-        return (
-          <span>
-            You may sign up for the same subscription package more than once to
-            increase the number of upgrades that you can use. Past invoices and
-            receipts are available below.
-            {help}
-          </span>
-        );
-      }
-    }
-
-    private render_info_link(): Rendered {
-      return (
-        <div style={{ marginTop: "1em", marginBottom: "1em", color: "#666" }}>
-          We offer many{" "}
-          <A href={PolicyPricingPageUrl}>pricing and subscription options</A>
-          .
-          <Space />
-          {this.render_suggested_next_step()}
-        </div>
-      );
-    }
-
-    private render_panel_header(icon, header): Rendered {
-      return (
-        <div style={{ cursor: "pointer" }}>
-          <Icon name={icon} style={{ width: "1.125em" }} /> {header}
-        </div>
-      );
-    }
-
-    private render_subscriptions(): Rendered {
-      return (
-        <SubscriptionList
-          customer={this.props.customer}
-          applied_coupons={this.props.applied_coupons}
-          coupon_error={this.props.coupon_error}
-          selected_plan={this.props.selected_plan}
-        />
-      );
-    }
-
-    private finish_first_subscription(): void {
-      const actions = redux.getActions("billing");
-      if (actions == null) return;
-      actions.set_selected_plan("");
-      actions.remove_all_coupons();
-      actions.setState({ continue_first_purchase: false });
-    }
-
     private render_page(): Rendered {
+      if (!this.props.for_course) return;
       if (!this.props.loaded) {
         // nothing loaded yet from backend
         return <Loading />;
@@ -267,26 +156,6 @@ export const BillingPage = rclass<ReactProps>(
         return (
           <div>
             <PaymentMethods sources={{ data: [] }} default="" />
-          </div>
-        );
-      } else if (
-        !this.props.for_course &&
-        (this.props.customer == null || this.props.continue_first_purchase)
-      ) {
-        return (
-          <div>
-            <PaymentMethods
-              sources={this.props.customer?.sources}
-              default={this.props.customer?.default_source}
-            />
-            <AddSubscription
-              hide_cancel_button={true}
-              on_close={this.finish_first_subscription.bind(this)}
-              selected_plan={this.props.selected_plan}
-              applied_coupons={this.props.applied_coupons}
-              coupon_error={this.props.coupon_error}
-              customer={this.props.customer}
-            />
           </div>
         );
       } else {
@@ -300,17 +169,6 @@ export const BillingPage = rclass<ReactProps>(
                 sources={this.props.customer.sources}
                 default={this.props.customer.default_source}
               />
-              {!this.props.for_course ? (
-                <Panel
-                  header={this.render_panel_header(
-                    "list-alt",
-                    "Subscriptions and Course Packages"
-                  )}
-                  eventKey="2"
-                >
-                  {this.render_subscriptions()}
-                </Panel>
-              ) : undefined}
             </div>
           );
         } else if (this.props.is_simplified) {
@@ -320,46 +178,60 @@ export const BillingPage = rclass<ReactProps>(
                 sources={this.props.customer.sources}
                 default={this.props.customer.default_source}
               />
-              {!this.props.for_course ? this.render_subscriptions() : undefined}
-            </div>
-          );
-        } else {
-          return (
-            <div>
-              <PaymentMethods
-                sources={this.props.customer.sources}
-                default={this.props.customer.default_source}
-              />
-              {!this.props.for_course ? this.render_subscriptions() : undefined}
-              <InvoiceHistory invoices={this.props.invoices} />
             </div>
           );
         }
       }
     }
 
+    private render_alert(): Rendered {
+      if (this.props.for_course) return;
+      return (
+        <Alert
+          showIcon
+          style={{ margin: "30px auto", fontSize: "125%" }}
+          icon={
+            <span style={{ fontSize: "150%", margin: "30px" }}>&#x26A0;</span>
+          }
+          type="warning"
+          message={
+            <>
+              The old purchasing page is no longer available. Instead, visit
+              these pages:
+              <br />
+              <ul>
+                <li>
+                  <A href={join(appBasePath, "pricing")}>Pricing</A>: get an
+                  overview about all offered products.
+                </li>
+                <li>
+                  <A href={join(appBasePath, "store")}>Store</A>: purchase
+                  license upgrades, boosts, dedicated resources, etc.
+                </li>
+                <li>
+                  <A href={join(appBasePath, "billing")}>Billing</A>:
+                  information about your purchases, ongoing subscriptions,
+                  credit cards, invoices, etc.
+                </li>
+              </ul>
+            </>
+          }
+        />
+      );
+    }
+
     public render(): Rendered {
       return (
-        <div>
-          <Alert
-            showIcon
-            style={{ maxWidth: "600px", margin: "30px auto" }}
-            type="warning"
-            message={
-              <>
-                This is the old purchasing page (which still works).{" "}
-                <A href={join(appBasePath, "billing")}>Try the new page...</A>
-              </>
-            }
-          />
+        <>
+          {this.render_alert()}
           <div>
-            {!this.props.for_course ? this.render_info_link() : undefined}
+            {!this.props.for_course ? this.render_help_suggestion() : undefined}
             {!this.props.no_stripe ? this.render_action() : undefined}
             {this.render_error()}
             {!this.props.no_stripe ? this.render_page() : undefined}
           </div>
           {!this.props.is_simplified ? <Footer /> : undefined}
-        </div>
+        </>
       );
     }
   }

--- a/src/packages/frontend/billing/subscription-list.tsx
+++ b/src/packages/frontend/billing/subscription-list.tsx
@@ -7,35 +7,20 @@ import { useActions, useTypedRedux } from "../app-framework";
 import { Button, Col, Row, Panel } from "../antd-bootstrap";
 import { Icon, Space } from "../components";
 import { Subscription } from "./subscription";
-import { AppliedCoupons, Customer } from "./types";
-import { AddSubscription } from "./add-subscription";
+import { Customer } from "./types";
 import { PurchaseOneLicense } from "../site-licenses/purchase";
 import { AboutLicenses } from "../account/licenses/about-licenses";
 
 interface Props {
   customer?: Customer;
-  selected_plan?: string;
-  applied_coupons: AppliedCoupons;
-  coupon_error?: string;
 }
 
-export const SubscriptionList: React.FC<Props> = ({
-  customer,
-  selected_plan,
-  applied_coupons,
-  coupon_error,
-}) => {
+export const SubscriptionList: React.FC<Props> = ({ customer }) => {
   const state = useTypedRedux("billing", "subscription_list_state") ?? "view";
   function set_state(subscription_list_state) {
     actions.setState({ subscription_list_state });
   }
   const actions = useActions("billing");
-
-  function close_buy_upgrades(): void {
-    set_state("view");
-    actions.set_selected_plan("");
-    actions.remove_all_coupons();
-  }
 
   function render_buy_license_button(): JSX.Element {
     return (
@@ -67,54 +52,14 @@ export const SubscriptionList: React.FC<Props> = ({
 
   function render_buy_upgrades_button(): JSX.Element {
     return (
-      <Button
-        bsStyle="primary"
-        disabled={true /*DEPRECATED;  was 'state != "view"'*/}
-        onClick={() => set_state("buy_upgrades")}
-      >
+      <Button bsStyle="primary" disabled={true}>
         <Icon name="plus-circle" /> Buy Upgrades (deprecated)...
       </Button>
     );
   }
 
   function render_buy_upgrades(): JSX.Element {
-    return (
-      <div>
-        <div style={{ fontSize: "14pt" }}>
-          <i>
-            The{" "}
-            <a
-              onClick={() => {
-                set_state("buy_license");
-              }}
-            >
-              new licenses
-            </a>{" "}
-            are vastly more flexible and affordable than upgrade packages, and
-            you should{" "}
-            <a
-              onClick={() => {
-                set_state("buy_license");
-              }}
-            >
-              purchase a license
-            </a>{" "}
-            instead.
-          </i>{" "}
-          Upgrades are still available just in case you need one for a specific
-          reason.
-        </div>
-        <br />
-        <br />
-        <AddSubscription
-          on_close={close_buy_upgrades}
-          selected_plan={selected_plan}
-          applied_coupons={applied_coupons}
-          coupon_error={coupon_error}
-          customer={customer}
-        />
-      </div>
-    );
+    return <div>deprecated</div>;
   }
 
   function render_header(): JSX.Element {

--- a/src/packages/frontend/project/explorer/explorer.tsx
+++ b/src/packages/frontend/project/explorer/explorer.tsx
@@ -403,18 +403,14 @@ export const Explorer = rclass(
     }
 
     render_upgrade_in_place() {
-      const cards =
-        (this.props.customer &&
-          this.props.customer.sources &&
-          this.props.customer.sources.total_count) ||
-        0;
+      const cards = this.props.customer?.sources?.total_count ?? 0;
 
       return (
         <div style={{ marginTop: "10px" }}>
           <BillingPage is_simplified={true} for_course={true} />
-          {cards && (
+          {cards > 0 ? (
             <PayCourseFee project_id={this.props.project_id} redux={redux} />
-          )}
+          ) : undefined}
         </div>
       );
     }

--- a/src/packages/frontend/site-licenses/purchase/purchase-method.tsx
+++ b/src/packages/frontend/site-licenses/purchase/purchase-method.tsx
@@ -18,10 +18,10 @@ import {
   useAsyncEffect,
   useTypedRedux,
   useState,
-} from "../../app-framework";
-import { Icon, Loading, Space } from "../../components";
-import { alert_message } from "../../alerts";
-import { PaymentMethods } from "../../billing/payment-methods";
+} from "@cocalc/frontend/app-framework";
+import { Icon, Loading, Space } from "@cocalc/frontend/components";
+import { alert_message } from "@cocalc/frontend/alerts";
+import { PaymentMethods } from "@cocalc/frontend/billing/payment-methods";
 
 interface Props {
   onClose: (id: string | undefined) => void;

--- a/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
+++ b/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
@@ -13,28 +13,28 @@ Editing a quota
 
 */
 
-import {
-  Button,
-  Checkbox,
-  InputNumber,
-  Row,
-  Col,
-  Select,
-  Typography,
-} from "antd";
-import { Space } from "../../components";
-import { CSS, React, useMemo, useState } from "../../app-framework";
-import { COSTS, GCE_COSTS } from "@cocalc/util/licenses/purchase/consts";
-import { money } from "@cocalc/util/licenses/purchase/utils";
-import { plural, round1 } from "@cocalc/util/misc";
-import { SiteLicenseQuota } from "@cocalc/util/types/site-licenses";
+import { CSS, React, useMemo, useState } from "@cocalc/frontend/app-framework";
+import { Space } from "@cocalc/frontend/components";
 import {
   LicenseIdleTimeouts,
   requiresMemberhosting,
   untangleUptime,
   Uptime,
 } from "@cocalc/util/consts/site-license";
+import { COSTS, GCE_COSTS } from "@cocalc/util/licenses/purchase/consts";
 import { User } from "@cocalc/util/licenses/purchase/types";
+import { money } from "@cocalc/util/licenses/purchase/utils";
+import { plural, round1 } from "@cocalc/util/misc";
+import { SiteLicenseQuota } from "@cocalc/util/types/site-licenses";
+import {
+  Button,
+  Checkbox,
+  Col,
+  InputNumber,
+  Row,
+  Select,
+  Typography,
+} from "antd";
 
 const ROW_STYLE: CSS = {
   border: "1px solid #eee",

--- a/src/packages/next/components/billing/layout.tsx
+++ b/src/packages/next/components/billing/layout.tsx
@@ -3,23 +3,20 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Alert, Layout } from "antd";
 import { unreachable } from "@cocalc/util/misc";
-import A from "components/misc/A";
-import { join } from "path";
-import basePath from "lib/base-path";
-import Menu from "./menu";
+import { Alert, Layout } from "antd";
 import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
-import useProfile from "lib/hooks/profile";
+import Anonymous from "components/misc/anonymous";
 import Loading from "components/share/loading";
-import { useRouter } from "next/router";
+import useProfile from "lib/hooks/profile";
 import useCustomize from "lib/use-customize";
+import { useRouter } from "next/router";
+import { MainPagesType } from "./consts";
+import InvoicesAndReceipts from "./invoices-and-receipts";
+import Menu from "./menu";
+import Overview from "./overview";
 import PaymentMethods from "./payment-methods";
 import Subscriptions from "./subscriptions";
-import InvoicesAndReceipts from "./invoices-and-receipts";
-import Overview from "./overview";
-import { MainPagesType } from "./consts";
-import Anonymous from "components/misc/anonymous";
 
 const { Content } = Layout;
 
@@ -70,7 +67,7 @@ export default function ConfigLayout({ page }: Props) {
   }
 
   if (is_anonymous) {
-    return <Anonymous/>;
+    return <Anonymous />;
   }
 
   // page could be an empty array, then main is undefined → overview page
@@ -107,20 +104,6 @@ export default function ConfigLayout({ page }: Props) {
           minHeight: 280,
         }}
       >
-        <div style={{ float: "right", margin: "0 0 15px 15px" }}>
-          <Alert
-            type="warning"
-            message={
-              <>
-                This is the new billing page (
-                <A href={join(basePath, "settings", "billing")} external>
-                  the old page
-                </A>
-                ).
-              </>
-            }
-          />
-        </div>
         {body()}
       </Content>
     </Layout>

--- a/src/packages/next/components/licenses/layout.tsx
+++ b/src/packages/next/components/licenses/layout.tsx
@@ -1,17 +1,14 @@
 import { Alert, Layout } from "antd";
-import A from "components/misc/A";
-import { join } from "path";
-import basePath from "lib/base-path";
-import Menu from "./menu";
 import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
-import useProfile from "lib/hooks/profile";
+import Anonymous from "components/misc/anonymous";
 import Loading from "components/share/loading";
+import useProfile from "lib/hooks/profile";
 import { useRouter } from "next/router";
+import HowUsed from "./how-used";
 import LicensedProjects from "./licensed-projects";
 import ManagedLicenses from "./managed";
-import HowUsed from "./how-used";
+import Menu from "./menu";
 import Overview from "./overview";
-import Anonymous from "components/misc/anonymous";
 
 const { Content } = Layout;
 
@@ -46,7 +43,7 @@ export default function ConfigLayout({ page }: Props) {
   }
 
   if (is_anonymous) {
-    return <Anonymous/>;
+    return <Anonymous />;
   }
 
   const [main] = page;
@@ -79,20 +76,6 @@ export default function ConfigLayout({ page }: Props) {
           minHeight: 280,
         }}
       >
-        <div style={{ float: "right", margin: "0 0 15px 15px" }}>
-          <Alert
-            type="warning"
-            message={
-              <>
-                This is the new licenses page (
-                <A href={join(basePath, "settings", "licenses")} external>
-                  the old page
-                </A>
-                ).
-              </>
-            }
-          />
-        </div>
         {body()}
       </Content>
     </Layout>


### PR DESCRIPTION
# Description

- weed out purchases page
- preserve the student pay option
- this also removes those yellow links to the old pages from the newer next.js's billing and licenses pages.

I'll only make a few changes. I think it's better to merge this earlier, and then go on with other changes in a different PR.  The only result of this is a more minimal purchases page, i.e.:

![Screenshot from 2022-05-12 17-16-26](https://user-images.githubusercontent.com/207405/168110142-a9b40a38-7171-459c-bb38-01aca47cf515.png)

… and I realized parts of that page are relevant for the student pay option, which is still working (and I did some minor fixes). i.e.

![Screenshot from 2022-05-12 17-17-17](https://user-images.githubusercontent.com/207405/168110277-7e782598-65a2-463b-9794-d4070a19aff3.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
