### PR TITLE
Fix sharing files with commas

### DIFF
--- a/src/packages/frontend/components/copy-to-clipboard.tsx
+++ b/src/packages/frontend/components/copy-to-clipboard.tsx
@@ -3,6 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { CSS } from "@cocalc/frontend/app-framework";
 import { CSSProperties, ReactNode, useEffect, useMemo, useState } from "react";
 import { Button, Input, Tooltip } from "antd";
 import { CopyToClipboard } from "react-copy-to-clipboard";
@@ -12,11 +13,27 @@ interface Props {
   value: string;
   style?: CSSProperties;
   label?: ReactNode;
+  labelStyle?: CSS;
+  inputStyle?: CSS;
   size?: "large" | "middle" | "small";
 }
 
-export default function CopyToClipBoard({ value, style, size, label }: Props) {
+const INPUT_STYLE: CSS = { display: "inline-block", flex: 1 } as const;
+
+const LABEL_STYLE: CSS = {
+  marginRight: "15px",
+  display: "flex",
+  flex: "0 0 auto",
+  justifyContent: "center",
+  alignContent: "center",
+  flexDirection: "column",
+} as const;
+
+export default function CopyToClipBoard(props: Props) {
+  const { value, style, size, label, labelStyle, inputStyle } = props;
+
   const [copied, setCopied] = useState<boolean>(false);
+
   useEffect(() => {
     setCopied(false);
   }, [value]);
@@ -55,18 +72,8 @@ export default function CopyToClipBoard({ value, style, size, label }: Props) {
   if (!label) return <div style={style}>{input}</div>;
   return (
     <div style={{ display: "flex", ...style }}>
-      <div
-        style={{
-          marginRight: "15px",
-          display: "flex",
-          justifyContent: "center",
-          alignContent: "center",
-          flexDirection: "column",
-        }}
-      >
-        {label}
-      </div>{" "}
-      <div style={{ display: "inline-block", flex: 1 }}>{input}</div>
+      <div style={{ ...LABEL_STYLE, ...labelStyle }}>{label}</div>{" "}
+      <div style={{ ...INPUT_STYLE, ...inputStyle }}>{input}</div>
     </div>
   );
 }

--- a/src/packages/frontend/share/config.tsx
+++ b/src/packages/frontend/share/config.tsx
@@ -22,15 +22,8 @@ between them.
 
 const SHARE_HELP_URL = "https://doc.cocalc.com/share.html";
 
-import {
-  Alert,
-  Button,
-  Row,
-  Col,
-  FormGroup,
-  FormControl,
-  Radio,
-} from "react-bootstrap";
+import { Alert, Button, FormGroup, FormControl, Radio } from "react-bootstrap";
+import { Row, Col } from "antd";
 import {
   redux,
   ReactDOM,
@@ -58,6 +51,10 @@ import {
   SHARE_AUTHENTICATED_EXPLANATION,
   SHARE_FLAGS,
 } from "@cocalc/util/consts/ui";
+import { Popover } from "antd";
+
+// https://ant.design/components/grid/
+const GUTTER: [number, number] = [16, 24];
 
 interface PublicInfo {
   created: Date;
@@ -369,10 +366,17 @@ class Configure extends Component<Props, State> {
       <>
         <h4>Link</h4>
         <div style={{ paddingBottom: "5px" }}>Your share will appear here.</div>
-        <Button bsStyle="default" onClick={() => open_new_tab(url)}>
-          <Icon name="external-link" />
-        </Button>
-        <CopyToClipBoard value={url} />
+        <CopyToClipBoard
+          value={url}
+          labelStyle={{ marginRight: "5px" }}
+          label={
+            <Popover content={"Open published file on share server."}>
+              <Button bsStyle="default" onClick={() => open_new_tab(url)}>
+                <Icon name="external-link" />
+              </Button>
+            </Popover>
+          }
+        />
       </>
     );
   }
@@ -381,12 +385,12 @@ class Configure extends Component<Props, State> {
     if (this.state.sharing_options_state === "private") return;
 
     return (
-      <Row>
-        <Col sm={6} style={{ color: "#666" }}>
+      <Row gutter={GUTTER} style={{ paddingTop: "12px" }}>
+        <Col span={12} style={{ color: "#666" }}>
           {this.render_description(parent_is_public)}
           {this.render_license(parent_is_public)}
         </Col>
-        <Col sm={6} style={{ color: "#666" }}>
+        <Col span={12} style={{ color: "#666" }}>
           {this.render_link(parent_is_public)}
           <ConfigureName
             project_id={this.props.project_id}
@@ -487,24 +491,26 @@ class Configure extends Component<Props, State> {
             {trunc_middle(this.props.path, 128)}
           </a>
         </h2>
-        <Row>
-          <VisibleMDLG>
-            <Col sm={6}>{this.render_how_shared_heading()}</Col>
-            <Col sm={6}>
+        <Row gutter={GUTTER}>
+          <Col span={12}>
+            <VisibleMDLG>{this.render_how_shared_heading()}</VisibleMDLG>
+          </Col>
+          <Col span={12}>
+            <VisibleMDLG>
               <span style={{ fontSize: "15pt" }}>How it works</span>
-            </Col>
-          </VisibleMDLG>
+            </VisibleMDLG>
+          </Col>
         </Row>
-        <Row>
-          <Col sm={6}>
+        <Row gutter={GUTTER}>
+          <Col span={12}>
             {this.render_how_shared(parent_is_public)}
             {this.render_share_warning(parent_is_public)}
           </Col>
-          <Col sm={6}>{this.render_share_defn()}</Col>
+          <Col span={12}>{this.render_share_defn()}</Col>
         </Row>
         {this.render_public_config(parent_is_public)}
-        <Row>
-          <Col sm={12}>{this.render_close_button()}</Col>
+        <Row gutter={GUTTER}>
+          <Col span={24}>{this.render_close_button()}</Col>
         </Row>
       </div>
     );

--- a/src/packages/frontend/share/configure-name.tsx
+++ b/src/packages/frontend/share/configure-name.tsx
@@ -35,6 +35,13 @@ export default function ConfigureName({ project_id, path }: Props) {
     }
   }
 
+    // if user presses the Esc key, we set choosingName to false and don't save
+  async function keyup(e) {
+    if (e.key === "Escape") {
+      setChoosingName(false);
+    }
+  }
+
   return (
     <div style={{ margin: "15px 0" }}>
       <h4>Name{name ? `: ${name}` : ""}</h4>
@@ -45,7 +52,7 @@ export default function ConfigureName({ project_id, path }: Props) {
       </span>
       {!name && !choosingName ? (
         <Button
-          style={{ marginLeft: "15px" }}
+          style={{ marginLeft: "0px" }}
           onClick={() => setChoosingName(true)}
         >
           Choose a name...
@@ -54,6 +61,7 @@ export default function ConfigureName({ project_id, path }: Props) {
         <span>
           <Input
             onPressEnter={save}
+            onKeyUp={keyup}
             onBlur={save}
             onChange={(e) => {
               if (e.target.value != name) {

--- a/src/packages/next/components/path/path.tsx
+++ b/src/packages/next/components/path/path.tsx
@@ -27,25 +27,29 @@ import {
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-export default function PublicPath({
-  id,
-  path,
-  project_id,
-  projectTitle,
-  relativePath,
-  description,
-  counter,
-  compute_image,
-  license,
-  contents,
-  error,
-  customize,
-  disabled,
-  unlisted,
-  authenticated,
-}) {
+export default function PublicPath(props) {
+  const {
+    id,
+    path,
+    project_id,
+    projectTitle,
+    relativePath,
+    description,
+    counter,
+    compute_image,
+    license,
+    contents,
+    error,
+    customize,
+    disabled,
+    unlisted,
+    authenticated,
+  } = props;
+
   useCounter(id);
+
   if (id == null) return <Loading style={{ fontSize: "30px" }} />;
+
   if (error != null) {
     return (
       <div>


### PR DESCRIPTION
# Description

This fixes #5928 and also tweaks the public files dialog in the frontend a little bit (line break, spacing).

The original path in the ticket is broken due to a comma being encoded, and the test path I used for development is `test/sub dir/file space, (comma ) .md`. So, that's fine. I got pretty lost when I started to test more variations. E.g. a percent sign and question marks in the filename don't work as well. I tried some ideas, but no luck. I think the underlying complication is next.js itself does decode the URL component, internally. So, maybe this must change to an query parameter (maybe that helps, I don't know) or more general, we might want to warn/block renaming files to contain such problematic characters (`?`, `%` and `#` come to my mind, there are probably more)

I also tried to switch to encode/decode with `...URI` instead of `...URIComponent`, but that causes crashes for special characters. 

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
