### PR TITLE
tsconfig: es2017

### DIFF
--- a/src/packages/backend/tsconfig.json
+++ b/src/packages/backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "types": ["node"],
     "lib": ["es7"],
     "rootDir": "./",

--- a/src/packages/frontend/tsconfig.json
+++ b/src/packages/frontend/tsconfig.json
@@ -4,7 +4,8 @@
     "incremental": false,
     "rootDir": "./",
     "outDir": "dist",
-    "target": "es5",
+    "target": "es2017",
+    "module": "es2020",
     "sourceMap": true,
     "lib": ["es5", "es6", "es2017", "dom"],
     "declaration": false

--- a/src/packages/next/tsconfig.json
+++ b/src/packages/next/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",

--- a/src/packages/project/tsconfig.json
+++ b/src/packages/project/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
+    "module": "es2020",
     "types": ["node"],
     "lib": ["es7"],
     "rootDir": "./",

--- a/src/packages/server/tsconfig.json
+++ b/src/packages/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "types": ["node", "jest"],
     "lib": ["ESNext"],
     "rootDir": "./",

--- a/src/packages/static/src/tsconfig.json
+++ b/src/packages/static/src/tsconfig.json
@@ -5,7 +5,7 @@
     "incremental": false,
     "rootDir": "./",
     "outDir": "../dist/src",
-    "target": "es5",
+    "target": "es2017",
     "sourceMap": true,
     "allowJs": false,
     "allowSyntheticDefaultImports": true,

--- a/src/packages/static/tsconfig.json
+++ b/src/packages/static/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "dist",
     "rootDirs": ["./src", "./node_modules/@cocalc/frontend/"],
     "sourceMap": true,
-    "target": "es5",
+    "target": "es2017",
   },
   "exclude": [
     "*__test__*",

--- a/src/packages/tsconfig.json
+++ b/src/packages/tsconfig.json
@@ -17,7 +17,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strictNullChecks": true,
-    "target": "es5"
+    "target": "es2017",
+    "module": "es2020"
   },
   "watchOptions": {
     "fallbackPolling": "dynamicPriority",

--- a/src/test/puppeteer/tsconfig.json
+++ b/src/test/puppeteer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "target": "es5",
+    "target": "es2017",
     "sourceMap": true,
     "lib": ["es5", "es6", "es2017", "dom"],
     "strictNullChecks": true,


### PR DESCRIPTION
# Description

I tried to just change the targets, and experimented with similar combinations, but this doesn't work. I think most of them build, but where I got stuck is next.js:

```
info  - Collecting page data ...ReferenceError: Cannot access 'OPTIONS' before initialization
[...]
    at /home/hsy/p/cocalc/src/packages/next/.next/server/pages/auth/sign-up.js:538:169
```

Which originates in importing MarkdownIT in the frontend code. So, my feeling is, this could be related to that "type: module" flag as a package, or only partially updating to target es2017 (although I guess, a lot of benefits are lost if this is compiled to es5 first, and then upgraded)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
