### PR TITLE
some fixes around processing server settings

### DIFF
--- a/src/packages/frontend/admin/site-settings.tsx
+++ b/src/packages/frontend/admin/site-settings.tsx
@@ -513,7 +513,7 @@ class SiteSettingsComponent extends Component<
       typeof conf.to_display == "function"
         ? `${conf.to_display(raw_value)}`
         : typeof conf.to_val == "function"
-        ? `${conf.to_val(raw_value)}`
+        ? `${conf.to_val(raw_value, this.state.edited)}`
         : undefined;
 
     const clearable = conf.clearable ?? false;

--- a/src/packages/static/src/load.tsx
+++ b/src/packages/static/src/load.tsx
@@ -5,13 +5,13 @@
 import "./init-app-base-path";
 // @ts-ignore
 import ReactDOM from "react-dom";
-import Primus from "./primus";
-import Manifest from "./manifest";
-import PreflightCheck from "./preflight-checks";
-import initError from "./webapp-error";
 import Favicons from "./favicons";
+import Manifest from "./manifest";
 import Meta from "./meta";
+import PreflightCheck from "./preflight-checks";
+import Primus from "./primus";
 import StartupBanner from "./startup-banner";
+import initError from "./webapp-error";
 
 initError();
 

--- a/src/packages/static/src/startup-banner.tsx
+++ b/src/packages/static/src/startup-banner.tsx
@@ -26,8 +26,8 @@ export default function StartupBanner() {
       let logo: string | undefined = undefined;
       try {
         // check for a custom logo
-        logo = (await (await fetch(join(appBasePath, "customize"))).json())
-          ?.configuration?.logo_rectangular;
+        const customizeData = await fetch(join(appBasePath, "customize"));
+        logo = (await customizeData.json())?.configuration?.logo_rectangular;
       } catch (err) {
         console.log("WARNING: problem loading customize data", err);
       }

--- a/src/packages/static/tsconfig.json
+++ b/src/packages/static/tsconfig.json
@@ -1,31 +1,31 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "es2020",
     "incremental": false,
-    "rootDir": "./node_modules/@cocalc/frontend/",
+    "lib": ["es5", "es6", "es2017", "dom"],
+    "module": "es2020",
     "outDir": "dist",
-    "target": "es5",
+    "rootDirs": ["./src", "./node_modules/@cocalc/frontend/"],
     "sourceMap": true,
-    "lib": ["es5", "es6", "es2017", "dom"]
+    "target": "es5",
   },
   "exclude": [
-    "dist",
-    "node_modules",
+    "*__test__*",
+    "*__tests__*",
     "account/test",
-    "jupyter/test",
+    "admin",
     "app-framework/__tests__/",
-    "frame-editors/sagews-editor",
+    "app",
+    "components/__tests__",
+    "dist",
     "frame-editors/generic/mocha-tests",
+    "frame-editors/sagews-editor",
     "frame-editors/settings/__tests__",
     "jupyter/output-messages/__test__",
+    "jupyter/test",
     "misc/__test__",
-    "components/__tests__",
+    "node_modules",
     "test-mocha",
-    "test",
-    "*__tests__*",
-    "*__test__*",
-    "admin",
-    "app"
+    "test"
   ]
 }

