### PR TITLE
next/server: fix email setup

### DIFF
--- a/src/packages/server/email/send-email.ts
+++ b/src/packages/server/email/send-email.ts
@@ -24,14 +24,12 @@ export default async function sendEmail(
   switch (email_backend) {
     case "":
     case "none":
-      return;
+      throw Error(`no email backend configured`);
     case "smtp":
       return await sendViaSMTP(message);
     case "sendgrid":
       return await sendViaSendgrid(message);
     default:
-      throw Error(
-        `no valid email backend configured: ${email_backend}`
-      );
+      throw Error(`no valid email backend configured: ${email_backend}`);
   }
 }

--- a/src/packages/server/email/send-email.ts
+++ b/src/packages/server/email/send-email.ts
@@ -9,29 +9,29 @@ or throw an exception if none is properly configured.
 */
 
 import type { Message } from "./message";
-import getPool from "@cocalc/database/pool";
 import sendViaSMTP from "./smtp";
 import sendViaSendgrid from "./sendgrid";
 import sendEmailThrottle from "./throttle";
+import { getServerSettings } from "../settings/server-settings";
 
 export default async function sendEmail(
   message: Message,
   account_id?: string // account that we are sending this email *on behalf of*, if any (used for throttling).
 ): Promise<void> {
-  const pool = getPool("long");
   await sendEmailThrottle(account_id);
-  const { rows } = await pool.query(
-    "SELECT value FROM server_settings WHERE name='email_backend'"
-  );
-  if (rows.length == 0) {
-    throw Error("no email backend is configured");
-  }
-  const { value } = rows[0];
-  if (value == "smtp") {
-    await sendViaSMTP(message);
-  } else if (value == "sendgrid") {
-    await sendViaSendgrid(message);
-  } else {
-    throw Error("no valid email backend configured");
+
+  const { email_backend } = await getServerSettings();
+  switch (email_backend) {
+    case "":
+    case "none":
+      return;
+    case "smtp":
+      return await sendViaSMTP(message);
+    case "sendgrid":
+      return await sendViaSendgrid(message);
+    default:
+      throw Error(
+        `no valid email backend configured: ${email_backend}`
+      );
   }
 }

--- a/src/packages/server/email/smtp.ts
+++ b/src/packages/server/email/smtp.ts
@@ -3,25 +3,28 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import getPool from "@cocalc/database/pool";
 import { createTransport } from "nodemailer";
 import type { Transporter } from "nodemailer";
 import type { Message } from "./message";
 import getHelpEmail from "./help";
 import appendFooter from "./footer";
+import { getServerSettings } from "../settings/server-settings";
+
+type BackendType = "email" | "password_reset";
 
 export default async function sendEmail(
   message: Message,
-  type: "email" | "password_reset" = "email"
+  type: BackendType = "email"
 ): Promise<void> {
-  let settings: Settings;
+  let settings: SMTPSettings;
   try {
-    settings = await getSettings(type);
+    settings = await getSMTPSettings(type);
   } catch (err) {
     throw Error(
       `SMTP ${type} is not properly configured for this server. Contact the site administrator. -- ${err}`
     );
   }
+
   if (!message.from) {
     if (settings.from) {
       message.from = settings.from;
@@ -52,7 +55,7 @@ async function getServer(settings): Promise<Transporter> {
   return server;
 }
 
-interface Settings {
+interface SMTPSettings {
   server: string;
   login: string;
   password: string;
@@ -60,21 +63,54 @@ interface Settings {
   port?: string;
 }
 
-async function getSettings(
-  type: "email" | "password_reset"
-): Promise<Settings> {
+/**
+ * Depending on if this is for regular emails or password resets,
+ * we return the SMTP settings depending on the server settings.
+ * Usually, password reset and regular email settings are the same for SMTP.
+ * Only exception is when that override entry is set to smtp, then use the
+ * secondary SMTP configuartion.
+ */
+async function getEmailServerSettings(
+  type: BackendType
+): Promise<SMTPSettings> {
+  const settings = await getServerSettings();
+
+  const defaultSMTP = {
+    server: settings.email_smtp_server,
+    login: settings.email_smtp_login,
+    password: settings.email_smtp_password,
+    from: settings.email_smtp_from,
+    port: settings.email_smtp_port,
+  };
+
+  if (type == "email") {
+    return defaultSMTP;
+  }
+
+  switch (settings.password_reset_override) {
+    case "default":
+      return defaultSMTP;
+
+    case "smtp":
+      return {
+        server: settings.password_reset_smtp_server,
+        login: settings.password_reset_smtp_login,
+        password: settings.password_reset_smtp_password,
+        from: settings.password_reset_smtp_from,
+        port: settings.password_reset_smtp_port,
+      };
+  }
+  throw new Error(
+    `unexpected password_reset_override: ${settings.password_reset_override}`
+  );
+}
+
+async function getSMTPSettings(type: BackendType): Promise<SMTPSettings> {
   if (type != "email" && type != "password_reset") {
     throw Error("type must be 'email' or 'password_reset'");
   }
-  const pool = getPool("long"); // rarely changes
-  const { rows } = await pool.query(
-    `SELECT name, value FROM server_settings WHERE name LIKE '${type}_smtp_%'`
-  );
-  const settings: Partial<Settings> = {};
-  const n = `${type}_smtp_`.length;
-  for (const row of rows) {
-    settings[row.name.slice(n)] = row.value;
-  }
+  const settings: SMTPSettings = await getEmailServerSettings(type);
+
   if (!settings.server) {
     throw Error(`SMTP ${type} server must be configured`);
   }
@@ -85,5 +121,5 @@ async function getSettings(
     throw Error(`SMTP ${type} password must be configured`);
   }
 
-  return settings as Settings;
+  return settings;
 }

--- a/src/packages/server/email/smtp.ts
+++ b/src/packages/server/email/smtp.ts
@@ -45,7 +45,7 @@ async function getServer(settings): Promise<Transporter> {
   server = await createTransport({
     host: settings.server,
     port: settings.port,
-    secure: !settings.port || settings.port == "465",
+    secure: settings.secure,
     auth: {
       user: settings.login,
       pass: settings.password,
@@ -59,6 +59,7 @@ interface SMTPSettings {
   server: string;
   login: string;
   password: string;
+  secure: boolean;
   from?: string;
   port?: string;
 }
@@ -79,6 +80,7 @@ async function getEmailServerSettings(
     server: settings.email_smtp_server,
     login: settings.email_smtp_login,
     password: settings.email_smtp_password,
+    secure: settings.email_smtp_secure,
     from: settings.email_smtp_from,
     port: settings.email_smtp_port,
   };
@@ -96,6 +98,7 @@ async function getEmailServerSettings(
         server: settings.password_reset_smtp_server,
         login: settings.password_reset_smtp_login,
         password: settings.password_reset_smtp_password,
+        secure: settings.password_reset_smtp_secure,
         from: settings.password_reset_smtp_from,
         port: settings.password_reset_smtp_port,
       };


### PR DESCRIPTION
# Description

- see #5949
- I also found something weird, the secure setting is set based on the port. I don't understand why this isn't the "secure" setting.
- ~~I didn't test this yet, didn't want to mess up the versions again.~~ ... ok, I tested this in my dev project, just the smtp settings. looks good, including making use of the override toggle. the sendgrid sending logic isn't touched, so, should be fine as well, but probably a good idea to double check before deploying.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
