### PR TITLE
onprem: load SSO configs via a file

### DIFF
--- a/src/packages/database/postgres/load-sso-conf.ts
+++ b/src/packages/database/postgres/load-sso-conf.ts
@@ -1,0 +1,96 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Client } from "pg";
+import getLogger from "@cocalc/backend/logger";
+import { PostgreSQL } from "@cocalc/database/postgres/types";
+import { lstat, readFile } from "fs/promises";
+
+const L = getLogger("auth:sso:import-sso-configuration").debug;
+
+// The path to the file. In actual use, this is a K8S secret exported as a file to /secrets/sso/sso.json
+// content of that file: "{ [strategy name]: {conf: {…}, info: {…}}, […] : { … } | null, … }"
+// further details are describe in src/packages/server/auth/sso/types.ts
+const SSO_JSON = process.env.COCALC_SSO_CONFIG;
+
+// This function imports the SSO configuration from a file into the database.
+// If a key points to "null", the entry is deleted.
+// This runs only once during startup, called by the hub's auth.ts.
+export async function loadSSOConf(db: PostgreSQL): Promise<void> {
+  if (SSO_JSON == null) {
+    L("No SSO configuration file specified via $COCALC_SSO_CONFIG.");
+    return;
+  }
+
+  // test if the path at SSO_JSON is a regular file and is readable
+  try {
+    const stats = await lstat(SSO_JSON);
+    if (!stats.isFile()) {
+      L(`SSO configuration file ${SSO_JSON} is not a regular file`);
+      return;
+    }
+  } catch (err) {
+    L(`SSO configuration file ${SSO_JSON} does not exist or is not readable`);
+    return;
+  }
+  await load(db);
+}
+
+async function load(db: PostgreSQL) {
+  if (SSO_JSON == null) {
+    throw new Error("SSO_JSON is not defined, should never happen");
+  }
+  // load the json data stored in the file SSO_JSON
+  L(`Loading SSO configuration from '${SSO_JSON}'`);
+
+  const client = db._client();
+  if (client == null) {
+    L(`no database client available -- skipping SSO configuration`);
+    return;
+  }
+
+  // throws upon JSON parsing errors
+  const data = JSON.parse(await readFile(SSO_JSON, "utf8"));
+
+  try {
+    await client.query("BEGIN");
+    for (const strategy in data) {
+      const val = data[strategy];
+      if (val == null) {
+        await deleteSSO(client, strategy);
+      } else {
+        await upsertSSO(client, strategy, val);
+      }
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    L(`ROLLBACK -- err=${err}`);
+    await client.query("ROLLBACK");
+  }
+}
+
+const deleteQuery = `
+DELETE FROM passport_settings
+WHERE strategy = $1`;
+
+async function deleteSSO(client: Client, strategy: string) {
+  L(`Deleting SSO configuration for ${strategy}`);
+  await client.query(deleteQuery, [strategy]);
+}
+
+const upsertQuery = `
+INSERT INTO passport_settings (strategy, conf, info)
+VALUES ($1, $2, $3)
+ON CONFLICT (strategy) DO UPDATE SET conf = $2, info = $3`;
+
+async function upsertSSO(
+  client: Client,
+  strategy: string,
+  val: { conf: object; info: object }
+) {
+  const { conf, info } = val;
+  L(`Updating SSO configuration for ${strategy}:`, { conf, info });
+  await client.query(upsertQuery, [strategy, conf, info]);
+}

--- a/src/packages/hub/auth.ts
+++ b/src/packages/hub/auth.ts
@@ -40,6 +40,7 @@ import base_path from "@cocalc/backend/base-path";
 import type { PostgreSQL } from "@cocalc/database/postgres/types";
 import { getLogger } from "@cocalc/hub/logger";
 import { getExtraStrategyConstructor } from "@cocalc/server/auth/sso/extra-strategies";
+import { loadSSOConf } from "@cocalc/database/postgres/load-sso-conf";
 import { addUserProfileCallback } from "@cocalc/server/auth/sso/oauth2-user-profile-callback";
 import { PassportLogin } from "@cocalc/server/auth/sso/passport-login";
 import {
@@ -272,6 +273,8 @@ export class PassportManager {
     // Define user serialization
     passport.serializeUser((user, done) => done(null, user));
     passport.deserializeUser((user: Express.User, done) => done(null, user));
+
+    await loadSSOConf(this.database);
 
     // this.router endpoints setup
     this.init_strategies_endpoint();

--- a/src/packages/server/auth/sso/types.ts
+++ b/src/packages/server/auth/sso/types.ts
@@ -153,7 +153,7 @@ export interface PassportStrategyDBConfig {
  * - exclusive_domains: a list of domain extensions, matching also subdomains, e.g. ["example.com", "example.org"]
  * would match foo@example.com and bar@baz.example.org
  * The ultimate intention is that users with such email addresses have to go through that authentication mechanism.
- * They're also prevented from linking with other passports.
+ * They're also prevented from linking with other passports, changing email address, or unlinking that passport from their account.
  * That way, the organization behind that SSO mechanism has full control over the user's account.
  * - display: The string that's presented to the user as the name of that SSO strategy.
  * - description: A longer description of the strategy, could be markdown, shown on the dedicated /sso/... pages.

--- a/src/scripts/auth/gen-sso.py
+++ b/src/scripts/auth/gen-sso.py
@@ -6,6 +6,8 @@
 # Usage:
 #    python3 cocalc-db-sso.py [dump]
 # which issues commands to psql directly, or add "dump" to see what it would do.
+#
+# The conf/info fields are described in src/packages/server/auth/sso/types.ts
 
 from typing_extensions import TypedDict
 from typing import Dict


### PR DESCRIPTION
# Description

This introduces a simple for administrators to configure the SSO settings, without having to fiddle around with the DB. Later, we can always implement something more sophisticated via a UI.

In any case, the idea is the env var `$COCALC_SSO_CONFIG` points to a file, containing a JSON config. This could easily be a k8s secret mounted as a file as well. If this file exists, upsert/delete operations are done accordingly, before the actual sso endpoint initialization happens.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