--- a/src/packages/static/webpack.config.js
+++ b/src/packages/static/webpack.config.js
@@ -128,23 +128,23 @@ if (useDiskCache) {
 module.exports = {
   cache: useDiskCache
     ? {
-        // This is supposed to cache the in-memory state to disk
-        // so initial startup time is less.  Don't do this in
-        // user home directory on cocalc, since it uses a LOT
-        // of disk IO, which makes everything very slow.
-        type: "filesystem",
-        buildDependencies: {
-          config: [__filename],
-        },
-        cacheDirectory,
-      }
+      // This is supposed to cache the in-memory state to disk
+      // so initial startup time is less.  Don't do this in
+      // user home directory on cocalc, since it uses a LOT
+      // of disk IO, which makes everything very slow.
+      type: "filesystem",
+      buildDependencies: {
+        config: [__filename],
+      },
+      cacheDirectory,
+    }
     : undefined,
   devtool: PRODMODE ? undefined : "eval-cheap-module-source-map",
   mode: PRODMODE ? "production" : "development",
   entry: {
     load: "./src/load.tsx",
-    app: "./src/webapp-cocalc.js",
-    embed: "./src/webapp-embed.js",
+    app: { import: "./src/webapp-cocalc.js", dependOn: "load" },
+    embed: { import: "./src/webapp-embed.js", dependOn: "load" },
   },
   /* Why chunkhash below, rather than contenthash? This says contenthash is a special
      thing for css and other text files only (??):

--- a/src/packages/tsconfig.json
+++ b/src/packages/tsconfig.json
@@ -1,27 +1,28 @@
 {
   "compilerOptions": {
-    "incremental": true,
-    "target": "es5",
-    "lib": ["es5", "es6", "es2017", "dom"],
     "allowJs": true,
     "declaration": true,
     "downlevelIteration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "incremental": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "lib": ["es5", "es6", "es2017", "dom"],
+    "moduleResolution": "node",
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "target": "es5"
   },
   "watchOptions": {
-    "watchFile": "useFsEvents",
-    "watchDirectory": "useFsEvents",
     "fallbackPolling": "dynamicPriority",
-    "synchronousWatchDirectory": true
+    "synchronousWatchDirectory": true,
+    "watchDirectory": "useFsEvents",
+    "watchFile": "useFsEvents"
   }
 }

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -357,6 +357,7 @@ export const site_settings_conf: SiteSettings = {
     desc: "A JSON-formatted default quota for projects. This is only for on-prem setups. The fields actual meaning is defined in hub's `quota.ts` code",
     default: "{}",
     show: only_onprem,
+    to_val: from_json,
   },
   max_upgrades: {
     name: "Maximum Quota Upgrades",
@@ -373,8 +374,8 @@ export const site_settings_conf: SiteSettings = {
     to_val: to_bool,
   },
   iframe_comm_hosts: {
-    name: "IFrame communication hosts",
-    desc: "List of allowed DNS names, which are allowed to communicate back and forth with an embedded CoCalc instance. If starting with a dot, also all subdomains. It picks all matching `[a-zA-Z0-9.-]+`",
+    name: "IFrame hosts",
+    desc: "List of allowed DNS names, which are allowed to embed and communicate back and forth with an embedded CoCalc instance. If starting with a dot, also all subdomains. It picks all matching `[a-zA-Z0-9.-]+`",
     default: "",
     to_val: split_iframe_comm_hosts,
     to_display: num_dns_hosts,

--- a/src/packages/util/upgrades/quota.ts
+++ b/src/packages/util/upgrades/quota.ts
@@ -134,6 +134,18 @@ export interface Upgrades {
   ephemeral_disk: number;
 }
 
+// this is onprem specific only!
+// this server setting configuration "default_quotas" is stored in the database
+// and used by the manage process to configure default quotas of projects.
+export interface DefaultQuotaSetting {
+  cpu: number; // limit cpu, usually 1
+  cpu_oc: number; // overcommit ratio for CPU, e.g 10: means 1/10 is requested
+  idle_timeout: number; // seconds
+  internet: boolean; // usually true
+  mem: number; // memory limit in MB
+  mem_oc: number; // overcommit ratio to derive memory request (e.g. 5 = 5x overcommit)
+}
+
 // upgrade raw data from users: {"<uuid4>": {"group": ...,
 // "upgrades":
 // {"cores": 0, "memory": 3000, "mintime": 86400, "network": 1,


### PR DESCRIPTION
# Description

1. process the string value using the `to_val` function right when the data comes in from the DB
2. the above means it is no longer necessary in the frontend
3. fix/enhance typing
4. I also noticed errors in "static", where the local source files are in `./src`. I added them.
5. … and when I edited the tsconfig file, it also complaint about not setting the module resolution ordering, i.e. if     `"resolveJsonModule": true` → I set `moduleResolution": "node"`. More background about that [in the moduleResolution documentation](https://www.typescriptlang.org/docs/handbook/module-resolution.html). If this setting introduces problems, which I hope it doesn't, we should definitely fix them and not revert the setting.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
