### PR TITLE
course: fix edge cases serial licensing strategy

### DIFF
--- a/src/packages/frontend/course/configuration/configuration-panel.tsx
+++ b/src/packages/frontend/course/configuration/configuration-panel.tsx
@@ -4,7 +4,7 @@
  */
 
 // CoCalc libraries
-import { webapp_client } from "../../webapp-client";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { contains_url, days_ago, plural } from "@cocalc/util/misc";
 import { debounce } from "lodash";
 // React libraries and Components
@@ -16,8 +16,8 @@ import {
   useActions,
   useStore,
   useTypedRedux,
-} from "../../app-framework";
-import { Button, ButtonGroup, Checkbox } from "../../antd-bootstrap";
+} from "@cocalc/frontend/app-framework";
+import { Button, ButtonGroup, Checkbox } from "@cocalc/frontend/antd-bootstrap";
 import { Alert, Card, Row, Col } from "antd";
 // CoCalc Components
 import {
@@ -30,10 +30,10 @@ import {
   TextInput,
   TimeAgo,
   ErrorDisplay,
-} from "../../components";
+} from "@cocalc/frontend/components";
 import { StudentProjectUpgrades } from "./upgrades";
 import { CourseActions } from "../actions";
-import { ProjectMap } from "../../todo-types";
+import { ProjectMap } from "@cocalc/frontend/todo-types";
 import { CourseSettingsRecord, CourseStore } from "../store";
 import { HelpBox } from "./help-box";
 


### PR DESCRIPTION
# Description

This fixes a few details:
1. what if there is already more than one license assigned to a student project? → only pick the first one which still has a seat free.
2. there was a fix to remove licenses from deleted student projects, but the `ids` never included the deleted student projects. This explicitly iterates over all deleted student projects and removes the licenses.
3. there is a toggle to upgrade the host/instructor project or not. if not, we do not deduce "1" from the number of available seats per license.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
