### PR TITLE
Tasks highlight active search

### DIFF
--- a/src/packages/frontend/editors/task-editor/editor.tsx
+++ b/src/packages/frontend/editors/task-editor/editor.tsx
@@ -80,7 +80,6 @@ export const TaskEditor: React.FC<Props> = React.memo(
 
         <Row>
           <Col md={7}>
-            {" "}
             <Find
               actions={actions}
               local_view_state={local_view_state}

--- a/src/packages/frontend/editors/task-editor/find.tsx
+++ b/src/packages/frontend/editors/task-editor/find.tsx
@@ -65,6 +65,7 @@ export const Find: React.FC<Props> = React.memo(
     }
 
     function render_search() {
+      const value = local_view_state.get("search") ?? "";
       return (
         <FormGroup style={{ marginBottom: 0, marginRight: "20px" }}>
           <InputGroup>
@@ -73,7 +74,7 @@ export const Find: React.FC<Props> = React.memo(
               ref={search_ref}
               componentClass="input"
               placeholder={"Search for tasks..."}
-              value={local_view_state.get("search") ?? ""}
+              value={value}
               onChange={() =>
                 actions.set_local_view_state({
                   search: ReactDOM.findDOMNode(search_ref.current).value,
@@ -84,7 +85,10 @@ export const Find: React.FC<Props> = React.memo(
               onKeyDown={key_down}
             />
             <InputGroup.Button>
-              <Button onClick={clear_and_focus_search_input}>
+              <Button
+                onClick={clear_and_focus_search_input}
+                bsStyle={value.length > 0 ? "warning" : "default"}
+              >
                 <Icon name="times-circle" />
               </Button>
             </InputGroup.Button>

--- a/src/packages/frontend/editors/task-editor/hashtag-bar.tsx
+++ b/src/packages/frontend/editors/task-editor/hashtag-bar.tsx
@@ -92,7 +92,7 @@ export function HashtagBar({
     return v.map((x) => x[1]);
   }
 
-  if (hashtags == null) return <></>;
+  if (hashtags == null || hashtags.size == 0) return <></>;
 
   return <div style={{ ...STYLE, ...style }}>{render_hashtags()}</div>;
 }


### PR DESCRIPTION
# Description

1. I overlooked several times that I had an active search, which is remembered across sessions. So, this just adds this warning highlight to the clear button, like it shows up in other search&find boxes as well
2. just something trivial: if there are no tags, don't render an empty div

![Screenshot from 2022-09-12 10-36-25](https://user-images.githubusercontent.com/207405/189609422-bf17cea1-53aa-4126-83e0-4e8e7ce3ec31.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
