### PR TITLE
next/billing+licenses: streamlining the layout similar to "store"

### DIFF
--- a/src/packages/next/components/billing/layout.tsx
+++ b/src/packages/next/components/billing/layout.tsx
@@ -4,10 +4,12 @@
  */
 
 import { unreachable } from "@cocalc/util/misc";
+import { COLORS } from "@cocalc/util/theme";
 import { Alert, Layout } from "antd";
 import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
 import Anonymous from "components/misc/anonymous";
 import Loading from "components/share/loading";
+import { MAX_WIDTH } from "lib/config";
 import useProfile from "lib/hooks/profile";
 import useCustomize from "lib/use-customize";
 import { useRouter } from "next/router";
@@ -88,15 +90,15 @@ export default function ConfigLayout({ page }: Props) {
     }
   }
 
+  // this layout is the same as ../store/index.tsx
   return (
     <Layout
       style={{
         padding: "0 24px 24px",
         backgroundColor: "white",
-        color: "#555",
+        color: COLORS.GRAY_D,
       }}
     >
-      <Menu main={main} />
       <Content
         style={{
           padding: 24,
@@ -104,7 +106,10 @@ export default function ConfigLayout({ page }: Props) {
           minHeight: 280,
         }}
       >
-        {body()}
+        <div style={{ maxWidth: MAX_WIDTH, margin: "auto" }}>
+          <Menu main={main} />
+          {body()}
+        </div>
       </Content>
     </Layout>
   );

--- a/src/packages/next/components/billing/menu.tsx
+++ b/src/packages/next/components/billing/menu.tsx
@@ -3,38 +3,44 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Menu } from "antd";
 import { Icon } from "@cocalc/frontend/components/icon";
+import { Menu, MenuProps, Typography } from "antd";
 import { useRouter } from "next/router";
+const { Text } = Typography;
+
+type MenuItem = Required<MenuProps>["items"][number];
 
 export default function ConfigMenu({ main }) {
   const router = useRouter();
+
+  function select(e) {
+    router.push(`/billing/${e.keyPath[0]}`, undefined, {
+      scroll: false,
+    });
+  }
+
+  const items: MenuItem[] = [
+    { label: <Text strong>Billing</Text>, key: "" },
+    { label: "Cards", key: "cards", icon: <Icon name={"credit-card"} /> },
+    {
+      label: "Subscriptions",
+      key: "subscriptions",
+      icon: <Icon name={"calendar"} />,
+    },
+    {
+      label: "Invoices and Receipts",
+      key: "receipts",
+      icon: <Icon name={"list"} />,
+    },
+  ];
 
   return (
     <Menu
       mode="horizontal"
       selectedKeys={[main]}
-      style={{ height: "100%" }}
-      onSelect={(e) => {
-        router.push(`/billing/${e.keyPath[0]}`, undefined, {
-          scroll: false,
-        });
-      }}
-    >
-      <Menu.Item key={""}>
-        <b style={{ color: "#666" }}>Billing</b>
-      </Menu.Item>
-      <Menu.Item key={"cards"}>
-        <Icon name={"credit-card"} style={{ marginRight: "5px" }} /> Credit
-        Cards
-      </Menu.Item>
-      <Menu.Item key={"subscriptions"}>
-        <Icon name={"calendar"} style={{ marginRight: "5px" }} /> Subscriptions
-      </Menu.Item>
-      <Menu.Item key={"receipts"}>
-        <Icon name={"list"} style={{ marginRight: "5px" }} /> Invoices and
-        Receipts
-      </Menu.Item>
-    </Menu>
+      style={{ height: "100%", marginBottom: "24px" }}
+      onSelect={select}
+      items={items}
+    />
   );
 }

--- a/src/packages/next/components/billing/overview.tsx
+++ b/src/packages/next/components/billing/overview.tsx
@@ -3,24 +3,66 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Icon } from "@cocalc/frontend/components/icon";
+import { Typography } from "antd";
 import A from "components/misc/A";
