### PR TITLE
frontend: let users add their license easily when they create a new project

### DIFF
--- a/src/packages/frontend/custom-software/selector.tsx
+++ b/src/packages/frontend/custom-software/selector.tsx
@@ -82,13 +82,12 @@ export function derive_project_img_name(
 interface Props {
   onChange: (obj: SoftwareEnvironmentState) => void;
   default_image?: string; // which one to initialize state to
+  showTitle?: boolean; // default true
 }
 
 // this is a selector for the software environment of a project
-export const SoftwareEnvironment: React.FC<Props> = ({
-  onChange,
-  default_image,
-}) => {
+export const SoftwareEnvironment: React.FC<Props> = (props: Props) => {
+  const { onChange, default_image, showTitle = true } = props;
   const images: ComputeImages | undefined = useTypedRedux(
     "compute_images",
     "images"
@@ -352,7 +351,7 @@ export const SoftwareEnvironment: React.FC<Props> = ({
   function render_type_selection() {
     return (
       <>
-        <ControlLabel>Software environment</ControlLabel>
+        {showTitle && <ControlLabel>Software environment</ControlLabel>}
 
         <FormGroup>
           {render_default()}

--- a/src/packages/frontend/projects/create-project.tsx
+++ b/src/packages/frontend/projects/create-project.tsx
@@ -34,12 +34,14 @@ import {
   KUCALC_ON_PREMISES,
 } from "@cocalc/util/db-schema/site-defaults";
 import { COLORS } from "@cocalc/util/theme";
-import { Col, Form, Input, Row } from "antd";
+import { Card, Col, Form, Input, Row } from "antd";
 import { delay } from "awaiting";
 import { SiteLicenseInput } from "@cocalc/frontend/site-licenses/input";
 import { isValidUUID } from "@cocalc/util/misc";
 
 const TOGGLE_STYLE: CSS = { margin: "10px 0" } as const;
+const TOGGLE_BUTTON_STYLE: CSS = { padding: "0" } as const;
+const CARD_STYLE: CSS = { marginTop: "10px", marginBottom: "10px" } as const;
 
 interface Props {
   start_in_edit_mode?: boolean;
@@ -59,7 +61,7 @@ export const NewProjectCreator: React.FC<Props> = (props: Props) => {
   const [error, set_error] = useState<string>("");
   const [show_advanced, set_show_advanced] = useState<boolean>(false);
   const [show_add_license, set_show_add_license] = useState<boolean>(false);
-  const [title_prefill, set_title_prefill] = useState<boolean>(true);
+  const [title_prefill, set_title_prefill] = useState<boolean>(false);
   const [license_id, set_license_id] = useState<string>("");
 
   const [custom_software, set_custom_software] =
@@ -249,16 +251,25 @@ export const NewProjectCreator: React.FC<Props> = (props: Props) => {
 
   function render_advanced() {
     if (!show_advanced) return;
-    return <SoftwareEnvironment onChange={custom_software_on_change} />;
+    return (
+      <Card size="small" title="Software environment" style={CARD_STYLE}>
+        <SoftwareEnvironment
+          onChange={custom_software_on_change}
+          showTitle={false}
+        />
+      </Card>
+    );
   }
 
   function render_add_license() {
     if (!show_add_license) return;
     return (
-      <SiteLicenseInput
-        confirmLabel={"Add this license"}
-        onChange={(lic) => set_license_id(lic)}
-      />
+      <Card size="small" title="Select license" style={CARD_STYLE}>
+        <SiteLicenseInput
+          confirmLabel={"Add this license"}
+          onChange={(lic) => set_license_id(lic)}
+        />
+      </Card>
     );
   }
 
@@ -268,7 +279,11 @@ export const NewProjectCreator: React.FC<Props> = (props: Props) => {
     if (show_advanced) return;
     return (
       <div style={TOGGLE_STYLE}>
-        <Button onClick={() => set_show_advanced(true)} bsStyle="link">
+        <Button
+          onClick={() => set_show_advanced(true)}
+          bsStyle="link"
+          style={TOGGLE_BUTTON_STYLE}
+        >
           <Icon name="plus" /> Customize the software environment...
         </Button>
       </div>
@@ -285,7 +300,11 @@ export const NewProjectCreator: React.FC<Props> = (props: Props) => {
     if (show_add_license) return;
     return (
       <div style={TOGGLE_STYLE}>
-        <Button onClick={() => set_show_add_license(true)} bsStyle="link">
+        <Button
+          onClick={() => set_show_add_license(true)}
+          bsStyle="link"
+          style={TOGGLE_BUTTON_STYLE}
+        >
           <Icon name="plus" /> Add a license key...
         </Button>
       </div>
@@ -305,7 +324,7 @@ export const NewProjectCreator: React.FC<Props> = (props: Props) => {
           >
             add/remove licenses
           </A>{" "}
-          later on in the project settings.
+          in the project settings later on.
         </div>
       );
     }

--- a/src/packages/frontend/projects/create-project.tsx
+++ b/src/packages/frontend/projects/create-project.tsx
@@ -8,33 +8,38 @@ Create a new project
 */
 
 import {
+  Alert,
+  Button,
+  ButtonToolbar,
+  Well,
+} from "@cocalc/frontend/antd-bootstrap";
+import {
+  CSS,
   React,
-  ReactDOM,
   redux,
   useEffect,
   useIsMountedRef,
   useRef,
   useState,
   useTypedRedux,
-} from "../app-framework";
-import { KUCALC_COCALC_COM } from "@cocalc/util/db-schema/site-defaults";
-import { delay } from "awaiting";
+} from "@cocalc/frontend/app-framework";
+import { A, ErrorDisplay, Icon, Space } from "@cocalc/frontend/components";
 import {
+  derive_project_img_name,
   SoftwareEnvironment,
   SoftwareEnvironmentState,
-  derive_project_img_name,
-} from "../custom-software/selector";
+} from "@cocalc/frontend/custom-software/selector";
 import {
-  Well,
-  Button,
-  ButtonToolbar,
-  FormControl,
-  FormGroup,
-  Alert,
-} from "../antd-bootstrap";
-import { Row, Col } from "antd";
-import { A, ErrorDisplay, Icon, Space } from "../components";
+  KUCALC_COCALC_COM,
+  KUCALC_ON_PREMISES,
+} from "@cocalc/util/db-schema/site-defaults";
 import { COLORS } from "@cocalc/util/theme";
+import { Col, Form, Input, Row } from "antd";
+import { delay } from "awaiting";
+import { SiteLicenseInput } from "@cocalc/frontend/site-licenses/input";
+import { isValidUUID } from "@cocalc/util/misc";
+
+const TOGGLE_STYLE: CSS = { margin: "10px 0" } as const;
 
 interface Props {
   start_in_edit_mode?: boolean;
@@ -43,10 +48,9 @@ interface Props {
 
 type EditState = "edit" | "view" | "saving";
 
-export const NewProjectCreator: React.FC<Props> = ({
-  start_in_edit_mode,
-  default_value,
-}: Props) => {
+export const NewProjectCreator: React.FC<Props> = (props: Props) => {
+  const { start_in_edit_mode, default_value } = props;
+
   // view --> edit --> saving --> view
   const [state, set_state] = useState<EditState>(
     start_in_edit_mode ? "edit" : "view"
@@ -54,27 +58,34 @@ export const NewProjectCreator: React.FC<Props> = ({
   const [title_text, set_title_text] = useState<string>(default_value ?? "");
   const [error, set_error] = useState<string>("");
   const [show_advanced, set_show_advanced] = useState<boolean>(false);
+  const [show_add_license, set_show_add_license] = useState<boolean>(false);
   const [title_prefill, set_title_prefill] = useState<boolean>(true);
+  const [license_id, set_license_id] = useState<string>("");
 
-  const [custom_software, set_custom_software] = useState<
-    SoftwareEnvironmentState
-  >({});
+  const [custom_software, set_custom_software] =
+    useState<SoftwareEnvironmentState>({});
 
   const new_project_title_ref = useRef(null);
 
   const is_anonymous = useTypedRedux("account", "is_anonymous");
   const customize_kucalc = useTypedRedux("customize", "kucalc");
 
+  const [form] = Form.useForm();
+
   useEffect(() => {
     select_text();
   }, []);
+
+  useEffect(() => {
+    form.setFieldsValue({ title: title_text });
+  }, [title_text]);
 
   const is_mounted_ref = useIsMountedRef();
 
   async function select_text(): Promise<void> {
     // wait for next render loop so the title actually is in the DOM...
     await delay(1);
-    ReactDOM.findDOMNode(new_project_title_ref.current)?.select();
+    (new_project_title_ref.current as any)?.input?.select();
   }
 
   function start_editing(): void {
@@ -90,7 +101,9 @@ export const NewProjectCreator: React.FC<Props> = ({
     set_error("");
     set_custom_software({});
     set_show_advanced(false);
+    set_show_add_license(false);
     set_title_prefill(true);
+    set_license_id("");
   }
 
   function toggle_editing(): void {
@@ -116,6 +129,9 @@ export const NewProjectCreator: React.FC<Props> = ({
       set_state("edit");
       set_error(`Error creating project -- ${err}`);
       return;
+    }
+    if (isValidUUID(license_id)) {
+      await actions.add_site_license_to_project(project_id, license_id);
     }
     // We also update the customer billing information so apply_default_upgrades works.
     const billing_actions = redux.getActions("billing");
@@ -212,7 +228,7 @@ export const NewProjectCreator: React.FC<Props> = ({
   }
 
   function input_on_change(): void {
-    const text = ReactDOM.findDOMNode(new_project_title_ref.current)?.value;
+    const text = (new_project_title_ref.current as any)?.input?.value;
     set_title(text);
   }
 
@@ -236,40 +252,95 @@ export const NewProjectCreator: React.FC<Props> = ({
     return <SoftwareEnvironment onChange={custom_software_on_change} />;
   }
 
+  function render_add_license() {
+    if (!show_add_license) return;
+    return (
+      <SiteLicenseInput
+        confirmLabel={"Add this license"}
+        onChange={(lic) => set_license_id(lic)}
+      />
+    );
+  }
+
   function render_advanced_toggle(): JSX.Element | undefined {
     // we only support custom images on cocalc.com
     if (customize_kucalc !== KUCALC_COCALC_COM) return;
     if (show_advanced) return;
     return (
-      <div style={{ margin: "10px 0 0" }}>
-        <a
-          onClick={() => set_show_advanced(true)}
-          style={{ cursor: "pointer" }}
-        >
-          <b>Customize the software environment...</b>
-        </a>
+      <div style={TOGGLE_STYLE}>
+        <Button onClick={() => set_show_advanced(true)} bsStyle="link">
+          <Icon name="plus" /> Customize the software environment...
+        </Button>
       </div>
     );
   }
 
+  function render_add_license_toggle(): JSX.Element | undefined {
+    // onprem and cocalc.com use licenses to adjust quota configs
+    if (
+      customize_kucalc !== KUCALC_COCALC_COM &&
+      customize_kucalc !== KUCALC_ON_PREMISES
+    )
+      return;
+    if (show_add_license) return;
+    return (
+      <div style={TOGGLE_STYLE}>
+        <Button onClick={() => set_show_add_license(true)} bsStyle="link">
+          <Icon name="plus" /> Add a license key...
+        </Button>
+      </div>
+    );
+  }
+
+  function render_license() {
+    if (isValidUUID(license_id)) {
+      return (
+        <div style={{ color: COLORS.GRAY }}>
+          This project will have the license <code>{license_id}</code> applied
+          to. You can{" "}
+          <A
+            href={
+              "https://doc.cocalc.com/project-settings.html#project-add-license"
+            }
+          >
+            add/remove licenses
+          </A>{" "}
+          later on in the project settings.
+        </div>
+      );
+    }
+  }
+
   function render_input_section(): JSX.Element | undefined {
+    const helpTxt =
+      "The title of your new project, you can easily change it later!";
     return (
       <Well style={{ backgroundColor: "#FFF" }}>
         <Row>
           <Col sm={12}>
-            <FormGroup>
-              <FormControl
-                ref={new_project_title_ref}
-                type="text"
-                placeholder="Project title -- you can easily change this at any time!"
-                disabled={state === "saving"}
-                value={title_text}
-                onChange={input_on_change}
-                onKeyDown={handle_keypress}
-                autoFocus
-              />
-            </FormGroup>
-            {render_advanced_toggle()}
+            <Form form={form}>
+              <Form.Item
+                label="Project Title"
+                name="title"
+                initialValue={title_text}
+                rules={[
+                  {
+                    required: true,
+                    min: 1,
+                    message: helpTxt,
+                  },
+                ]}
+              >
+                <Input
+                  ref={new_project_title_ref}
+                  placeholder={"A name for your new project..."}
+                  disabled={state === "saving"}
+                  onChange={input_on_change}
+                  onKeyDown={handle_keypress}
+                  autoFocus
+                />
+              </Form.Item>
+            </Form>
           </Col>
           <Col sm={12}>
             <div style={{ color: COLORS.GRAY, marginLeft: "30px" }}>
@@ -280,7 +351,11 @@ export const NewProjectCreator: React.FC<Props> = ({
             </div>
           </Col>
         </Row>
+        {render_advanced_toggle()}
         {render_advanced()}
+        {render_add_license_toggle()}
+        {render_add_license()}
+        {render_license()}
         <Row>
           <Col sm={24} style={{ marginTop: "10px" }}>
             <ButtonToolbar>
@@ -292,7 +367,8 @@ export const NewProjectCreator: React.FC<Props> = ({
                 onClick={() => create_project()}
                 bsStyle="success"
               >
-                Create Project{create_disabled() ? " (enter a title above!)" : ""}
+                Create Project
+                {create_disabled() ? " (enter a title above!)" : ""}
               </Button>
             </ButtonToolbar>
           </Col>

--- a/src/packages/frontend/projects/projects-page.tsx
+++ b/src/packages/frontend/projects/projects-page.tsx
@@ -6,43 +6,40 @@
 // ensure redux stuff (actions and store) are initialized:
 import "./actions";
 
+import { Footer } from "@cocalc/frontend/customize";
 import { Map, Set } from "immutable";
-
+import { UsersViewing } from "../account/avatar/users-viewing";
+import { Col, Row } from "../antd-bootstrap";
 import {
   React,
   redux,
   useActions,
-  useTypedRedux,
-  useState,
   useMemo,
+  useState,
+  useTypedRedux,
 } from "../app-framework";
 import { Icon, Loading, LoginLink } from "../components";
-import { Row, Col } from "../antd-bootstrap";
-
-import { UsersViewing } from "../account/avatar/users-viewing";
-
 import { NewProjectCreator } from "./create-project";
+import { Hashtags } from "./hashtags";
+import ProjectList from "./project-list";
+import { ProjectsListingDescription } from "./project-list-desc";
 import { ProjectsFilterButtons } from "./projects-filter-buttons";
 import { ProjectsSearch } from "./search";
 import { AddToProjectToken } from "./token";
-import { Hashtags } from "./hashtags";
-import { ProjectsListingDescription } from "./project-list-desc";
-import ProjectList from "./project-list";
-import { get_visible_projects, get_visible_hashtags } from "./util";
-import { Footer } from "@cocalc/frontend/customize";
+import { get_visible_hashtags, get_visible_projects } from "./util";
 
 const PROJECTS_TITLE_STYLE: React.CSSProperties = {
   color: "#666",
   fontSize: "24px",
   fontWeight: 500,
   marginBottom: "1ex",
-};
+} as const;
 
 const LOADING_STYLE: React.CSSProperties = {
   fontSize: "40px",
   textAlign: "center",
   color: "#999999",
-};
+} as const;
 
 export const ProjectsPage: React.FC = () => {
   const actions = useActions("projects");
@@ -107,11 +104,12 @@ export const ProjectsPage: React.FC = () => {
       // on n when it is *first* rendered.
       return;
     }
+    const ts = new Date().toISOString().split("T")[0];
     return (
       <div style={{ margin: "15px auto", maxWidth: "900px" }}>
         <NewProjectCreator
           start_in_edit_mode={n === 0}
-          default_value={search ?? "Untitled"}
+          default_value={search || `Untitled ${ts}`}
         />
       </div>
     );

--- a/src/packages/frontend/site-licenses/input.tsx
+++ b/src/packages/frontend/site-licenses/input.tsx
@@ -26,14 +26,23 @@ export function useManagedLicenses() {
 }
 
 interface Props {
-  onSave: (licenseId: string) => void;
-  onCancel: () => void;
+  onSave?: (licenseId: string) => void;
+  onCancel?: () => void;
+  onChange?: (licenseId: string) => void;
+  confirmLabel?: string;
   exclude?: string[];
   style?: CSS;
 }
 
 export const SiteLicenseInput: React.FC<Props> = (props: Props) => {
-  const { onSave, onCancel, exclude, style } = props;
+  const {
+    onSave,
+    onCancel,
+    onChange,
+    exclude,
+    style,
+    confirmLabel = "Apply License",
+  } = props;
 
   const managedLicenses = useManagedLicenses();
 
@@ -43,9 +52,10 @@ export const SiteLicenseInput: React.FC<Props> = (props: Props) => {
     <SelectLicense
       onSave={onSave}
       onCancel={onCancel}
+      onChange={onChange}
       exclude={exclude}
       managedLicenses={managedLicenses.toJS() as { [id: string]: License }}
-      confirmLabel={"Apply License"}
+      confirmLabel={confirmLabel}
       style={style}
     />
   );

--- a/src/packages/frontend/site-licenses/select-license.tsx
+++ b/src/packages/frontend/site-licenses/select-license.tsx
@@ -6,7 +6,7 @@ Component takes as input data that describes a licens.
 IMPORTANT: this component must work in *both* from nextjs and static.
 */
 
-import { CSS } from "@cocalc/frontend/app-framework";
+import { CSS, Rendered } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components/icon";
 import { describe_quota as describeQuota } from "@cocalc/util/licenses/describe-quota";
 import { days_ago as daysAgo, isValidUUID, len } from "@cocalc/util/misc";
@@ -33,16 +33,17 @@ interface Props {
   style?: CSS;
 }
 
-export default function SelectLicense({
-  defaultLicenseId,
-  onSave,
-  onChange,
-  onCancel,
-  exclude,
-  managedLicenses,
-  confirmLabel,
-  style,
-}: Props) {
+export default function SelectLicense(props: Props) {
+  const {
+    defaultLicenseId,
+    onSave,
+    onChange,
+    onCancel,
+    exclude,
+    managedLicenses,
+    confirmLabel,
+    style,
+  } = props;
   const isBlurredRef = useRef<boolean>(true);
   const [licenseId, setLicenseId] = useState<string>(defaultLicenseId ?? "");
   const [showAll, setShowAll] = useState<boolean>(false);
@@ -95,6 +96,27 @@ export default function SelectLicense({
 
   const valid = isValidUUID(licenseId);
 
+  function renderButton(): Rendered {
+    if (!(onSave || onCancel)) return;
+
+    return (
+      <Space>
+        {onSave && (
+          <Button
+            disabled={!valid}
+            type="primary"
+            onClick={() => {
+              onSave(licenseId);
+            }}
+          >
+            <Icon name="check" /> {confirmLabel ?? "Apply License"}
+          </Button>
+        )}
+        {onCancel && <Button onClick={onCancel}>Cancel</Button>}
+      </Space>
+    );
+  }
+
   return (
     <div style={style}>
       <div style={{ width: "100%", display: "flex" }}>
@@ -140,22 +162,7 @@ export default function SelectLicense({
           </Checkbox>
         )}
       </div>
-      {(onSave || onCancel) && (
-        <Space>
-          {onSave && (
-            <Button
-              disabled={!valid}
-              type="primary"
-              onClick={() => {
-                onSave(licenseId);
-              }}
-            >
-              <Icon name="check" /> {confirmLabel ?? "Apply License"}
-            </Button>
-          )}
-          {onCancel && <Button onClick={onCancel}>Cancel</Button>}
-        </Space>
-      )}
+      {renderButton()}
       {!valid && licenseId && (
         <Alert
           style={{ margin: "15px" }}

--- a/src/packages/frontend/site-licenses/select-license.tsx
+++ b/src/packages/frontend/site-licenses/select-license.tsx
@@ -154,7 +154,7 @@ export default function SelectLicense(props: Props) {
 
         {(showAll || licenseIds.length < len(managedLicenses)) && (
           <Checkbox
-            style={{ marginTop: "10px", color: "#666" }}
+            style={{ marginTop: "10px", color: "#666", whiteSpace: "nowrap" }}
             checked={showAll}
             onChange={() => setShowAll(!showAll)}
           >


### PR DESCRIPTION
# Description

This adds a bit of "antd" to the new project dialog and a dropdown to add or select a license. I also saw traces of giving projects a default name, which didn't work. It's fixed and I'm also adding a timestamp to the default name.

how it looks now:

![Screenshot from 2022-08-04 10-55-38](https://user-images.githubusercontent.com/207405/182807122-0b1a390a-2b95-4546-8d23-0eba101fa145.png)


and after expanding the add license part:

![Screenshot from 2022-08-04 10-55-23](https://user-images.githubusercontent.com/207405/182807143-487d8be7-61c4-4cef-b59b-36521e8b8ce1.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
