### PR TITLE
landing page + settings: no shared listing on landing page

### DIFF
--- a/src/packages/next/components/landing/content.tsx
+++ b/src/packages/next/components/landing/content.tsx
@@ -57,25 +57,15 @@ export default function Content(props: Props) {
     subtitle,
     subtitleBelow = false,
   } = props;
+
   const { sandboxProjectId } = useCustomize();
 
   function renderIndexInfo() {
     if (!indexInfo) return;
-
     return (
-      <>
-        <Col
-          xs={24}
-          style={{
-            borderTop: "1px solid lightgrey",
-            marginTop: "20px",
-            marginBottom: "20px",
-          }}
-        ></Col>
-        <Col sm={{ span: 12, offset: 6 }} xs={{ span: 24, offset: 0 }}>
-          <SanitizedMarkdown value={indexInfo} />
-        </Col>
-      </>
+      <Col xs={20}>
+        <SanitizedMarkdown value={indexInfo} style={{ padding: "20xp" }} />
+      </Col>
     );
   }
 
@@ -96,6 +86,39 @@ export default function Content(props: Props) {
         </Col>
       </>
     );
+  }
+
+  function renderImage() {
+    // if the index info is anything more than an empty string, we render this here instead
+    if (!!indexInfo) return renderIndexInfo();
+    if (!image) return;
+    return (
+      <>
+        <Image
+          src={image}
+          priority={true}
+          style={{ padding: "15px" }}
+          alt={alt ?? `Image illustrating ${title}`}
+        />
+        <div style={{ textAlign: "center", color: "#333", fontSize: "12pt" }}>
+          {caption}
+        </div>
+      </>
+    );
+  }
+
+  function renderAboveImage() {
+    return aboveImage != null
+      ? aboveImage
+      : sandboxProjectId && (
+          <div style={{ margin: "15px" }}>
+            <Path
+              style={{ marginBottom: "15px" }}
+              project_id={sandboxProjectId}
+              description="Public Sandbox"
+            />
+          </div>
+        );
   }
 
   return (
@@ -123,35 +146,10 @@ export default function Content(props: Props) {
           </div>
         </Col>
         <Col sm={14} xs={24}>
-          {aboveImage != null
-            ? aboveImage
-            : sandboxProjectId && (
-                <div style={{ margin: "15px" }}>
-                  <Path
-                    style={{ marginBottom: "15px" }}
-                    project_id={sandboxProjectId}
-                    description="Public Sandbox"
-                  />
-                </div>
-              )}
-          {image && (
-            <>
-              <Image
-                src={image}
-                priority={true}
-                style={{ padding: "15px" }}
-                alt={alt ?? `Image illustrating ${title}`}
-              />
-              <div
-                style={{ textAlign: "center", color: "#333", fontSize: "12pt" }}
-              >
-                {caption}
-              </div>
-            </>
-          )}
+          {renderAboveImage()}
+          {renderImage()}
         </Col>
         {renderSubtitleBelow()}
-        {renderIndexInfo()}
       </Row>
       <SignIn startup={startup ?? title} hideFree={true} />
     </div>

--- a/src/packages/next/components/landing/sign-in.tsx
+++ b/src/packages/next/components/landing/sign-in.tsx
@@ -19,7 +19,7 @@ interface Props {
 const STYLE: CSSProperties = {
   textAlign: "center",
   padding: "30px 15px 0 15px",
-};
+} as const;
 
 export default function SignIn({ startup, hideFree }: Props) {
   const { anonymousSignup, siteName, account } = useCustomize();

--- a/src/packages/next/pages/index.tsx
+++ b/src/packages/next/pages/index.tsx
@@ -32,7 +32,48 @@ export default function Home({ customize, publicPaths }) {
     splashImage,
     indexInfo,
     sandboxProjectId,
+    onCoCalcCom,
   } = customize;
+
+  function renderAboveImage() {
+    return (
+      <>
+        {sandboxProjectId && (
+          <div style={{ marginBottom: "30px" }}>
+            <h3 style={{ textAlign: "center", color: "#666" }}>
+              The Public {siteName} Sandbox
+            </h3>
+            <Path
+              style={{ marginRight: "15px", marginBottom: "15px" }}
+              project_id={sandboxProjectId}
+              description="Public Sandbox"
+            />
+          </div>
+        )}
+        {shareServer && onCoCalcCom && (
+          <>
+            <h3 style={{ textAlign: "center" }}>
+              <A href="/share/public_paths/page/1">
+                Explore what people have shared using {siteName}!
+              </A>
+            </h3>
+            {publicPaths && (
+              <div
+                style={{
+                  maxHeight: "60vh",
+                  overflow: "auto",
+                  marginRight: "15px",
+                }}
+              >
+                <PublicPaths publicPaths={publicPaths} />
+              </div>
+            )}
+          </>
+        )}
+      </>
+    );
+  }
+
   return (
     <Customize value={customize}>
       <Head title="Collaborative Calculation" />
@@ -143,7 +184,7 @@ export default function Home({ customize, publicPaths }) {
                     hosted by <A href={organizationURL}>{organizationName}</A>
                   </>
                 )}
-                {customize.onCoCalcCom && (
+                {onCoCalcCom && (
                   <div style={{ marginTop: "15px" }}>
                     <A href="https://about.cocalc.com">
                       Mission and Features of CoCalc
@@ -171,42 +212,7 @@ export default function Home({ customize, publicPaths }) {
                 ? splashImage
                 : screenshot
             }
-            aboveImage={
-              <>
-                {sandboxProjectId && (
-                  <div style={{ marginBottom: "30px" }}>
-                    <h3 style={{ textAlign: "center", color: "#666" }}>
-                      The Public {siteName} Sandbox
-                    </h3>
-                    <Path
-                      style={{ marginRight: "15px", marginBottom: "15px" }}
-                      project_id={sandboxProjectId}
-                      description="Public Sandbox"
-                    />
-                  </div>
-                )}
-                {shareServer && (
-                  <>
-                    <h3 style={{ textAlign: "center" }}>
-                      <A href="/share/public_paths/page/1">
-                        Explore what people have shared using {siteName}!
-                      </A>
-                    </h3>
-                    {publicPaths && (
-                      <div
-                        style={{
-                          maxHeight: "60vh",
-                          overflow: "auto",
-                          marginRight: "15px",
-                        }}
-                      >
-                        <PublicPaths publicPaths={publicPaths} />
-                      </div>
-                    )}
-                  </>
-                )}
-              </>
-            }
+            aboveImage={renderAboveImage()}
             alt={"Screenshot showing CoCalc in action!"}
             indexInfo={indexInfo}
           />

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -249,7 +249,7 @@ export const site_settings_conf: SiteSettings = {
   },
   index_info_html: {
     name: "Index page info",
-    desc: "An HTML/Markdown string displayed on the index page.",
+    desc: "An HTML/Markdown string displayed on the index page. If set, replaces the Index page picture!",
     default: "",
     clearable: true,
     show: show_theming_vars,
@@ -374,8 +374,8 @@ export const site_settings_conf: SiteSettings = {
     to_val: to_bool,
   },
   iframe_comm_hosts: {
-    name: "IFrame hosts",
-    desc: "List of allowed DNS names, which are allowed to embed and communicate back and forth with an embedded CoCalc instance. If starting with a dot, also all subdomains. It picks all matching `[a-zA-Z0-9.-]+`",
+    name: "IFrame embedding",
+    desc: "DNS hostnames, which are allowed to embed and communicate with this CoCalc instance. Strings starting with a dot will match subdomains. Hosts are tokens matching `[a-zA-Z0-9.-]+`. In production, this needs `co proxy update-config` & restart.",
     default: "",
     to_val: split_iframe_comm_hosts,
     to_display: num_dns_hosts,


### PR DESCRIPTION
# Description

- got some feedback, and it's not ideal to show the shared files listing on the landing page for onprem. hence this changes it to only show up if in production
- the additional information block replaces the image right at the top, to make that text visible above the fold (if someone wants to show an image in the text, it's possible via html or markdown, no problem)
- finally, I'm also tweaking the description texts for the iframe and index page info site setting configuration.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
