### PR TITLE
frontend: replace "Buy a license" button in project settings with link to store

### DIFF
--- a/src/packages/frontend/project/settings/site-license.tsx
+++ b/src/packages/frontend/project/settings/site-license.tsx
@@ -11,12 +11,12 @@ import { Button } from "@cocalc/frontend/antd-bootstrap";
 import { redux, Rendered, useState } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
 import { SiteLicenseInput } from "@cocalc/frontend/site-licenses/input";
-import { PurchaseOneLicenseLink } from "@cocalc/frontend/site-licenses/purchase";
 import { LICENSE_INFORMATION } from "@cocalc/frontend/site-licenses/rules";
 import { SiteLicensePublicInfoTable } from "@cocalc/frontend/site-licenses/site-license-public-info";
 import { SiteLicenses } from "@cocalc/frontend/site-licenses/types";
 import { Card, Popover } from "antd";
 import { Map } from "immutable";
+import { BuyLicenseForProject } from "@cocalc/frontend/site-licenses/purchase/buy-license-for-project";
 
 interface Props {
   project_id: string;
@@ -133,7 +133,7 @@ export const SiteLicense: React.FC<Props> = (props: Props) => {
         <br />
         <br />
         <span style={{ fontSize: "13pt" }}>
-          <PurchaseOneLicenseLink />
+          <BuyLicenseForProject project_id={project_id} />
         </span>
       </div>
     </Card>

--- a/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
+++ b/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
@@ -1,0 +1,30 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Icon } from "@cocalc/frontend/components/icon";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { open_new_tab } from "@cocalc/frontend/misc";
+import { Button } from "antd";
+import { join } from "path";
+
+export const BuyLicenseForProject: React.FC<{ project_id: string }> = (props: {
+  project_id: string;
+}) => {
+  const { project_id } = props;
+  const base = join(appBasePath, "store", "site-license");
+  const url = `${base}?project_id=${project_id}`;
+
+  return (
+    <Button
+      type="primary"
+      icon={<Icon name="shopping-cart" />}
+      onClick={() => {
+        open_new_tab(url);
+      }}
+    >
+      Buy a license ...
+    </Button>
+  );
+};


### PR DESCRIPTION
# Description

This is a follow up of that PR about purchasing a license for a project (with automatic application). All this does is to replace the "Buy a license" link with an identical one, which opens the store with that `?project_id=` query param. Pretty trivial. 

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
