### PR TITLE
util/compute-images: adding 2022-08-17

### DIFF
--- a/src/packages/util/compute-images.ts
+++ b/src/packages/util/compute-images.ts
@@ -111,6 +111,12 @@ export const COMPUTE_IMAGES: { [key: string]: ComputeImage } = {
     group: "Ubuntu 20.04",
     descr: "Frozen on 2022-04-19 and no longer updated",
   },
+  "ubuntu2004-2022-08-17": {
+    title: "Ubuntu 20.04 (2022-08-17)",
+    short: "2022-08-17",
+    group: "Ubuntu 20.04",
+    descr: "Frozen on 2022-08-17 and no longer updated",
+  },
   previous: {
     order: -2,
     title: "Ubuntu 18.04 (Previous)",


### PR DESCRIPTION
# Description

our most recent frozen compute image is from april. This is a new one, i.e. 2022-08-17` was pretty stable and from before the fall started.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
