### PR TITLE
Account/licenses: link to store

### DIFF
--- a/src/packages/frontend/account/licenses/about-licenses.tsx
+++ b/src/packages/frontend/account/licenses/about-licenses.tsx
@@ -1,5 +1,10 @@
-import { A } from "../../components";
-import { DOC_LICENSE_URL } from "../../billing/data";
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { DOC_LICENSE_URL } from "@cocalc/frontend/billing/data";
+import { A } from "@cocalc/frontend/components";
 
 export const AboutLicenses: React.FC = () => {
   return (

--- a/src/packages/frontend/account/licenses/licenses-page.tsx
+++ b/src/packages/frontend/account/licenses/licenses-page.tsx
@@ -3,15 +3,15 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { A } from "@cocalc/frontend/components";
+import { Footer } from "@cocalc/frontend/customize";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { BuyLicenseForProject } from "@cocalc/frontend/site-licenses/purchase/buy-license-for-project";
+import { Alert } from "antd";
+import { join } from "path";
+import { AboutLicenses } from "./about-licenses";
 import { ManagedLicenses } from "./managed-licenses";
 import { ProjectsWithLicenses } from "./projects-with-licenses";
-import { AboutLicenses } from "./about-licenses";
-import { PurchaseOneLicenseLink } from "../../site-licenses/purchase";
-import { Footer } from "@cocalc/frontend/customize";
-import { A } from "@cocalc/frontend/components";
-import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
-import { join } from "path";
-import { Alert } from "antd";
 
 export const LicensesPage: React.FC = () => {
   return (
@@ -29,7 +29,7 @@ export const LicensesPage: React.FC = () => {
       />
       <AboutLicenses />
       <br />
-      <PurchaseOneLicenseLink />
+      <BuyLicenseForProject />
       <br />
       <ManagedLicenses />
       <br />

--- a/src/packages/frontend/account/licenses/licenses-page.tsx
+++ b/src/packages/frontend/account/licenses/licenses-page.tsx
@@ -29,7 +29,9 @@ export const LicensesPage: React.FC = () => {
       />
       <AboutLicenses />
       <br />
-      <BuyLicenseForProject />
+      <div>
+        <BuyLicenseForProject />
+      </div>
       <br />
       <ManagedLicenses />
       <br />

--- a/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
+++ b/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
@@ -6,22 +6,32 @@
 import { Icon } from "@cocalc/frontend/components/icon";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 import { open_new_tab } from "@cocalc/frontend/misc";
+import { is_valid_uuid_string } from "@cocalc/util/misc";
 import { Button } from "antd";
 import { join } from "path";
 
-export const BuyLicenseForProject: React.FC<{ project_id: string }> = (props: {
-  project_id: string;
-}) => {
+interface Props {
+  project_id?: string;
+}
+
+export const BuyLicenseForProject: React.FC<Props> = (props: Props) => {
   const { project_id } = props;
-  const base = join(appBasePath, "store", "site-license");
-  const url = `${base}?project_id=${project_id}`;
+
+  function url(): string {
+    const base = join(appBasePath, "store", "site-license");
+    if (is_valid_uuid_string(project_id)) {
+      return `${base}?project_id=${project_id}`;
+    } else {
+      return base;
+    }
+  }
 
   return (
     <Button
       type="primary"
       icon={<Icon name="shopping-cart" />}
       onClick={() => {
-        open_new_tab(url);
+        open_new_tab(url());
       }}
     >
       Buy a license ...

--- a/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
+++ b/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
@@ -9,6 +9,7 @@ import { open_new_tab } from "@cocalc/frontend/misc";
 import { is_valid_uuid_string } from "@cocalc/util/misc";
 import { Button } from "antd";
 import { join } from "path";
+import { useTypedRedux } from "../../app-framework";
 
 interface Props {
   project_id?: string;
@@ -16,6 +17,8 @@ interface Props {
 
 export const BuyLicenseForProject: React.FC<Props> = (props: Props) => {
   const { project_id } = props;
+
+  const commercial = useTypedRedux("customize", "commercial");
 
   function url(): string {
     const base = join(appBasePath, "store", "site-license");
@@ -26,15 +29,19 @@ export const BuyLicenseForProject: React.FC<Props> = (props: Props) => {
     }
   }
 
-  return (
-    <Button
-      type="primary"
-      icon={<Icon name="shopping-cart" />}
-      onClick={() => {
-        open_new_tab(url());
-      }}
-    >
-      Buy a license ...
-    </Button>
-  );
+  if (!commercial) {
+    return null;
+  } else {
+    return (
+      <Button
+        type="primary"
+        icon={<Icon name="shopping-cart" />}
+        onClick={() => {
+          open_new_tab(url());
+        }}
+      >
+        Buy a license ...
+      </Button>
+    );
+  }
 };

--- a/src/packages/frontend/site-licenses/purchase/link.tsx
+++ b/src/packages/frontend/site-licenses/purchase/link.tsx
@@ -5,10 +5,10 @@
 
 /* Link to purchasing a license */
 
-import { useTypedRedux, redux } from "../../app-framework";
-import { PurchaseOneLicense } from "./purchase";
+import { redux, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { Icon, Space } from "@cocalc/frontend/components";
 import { Button } from "antd";
-import { Icon, Space } from "../../components";
+import { PurchaseOneLicense } from "./purchase";
 
 export const PurchaseOneLicenseLink: React.FC = () => {
   const expand = useTypedRedux("account", "show_purchase_form") ?? false;


### PR DESCRIPTION
# Description

This replaces the embedded form in account/licenses with a link to the store. It also only shows that button-link, if customize/commercial is true!

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
