### PR TITLE
add a few entries to reserved usernames and implement .well-known/change-password

### DIFF
--- a/src/packages/next/pages/.well-known/change-password.tsx
+++ b/src/packages/next/pages/.well-known/change-password.tsx
@@ -1,0 +1,26 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { useRouter } from "next/router";
+import React, { CSSProperties, useEffect } from "react";
+import A from "components/misc/A";
+
+export default function WellKnownPassword() {
+  const router = useRouter();
+  const url = "/config/account/password";
+  useEffect(() => {
+    router.push(url);
+  }, []);
+  const style: CSSProperties = {
+    textAlign: "center",
+    margin: "10vh 0",
+  };
+  return (
+    <div style={style}>
+      Your're redirected to the account's <A href={url}>change password </A>{" "}
+      page.
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

quick implementation of https://w3c.github.io/webappsec-change-password-url/ to help e.g. password managers to point users to the page to change their password



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
