### PR TITLE
db: expire entries in password_reset_attempts

### DIFF
--- a/src/packages/database/postgres-server-queries.coffee
+++ b/src/packages/database/postgres-server-queries.coffee
@@ -1487,6 +1487,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
         opts = defaults opts,
             email_address : required
             ip_address    : required
+            ttl           : required
             cb            : required   # cb(err)
         @_query
             query  : 'INSERT INTO password_reset_attempts'
@@ -1495,6 +1496,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                 "email_address :: TEXT "     : opts.email_address
                 "ip_address    :: INET"      : opts.ip_address
                 "time          :: TIMESTAMP" : "NOW()"
+                "expire        :: TIMESTAMP" : expire_time(opts.ttl)
             cb     : opts.cb
 
     count_password_reset_attempts: (opts) =>

--- a/src/packages/hub/password.coffee
+++ b/src/packages/hub/password.coffee
@@ -56,6 +56,7 @@ exports.forgot_password = (opts) ->
             opts.database.record_password_reset_attempt
                 email_address : opts.mesg.email_address
                 ip_address    : opts.ip_address
+                ttl           : 24*60*60 # 1 day, enough to check, we only look at one hour in the past
                 cb            : cb
         (cb) ->
             # POLICY 1: We limit the number of password resets that an email address can receive

--- a/src/packages/server/auth/password-reset.ts
+++ b/src/packages/server/auth/password-reset.ts
@@ -1,3 +1,8 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { v4 } from "uuid";
 import getPool from "@cocalc/database/pool";
 import { expireTime } from "@cocalc/database/pool/util";
@@ -26,7 +31,7 @@ export async function createReset(
   // Record that there was an attempt:
   if (ip_address) {
     await pool.query(
-      "INSERT INTO password_reset_attempts(id, email_address,ip_address,time) VALUES($1::UUID,$2::TEXT,$3,NOW())",
+      "INSERT INTO password_reset_attempts(id, email_address,ip_address,time,expire) VALUES($1::UUID,$2::TEXT,$3,NOW(),NOW() + INTERVAL '1 day')",
       [v4(), email_address, ip_address]
     );
   }

--- a/src/packages/util/db-schema/password-reset.ts
+++ b/src/packages/util/db-schema/password-reset.ts
@@ -44,5 +44,8 @@ Table({
     time: {
       type: "timestamp",
     },
+    expire: {
+      type: "timestamp",
+    },
   },
 });


### PR DESCRIPTION
# Description

This adds an expiration field, for one day. More than enough. 

Before this goes live we have to clean up that table...

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
