### PR TITLE
next.js/express.js: disable X-Powered-By everywhere 

### DIFF
--- a/src/packages/hub/servers/express-app.ts
+++ b/src/packages/hub/servers/express-app.ts
@@ -51,6 +51,7 @@ export default async function init(opts: Options): Promise<{
 
   // Create an express application
   const app = express();
+  app.disable("x-powered-by"); // https://github.com/sagemathinc/cocalc/issues/6101
 
   // healthchecks are for internal use, no basePath prefix
   // they also have to come first, since e.g. the vhost depends

--- a/src/packages/next/next.config.js
+++ b/src/packages/next/next.config.js
@@ -62,4 +62,5 @@ module.exports = {
     locales: ["en-US"],
     defaultLocale: "en-US",
   },
+  poweredByHeader: false, // https://github.com/sagemathinc/cocalc/issues/6101
 };

--- a/src/packages/project/http-api/server.ts
+++ b/src/packages/project/http-api/server.ts
@@ -38,6 +38,7 @@ export default async function init(): Promise<void> {
   if (client == null) throw Error("client must be defined");
   const dbg: Function = client.dbg("api_server");
   const app: express.Application = express();
+  app.disable("x-powered-by"); // https://github.com/sagemathinc/cocalc/issues/6101
 
   dbg("configuring server...");
   configure(app, dbg);

--- a/src/packages/project/servers/browser/http-server.ts
+++ b/src/packages/project/servers/browser/http-server.ts
@@ -36,6 +36,8 @@ export default async function init(): Promise<void> {
   winston.info("starting server...");
 
   const app = express();
+  app.disable("x-powered-by"); // https://github.com/sagemathinc/cocalc/issues/6101
+
   const server = createServer(app);
 
   // suggested by http://expressjs.com/en/advanced/best-practice-performance.html#use-gzip-compression


### PR DESCRIPTION
# Description

- ref #6101
- for testing, I used curl in my dev project:

before:

```
~$ curl -I http://localhost:5000/.../port/5000/info
HTTP/1.1 200 OK
X-Powered-By: Next.js
[...]

~$ curl -I http://localhost:5000/.../port/projects/.../files/
HTTP/1.1 308 Permanent Redirect
X-Powered-By: Express
[...]
```

and with this patch these headers are gone.


```
~$ curl -Is http://localhost:5000/.../port/5000/info | grep Powered
~$ curl -Is http://localhost:5000/.../port/projects/.../files/ | grep Powered
```


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
