### PR TITLE
onprem: license quota to make /ext read/writeable

### DIFF
--- a/src/packages/frontend/admin/page.tsx
+++ b/src/packages/frontend/admin/page.tsx
@@ -17,7 +17,7 @@ export const AdminPage: React.FC = React.memo(() => {
   return (
     <div
       style={{
-        overflowY: "scroll",
+        overflowY: "auto",
         overflowX: "hidden",
         padding: "30px 45px",
       }}

--- a/src/packages/frontend/site-licenses/admin/actions.ts
+++ b/src/packages/frontend/site-licenses/admin/actions.ts
@@ -3,19 +3,19 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { fromJS, Map, Set } from "immutable";
-import { Actions, redux, TypedMap } from "../../app-framework";
-import { SiteLicensesState, license_field_names, ManagerInfo } from "./types";
-import { store } from "./store";
+import { Actions, redux, TypedMap } from "@cocalc/frontend/app-framework";
 import {
   query,
   server_time,
   user_search,
-} from "../../frame-editors/generic/client";
+} from "@cocalc/frontend/frame-editors/generic/client";
 import { is_valid_uuid_string, uuid } from "@cocalc/util/misc";
-import { normalize_upgrades_for_save } from "./upgrades";
-import jsonic from "jsonic";
 import { SiteLicense } from "@cocalc/util/types/site-licenses";
+import { fromJS, Map, Set } from "immutable";
+import jsonic from "jsonic";
+import { store } from "./store";
+import { license_field_names, ManagerInfo, SiteLicensesState } from "./types";
+import { normalize_upgrades_for_save } from "./upgrades";
 
 export class SiteLicensesActions extends Actions<SiteLicensesState> {
   public set_error(error: any): void {

--- a/src/packages/frontend/site-licenses/admin/actions.ts
+++ b/src/packages/frontend/site-licenses/admin/actions.ts
@@ -9,6 +9,7 @@ import {
   server_time,
   user_search,
 } from "@cocalc/frontend/frame-editors/generic/client";
+import { KUCALC_COCALC_COM } from "@cocalc/util/db-schema/site-defaults";
 import { is_valid_uuid_string, uuid } from "@cocalc/util/misc";
 import { SiteLicense } from "@cocalc/util/types/site-licenses";
 import { fromJS, Map, Set } from "immutable";
@@ -91,6 +92,14 @@ export class SiteLicensesActions extends Actions<SiteLicensesState> {
   }
 
   public async create_new_license(): Promise<void> {
+    const kucalc = redux.getStore("customize").get("kucalc");
+    const isCoCalcCom = kucalc === KUCALC_COCALC_COM;
+    // member hosting and disk quota are not supported on cocalc.com
+    const quota = {
+      cpu: 1,
+      ram: 1,
+      ...(isCoCalcCom ? { member: true, disk: 1 } : undefined),
+    };
     const id = uuid();
     try {
       this.setState({ creating: true });
@@ -103,7 +112,7 @@ export class SiteLicensesActions extends Actions<SiteLicensesState> {
             last_used: now,
             activates: now,
             run_limit: 1,
-            quota: { member: true, cpu: 1, disk: 1, ram: 1 },
+            quota,
           },
         },
       });

--- a/src/packages/frontend/site-licenses/admin/component.tsx
+++ b/src/packages/frontend/site-licenses/admin/component.tsx
@@ -28,14 +28,20 @@ import {
   useState,
   useTypedRedux,
   useIsMountedRef,
-} from "../../app-framework";
+} from "@cocalc/frontend/app-framework";
 import { plural } from "@cocalc/util/misc";
-import { ErrorDisplay, Icon, Loading, Space, r_join } from "../../components";
+import {
+  ErrorDisplay,
+  Icon,
+  Loading,
+  Space,
+  r_join,
+} from "@cocalc/frontend/components";
 import { actions } from "./actions";
 import { Alert, Button, Popconfirm } from "antd";
 import { License } from "./license";
 import { COLORS } from "@cocalc/util/theme";
-import { webapp_client } from "../../webapp-client";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 
 const LICENSE_QUERY = {
   site_licenses: [

--- a/src/packages/frontend/site-licenses/admin/license.tsx
+++ b/src/packages/frontend/site-licenses/admin/license.tsx
@@ -110,9 +110,9 @@ export const License: React.FC<Props> = (props: Props) => {
         <Row
           key={field}
           style={{
-            borderBottom: "1px solid lightgrey",
+            borderTop: "1px solid lightgrey",
             backgroundColor,
-            padding: editing ? "5px 0" : undefined,
+            padding: editing ? "15px 10px" : "10px",
           }}
         >
           <Col span={4}>{format_as_label(field)}</Col>
@@ -509,7 +509,11 @@ export const License: React.FC<Props> = (props: Props) => {
         </>
       );
     } else {
-      buttons = <Button onClick={() => actions.start_editing(id)}>Edit</Button>;
+      buttons = (
+        <Button bsStyle={"primary"} onClick={() => actions.start_editing(id)}>
+          Edit
+        </Button>
+      );
     }
     return <div style={{ float: "right" }}>{buttons}</div>;
   }
@@ -596,7 +600,7 @@ export const License: React.FC<Props> = (props: Props) => {
       style={{
         border: "1px solid lightgrey",
         borderRadius: "5px",
-        padding: "10px",
+        padding: "0px",
       }}
     >
       {render_buttons()}

--- a/src/packages/frontend/site-licenses/admin/quota.tsx
+++ b/src/packages/frontend/site-licenses/admin/quota.tsx
@@ -2,12 +2,12 @@
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
-import { fromJS } from "immutable";
-import { React, TypedMap } from "../../app-framework";
-import { license_field_names } from "./types";
-import { actions } from "./actions";
-import { QuotaEditor } from "../purchase/quota-editor";
+import { React, TypedMap } from "@cocalc/frontend/app-framework";
 import { SiteLicenseQuota } from "@cocalc/util/types/site-licenses";
+import { fromJS } from "immutable";
+import { QuotaEditor } from "../purchase/quota-editor";
+import { actions } from "./actions";
+import { license_field_names } from "./types";
 type QuotaMap = TypedMap<SiteLicenseQuota>;
 
 interface Props {

--- a/src/packages/frontend/site-licenses/admin/store.ts
+++ b/src/packages/frontend/site-licenses/admin/store.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Store, redux } from "../../app-framework";
+import { Store, redux } from "@cocalc/frontend/app-framework";
 import { SiteLicensesState } from "./types";
 
 export class SiteLicensesStore extends Store<SiteLicensesState> {}

--- a/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
+++ b/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
@@ -82,7 +82,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     adminMode = false,
   } = props;
   const customize_kucalc = useTypedRedux("customize", "kucalc");
-  const is_on_prem = customize_kucalc === KUCALC_ON_PREMISES;
+  const isOnPrem = customize_kucalc === KUCALC_ON_PREMISES;
 
   const [show_advanced, set_show_advanced] = useState<boolean>(
     show_advanced_default ?? false
@@ -291,7 +291,8 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_disk(): JSX.Element {
+  function render_disk(): JSX.Element | null {
+    if (isOnPrem) return null;
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control - col.max}>
@@ -334,7 +335,8 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_member(): JSX.Element {
+  function render_member(): JSX.Element | null {
+    if (isOnPrem) return null;
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control}>
@@ -542,7 +544,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
       {show_advanced && render_dedicated_cpu()}
       {show_advanced && render_dedicated_ram()}
       {show_advanced && !hideExtra && render_dedicated()}
-      {is_on_prem && render_ext_rw()}
+      {isOnPrem && render_ext_rw()}
     </div>
   );
 };

--- a/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
+++ b/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
@@ -13,7 +13,13 @@ Editing a quota
 
 */
 
-import { CSS, React, useMemo, useState } from "@cocalc/frontend/app-framework";
+import {
+  CSS,
+  React,
+  useMemo,
+  useState,
+  useTypedRedux,
+} from "@cocalc/frontend/app-framework";
 import { Space } from "@cocalc/frontend/components";
 import {
   LicenseIdleTimeouts,
@@ -21,6 +27,7 @@ import {
   untangleUptime,
   Uptime,
 } from "@cocalc/util/consts/site-license";
+import { KUCALC_ON_PREMISES } from "@cocalc/util/db-schema/site-defaults";
 import { COSTS, GCE_COSTS } from "@cocalc/util/licenses/purchase/consts";
 import { User } from "@cocalc/util/licenses/purchase/types";
 import { money } from "@cocalc/util/licenses/purchase/utils";
@@ -74,6 +81,9 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     show_advanced_default,
     adminMode = false,
   } = props;
+  const customize_kucalc = useTypedRedux("customize", "kucalc");
+  const is_on_prem = customize_kucalc === KUCALC_ON_PREMISES;
+
   const [show_advanced, set_show_advanced] = useState<boolean>(
     show_advanced_default ?? false
   );
@@ -99,7 +109,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
   const isDedicated =
     quota.dedicated_vm != null || quota.dedicated_disk != null;
 
-  function render_cpu() {
+  function render_cpu(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control - col.max}>
@@ -144,7 +154,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_ram() {
+  function render_ram(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control - col.max}>
@@ -159,7 +169,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
             }}
           />
           <Space />
-          <span style={UNIT_STYLE}>shared GB RAM</span>
+          <span style={UNIT_STYLE}>shared G RAM</span>
         </Col>
         <Col md={col.max}>
           <Button
@@ -187,7 +197,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_dedicated_cpu() {
+  function render_dedicated_cpu(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control - col.max}>
@@ -236,7 +246,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_dedicated_ram() {
+  function render_dedicated_ram(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control - col.max}>
@@ -281,7 +291,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_disk() {
+  function render_disk(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control - col.max}>
@@ -324,7 +334,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_member() {
+  function render_member(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control}>
@@ -349,6 +359,22 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
             )}
           </Col>
         )}
+      </Row>
+    );
+  }
+
+  function render_ext_rw(): JSX.Element {
+    return (
+      <Row style={ROW_STYLE}>
+        <Col md={col.control}>
+          <Checkbox
+            checked={quota.ext_rw}
+            disabled={disabled}
+            onChange={(e) => onChange({ ext_rw: e.target.checked })}
+          >
+            on-premises: mount <code>/ext</code> read/writeable
+          </Checkbox>
+        </Col>
       </Row>
     );
   }
@@ -403,7 +429,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_idle_timeout() {
+  function render_idle_timeout(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control} style={{ whiteSpace: "nowrap" }}>
@@ -420,7 +446,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_support() {
+  function render_support(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control}>
@@ -442,7 +468,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_network() {
+  function render_network(): JSX.Element {
     return (
       <Row style={ROW_STYLE}>
         <Col md={col.control}>
@@ -464,7 +490,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     );
   }
 
-  function render_show_advanced_link() {
+  function render_show_advanced_link(): JSX.Element {
     if (show_advanced) {
       return (
         <a
@@ -485,7 +511,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
       );
   }
 
-  function render_dedicated() {
+  function render_dedicated(): JSX.Element {
     return (
       <div style={ROW_STYLE}>
         We also offer <b>dedicated virtual machines</b>, which are usually a
@@ -516,6 +542,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
       {show_advanced && render_dedicated_cpu()}
       {show_advanced && render_dedicated_ram()}
       {show_advanced && !hideExtra && render_dedicated()}
+      {is_on_prem && render_ext_rw()}
     </div>
   );
 };

--- a/src/packages/util/types/site-licenses.ts
+++ b/src/packages/util/types/site-licenses.ts
@@ -23,6 +23,7 @@ export interface SiteLicenseQuota {
   // 2. we define the timeout spans indirectly, gives us a bit of room to modify this later on.
   idle_timeout?: "short" | "medium" | "day";
   boost?: boolean; // default false
+  ext_rw?: boolean; // on-prem: make the /ext mountpoint read/writable
 }
 
 // For typescript use of these from user side, we make this available:


### PR DESCRIPTION
# Description

- this is for onprem only. admins get a way to define `{ext_rw:true}` which mounts the readonly `/ext` directory as read/write. this is only for the license.
- it hides member hosting, that makes no sense for onprem
- this tweaks a bit the UI of the license admin panel
- it does not touch the embedded payment form, and for non-onprem there is no change in actual functionality

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
