### PR TITLE
db: fix initial setup if DB does not yet exist and a password is required

### DIFF
--- a/src/packages/database/postgres-base.coffee
+++ b/src/packages/database/postgres-base.coffee
@@ -857,6 +857,8 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                 misc_node.execute_code
                     command : 'createdb'
                     args    : ['--host', @_host, '--port', @_port, @_database]
+                    env     :
+                        PGPASSWORD : @_password
                     cb      : cb
 
     _confirm_delete: (opts) =>


### PR DESCRIPTION
# Description

this fixes #6030

Main hurdle was to replicate the problem. i.e. I made a new database setup, new user, require password auth, etc. Then `env DATA=... PGUSER=postgres PGHOST=127.0.0.1 PGDATABASE=cocalc ./node_modules/.bin/cocalc-hub-server --mode=kucalc --hostname=localhost --update-database-schema --websocket-server` to mimic kucalc's setup.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