+import {
+  OverviewRow,
+  OVERVIEW_LARGE_ICON_MARGIN,
+  OVERVIEW_STYLE,
+  Product,
+} from "lib/styles/layouts";
+const { Text } = Typography;
 
 export default function Overview() {
   return (
-    <div>
-      <p>
-        You can see and edit your{" "}
-        <A href="/billing/cards">your payment methods</A>, view or cancel{" "}
-        <A href="/billing/subscriptions">your subscriptions</A>, and see{" "}
-        <A href="/billing/receipts">your invoices and receipts</A>.
-      </p>
+    <div style={OVERVIEW_STYLE}>
+      <Icon style={OVERVIEW_LARGE_ICON_MARGIN} name="credit-card" />
+
+      <h2 style={{ marginBottom: "30px" }}>Billing management</h2>
+
+      <OverviewRow>
+        <Product
+          icon="credit-card"
+          title="Payment methods"
+          href="/billing/cards"
+        >
+          Add, remove, or change your <Text strong>credit cards</Text>.
+        </Product>
+
+        <Product
+          icon="calendar"
+          title="Subscriptions"
+          href="/billing/subscriptions"
+        >
+          View or <Text strong>cancel</Text> your subscriptions
+        </Product>
+
+        <Product
+          icon="list"
+          title="Invoices and receipts"
+          href="/billing/receipts"
+        >
+          View your <Text strong>invoices</Text> and{" "}
+          <Text strong>receipts</Text>
+        </Product>
+
+        <Product icon="key" title="Manage licenses" href="/licenses/managed">
+          View and manage your licenses
+          <br />
+          <Text type="secondary">
+            (in <A href={"/licenses"}>Licenses</A>)
+          </Text>
+        </Product>
+      </OverviewRow>
+
       <p>
         You can also <A href="/store/site-license">buy a license</A> at{" "}
         <A href="/store">the store</A> and{" "}
         <A href="/licenses/managed">browse your existing licenses</A>.
       </p>
       <p>
-        You can also read{" "}
+        More general, you can also read{" "}
         <A href="https://doc.cocalc.com/account/purchases.html#subscription-list">
           the billing documentation
         </A>

--- a/src/packages/next/components/billing/payment-methods.tsx
+++ b/src/packages/next/components/billing/payment-methods.tsx
@@ -280,7 +280,7 @@ export default function PaymentMethods({ startMinimized, setTaxRate }: Props) {
           columns={columns(call) as any}
           dataSource={cards}
           rowKey={"id"}
-          style={{ marginTop: "15px", overflowX: "scroll" }}
+          style={{ marginTop: "15px", overflowX: "auto" }}
           pagination={{ hideOnSinglePage: true, pageSize: 100 }}
         />
       )}

--- a/src/packages/next/components/licenses/layout.tsx
+++ b/src/packages/next/components/licenses/layout.tsx
@@ -1,3 +1,10 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { unreachable } from "@cocalc/util/misc";
+import { COLORS } from "@cocalc/util/theme";
 import { Alert, Layout } from "antd";
 import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
 import Anonymous from "components/misc/anonymous";
@@ -9,14 +16,15 @@ import LicensedProjects from "./licensed-projects";
 import ManagedLicenses from "./managed";
 import Menu from "./menu";
 import Overview from "./overview";
+import { MAX_WIDTH } from "lib/config";
 
 const { Content } = Layout;
 
 interface Props {
-  page: string;
+  page: ("projects" | "how-used" | "managed" | undefined)[];
 }
 
-export default function ConfigLayout({ page }: Props) {
+export default function LicensesLayout({ page }: Props) {
   const router = useRouter();
   const profile = useProfile({ noCache: true });
   if (!profile) {
@@ -49,6 +57,7 @@ export default function ConfigLayout({ page }: Props) {
   const [main] = page;
 
   function body() {
+    if (main == null) return <Overview />;
     switch (main) {
       case "projects":
         return <LicensedProjects />;
@@ -56,19 +65,20 @@ export default function ConfigLayout({ page }: Props) {
         return <ManagedLicenses />;
       case "how-used":
         return <HowUsed account_id={account_id} />;
+      default:
+        unreachable(main);
     }
-    return <Overview />;
   }
 
+  // this is layout the same way as ../store/index.tsx
   return (
     <Layout
       style={{
         padding: "0 24px 24px",
         backgroundColor: "white",
-        color: "#555",
+        color: COLORS.GRAY_D,
       }}
     >
-      <Menu main={main} />
       <Content
         style={{
           padding: 24,
@@ -76,7 +86,10 @@ export default function ConfigLayout({ page }: Props) {
           minHeight: 280,
         }}
       >
-        {body()}
+        <div style={{ maxWidth: MAX_WIDTH, margin: "auto" }}>
+          <Menu main={main} />
+          {body()}
+        </div>
       </Content>
     </Layout>
   );

--- a/src/packages/next/components/licenses/menu.tsx
+++ b/src/packages/next/components/licenses/menu.tsx
@@ -1,6 +1,12 @@
-import { Menu, MenuProps } from "antd";
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Icon } from "@cocalc/frontend/components/icon";
+import { Menu, MenuProps, Typography } from "antd";
 import { useRouter } from "next/router";
+const { Text } = Typography;
 
 type MenuItem = Required<MenuProps>["items"][number];
 
@@ -8,22 +14,24 @@ export default function ConfigMenu({ main }) {
   const router = useRouter();
 
   const items: MenuItem[] = [
-    { label: <b style={{ color: "#666" }}>Licenses</b>, key: "" },
+    { label: <Text strong>Licenses</Text>, key: "" },
     { label: "Manage", key: "managed", icon: <Icon name={"key"} /> },
     { label: "Projects", key: "projects", icon: <Icon name={"edit"} /> },
-    { label: "How Used", key: "how-used", icon: <Icon name={"key"} /> },
+    { label: "How Used", key: "how-used", icon: <Icon name={"graph"} /> },
   ];
+
+  function select(e) {
+    router.push(`/licenses/${e.keyPath[0]}`, undefined, {
+      scroll: false,
+    });
+  }
 
   return (
     <Menu
       mode="horizontal"
       selectedKeys={[main]}
-      style={{ height: "100%" }}
-      onSelect={(e) => {
-        router.push(`/licenses/${e.keyPath[0]}`, undefined, {
-          scroll: false,
-        });
-      }}
+      style={{ height: "100%", marginBottom: "24px" }}
+      onSelect={select}
       items={items}
     />
   );

--- a/src/packages/next/components/licenses/overview.tsx
+++ b/src/packages/next/components/licenses/overview.tsx
@@ -1,29 +1,71 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Icon } from "@cocalc/frontend/components/icon";
+import { Typography } from "antd";
 import A from "components/misc/A";
+import {
+  OverviewRow,
+  OVERVIEW_LARGE_ICON_MARGIN,
+  OVERVIEW_STYLE,
+  Product,
+} from "lib/styles/layouts";
 import useCustomize from "lib/use-customize";
+const { Text } = Typography;
 
 export default function Overview() {
   const { isCommercial } = useCustomize();
   return (
-    <div>
-      <p>
-        You can{" "}
+    <div style={OVERVIEW_STYLE}>
+      <Icon style={OVERVIEW_LARGE_ICON_MARGIN} name="key" />
+
+      <h2 style={{ marginBottom: "30px" }}>License management</h2>
+
+      <OverviewRow>
+        <Product icon="key" title="Manage licenses" href="/licenses/managed">
+          View and manage your licenses
+        </Product>
+
+        <Product
+          icon="edit"
+          href="/licenses/projects"
+          title="Licensed projects"
+        >
+          Browse licensed projects you collaborate on
+        </Product>
+
+        <Product icon="rocket" href="/licenses/how-used" title="How used">
+          See how a specific site license is being used
+        </Product>
+
         {isCommercial && (
-          <>
-            <A href="/store/site-license">buy a site license</A>,
-          </>
-        )}{" "}
-        see the <A href="/licenses/managed">licenses you manage</A>, browse the{" "}
-        <A href="/licenses/projects">licensed projects you collaborate on</A>,
-        and see how{" "}
-        <A href="/licenses/how-used">a specific site licenses is being used</A>.{" "}
-      </p>
+          <Product
+            icon="ban"
+            title="Cancel subscription"
+            href="/billing/subscriptions"
+          >
+            Cancel an ongoing subscription
+            <br />
+            <Text type="secondary">
+              (in <A href={"/billing"}>Billing</A>)
+            </Text>
+          </Product>
+        )}
+      </OverviewRow>
+
+      {isCommercial && (
+        <p>
+          You can also <A href="/store/site-license">buy a site license</A>,{" "}
+          <A href="/billing/subscriptions">
+            manage your purchased subscriptions
+          </A>{" "}
+          or browse <A href="/billing/receipts">your receipts and invoices</A>.
+        </p>
+      )}
       <p>
-        You can also{" "}
-        <A href="/billing/subscriptions">manage your purchased subscriptions</A>{" "}
-        and browse <A href="/billing/receipts">your receipts and invoices</A>.
-      </p>
-      <p>
-        Read{" "}
+        More general, you can also read{" "}
         <A href="https://doc.cocalc.com/licenses.html">
           the license documentation
         </A>

--- a/src/packages/next/components/statistics/index.tsx
+++ b/src/packages/next/components/statistics/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default function Statistics({ stats }: Props) {
   return (
-    <div style={{ maxWidth: "100%", overflowX: "scroll" }}>
+    <div style={{ maxWidth: "100%", overflowX: "auto" }}>
       Last Updated: {new Date(stats.time).toLocaleString()}{" "}
       <A href="/info/status">(update)</A>
       <br />

--- a/src/packages/next/components/store/index.tsx
+++ b/src/packages/next/components/store/index.tsx
@@ -3,12 +3,14 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { unreachable } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { Alert, Layout } from "antd";
 import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
 import Anonymous from "components/misc/anonymous";
 import Loading from "components/share/loading";
 import SiteName from "components/share/site-name";
+import { MAX_WIDTH } from "lib/config";
 import useProfile from "lib/hooks/profile";
 import useCustomize from "lib/use-customize";
 import { useRouter } from "next/router";
@@ -21,12 +23,19 @@ import DedicatedResource from "./dedicated";
 import Menu from "./menu";
 import Overview from "./overview";
 import SiteLicense from "./site-license";
-import { MAX_WIDTH } from "lib/config";
 
 const { Content } = Layout;
 
 interface Props {
-  page: string;
+  page: (
+    | "site-license"
+    | "boost"
+    | "dedicated"
+    | "cart"
+    | "checkout"
+    | "congrats"
+    | undefined
+  )[];
 }
 
 export default function StoreLayout({ page }: Props) {
@@ -87,6 +96,7 @@ export default function StoreLayout({ page }: Props) {
   const [main] = page;
 
   function body() {
+    if (main == null) return <Overview />;
     switch (main) {
       case "site-license":
         return <SiteLicense />;
@@ -100,10 +110,12 @@ export default function StoreLayout({ page }: Props) {
         return <Checkout />;
       case "congrats":
         return <Congrats />;
+      default:
+        unreachable(main);
     }
-    return <Overview />;
   }
 
+  // this layout is the same as ../licenses/layout.tsx and ../billing/layout.tsx
   return (
     <Layout
       style={{

--- a/src/packages/next/components/store/menu.tsx
+++ b/src/packages/next/components/store/menu.tsx
@@ -1,3 +1,8 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Icon } from "@cocalc/frontend/components/icon";
 import { Menu, MenuProps, Typography } from "antd";
 import { useRouter } from "next/router";
@@ -7,8 +12,6 @@ type MenuItem = Required<MenuProps>["items"][number];
 
 export default function ConfigMenu({ main }) {
   const router = useRouter();
-
-  // const style = { marginRight: "5px" };
 
   function select(e) {
     router.push(`/store/${e.keyPath[0]}`, undefined, {
@@ -27,7 +30,7 @@ export default function ConfigMenu({ main }) {
   }
 
   const items: MenuItem[] = [
-    { label: "Store", key: "" },
+    { label: <Text strong>Store</Text>, key: "" },
     { label: "Site License", key: "site-license", icon: <Icon name="key" /> },
     {
       label: <>Boost {renderNew()}</>,

--- a/src/packages/next/components/store/overview.tsx
+++ b/src/packages/next/components/store/overview.tsx
@@ -4,14 +4,16 @@
  */
 
 import { Icon } from "@cocalc/frontend/components/icon";
-import { COLORS } from "@cocalc/util/theme";
 import A from "components/misc/A";
 import SiteName from "components/share/site-name";
-import { Col, Row } from "antd";
-import { useEffect } from "react";
+import {
+  OverviewRow,
+  OVERVIEW_LARGE_ICON,
+  OVERVIEW_STYLE,
+  Product,
+} from "lib/styles/layouts";
 import { useRouter } from "next/router";
-
-const gridProps = { sm: 24, md: 12 };
+import { useEffect } from "react";
 
 export default function Overview() {
   const router = useRouter();
@@ -21,48 +23,15 @@ export default function Overview() {
     router.prefetch("/store/site-license");
   }, []);
 
-  function Product({ icon, title, href, children }) {
-    return (
-      <Col {...gridProps}>
-        <A href={href}>
-          <Icon
-            style={{ fontSize: "50px", fontWeight: "bold", display: "block" }}
-            name={icon}
-          />
-          <p style={{ fontSize: "25px", marginBottom: "15px" }}>{title}</p>
-        </A>
-        {children}
-      </Col>
-    );
-  }
-
   return (
-    <div
-      style={{ textAlign: "center", width: "75%", margin: "0px auto 0px auto" }}
-    >
-      <Icon
-        style={{
-          fontSize: "100px",
-          color: COLORS.COCALC_BLUE,
-          borderRadius: "50%",
-          backgroundColor: COLORS.COCALC_ORANGE,
-          border: `15px solid ${COLORS.COCALC_BLUE}`,
-          padding: "15px 15px 10px 10px",
-          display: "inline-block",
-          margin: "30px 0px 40px 0px",
-          boxShadow: "0px 2px 10px 2px",
-        }}
-        name="shopping-cart"
-      />
+    <div style={OVERVIEW_STYLE}>
+      <Icon style={OVERVIEW_LARGE_ICON} name="shopping-cart" />
 
       <h2 style={{ marginBottom: "30px" }}>
         Welcome to the <SiteName /> Store!
       </h2>
 
-      <Row
-        gutter={[25, 50]}
-        style={{ marginTop: "30px", marginBottom: "60px" }}
-      >
+      <OverviewRow>
         <Product
           icon="key"
           title="Site License Upgrade"
@@ -88,7 +57,7 @@ export default function Overview() {
         >
           Move your project to a much more powerful VM.
         </Product>
-      </Row>
+      </OverviewRow>
       <div style={{ marginTop: "4em" }}>
         If you already selected one or more items, view your{" "}
         <A href="/store/cart">shopping cart</A> or go straight to{" "}

--- a/src/packages/next/lib/styles/layouts.tsx
+++ b/src/packages/next/lib/styles/layouts.tsx
@@ -1,0 +1,59 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Icon } from "@cocalc/frontend/components/icon";
+import { COLORS } from "@cocalc/util/theme";
+import { Col, Row } from "antd";
+import A from "components/misc/A";
+
+const gridProps = { sm: 24, md: 12 } as const;
+
+export const OVERVIEW_STYLE: React.CSSProperties = {
+  textAlign: "center",
+  width: "75%",
+  margin: "0px auto 0px auto",
+};
+
+export const OVERVIEW_LARGE_ICON: React.CSSProperties = {
+  fontSize: "100px",
+  color: COLORS.COCALC_BLUE,
+  borderRadius: "50%",
+  backgroundColor: COLORS.COCALC_ORANGE,
+  border: `15px solid ${COLORS.COCALC_BLUE}`,
+  padding: "20px 20px 15px 15px",
+  display: "inline-block",
+  margin: "30px 0px 40px 0px",
+  boxShadow: "0px 2px 10px 2px",
+};
+
+// variation of the above, since some icons need more margin
+export const OVERVIEW_LARGE_ICON_MARGIN: React.CSSProperties = {
+  ...OVERVIEW_LARGE_ICON,
+  padding: "23px 20px 20px 20px",
+  fontSize: "80px",
+};
+
+export function Product({ icon, title, href, children }) {
+  return (
+    <Col {...gridProps}>
+      <A href={href}>
+        <Icon
+          style={{ fontSize: "50px", fontWeight: "bold", display: "block" }}
+          name={icon}
+        />
+        <p style={{ fontSize: "25px", marginBottom: "15px" }}>{title}</p>
+      </A>
+      {children}
+    </Col>
+  );
+}
+
+export function OverviewRow({ children }) {
+  return (
+    <Row gutter={[25, 50]} style={{ marginTop: "30px", marginBottom: "60px" }}>
+      {children}
+    </Row>
+  );
+}

--- a/src/packages/next/pages/billing/[[...page]].tsx
+++ b/src/packages/next/pages/billing/[[...page]].tsx
@@ -3,23 +3,27 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { capitalize } from "@cocalc/util/misc";
 import { Layout } from "antd";
-import Error from "next/error";
-import Header from "components/landing/header";
+import { MainPages } from "components/billing/consts";
+import Billing from "components/billing/layout";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
-import Billing from "components/billing/layout";
-import { MainPages } from "components/billing/consts";
+import Header from "components/landing/header";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
+import Error from "next/error";
 
 export default function Preferences({ customize, pageNotFound, page }) {
   if (pageNotFound) {
     return <Error statusCode={404} />;
   }
+
+  const subpage = page[0] != null ? ` - ${capitalize(page[0])}` : "";
+
   return (
     <Customize value={customize}>
-      <Head title="Billing" />
+      <Head title={`Billing${subpage}`} />
       <Layout>
         <Header />
         <Billing page={page} />

--- a/src/packages/next/pages/licenses/[[...page]].tsx
+++ b/src/packages/next/pages/licenses/[[...page]].tsx
@@ -3,6 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { capitalize } from "@cocalc/util/misc";
 import { Layout } from "antd";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
@@ -12,9 +13,11 @@ import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
 
 export default function Preferences({ customize, page }) {
+  const subpage = page[0] != null ? ` - ${capitalize(page[0])}` : "";
+
   return (
     <Customize value={customize}>
-      <Head title={`Licenses – ${page[0]}`} />
+      <Head title={`Licenses${subpage}`} />
       <Layout>
         <Header />
         <Licenses page={page} />

--- a/src/packages/next/pages/licenses/[[...page]].tsx
+++ b/src/packages/next/pages/licenses/[[...page]].tsx
@@ -1,7 +1,12 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Layout } from "antd";
-import Header from "components/landing/header";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
+import Header from "components/landing/header";
 import Licenses from "components/licenses/layout";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
@@ -9,7 +14,7 @@ import withCustomize from "lib/with-customize";
 export default function Preferences({ customize, page }) {
   return (
     <Customize value={customize}>
-      <Head title="Licenses" />
+      <Head title={`Licenses – ${page[0]}`} />
       <Layout>
         <Header />
         <Licenses page={page} />

--- a/src/packages/next/pages/policies/accessibility.tsx
+++ b/src/packages/next/pages/policies/accessibility.tsx
@@ -31,7 +31,7 @@ export default function AccessibilityPage({ customize }) {
             </h1>
             <h2>Last Updated: July 3, 2019</h2>
           </div>
-          <div style={{ fontSize: "12pt", overflowX: "scroll" }}>
+          <div style={{ fontSize: "12pt", overflowX: "auto" }}>
             <Accessibility />
           </div>
         </div>

--- a/src/packages/next/pages/store/[[...page]].tsx
+++ b/src/packages/next/pages/store/[[...page]].tsx
@@ -10,11 +10,14 @@ import Head from "components/landing/head";
 import Store from "components/store";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
+import { capitalize } from "@cocalc/util/misc";
 
 export default function Preferences({ customize, page }) {
+  const subpage = page[0] != null ? ` - ${capitalize(page[0])}` : "";
+
   return (
     <Customize value={customize}>
-      <Head title="Store" />
+      <Head title={`Store${subpage}`} />
       <Layout>
         <Header />
         <Store page={page} />


### PR DESCRIPTION
# Description

this enhances the look&feel of licenses and billing pages, and to make to 2x2 matrix of icons complete (for commercial mode only), I'm adding cross references to cancelling or managing licenses from either side.

![Screenshot from 2022-09-08 15-38-15](https://user-images.githubusercontent.com/207405/189137041-97ec6039-fb94-4a5c-9ef7-cbca99fb104c.png)

![Screenshot from 2022-09-08 15-37-55](https://user-images.githubusercontent.com/207405/189137104-88d94600-0ca6-4aed-b3ed-2dcea67179d7.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
