### PR TITLE
fix some /pricing pages

### DIFF
--- a/src/packages/frontend/billing/explain-course-licenses.tsx
+++ b/src/packages/frontend/billing/explain-course-licenses.tsx
@@ -3,12 +3,12 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { React } from "@cocalc/frontend/app-framework";
+import { A, IconName, Space } from "@cocalc/frontend/components";
 import { Uptime } from "@cocalc/util/consts/site-license";
 import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
 import { discount_pct } from "@cocalc/util/licenses/purchase/consts";
 import { PurchaseInfo } from "@cocalc/util/licenses/purchase/types";
-import { React } from "../app-framework";
-import { A, IconName, Space } from "../components";
 import {
   DOC_ACCOUNT_LICENSES,
   DOC_LICENSE_URL,

--- a/src/packages/next/components/landing/pricing-item.tsx
+++ b/src/packages/next/components/landing/pricing-item.tsx
@@ -1,6 +1,12 @@
-import { ReactNode } from "react";
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Icon, IconName } from "@cocalc/frontend/components/icon";
+import { COLORS } from "@cocalc/util/theme";
 import { Card, List } from "antd";
+import { ReactNode } from "react";
 
 interface Props {
   children: ReactNode;
@@ -13,7 +19,7 @@ export default function PricingItem({ icon, children, title }: Props) {
     <List.Item>
       <Card
         headStyle={{ backgroundColor: "#d9edf7" }}
-        style={{ color: "#777" }}
+        style={{ color: COLORS.GRAY }}
         type="inner"
         title={
           <>
@@ -28,15 +34,19 @@ export default function PricingItem({ icon, children, title }: Props) {
   );
 }
 
-const STYLE = { marginRight: "5px", display: "inline-block", color: "#555" };
+const STYLE: React.CSSProperties = {
+  marginRight: "5px",
+  display: "inline-block",
+  color: COLORS.GRAY_DD,
+} as const;
 
-export function Line({
-  amount,
-  desc,
-}: {
+interface Line {
   amount?: string | number;
   desc?: string;
-}) {
+}
+
+export function Line(props: Line) {
+  const { amount, desc } = props;
   if (!amount)
     return (
       <div>

--- a/src/packages/next/components/store/link.tsx
+++ b/src/packages/next/components/store/link.tsx
@@ -1,0 +1,50 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Uptime } from "@cocalc/util/consts/site-license";
+import { Button } from "antd";
+import { useRouter } from "next/router";
+
+export interface StoreConf {
+  run_limit: number;
+  disk: number;
+  ram: number;
+  cpu: number;
+  user: "academic" | "business";
+  start?: Date;
+  end?: Date;
+  uptime: Uptime;
+}
+
+interface Props {
+  conf: StoreConf;
+}
+
+const STYLE: React.CSSProperties = {
+  fontSize: "150%",
+  fontWeight: "bold",
+  textAlign: "center",
+  marginTop: "30px",
+};
+
+export function LinkToStore(props: Props) {
+  const { conf } = props;
+
+  const router = useRouter();
+
+  const params = Object.entries(conf)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+
+  const url = `/store/site-license?${params}`;
+
+  return (
+    <div style={STYLE}>
+      <Button size={"large"} type={"primary"} onClick={() => router.push(url)}>
+        Buy
+      </Button>
+    </div>
+  );
+}

--- a/src/packages/next/components/store/link.tsx
+++ b/src/packages/next/components/store/link.tsx
@@ -3,6 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Icon } from "@cocalc/frontend/components/icon";
 import { Uptime } from "@cocalc/util/consts/site-license";
 import { Button } from "antd";
 import { useRouter } from "next/router";
@@ -27,7 +28,7 @@ const STYLE: React.CSSProperties = {
   fontWeight: "bold",
   textAlign: "center",
   marginTop: "30px",
-};
+} as const;
 
 export function LinkToStore(props: Props) {
   const { conf } = props;
@@ -42,8 +43,13 @@ export function LinkToStore(props: Props) {
 
   return (
     <div style={STYLE}>
-      <Button size={"large"} type={"primary"} onClick={() => router.push(url)}>
-        Buy
+      <Button
+        size={"large"}
+        type={"default"}
+        onClick={() => router.push(url)}
+        icon={<Icon name="shopping-cart" />}
+      >
+        Select
       </Button>
     </div>
   );

--- a/src/packages/next/components/store/quota-query-params.ts
+++ b/src/packages/next/components/store/quota-query-params.ts
@@ -26,7 +26,7 @@ import { MAX_ALLOWED_RUN_LIMIT } from "./run-limit";
 
 // Various support functions for storing quota parameters as a query parameter in the browser URL
 
-function encodeRange(vals: DateRange): string {
+export function encodeRange(vals: DateRange): string {
   // the list of val is encoded as YYYY-MM-DD and separated by a comma
   // this happens after the "correction" of timestamps in the range selector
   // that's why here is (yet again) some rounding to the start/end of the day.

--- a/src/packages/next/pages/pricing/_shared.tsx
+++ b/src/packages/next/pages/pricing/_shared.tsx
@@ -1,0 +1,54 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Typography } from "antd";
+import A from "components/misc/A";
+const { Text, Paragraph } = Typography;
+
+export function listedPrices(): JSX.Element {
+  return (
+    <Paragraph>
+      Listed prices are in <Text strong>US dollars</Text>. When charging in
+      local currency, the prices are converted into local currency using the
+      conversion rates published by leading financial institutions.
+    </Paragraph>
+  );
+}
+
+export function pricingQuestions(): JSX.Element {
+  return (
+    <>
+      <h2>Questions</h2>
+      <Paragraph>
+        Please immediately email us at{" "}
+        <A href="mailto:help@cocalc.com">help@cocalc.com</A> if anything is
+        unclear to you. Also, contact us if you need customized{" "}
+        <A href="/pricing/courses">course packages</A>, modified{" "}
+        <A href="/policies/terms">terms of service</A>, additional{" "}
+        <A href="/policies/privacy">legal</A>{" "}
+        <A href="/policies/ferpa">agreements</A>, purchase orders or priority
+        technical support.
+      </Paragraph>
+    </>
+  );
+}
+
+export function applyLicense(): JSX.Element {
+  return (
+    <p>
+      Any subscription or{" "}
+      <A href="https://doc.cocalc.com/account/licenses.html">license upgrade</A>{" "}
+      must be{" "}
+      <A href="https://doc.cocalc.com/project-settings.html#add-a-license-to-a-project">
+        applied explicitly to your project
+      </A>{" "}
+      or{" "}
+      <A href="https://doc.cocalc.com/teaching-upgrade-course.html">
+        distributed to student projects
+      </A>
+      .
+    </p>
+  );
+}

--- a/src/packages/next/pages/pricing/courses.tsx
+++ b/src/packages/next/pages/pricing/courses.tsx
@@ -21,6 +21,7 @@ import { encodeRange } from "components/store/quota-query-params";
 import { MAX_WIDTH } from "lib/config";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
+import { listedPrices } from "./_shared";
 
 interface Item {
   title: string;
@@ -199,178 +200,180 @@ export default function Courses({ customize }) {
           backgroundColor: "white",
         }}
       >
-        <div
-          style={{
-            maxWidth: MAX_WIDTH,
-            margin: "15px auto",
-            padding: "15px",
-            backgroundColor: "white",
-          }}
-        >
-          <div style={{ textAlign: "center", color: "#444" }}>
-            <h1 style={{ fontSize: "28pt" }}>
-              <Icon name="graduation-cap" style={{ marginRight: "30px" }} />
-              CoCalc - Course licenses
-            </h1>
-          </div>
-          <div style={{ fontSize: "12pt" }}>
-            <p>
-              You{" "}
-              <A href="https://doc.cocalc.com/teaching-instructors.html">
-                teach a course
-              </A>{" "}
-              on <span>CoCalc</span> by creating one project for each student,
-              sending your students assignments and handouts, then guiding their
-              progress using collaboration and chat. You can then collect,
-              grade, comment on, and return their work.
-            </p>
-            <p>
-              You will need to purchase an appropriate license for your course,
-              or have the students pay the one-time $14 fee, since CoCalc is not
-              funded by advertisers or other intrusive methods.
-            </p>
-
-            <h2>How to get started?</h2>
-            <p>
-              You can{" "}
-              <A href="/store/site-license" external>
-                purchase a license for your course
-              </A>{" "}
-              in the{" "}
-              <A href="/store" external>
-                store
-              </A>
-              .
-            </p>
-            <p>
-              Minimal upgrades might be okay for beginner courses, but we find
-              that many data and computational science courses run better with
-              additional RAM and CPU.{" "}
-              <A href="mailto:help@cocalc.com">Contact us</A> if you have
-              questions or need a trial license to test out different
-              possibilities.
-            </p>
-            <p>
-              Once you obtain a license key,{" "}
-              <A href="https://doc.cocalc.com/teaching-upgrade-course.html">
-                apply it to all your student projects
-              </A>
-              .
-            </p>
-            <p>
-              You can acquire several licenses, e.g., to partition a semester
-              into smaller parts with different requirements, or to keep
-              upgrades separate between certain groups of courses or
-              instructors.
-            </p>
-
-            <h2>Payment options</h2>
-            <ul style={{ paddingLeft: "20px" }}>
-              <li>
-                <b>
-                  <A href="https://doc.cocalc.com/teaching-upgrade-course.html#teacher-or-institution-pays-for-upgrades">
-                    You or your institution pays
-                  </A>
-                </b>{" "}
-                for one or more license upgrades. You distribute the license
-                upgrades to all projects of the course via the course
-                configuration tab of the course management interface.
-              </li>
-              <li>
-                <b>
-                  <A href="https://doc.cocalc.com/teaching-upgrade-course.html#students-pay-for-upgrades">
-                    Students pay a one-time fee.
-                  </A>
-                </b>{" "}
-                In the configuration frame of the course management file, you
-                opt to require all students to pay a one-time $14 fee to upgrade
-                their own projects.
-              </li>
-            </ul>
-
-            <h2>Examples</h2>
-            <p>
-              Here are three typical configurations, which you can{" "}
-              <A href="/store/site-license" external>
-                modify and purchase here
-              </A>
-              . All parameters can be adjusted to fit your needs. Listed
-              upgrades are for each project. Exact prices may vary. Only
-              self-service online purchases are available below $100.
-            </p>
-
-            <List
-              grid={{ gutter: 16, column: 3, xs: 1, sm: 1 }}
-              dataSource={data}
-              renderItem={(item) => {
-                const conf = {
-                  ...item.conf,
-                  period: "range",
-                  range: encodeRange([item.conf.start, item.conf.end]),
-                };
-                return (
-                  <PricingItem title={item.title} icon={item.icon}>
-                    <Line amount={item.teachers} desc="Teacher" />
-                    <Line amount={item.students} desc="Students" />
-                    <Line amount={item.duration} desc="Duration" />
-                    <Line amount={item.uptime} desc="Idle timeout" />
-                    <Line amount={item.shared_ram} desc="Shared RAM" />
-                    <Line amount={item.shared_cores} desc="Shared CPU" />
-                    <Line amount={item.disk} desc="Disk space" />
-                    {item.academic && (
-                      <Line
-                        amount={`${discount_pct}%`}
-                        desc="Academic discount"
-                      />
-                    )}
-                    <br />
-                    <br />
-                    <div>
-                      <span
-                        style={{
-                          fontWeight: "bold",
-                          fontSize: "18pt",
-                          color: COLORS.GRAY_DD,
-                        }}
-                      >
-                        {money(item.online, true)}
-                      </span>{" "}
-                    </div>
-                    {item.retail ? (
-                      <div style={{ color: COLORS.GRAY }}>
-                        (
-                        <span
-                          style={{
-                            fontWeight: "bold",
-                            fontSize: "14pt",
-                          }}
-                        >
-                          {money(item.retail, true)}
-                        </span>{" "}
-                        via purchase order)
-                      </div>
-                    ) : (
-                      <div>
-                        <span style={{ fontSize: "14pt" }}>&nbsp;</span>
-                      </div>
-                    )}
-                    <LinkToStore conf={conf} />
-                  </PricingItem>
-                );
-              }}
-            />
-
-            <h2>Contact us</h2>
-            <p>
-              To learn more about your teaching options, email us at{" "}
-              <A href="mailto:help@cocalc.com">help@cocalc.com</A> with a
-              description of your specific requirements.
-            </p>
-          </div>
-        </div>
+        <Body />
         <Footer />
       </Layout.Content>
     </Customize>
+  );
+}
+
+function Body(): JSX.Element {
+  return (
+    <div
+      style={{
+        maxWidth: MAX_WIDTH,
+        margin: "15px auto",
+        padding: "15px",
+        backgroundColor: "white",
+      }}
+    >
+      <div style={{ textAlign: "center", color: "#444" }}>
+        <h1 style={{ fontSize: "28pt" }}>
+          <Icon name="graduation-cap" style={{ marginRight: "30px" }} />
+          CoCalc - Course licenses
+        </h1>
+      </div>
+      <div style={{ fontSize: "12pt" }}>
+        <p>
+          You{" "}
+          <A href="https://doc.cocalc.com/teaching-instructors.html">
+            teach a course
+          </A>{" "}
+          on <span>CoCalc</span> by creating one project for each student,
+          sending your students assignments and handouts, then guiding their
+          progress using collaboration and chat. You can then collect, grade,
+          comment on, and return their work.
+        </p>
+        <p>
+          You will need to purchase an appropriate license for your course, or
+          have the students pay the one-time $14 fee, since CoCalc is not funded
+          by advertisers or other intrusive methods.
+        </p>
+
+        <h2>How to get started?</h2>
+        <p>
+          You can{" "}
+          <A href="/store/site-license" external>
+            purchase a license for your course
+          </A>{" "}
+          in the{" "}
+          <A href="/store" external>
+            store
+          </A>
+          .
+        </p>
+        <p>
+          Minimal upgrades might be okay for beginner courses, but we find that
+          many data and computational science courses run better with additional
+          RAM and CPU. <A href="mailto:help@cocalc.com">Contact us</A> if you
+          have questions or need a trial license to test out different
+          possibilities.
+        </p>
+        <p>
+          Once you obtain a license key,{" "}
+          <A href="https://doc.cocalc.com/teaching-upgrade-course.html">
+            apply it to all your student projects
+          </A>
+          .
+        </p>
+        <p>
+          You can acquire several licenses, e.g., to partition a semester into
+          smaller parts with different requirements, or to keep upgrades
+          separate between certain groups of courses or instructors.
+        </p>
+
+        <h2>Payment options</h2>
+        <ul style={{ paddingLeft: "20px" }}>
+          <li>
+            <b>
+              <A href="https://doc.cocalc.com/teaching-upgrade-course.html#teacher-or-institution-pays-for-upgrades">
+                You or your institution pays
+              </A>
+            </b>{" "}
+            for one or more license upgrades. You distribute the license
+            upgrades to all projects of the course via the course configuration
+            tab of the course management interface.
+          </li>
+          <li>
+            <b>
+              <A href="https://doc.cocalc.com/teaching-upgrade-course.html#students-pay-for-upgrades">
+                Students pay a one-time fee.
+              </A>
+            </b>{" "}
+            In the configuration frame of the course management file, you opt to
+            require all students to pay a one-time $14 fee to upgrade their own
+            projects.
+          </li>
+        </ul>
+
+        <h2>Examples</h2>
+        <p>
+          Here are three typical configurations, which you can{" "}
+          <A href="/store/site-license" external>
+            modify and purchase here
+          </A>
+          . All parameters can be adjusted to fit your needs. Listed upgrades
+          are for each project. Exact prices may vary. Only self-service online
+          purchases are available below $100.
+        </p>
+
+        <List
+          grid={{ gutter: 16, column: 3, xs: 1, sm: 1 }}
+          dataSource={data}
+          renderItem={(item) => {
+            const conf = {
+              ...item.conf,
+              period: "range",
+              range: encodeRange([item.conf.start, item.conf.end]),
+            };
+            return (
+              <PricingItem title={item.title} icon={item.icon}>
+                <Line amount={item.teachers} desc="Teacher" />
+                <Line amount={item.students} desc="Students" />
+                <Line amount={item.duration} desc="Duration" />
+                <Line amount={item.uptime} desc="Idle timeout" />
+                <Line amount={item.shared_ram} desc="Shared RAM" />
+                <Line amount={item.shared_cores} desc="Shared CPU" />
+                <Line amount={item.disk} desc="Disk space" />
+                {item.academic && (
+                  <Line amount={`${discount_pct}%`} desc="Academic discount" />
+                )}
+                <br />
+                <br />
+                <div>
+                  <span
+                    style={{
+                      fontWeight: "bold",
+                      fontSize: "18pt",
+                      color: COLORS.GRAY_DD,
+                    }}
+                  >
+                    {money(item.online, true)}
+                  </span>{" "}
+                </div>
+                {item.retail ? (
+                  <div style={{ color: COLORS.GRAY }}>
+                    (
+                    <span
+                      style={{
+                        fontWeight: "bold",
+                        fontSize: "14pt",
+                      }}
+                    >
+                      {money(item.retail, true)}
+                    </span>{" "}
+                    via purchase order)
+                  </div>
+                ) : (
+                  <div>
+                    <span style={{ fontSize: "14pt" }}>&nbsp;</span>
+                  </div>
+                )}
+                <LinkToStore conf={conf} />
+              </PricingItem>
+            );
+          }}
+        />
+        {listedPrices()}
+
+        <h2>Contact us</h2>
+        <p>
+          To learn more about your teaching options, email us at{" "}
+          <A href="mailto:help@cocalc.com">help@cocalc.com</A> with a
+          description of your specific requirements.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/src/packages/next/pages/pricing/courses.tsx
+++ b/src/packages/next/pages/pricing/courses.tsx
@@ -1,13 +1,23 @@
-import Footer from "components/landing/footer";
-import Header from "components/landing/header";
-import Head from "components/landing/head";
-import { List, Layout } from "antd";
-import withCustomize from "lib/with-customize";
-import { Customize } from "lib/customize";
-import A from "components/misc/A";
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Icon, IconName } from "@cocalc/frontend/components/icon";
+import { LicenseIdleTimeouts, Uptime } from "@cocalc/util/consts/site-license";
+import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
+import { discount_pct } from "@cocalc/util/licenses/purchase/consts";
+import { PurchaseInfo } from "@cocalc/util/licenses/purchase/types";
+import { round2 } from "@cocalc/util/misc";
+import { Layout, List } from "antd";
+import Footer from "components/landing/footer";
+import Head from "components/landing/head";
+import Header from "components/landing/header";
 import PricingItem, { Line } from "components/landing/pricing-item";
+import A from "components/misc/A";
 import { MAX_WIDTH } from "lib/config";
+import { Customize } from "lib/customize";
+import withCustomize from "lib/with-customize";
 
 interface Item {
   title: string;
@@ -17,56 +27,149 @@ interface Item {
   duration: string;
   disk: number;
   shared_ram: number;
-  dedicated_ram?: number;
   shared_cores: number;
-  dedicated_cores?: number;
   academic: boolean;
   retail?: number;
   online?: number;
+  uptime?: string;
 }
 
-const data: Item[] = [
-  {
-    title: "5 Day Professional Training",
+const training: Item = (() => {
+  const students = 10;
+  const conf = {
+    n: students + 1,
+    days: 5,
+    ram: 5,
+    disk: 5,
+    cpu: 1,
+    uptime: "medium" as Uptime,
+  } as const;
+
+  const profPrice = compute_cost({
+    type: "quota",
+    user: "business",
+    upgrade: "custom",
+    quantity: conf.n,
+    subscription: "no",
+    start: new Date(),
+    end: new Date(new Date().getTime() + conf.days * 24 * 60 * 60 * 1000),
+    custom_ram: conf.ram,
+    custom_cpu: conf.cpu,
+    custom_disk: conf.disk,
+    custom_member: true,
+    custom_dedicated_ram: 0,
+    custom_dedicated_cpu: 0,
+    custom_uptime: conf.uptime,
+  } as PurchaseInfo);
+
+  return {
+    title: `${conf.days} Day Professional Training`,
     icon: "battery-quarter",
     teachers: 1,
-    students: 5,
-    duration: "5 days",
-    disk: 5,
-    shared_ram: 2,
-    dedicated_ram: 1,
-    shared_cores: 1,
-    dedicated_cores: 0.5,
+    students,
+    duration: `${conf.days} days`,
+    disk: conf.disk,
+    uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
+    shared_ram: conf.ram,
+    dedicated_ram: 0,
+    shared_cores: conf.cpu,
+    dedicated_cores: 0,
     academic: false,
-    online: 33.83,
-  },
-  {
-    title: "20 Students for 1 Month",
+    online: round2(profPrice.discounted_cost),
+  };
+})();
+
+const courseSmall: Item = (() => {
+  const students = 10;
+  const conf = {
+    n: students + 1,
+    days: 30,
+    ram: 2,
+    disk: 3,
+    cpu: 1,
+    uptime: "short",
+  } as const;
+
+  const price = compute_cost({
+    type: "quota",
+    user: "academic",
+    upgrade: "custom",
+    quantity: conf.n,
+    subscription: "no",
+    start: new Date(),
+    end: new Date(new Date().getTime() + conf.days * 24 * 60 * 60 * 1000),
+    custom_ram: conf.ram,
+    custom_cpu: conf.cpu,
+    custom_disk: conf.disk,
+    custom_member: true,
+    custom_dedicated_ram: 0,
+    custom_dedicated_cpu: 0,
+    custom_uptime: conf.uptime,
+  } as PurchaseInfo);
+
+  return {
+    title: `${students} students for ${conf.days} days`,
     icon: "battery-half",
     teachers: 1,
-    students: 20,
-    duration: "1 month",
-    disk: 1,
-    shared_ram: 2,
-    shared_cores: 1,
+    students,
+    duration: `${conf.days} days`,
+    disk: conf.disk,
+    uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
+    shared_ram: conf.ram,
+    shared_cores: conf.cpu,
     academic: true,
-    retail: 113.03,
-    online: 84.77,
-  },
-  {
-    title: "120 Students for 4 Months",
+    retail: round2(price.cost),
+    online: round2(price.discounted_cost),
+  };
+})();
+
+const courseLarge: Item = (() => {
+  const students = 150;
+  const months = 4;
+  const days = months * 30;
+  const conf = {
+    n: students + 1,
+    days,
+    ram: 2,
+    disk: 3,
+    cpu: 1,
+    uptime: "short",
+  } as const;
+
+  const price = compute_cost({
+    type: "quota",
+    user: "academic",
+    upgrade: "custom",
+    quantity: conf.n,
+    subscription: "no",
+    start: new Date(),
+    end: new Date(new Date().getTime() + conf.days * 24 * 60 * 60 * 1000),
+    custom_ram: conf.ram,
+    custom_cpu: conf.cpu,
+    custom_disk: conf.disk,
+    custom_member: true,
+    custom_dedicated_ram: 0,
+    custom_dedicated_cpu: 0,
+    custom_uptime: conf.uptime,
+  } as PurchaseInfo);
+
+  return {
+    title: `${students} Students for ${months} Months`,
     icon: "battery-full",
     teachers: 1,
-    students: 120,
-    duration: "4 months",
-    disk: 1,
-    shared_ram: 1,
-    shared_cores: 1,
+    students,
+    duration: `${days} days`,
+    disk: conf.disk,
+    uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
+    shared_ram: conf.ram,
+    shared_cores: conf.cpu,
     academic: true,
-    retail: 2203.41,
-    online: 1652.56,
-  },
-];
+    retail: round2(price.cost),
+    online: round2(price.discounted_cost),
+  };
+})();
+
+const data: Item[] = [training, courseSmall, courseLarge];
 
 export default function Courses({ customize }) {
   return (
@@ -186,11 +289,16 @@ export default function Courses({ customize }) {
                   <Line amount={item.teachers} desc="Teacher" />
                   <Line amount={item.students} desc="Students" />
                   <Line amount={item.duration} desc="Duration" />
+                  <Line amount={item.uptime} desc="Idle timeout" />
                   <Line amount={item.shared_ram} desc="Shared RAM" />
                   <Line amount={item.shared_cores} desc="Shared CPU" />
                   <Line amount={item.disk} desc="Disk space" />
-                  <Line amount={item.dedicated_ram} desc="Dedicated RAM" />
-                  <Line amount={item.dedicated_cores} desc="Dedicated CPU" />
+                  {item.academic && (
+                    <Line
+                      amount={`${discount_pct}%`}
+                      desc="Academic discount"
+                    />
+                  )}
                   <br />
                   <br />
                   <div>

--- a/src/packages/next/pages/pricing/dedicated.tsx
+++ b/src/packages/next/pages/pricing/dedicated.tsx
@@ -6,7 +6,7 @@
 import Footer from "components/landing/footer";
 import Header from "components/landing/header";
 import Head from "components/landing/head";
-import { Layout, Typography } from "antd";
+import { Button, Layout, Typography } from "antd";
 const { Text } = Typography;
 import withCustomize from "lib/with-customize";
 import { Customize } from "lib/customize";
@@ -18,6 +18,8 @@ import { PRICES } from "@cocalc/util/upgrades/dedicated";
 import { AVG_MONTH_DAYS } from "@cocalc/util/consts/billing";
 import { DOC_CLOUD_STORAGE_URL } from "@cocalc/util/consts/project";
 import { MAX_WIDTH } from "lib/config";
+import { listedPrices } from "./_shared";
+import { useRouter } from "next/router";
 
 interface Item {
   title: string;
@@ -77,6 +79,7 @@ const DISK_CONFIGS: Item[] = ICONS.slice(1).map((battery, idx) => {
 
 export default function Products({ customize }) {
   const { siteName } = customize;
+  const router = useRouter();
   return (
     <Customize value={customize}>
       <Head title={"Dedicated virtual machines and disks"} />
@@ -139,6 +142,18 @@ export default function Products({ customize }) {
                 </PricingItem>
               )}
             />
+            <p style={{ textAlign: "center" }}>
+              <Button
+                size={"large"}
+                type={"primary"}
+                onClick={() => router.push("/store/dedicated?type=vm")}
+                icon={<Icon name="shopping-cart" />}
+              >
+                Order a VM license
+              </Button>
+            </p>
+            <br />
+            <hr />
             <br />
             <h2>
               <strong>Dedicated Disks</strong>
@@ -185,6 +200,16 @@ export default function Products({ customize }) {
                 </PricingItem>
               )}
             />
+            <p style={{ textAlign: "center" }}>
+              <Button
+                size={"large"}
+                type={"primary"}
+                onClick={() => router.push("/store/dedicated?type=disk")}
+                icon={<Icon name="shopping-cart" />}
+              >
+                Subscribe for a dedicated disk
+              </Button>
+            </p>
             <p>
               <Icon name="info-circle" /> To ease data transfer, make sure to
               check out how to mount{" "}
@@ -194,6 +219,8 @@ export default function Products({ customize }) {
               into your project as well.
             </p>
           </div>
+          <hr />
+          {listedPrices()}
         </div>
         <Footer />
       </Layout.Content>

--- a/src/packages/next/pages/pricing/index.tsx
+++ b/src/packages/next/pages/pricing/index.tsx
@@ -65,7 +65,7 @@ const dataSource: DataSource = [
   {
     link: "/pricing/onprem",
     title: "On Premises Installations",
-    logo: "laptop",
+    logo: "network-wired",
     description: (
       <>
         You can run CoCalc on{" "}
@@ -81,7 +81,7 @@ export default function Pricing({ customize }) {
       <Head title="Pricing" />
       <Header page="pricing" />
       <IndexList
-        title="Subscriptions and Pricing"
+        title="Products and Pricing"
         description={
           <>
             You can read more about {customize.siteName} products and

--- a/src/packages/next/pages/pricing/index.tsx
+++ b/src/packages/next/pages/pricing/index.tsx
@@ -1,12 +1,17 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import Footer from "components/landing/footer";
-import Header from "components/landing/header";
 import Head from "components/landing/head";
-import withCustomize from "lib/with-customize";
-import { Customize } from "lib/customize";
+import Header from "components/landing/header";
 import IndexList, { DataSource } from "components/landing/index-list";
 import A from "components/misc/A";
+import { Customize } from "lib/customize";
+import withCustomize from "lib/with-customize";
 
-const dataSource = [
+const dataSource: DataSource = [
   {
     link: "/pricing/products",
     title: "Products",
@@ -68,7 +73,7 @@ const dataSource = [
       </>
     ),
   },
-] as DataSource;
+];
 
 export default function Pricing({ customize }) {
   return (

--- a/src/packages/next/pages/pricing/onprem.tsx
+++ b/src/packages/next/pages/pricing/onprem.tsx
@@ -4,14 +4,17 @@
  */
 
 import { Icon } from "@cocalc/frontend/components/icon";
-import { Layout } from "antd";
+import { COLORS } from "@cocalc/util/theme";
+import { Alert, Layout, Typography } from "antd";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
 import A from "components/misc/A";
 import { MAX_WIDTH } from "lib/config";
-import { Customize } from "lib/customize";
+import { Customize, useCustomize } from "lib/customize";
 import withCustomize from "lib/with-customize";
+
+const { Paragraph, Text } = Typography;
 
 export default function OnPrem({ customize }) {
   return (
@@ -23,50 +26,92 @@ export default function OnPrem({ customize }) {
           backgroundColor: "white",
         }}
       >
-        <div
-          style={{
-            maxWidth: MAX_WIDTH,
-            margin: "15px auto",
-            padding: "15px",
-            backgroundColor: "white",
-          }}
-        >
-          <div style={{ textAlign: "center", color: "#444" }}>
-            <h1 style={{ fontSize: "28pt" }}>
-              {" "}
-              <Icon name="laptop" style={{ marginRight: "30px" }} /> CoCalc - On
-              Premises Offerings
-            </h1>
-          </div>
-          <div style={{ fontSize: "12pt" }}>
-            Contact us at <A href="mailto:help@cocalc.com">help@cocalc.com</A>{" "}
-            for questions about our commercial on premises offerings.
-            <br />
-            <br />
-            <ul>
-              <li style={{ margin: "10px 0" }}>
-                <A href="https://github.com/sagemathinc/cocalc-docker/blob/master/README.md">
-                  CoCalc-Docker:
-                </A>{" "}
-                use CoCalc on your own laptop, desktop or server ($999/year).
-              </li>
-              <li style={{ margin: "10px 0" }}>
-                <A href="https://github.com/sagemathinc/cocalc-kubernetes/blob/master/README.md">
-                  CoCalc-Kubernetes:
-                </A>{" "}
-                use CoCalc on a small Kubernetes cluster ($1499/year)
-              </li>
-              <li style={{ margin: "10px 0" }}>
-                <b>CoCalc-Cloud:</b> we manage CoCalc on your larger Kubernetes
-                cluster (<A href="mailto:help@cocalc.com">contact us</A> for
-                pricing).
-              </li>
-            </ul>
-          </div>
-        </div>
+        <Body />
         <Footer />
       </Layout.Content>
     </Customize>
+  );
+}
+
+function Body() {
+  const { helpEmail } = useCustomize();
+  return (
+    <div
+      style={{
+        maxWidth: MAX_WIDTH,
+        margin: "15px auto",
+        padding: "15px",
+        backgroundColor: "white",
+      }}
+    >
+      <div style={{ textAlign: "center", color: COLORS.GRAY_DD }}>
+        <h1 style={{ fontSize: "28pt" }}>
+          {" "}
+          <Icon name="laptop" style={{ marginRight: "30px" }} /> CoCalc - On
+          Premises Offerings
+        </h1>
+      </div>
+      <div>
+        <Alert
+          type="info"
+          banner={true}
+          showIcon={false}
+          style={{
+            textAlign: "center",
+            fontSize: "125%",
+            marginTop: "30px",
+            marginBottom: "30px",
+          }}
+          message={
+            <>
+              Contact us at <A href={`mailto:${helpEmail}`}>{helpEmail}</A> for
+              questions, licensing details, and purchase.
+            </>
+          }
+        />
+        <h2>CoCalc Docker</h2>
+        <Paragraph>
+          <Text strong>
+            <A
+              href={"https://github.com/sagemathinc/cocalc-docker#what-is-this"}
+            >
+              CoCalc Docker
+            </A>
+          </Text>{" "}
+          is a feature complete, but downsized version CoCalc. It can be used on
+          your own laptop, desktop or server. It is suitable for{" "}
+          <Text strong>personal use</Text> or a small{" "}
+          <Text strong>working group</Text>, e.g. a few researchers in an office
+          or lab.
+        </Paragraph>
+        <Text strong>Features</Text>: it includes support for Jupyter Notebooks,
+        a recent version of Sage, Python 3, R, Julia, Octave and LaTeX. Also,
+        X11 support, editing and compiling code and much more is included as
+        well. If something is missing, you could{" "}
+        <A
+          href={
+            "https://github.com/sagemathinc/cocalc-docker#adding-custom-software-to-your-cocalc-instance"
+          }
+        >
+          extend the base image
+        </A>{" "}
+        to your needs.
+        <Paragraph></Paragraph>
+        <Paragraph>
+          The setup is very easy: CoCalc Docker comes as a pre-packaged single
+          Docker image. All services are included and ready to work out of the
+          box.
+        </Paragraph>
+        <Paragraph>
+          The The license is business-friendly and costs $999/year.
+        </Paragraph>
+        <h2>CoCalc Cloud</h2>
+        <Paragraph>
+          Manage CoCalc on your larger Kubernetes cluster (
+          <A href={`mailto:${helpEmail}`}>contact us</A> for pricing).
+        </Paragraph>
+      </div>
+    </div>
   );
 }
 

--- a/src/packages/next/pages/pricing/onprem.tsx
+++ b/src/packages/next/pages/pricing/onprem.tsx
@@ -4,7 +4,6 @@
  */
 
 import { Icon } from "@cocalc/frontend/components/icon";
-import { DOC_CLOUD_STORAGE_URL } from "@cocalc/util/consts/project";
 import { COLORS } from "@cocalc/util/theme";
 import { Alert, Layout, Typography } from "antd";
 import Footer from "components/landing/footer";
@@ -51,8 +50,8 @@ function Body() {
               CoCalc Docker
             </A>
           </Text>{" "}
-          is a feature complete, but downsized version CoCalc. It can be used on
-          your own laptop, desktop or server. It is suitable for{" "}
+          is a downsized but feature complete version of CoCalc. It can be used
+          on your own laptop, desktop or server. It is suitable for{" "}
           <Text strong>personal use</Text> or a small{" "}
           <Text strong>working group</Text>, e.g. a few researchers in an office
           or lab.
@@ -71,9 +70,9 @@ function Body() {
         to fit your needs.
         <Paragraph></Paragraph>
         <Paragraph>
-          The setup is very easy: CoCalc Docker comes as a pre-packaged single
-          Docker image. All services are included and ready to work out of the
-          box.
+          The <Text strong>setup</Text> is very easy: CoCalc Docker comes as a
+          pre-packaged single <A href={"https://www.docker.com/"}>Docker</A>{" "}
+          image. All services are included and ready to work out of the box.
         </Paragraph>
         <Paragraph>
           The license is business-friendly and costs $999/year.
@@ -89,27 +88,26 @@ function Body() {
           CoCalc Cloud <Icon name="network-wired" style={{ float: "right" }} />
         </h2>
         <Paragraph>
-          This version of CoCalc on-prem runs on a full-fledged{" "}
+          This version of on-prem CoCalc runs on a full-fledged{" "}
           <A href={"https://kubernetes.io"}>Kubernetes Cluster</A>. The
-          underlying services and their architecture are the same as for the
-          SaaS site at <code>cocalc.com</code>. This means you get the same
-          overall performance, scalability and reliability as for the SaaS site.
+          underlying services and their architecture are the same as the ones
+          that power the main service at cocalc.com. This means you get the same
+          overall performance, scalability and reliability as the main SaaS
+          site.
         </Paragraph>
         <Paragraph>
-          <Text strong>Features:</Text>
+          <Text strong>Features</Text>
           <ul>
             <li>
-              Support for Jupyter Notebooks, a recent version of Sage, Python 3,
-              R, Julia, Octave and LaTeX. Editing code and text-files, Linux
-              terminal, compiling code, and virtual X11 desktop are included as
-              well.
+              Jupyter Notebooks, a recent version of Sage, Python 3, R, Octave
+              and LaTeX. Editing code and text-files, Linux terminal, compiling
+              code, and virtual X11 desktop are included as well. Beyond the
+              standard set of included software, it's also possible to define
+              and build customized software environments.
             </li>
             <li>
-              It's possible to define and build customized software environments
-              for projects.
-            </li>
-            <li>
-              Support for <Text strong>single-sign-on</Text>, in particular SAML
+              Support for <Text strong>single-sign-on</Text>, in particular,
+              includes SAML.
             </li>
             <li>
               The networking is defined by standard{" "}
@@ -120,24 +118,24 @@ function Body() {
             </li>
             <li>
               You can <Text strong>deploy</Text> this solution on your own
-              bare-metal cluster,{" "}
-              <A href={"https://aws.amazon.com/eks/"}>Amazon's AWS EKS</A>, or{" "}
+              bare-metal cluster or managed kubernetes clusters like{" "}
+              <A href={"https://aws.amazon.com/eks/"}>Amazon's AWS EKS</A> or{" "}
               <A href={"https://cloud.google.com/kubernetes-engine"}>
                 Google's GCE GKE
-              </A>{" "}
-              managed kubernetes clusters. Other options should work as well.
+              </A>
+              . Other options should work as well.
             </li>
           </ul>
         </Paragraph>
         <Paragraph>
-          <Text strong>Prerequesites</Text>:
+          <Text strong>Prerequisites</Text>
           <ul>
             <li>
               A <Text strong>Kubernetes cluster</Text> and some experience
-              managing it. We'll give you enough information to be able to
-              manage the services, react to any issues, know the exact resource
-              requirements, and know how to scale the various services to your
-              expected usage.
+              managing it. We'll guide you through the setup and give you enough
+              information to be able to manage the service, react to issues,
+              plan resource requirements, and know how to scale the various
+              services to your expected usage.
             </li>
             <li>
               Some experience working with{" "}
@@ -158,7 +156,7 @@ function Body() {
               database.
             </li>
             <li>
-              And finally regarding storage, a network file-system like{" "}
+              Regarding storage, a network file-system like{" "}
               <Text strong>NFS</Text>, supporting{" "}
               <A
                 href={
@@ -167,12 +165,12 @@ function Body() {
               >
                 ReadWriteMany
               </A>
-              .
+              , will hold the data of all projects.
             </li>
           </ul>
         </Paragraph>
         <Paragraph>
-          The license is business-friendly and{" "}
+          The license is business-friendly and please{" "}
           <A href={`mailto:${helpEmail}`}>contact us</A> for pricing.
         </Paragraph>
       </>
@@ -214,7 +212,7 @@ function Body() {
           }
         />
         {docker()}
-        <hr style={{ margin: "20px 0" }} />
+        <hr style={{ margin: "30px 0" }} />
         {cloud()}
       </div>
     </div>

--- a/src/packages/next/pages/pricing/onprem.tsx
+++ b/src/packages/next/pages/pricing/onprem.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Icon } from "@cocalc/frontend/components/icon";
+import { DOC_CLOUD_STORAGE_URL } from "@cocalc/util/consts/project";
 import { COLORS } from "@cocalc/util/theme";
 import { Alert, Layout, Typography } from "antd";
 import Footer from "components/landing/footer";
@@ -35,6 +36,149 @@ export default function OnPrem({ customize }) {
 
 function Body() {
   const { helpEmail } = useCustomize();
+
+  function docker(): JSX.Element {
+    return (
+      <>
+        <h2>
+          CoCalc Docker <Icon name="docker" style={{ float: "right" }} />
+        </h2>
+        <Paragraph>
+          <Text strong>
+            <A
+              href={"https://github.com/sagemathinc/cocalc-docker#what-is-this"}
+            >
+              CoCalc Docker
+            </A>
+          </Text>{" "}
+          is a feature complete, but downsized version CoCalc. It can be used on
+          your own laptop, desktop or server. It is suitable for{" "}
+          <Text strong>personal use</Text> or a small{" "}
+          <Text strong>working group</Text>, e.g. a few researchers in an office
+          or lab.
+        </Paragraph>
+        <Text strong>Features</Text>: it includes support for Jupyter Notebooks,
+        a recent version of Sage, Python 3, R, Julia, Octave and LaTeX. Also,
+        X11 support, editing and compiling code and much more is included as
+        well. If something is missing, you could{" "}
+        <A
+          href={
+            "https://github.com/sagemathinc/cocalc-docker#adding-custom-software-to-your-cocalc-instance"
+          }
+        >
+          extend the base image
+        </A>{" "}
+        to fit your needs.
+        <Paragraph></Paragraph>
+        <Paragraph>
+          The setup is very easy: CoCalc Docker comes as a pre-packaged single
+          Docker image. All services are included and ready to work out of the
+          box.
+        </Paragraph>
+        <Paragraph>
+          The license is business-friendly and costs $999/year.
+        </Paragraph>
+      </>
+    );
+  }
+
+  function cloud(): JSX.Element {
+    return (
+      <>
+        <h2>
+          CoCalc Cloud <Icon name="network-wired" style={{ float: "right" }} />
+        </h2>
+        <Paragraph>
+          This version of CoCalc on-prem runs on a full-fledged{" "}
+          <A href={"https://kubernetes.io"}>Kubernetes Cluster</A>. The
+          underlying services and their architecture are the same as for the
+          SaaS site at <code>cocalc.com</code>. This means you get the same
+          overall performance, scalability and reliability as for the SaaS site.
+        </Paragraph>
+        <Paragraph>
+          <Text strong>Features:</Text>
+          <ul>
+            <li>
+              Support for Jupyter Notebooks, a recent version of Sage, Python 3,
+              R, Julia, Octave and LaTeX. Editing code and text-files, Linux
+              terminal, compiling code, and virtual X11 desktop are included as
+              well.
+            </li>
+            <li>
+              It's possible to define and build customized software environments
+              for projects.
+            </li>
+            <li>
+              Support for <Text strong>single-sign-on</Text>, in particular SAML
+            </li>
+            <li>
+              The networking is defined by standard{" "}
+              <A href={"https://kubernetes.github.io/ingress-nginx/"}>
+                NGINX ingress rules
+              </A>
+              . It's possible to run inside a VPN as well.
+            </li>
+            <li>
+              You can <Text strong>deploy</Text> this solution on your own
+              bare-metal cluster,{" "}
+              <A href={"https://aws.amazon.com/eks/"}>Amazon's AWS EKS</A>, or{" "}
+              <A href={"https://cloud.google.com/kubernetes-engine"}>
+                Google's GCE GKE
+              </A>{" "}
+              managed kubernetes clusters. Other options should work as well.
+            </li>
+          </ul>
+        </Paragraph>
+        <Paragraph>
+          <Text strong>Prerequesites</Text>:
+          <ul>
+            <li>
+              A <Text strong>Kubernetes cluster</Text> and some experience
+              managing it. We'll give you enough information to be able to
+              manage the services, react to any issues, know the exact resource
+              requirements, and know how to scale the various services to your
+              expected usage.
+            </li>
+            <li>
+              Some experience working with{" "}
+              <A href={"https://helm.sh/"}>
+                <Text strong>HELM</Text> charts
+              </A>
+              .
+            </li>
+            <li>
+              A (sub)<Text strong>domain</Text> and TLS certificate (e.g.{" "}
+              <A href={"https://letsencrypt.org/"}>letsencrypt</A>).
+            </li>
+            <li>
+              A standard{" "}
+              <A href={"https://www.postgresql.org/"}>
+                <Text strong>PostgreSQL</Text>
+              </A>{" "}
+              database.
+            </li>
+            <li>
+              And finally regarding storage, a network file-system like{" "}
+              <Text strong>NFS</Text>, supporting{" "}
+              <A
+                href={
+                  "https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes"
+                }
+              >
+                ReadWriteMany
+              </A>
+              .
+            </li>
+          </ul>
+        </Paragraph>
+        <Paragraph>
+          The license is business-friendly and{" "}
+          <A href={`mailto:${helpEmail}`}>contact us</A> for pricing.
+        </Paragraph>
+      </>
+    );
+  }
+
   return (
     <div
       style={{
@@ -65,51 +209,13 @@ function Body() {
           message={
             <>
               Contact us at <A href={`mailto:${helpEmail}`}>{helpEmail}</A> for
-              questions, licensing details, and purchase.
+              questions, licensing details, and purchasing.
             </>
           }
         />
-        <h2>CoCalc Docker</h2>
-        <Paragraph>
-          <Text strong>
-            <A
-              href={"https://github.com/sagemathinc/cocalc-docker#what-is-this"}
-            >
-              CoCalc Docker
-            </A>
-          </Text>{" "}
-          is a feature complete, but downsized version CoCalc. It can be used on
-          your own laptop, desktop or server. It is suitable for{" "}
-          <Text strong>personal use</Text> or a small{" "}
-          <Text strong>working group</Text>, e.g. a few researchers in an office
-          or lab.
-        </Paragraph>
-        <Text strong>Features</Text>: it includes support for Jupyter Notebooks,
-        a recent version of Sage, Python 3, R, Julia, Octave and LaTeX. Also,
-        X11 support, editing and compiling code and much more is included as
-        well. If something is missing, you could{" "}
-        <A
-          href={
-            "https://github.com/sagemathinc/cocalc-docker#adding-custom-software-to-your-cocalc-instance"
-          }
-        >
-          extend the base image
-        </A>{" "}
-        to your needs.
-        <Paragraph></Paragraph>
-        <Paragraph>
-          The setup is very easy: CoCalc Docker comes as a pre-packaged single
-          Docker image. All services are included and ready to work out of the
-          box.
-        </Paragraph>
-        <Paragraph>
-          The The license is business-friendly and costs $999/year.
-        </Paragraph>
-        <h2>CoCalc Cloud</h2>
-        <Paragraph>
-          Manage CoCalc on your larger Kubernetes cluster (
-          <A href={`mailto:${helpEmail}`}>contact us</A> for pricing).
-        </Paragraph>
+        {docker()}
+        <hr style={{ margin: "20px 0" }} />
+        {cloud()}
       </div>
     </div>
   );

--- a/src/packages/next/pages/pricing/onprem.tsx
+++ b/src/packages/next/pages/pricing/onprem.tsx
@@ -1,12 +1,17 @@
-import Footer from "components/landing/footer";
-import Header from "components/landing/header";
-import Head from "components/landing/head";
-import { Layout } from "antd";
-import withCustomize from "lib/with-customize";
-import { Customize } from "lib/customize";
-import A from "components/misc/A";
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Icon } from "@cocalc/frontend/components/icon";
+import { Layout } from "antd";
+import Footer from "components/landing/footer";
+import Head from "components/landing/head";
+import Header from "components/landing/header";
+import A from "components/misc/A";
 import { MAX_WIDTH } from "lib/config";
+import { Customize } from "lib/customize";
+import withCustomize from "lib/with-customize";
 
 export default function OnPrem({ customize }) {
   return (

--- a/src/packages/next/pages/pricing/products.tsx
+++ b/src/packages/next/pages/pricing/products.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Icon } from "@cocalc/frontend/components/icon";
-import { Layout } from "antd";
+import { Layout, Typography } from "antd";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
@@ -12,6 +12,8 @@ import A from "components/misc/A";
 import { MAX_WIDTH } from "lib/config";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
+
+const { Text } = Typography;
 
 export default function Products({ customize }) {
   return (
@@ -23,176 +25,145 @@ export default function Products({ customize }) {
           backgroundColor: "white",
         }}
       >
-        <div
-          style={{
-            maxWidth: MAX_WIDTH,
-            margin: "15px auto",
-            padding: "15px",
-            backgroundColor: "white",
-          }}
-        >
-          <div style={{ textAlign: "center", color: "#444" }}>
-            <h1 style={{ fontSize: "28pt" }}>
-              <Icon name="credit-card" style={{ marginRight: "30px" }} /> CoCalc
-              - Products
-            </h1>
-          </div>
-          <div style={{ fontSize: "12pt" }}>
-            <p>
-              Initially, you start using CoCalc under a{" "}
-              <A href="https://doc.cocalc.com/trial.html">free trial plan</A> in
-              order to test out the service. If CoCalc works for you, please
-              purchase a license.
-            </p>
-            <p>
-              You can{" "}
-              <A href="/store/site-license">
-                <strong>purchase a license in the store</strong>
-              </A>
-              .
-            </p>
-            <p>
-              Any subscription or{" "}
-              <A href="https://doc.cocalc.com/account/licenses.html">
-                license upgrade
-              </A>{" "}
-              must be{" "}
-              <A href="https://doc.cocalc.com/project-settings.html#project-usage-and-quotas">
-                applied explicitly to your project
-              </A>{" "}
-              or{" "}
-              <A href="https://doc.cocalc.com/teaching-notes.html#site-license-course-setup">
-                distributed to student projects
-              </A>
-              .
-            </p>
-            <p>
-              Listed prices are in <b>US dollars</b>. When charging in local
-              currency, the prices are converted into local currency using the
-              conversion rates published by leading financial institutions.{" "}
-            </p>
-            <br />
-
-            <h2>Questions</h2>
-            <p>
-              Please immediately email us at{" "}
-              <A href="mailto:help@cocalc.com">help@cocalc.com</A> if anything
-              is unclear to you. Also, contact us if you need customized{" "}
-              <A href="/pricing/courses">course packages</A>, modified{" "}
-              <A href="/policies/terms">terms of service</A>, additional{" "}
-              <A href="/policies/privacy">legal</A>{" "}
-              <A href="/policies/ferpa">agreements</A>, purchase orders or
-              priority technical support.
-            </p>
-            <br />
-
-            <h2>Projects</h2>
-            <p>
-              Your work on <span>CoCalc</span> happens inside one or more{" "}
-              <A href="https://doc.cocalc.com/project.html">projects</A>. They
-              form your personal workspaces, where you privately store your
-              files, computational worksheets, and data. You typically run
-              computations through a web browser, either via a{" "}
-              <A href="https://doc.cocalc.com/sagews.html">Sage Worksheet</A>,{" "}
-              <A href="https://doc.cocalc.com/jupyter.html">Jupyter Notebook</A>
-              , or by executing a program in a{" "}
-              <A href="https://doc.cocalc.com/terminal.html">terminal</A>. You
-              can also{" "}
-              <A href="https://doc.cocalc.com/project-settings.html#add-new-collaborators">
-                invite collaborators
-              </A>{" "}
-              to work with you inside a project, and you can explicitly make
-              files or directories{" "}
-              <A href="https://doc.cocalc.com/share.html">
-                publicly available to everybody
-              </A>
-              .
-            </p>
-
-            <br />
-            <h2>Shared Resources</h2>
-            <p>
-              Each project runs on a server, where it shares disk space, CPU,
-              and RAM with other projects. Initially, you work in a{" "}
-              <A href="https://doc.cocalc.com/trial.html">trial project</A>,
-              which runs with default quotas on heavily used machines that are
-              rebooted frequently. Upgrading to "member hosting" moves your
-              project to a machine with higher-quality hosting and less
-              competition for resources.
-            </p>
-
-            <h2>Upgrading Projects</h2>
-            <p>
-              By purchasing one or more of our subscriptions or plans, you
-              receive a certain amount of{" "}
-              <A href="https://doc.cocalc.com/billing.html#quota-upgrades">
-                quota upgrades
-              </A>
-              . Use these upgrades to improve hosting quality, enable internet
-              access from within a project or increase quotas for CPU and RAM in
-              order to work on larger problems and do more computations
-              simultaneously. On top of that, your{" "}
-              <A href="mailto:help@cocalc.com">support questions</A> are
-              prioritized.
-            </p>
-            <p>
-              All project collaborators <em>collectively contribute</em> to the
-              same project — their contributions benefit all project
-              collaborators equally.
-            </p>
-
-            <br />
-            <h2>License Keys</h2>
-            <p>
-              <A href="https://doc.cocalc.com/licenses.html">License Keys</A>{" "}
-              are applied to projects. One license key can upgrade up to a
-              certain number of <b>simultaneously running projects</b> with the
-              given upgrade schema. You can apply a single license key to an
-              unlimited number of projects.
-            </p>
-            <p>The following parameters determine the price:</p>
-            <ul style={{ paddingLeft: "20px" }}>
-              <li>The number of projects</li>
-              <li>If you qualify for an academic discount</li>
-              <li>
-                Upgrade schema per project: a small 1 GB memory / 1 shared CPU
-                upgrade is fine for basic calculations, but we find that many
-                data and computational science projects run better with
-                additional RAM and CPU.
-              </li>
-              <li>
-                Duration: monthly/yearly subscription or explicit start and end
-                dates.
-              </li>
-              <li>
-                Purchase method: online self-service purchasing versus a
-                purchase order (which may require customized terms of service,
-                wire transfers, etc.)
-              </li>
-            </ul>
-
-            <br />
-            <h2>Frequently Asked Questions</h2>
-            <div>
-              <A id="faq"></A>
-              <ul style={{ paddingLeft: "20px" }}>
-                <li>
-                  <A href="https://doc.cocalc.com/billing.html">
-                    Billing, quotas, and upgrades FAQ
-                  </A>
-                </li>
-                <li>
-                  <A href="https://doc.cocalc.com/project-faq.html">
-                    Projects FAQ
-                  </A>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
+        <Body />
         <Footer />
       </Layout.Content>
     </Customize>
+  );
+}
+
+function Body(): JSX.Element {
+  return (
+    <div
+      style={{
+        maxWidth: MAX_WIDTH,
+        margin: "15px auto",
+        padding: "15px",
+        backgroundColor: "white",
+      }}
+    >
+      <div style={{ textAlign: "center", color: "#444" }}>
+        <h1 style={{ fontSize: "28pt" }}>
+          <Icon name="credit-card" style={{ marginRight: "30px" }} /> CoCalc -
+          Products
+        </h1>
+      </div>
+      <div style={{ fontSize: "12pt" }}>
+        <h2>Collaborative projects</h2>
+        <p>
+          Your work on <span>CoCalc</span> happens inside one or more{" "}
+          <A href="https://doc.cocalc.com/project.html">projects</A>. They form
+          your personal workspaces, where you privately store your files,
+          computational worksheets, and data. You typically run computations
+          through a web browser, either via a{" "}
+          <A href="https://doc.cocalc.com/sagews.html">Sage Worksheet</A>,{" "}
+          <A href="https://doc.cocalc.com/jupyter.html">Jupyter Notebook</A>, or
+          by executing a program in a{" "}
+          <A href="https://doc.cocalc.com/terminal.html">terminal</A>. You can
+          also{" "}
+          <A href="https://doc.cocalc.com/project-settings.html#add-new-collaborators">
+            invite collaborators
+          </A>{" "}
+          to work with you inside a project, and you can explicitly make files
+          or directories{" "}
+          <A href="https://doc.cocalc.com/share.html">
+            publicly available to everybody
+          </A>
+          .
+        </p>
+
+        <h2>Teaching Courses</h2>
+        <p>
+          Teaching a course on CoCalc usually involves one{" "}
+          <Text italic>instructor project</Text> hosting the course and one
+          project for each student. Additionally, a shared project could be set
+          up as a common space. Please check out{" "}
+          <Text strong>
+            <A href="./courses">course licenses</A>
+          </Text>{" "}
+          for more details.
+        </p>
+
+        <h2>Project resources</h2>
+        <p>
+          Each project runs on a server, where it shares disk space, CPU, and
+          RAM with other projects. Initially, you work in a{" "}
+          <A href="https://doc.cocalc.com/trial.html">trial project</A>, which
+          runs with default quotas on heavily used machines that are rebooted
+          frequently. Upgrading to "member hosting" moves your project to a
+          machine with higher-quality hosting and less competition for
+          resources.
+        </p>
+
+        <h2>Upgrading projects</h2>
+        <p>
+          Each license you purchase provides upgrades to the project{" "}
+          <A href="https://doc.cocalc.com/project-settings.html#add-a-license-to-a-project">
+            the license is assigned to
+          </A>
+          . This improves hosting quality, enables internet access from within a
+          project or increases quotas for CPU and RAM in order to work on larger
+          problems and do more computations simultaneously. On top of that, your{" "}
+          <A href="mailto:help@cocalc.com">support questions</A> are
+          prioritized.
+        </p>
+        <p>
+          All project collaborators <em>collectively contribute</em> to the same
+          project — their contributions benefit all project collaborators
+          equally.
+        </p>
+
+        <h2>License Keys</h2>
+        <p>
+          <A href="https://doc.cocalc.com/licenses.html">License Keys</A> are
+          applied to projects. One license key can upgrade up to a certain
+          number of <b>simultaneously running projects</b> with the given
+          upgrade schema. You can apply a single license key to an unlimited
+          number of projects.
+        </p>
+        <p>The following parameters determine the price:</p>
+        <ul style={{ paddingLeft: "20px" }}>
+          <li>The number of projects</li>
+          <li>If you qualify for an academic discount</li>
+          <li>
+            Upgrade schema per project: a small 2 GB memory / 1 shared CPU
+            upgrade is fine for basic calculations, but we find that many data
+            and computational science projects run better with additional RAM
+            and CPU.
+          </li>
+          <li>
+            Duration: monthly/yearly subscription or explicit start and end
+            dates.
+          </li>
+          <li>
+            Purchase method: online self-service purchasing versus a purchase
+            order (which may require customized terms of service, wire
+            transfers, etc.)
+          </li>
+        </ul>
+
+        <h2>Frequently Asked Questions</h2>
+        <div>
+          <A id="faq"></A>
+          <ul style={{ paddingLeft: "20px" }}>
+            <li>
+              <A href="https://doc.cocalc.com/billing.html">
+                Billing, quotas, and upgrades FAQ
+              </A>
+            </li>
+            <li>
+              <A href="https://doc.cocalc.com/project-faq.html">Projects FAQ</A>
+            </li>
+          </ul>
+        </div>
+
+        <h2>On premises</h2>
+        <div>
+          It's also possible to run CoCalc on your own hardware. Please see{" "}
+          <A href={"./onprem"}>on premises options</A> for more information.
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/packages/next/pages/pricing/products.tsx
+++ b/src/packages/next/pages/pricing/products.tsx
@@ -1,12 +1,17 @@
-import Footer from "components/landing/footer";
-import Header from "components/landing/header";
-import Head from "components/landing/head";
-import { Layout } from "antd";
-import withCustomize from "lib/with-customize";
-import { Customize } from "lib/customize";
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Icon } from "@cocalc/frontend/components/icon";
+import { Layout } from "antd";
+import Footer from "components/landing/footer";
+import Head from "components/landing/head";
+import Header from "components/landing/header";
 import A from "components/misc/A";
 import { MAX_WIDTH } from "lib/config";
+import { Customize } from "lib/customize";
+import withCustomize from "lib/with-customize";
 
 export default function Products({ customize }) {
   return (
@@ -145,28 +150,26 @@ export default function Products({ customize }) {
               given upgrade schema. You can apply a single license key to an
               unlimited number of projects.
             </p>
-            <p>
-              The following parameters determine the price:
-              <ul style={{ paddingLeft: "20px" }}>
-                <li>The number of projects</li>
-                <li>If you qualify for an academic discount</li>
-                <li>
-                  Upgrade schema per project: a small 1 GB memory / 1 shared CPU
-                  upgrade is fine for basic calculations, but we find that many
-                  data and computational science projects run better with
-                  additional RAM and CPU.
-                </li>
-                <li>
-                  Duration: monthly/yearly subscription or explicit start and
-                  end dates.
-                </li>
-                <li>
-                  Purchase method: online self-service purchasing versus a
-                  purchase order (which may require customized terms of service,
-                  wire transfers, etc.)
-                </li>
-              </ul>
-            </p>
+            <p>The following parameters determine the price:</p>
+            <ul style={{ paddingLeft: "20px" }}>
+              <li>The number of projects</li>
+              <li>If you qualify for an academic discount</li>
+              <li>
+                Upgrade schema per project: a small 1 GB memory / 1 shared CPU
+                upgrade is fine for basic calculations, but we find that many
+                data and computational science projects run better with
+                additional RAM and CPU.
+              </li>
+              <li>
+                Duration: monthly/yearly subscription or explicit start and end
+                dates.
+              </li>
+              <li>
+                Purchase method: online self-service purchasing versus a
+                purchase order (which may require customized terms of service,
+                wire transfers, etc.)
+              </li>
+            </ul>
 
             <br />
             <h2>Frequently Asked Questions</h2>

--- a/src/packages/next/pages/pricing/subscriptions.tsx
+++ b/src/packages/next/pages/pricing/subscriptions.tsx
@@ -1,13 +1,27 @@
-import Footer from "components/landing/footer";
-import Header from "components/landing/header";
-import Head from "components/landing/head";
-import { Alert, Layout, List } from "antd";
-import withCustomize from "lib/with-customize";
-import { Customize } from "lib/customize";
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Icon, IconName } from "@cocalc/frontend/components/icon";
-import A from "components/misc/A";
+import { LicenseIdleTimeouts } from "@cocalc/util/consts/site-license";
+import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
+import {
+  discount_monthly_pct,
+  discount_yearly_pct,
+  MIN_QUOTE,
+} from "@cocalc/util/licenses/purchase/consts";
+import { PurchaseInfo } from "@cocalc/util/licenses/purchase/types";
+import { round2 } from "@cocalc/util/misc";
+import { Alert, Layout, List } from "antd";
+import Footer from "components/landing/footer";
+import Head from "components/landing/head";
+import Header from "components/landing/header";
 import PricingItem, { Line } from "components/landing/pricing-item";
+import A from "components/misc/A";
 import { MAX_WIDTH } from "lib/config";
+import { Customize } from "lib/customize";
+import withCustomize from "lib/with-customize";
 
 interface Item {
   title: string;
@@ -15,55 +29,135 @@ interface Item {
   projects: number;
   disk: number;
   shared_ram: number;
-  dedicated_ram?: number;
   shared_cores: number;
-  dedicated_cores?: number;
   academic?: boolean;
+  uptime?: string;
   monthly?: number;
   yearly?: number;
 }
 
-const data: Item[] = [
-  {
+const hobby: Item = (() => {
+  const conf = { n: 2, disk: 3, ram: 2, cpu: 1, uptime: "short" } as const;
+
+  const info: PurchaseInfo = {
+    type: "quota",
+    user: "academic",
+    upgrade: "custom",
+    quantity: conf.n,
+    subscription: "monthly",
+    start: new Date(),
+    custom_ram: conf.ram,
+    custom_cpu: conf.cpu,
+    custom_disk: conf.disk,
+    custom_member: true,
+    custom_dedicated_ram: 0,
+    custom_dedicated_cpu: 0,
+    custom_uptime: conf.uptime,
+  };
+
+  const priceM = compute_cost(info);
+  const priceY = compute_cost({ ...info, subscription: "yearly" });
+
+  return {
     title: "Hobbyist",
     icon: "battery-quarter",
-    projects: 2,
-    shared_ram: 1,
-    shared_cores: 1,
-    disk: 1,
-    dedicated_ram: 0,
-    dedicated_cores: 0,
+    projects: conf.n,
+    shared_ram: conf.ram,
+    shared_cores: conf.cpu,
+    disk: conf.disk,
     academic: true,
-    monthly: 6.15,
-    yearly: 69.65,
-  },
-  {
+    uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
+    monthly: round2(priceM.discounted_cost),
+    yearly: round2(priceY.discounted_cost),
+  };
+})();
+
+const academic: Item = (() => {
+  const conf = {
+    n: 3,
+    disk: 10,
+    ram: 5,
+    cpu: 2,
+    uptime: "day",
+  } as const;
+
+  const info: PurchaseInfo = {
+    type: "quota",
+    user: "academic",
+    upgrade: "custom",
+    quantity: conf.n,
+    subscription: "monthly",
+    start: new Date(),
+    custom_ram: conf.ram,
+    custom_cpu: conf.cpu,
+    custom_disk: conf.disk,
+    custom_member: true,
+    custom_dedicated_ram: 0,
+    custom_dedicated_cpu: 0,
+    custom_uptime: conf.uptime,
+  };
+
+  const priceM = compute_cost(info);
+  const priceY = compute_cost({ ...info, subscription: "yearly" });
+
+  return {
     title: "Academic Researcher Group",
     icon: "battery-half",
-    projects: 7,
-    shared_ram: 5,
-    dedicated_ram: 1,
-    shared_cores: 2,
-    disk: 10,
+    projects: conf.n,
+    shared_ram: conf.ram,
+    shared_cores: conf.cpu,
+    disk: conf.disk,
     dedicated_cores: 0,
     academic: true,
-    monthly: 73.36,
-    yearly: 831.36,
-  },
-  {
+    uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
+    monthly: round2(priceM.discounted_cost),
+    yearly: round2(priceY.discounted_cost),
+  };
+})();
+
+const business: Item = (() => {
+  const conf = {
+    n: 5,
+    disk: 5,
+    ram: 4,
+    cpu: 1,
+    uptime: "medium",
+  } as const;
+
+  const info: PurchaseInfo = {
+    type: "quota",
+    user: "business",
+    upgrade: "custom",
+    quantity: conf.n,
+    subscription: "monthly",
+    start: new Date(),
+    custom_ram: conf.ram,
+    custom_cpu: conf.cpu,
+    custom_disk: conf.disk,
+    custom_member: true,
+    custom_dedicated_ram: 0,
+    custom_dedicated_cpu: 0,
+    custom_uptime: conf.uptime,
+  };
+
+  const priceM = compute_cost(info);
+  const priceY = compute_cost({ ...info, subscription: "yearly" });
+
+  return {
     title: "Business Working Group",
     icon: "battery-full",
-    projects: 3,
-    shared_ram: 3,
-    shared_cores: 1,
-    disk: 5,
-    dedicated_ram: 0,
-    dedicated_cores: 1,
+    projects: conf.n,
+    shared_ram: conf.ram,
+    shared_cores: conf.cpu,
+    disk: conf.disk,
     academic: false,
-    monthly: 157.85,
-    yearly: 1788.95,
-  },
-];
+    uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
+    monthly: round2(priceM.discounted_cost),
+    yearly: round2(priceY.discounted_cost),
+  };
+})();
+
+const data: Item[] = [hobby, academic, business];
 
 export default function Subscriptions({ customize }) {
   return (
@@ -126,9 +220,10 @@ export default function Subscriptions({ customize }) {
               We list three typical configurations below, which you can{" "}
               <A href="/store/site-license">modify and purchase here</A>. All
               parameters can be adjusted to fit your needs. Listed upgrades are
-              for each project. Exact prices may vary. Below $100, only online
-              purchases are available (no purchase orders). Subscriptions
-              receive a 10% discount for monthly and 15% for yearly periods.
+              for each project. Exact prices may vary. Below ${MIN_QUOTE}, only
+              online purchases are available (no purchase orders). Subscriptions
+              receive a {discount_monthly_pct}% discount for monthly and{" "}
+              {discount_yearly_pct}% for yearly periods.
             </p>
             <List
               grid={{ gutter: 16, column: 3, xs: 1, sm: 1 }}
@@ -145,14 +240,7 @@ export default function Subscriptions({ customize }) {
                     desc="Shared CPU per project"
                   />
                   <Line amount={item.disk} desc="Disk space per project" />
-                  <Line
-                    amount={item.dedicated_ram}
-                    desc="Dedicated RAM per project"
-                  />
-                  <Line
-                    amount={item.dedicated_cores}
-                    desc="Dedicated CPU per project"
-                  />
+                  <Line amount={item.uptime} desc="Idle timeout" />
                   <Line amount={"Unlimited"} desc="Collaborators" />
                   {item.academic ? (
                     <Line amount="40%" desc="Academic discount" />

--- a/src/packages/next/pages/pricing/subscriptions.tsx
+++ b/src/packages/next/pages/pricing/subscriptions.tsx
@@ -24,6 +24,7 @@ import { LinkToStore, StoreConf } from "components/store/link";
 import { MAX_WIDTH } from "lib/config";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
+import { applyLicense, listedPrices, pricingQuestions } from "./_shared";
 
 interface Item {
   title: string;
@@ -174,6 +175,23 @@ const business: Item = (() => {
 
 const data: Item[] = [hobby, academic, business];
 
+function dedicated(): JSX.Element {
+  return (
+    <Alert
+      style={{ margin: "15px 0" }}
+      message="Dedicated Virtual Machines"
+      description={
+        <span style={{ fontSize: "11pt" }}>
+          For more intensive workloads you can also rent a{" "}
+          <A href="/pricing/dedicated">dedicated virtual machine or disk</A>.
+        </span>
+      }
+      type="info"
+      showIcon
+    />
+  );
+}
+
 export default function Subscriptions({ customize }) {
   return (
     <Customize value={customize}>
@@ -184,120 +202,117 @@ export default function Subscriptions({ customize }) {
           backgroundColor: "white",
         }}
       >
-        <div
-          style={{
-            maxWidth: MAX_WIDTH,
-            margin: "15px auto",
-            padding: "15px",
-            backgroundColor: "white",
-          }}
-        >
-          <div style={{ textAlign: "center", color: "#444" }}>
-            <h1 style={{ fontSize: "28pt" }}>
-              <Icon name="calendar" style={{ marginRight: "30px" }} /> CoCalc -
-              Subscriptions
-            </h1>
-          </div>
-          <div style={{ fontSize: "12pt" }}>
-            <a id="subscriptions"></a>
-            <p>
-              A subscription provides you with a{" "}
-              <A href="https://doc.cocalc.com/licenses.html">license key</A> for{" "}
-              <A href="https://doc.cocalc.com/project-settings.html#licenses">
-                upgrading your projects
-              </A>{" "}
-              or other projects where you are a collaborator — everyone using an
-              upgraded project benefits equally. Such a{" "}
-              <A href="/billing/subscriptions">subscription</A>{" "}
-              <b>automatically renews</b> at the end of each period. You can{" "}
-              <A href="/billing/subscriptions">
-                <b>cancel at any time</b>
-              </A>
-              .
-            </p>
-            <Alert
-              style={{ margin: "15px 0" }}
-              message="Dedicated Virtual Machines"
-              description={
-                <span style={{ fontSize: "11pt" }}>
-                  For more intensive workloads you can also rent a{" "}
-                  <A href="/pricing/dedicated">
-                    dedicated virtual machine or disk
-                  </A>
-                  .
-                </span>
-              }
-              type="info"
-              showIcon
-            />
-            <h2>Examples</h2>
-            <p>
-              We list three typical configurations below, which you can{" "}
-              <A href="/store/site-license">modify and purchase here</A>. All
-              parameters can be adjusted to fit your needs. Listed upgrades are
-              for each project. Exact prices may vary. Below ${MIN_QUOTE}, only
-              online purchases are available (no purchase orders). Subscriptions
-              receive a {discount_monthly_pct}% discount for monthly and{" "}
-              {discount_yearly_pct}% for yearly periods.
-            </p>
-            <List
-              grid={{ gutter: 16, column: 3, xs: 1, sm: 1 }}
-              dataSource={data}
-              renderItem={(item) => (
-                <PricingItem title={item.title} icon={item.icon}>
-                  <Line amount={item.projects} desc="Projects" />
-                  <Line
-                    amount={item.shared_ram}
-                    desc="Shared RAM per project"
-                  />
-                  <Line
-                    amount={item.shared_cores}
-                    desc="Shared CPU per project"
-                  />
-                  <Line amount={item.disk} desc="Disk space per project" />
-                  <Line amount={item.uptime} desc="Idle timeout" />
-                  <Line amount={"Unlimited"} desc="Collaborators" />
-                  {item.academic ? (
-                    <Line amount="40%" desc="Academic discount" />
-                  ) : (
-                    <Line amount="" desc="" />
-                  )}
-
-                  <br />
-                  <br />
-                  <div>
-                    <span
-                      style={{
-                        fontWeight: "bold",
-                        fontSize: "18pt",
-                        color: COLORS.GRAY_DD,
-                      }}
-                    >
-                      {money(item.monthly, true)}
-                    </span>{" "}
-                    / month
-                  </div>
-                  <div>
-                    <span
-                      style={{
-                        fontWeight: "bold",
-                        fontSize: "18pt",
-                        color: COLORS.GRAY_DD,
-                      }}
-                    >
-                      {money(item.yearly, true)}
-                    </span>{" "}
-                    / year
-                  </div>
-                  <LinkToStore conf={item.conf} />
-                </PricingItem>
-              )}
-            />
-          </div>
-        </div>
+        <Body />
         <Footer />
       </Layout.Content>
     </Customize>
+  );
+}
+
+function Body(): JSX.Element {
+  return (
+    <div
+      style={{
+        maxWidth: MAX_WIDTH,
+        margin: "15px auto",
+        padding: "15px",
+        backgroundColor: "white",
+      }}
+    >
+      <div style={{ textAlign: "center", color: "#444" }}>
+        <h1 style={{ fontSize: "28pt" }}>
+          <Icon name="calendar" style={{ marginRight: "30px" }} /> CoCalc -
+          Subscriptions
+        </h1>
+      </div>
+      <div style={{ fontSize: "12pt" }}>
+        <a id="subscriptions"></a>
+        <p>
+          Initially, you start using CoCalc under a{" "}
+          <A href="https://doc.cocalc.com/trial.html">free trial plan</A> in
+          order to test out the service. If CoCalc works for you, please
+          purchase a license.
+        </p>
+        <p>
+          A subscription provides you with a{" "}
+          <A href="https://doc.cocalc.com/licenses.html">license key</A> for{" "}
+          <A href="https://doc.cocalc.com/project-settings.html#licenses">
+            upgrading your projects
+          </A>{" "}
+          or other projects where you are a collaborator — everyone using an
+          upgraded project benefits equally. Such a{" "}
+          <A href="/billing/subscriptions">subscription</A>{" "}
+          <b>automatically renews</b> at the end of each period. You can{" "}
+          <A href="/billing/subscriptions">
+            <b>cancel at any time</b>
+          </A>
+          .
+        </p>
+
+        {applyLicense()}
+
+        <h2>Examples</h2>
+        <p>
+          We list three typical configurations below, which you can{" "}
+          <A href="/store/site-license">modify and purchase here</A>. All
+          parameters can be adjusted to fit your needs. Listed upgrades are for
+          each project. Exact prices may vary. Below ${MIN_QUOTE}, only online
+          purchases are available (no purchase orders). Subscriptions receive a{" "}
+          {discount_monthly_pct}% discount for monthly and {discount_yearly_pct}
+          % for yearly periods.
+        </p>
+        <List
+          grid={{ gutter: 16, column: 3, xs: 1, sm: 1 }}
+          dataSource={data}
+          renderItem={(item) => (
+            <PricingItem title={item.title} icon={item.icon}>
+              <Line amount={item.projects} desc="Projects" />
+              <Line amount={item.shared_ram} desc="Shared RAM per project" />
+              <Line amount={item.shared_cores} desc="Shared CPU per project" />
+              <Line amount={item.disk} desc="Disk space per project" />
+              <Line amount={item.uptime} desc="Idle timeout" />
+              <Line amount={"Unlimited"} desc="Collaborators" />
+              {item.academic ? (
+                <Line amount="40%" desc="Academic discount" />
+              ) : (
+                <Line amount="" desc="" />
+              )}
+
+              <br />
+              <br />
+              <div>
+                <span
+                  style={{
+                    fontWeight: "bold",
+                    fontSize: "18pt",
+                    color: COLORS.GRAY_DD,
+                  }}
+                >
+                  {money(item.monthly, true)}
+                </span>{" "}
+                / month
+              </div>
+              <div>
+                <span
+                  style={{
+                    fontWeight: "bold",
+                    fontSize: "18pt",
+                    color: COLORS.GRAY_DD,
+                  }}
+                >
+                  {money(item.yearly, true)}
+                </span>{" "}
+                / year
+              </div>
+              <LinkToStore conf={item.conf} />
+            </PricingItem>
+          )}
+        />
+        {listedPrices()}
+        {pricingQuestions()}
+      </div>
+      {dedicated()}
+    </div>
   );
 }
 

--- a/src/packages/next/pages/pricing/subscriptions.tsx
+++ b/src/packages/next/pages/pricing/subscriptions.tsx
@@ -12,13 +12,15 @@ import {
   MIN_QUOTE,
 } from "@cocalc/util/licenses/purchase/consts";
 import { PurchaseInfo } from "@cocalc/util/licenses/purchase/types";
-import { round2 } from "@cocalc/util/misc";
+import { money } from "@cocalc/util/licenses/purchase/utils";
+import { COLORS } from "@cocalc/util/theme";
 import { Alert, Layout, List } from "antd";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
 import PricingItem, { Line } from "components/landing/pricing-item";
 import A from "components/misc/A";
+import { LinkToStore, StoreConf } from "components/store/link";
 import { MAX_WIDTH } from "lib/config";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
@@ -32,18 +34,26 @@ interface Item {
   shared_cores: number;
   academic?: boolean;
   uptime?: string;
-  monthly?: number;
-  yearly?: number;
+  monthly: number;
+  yearly: number;
+  conf: StoreConf;
 }
 
 const hobby: Item = (() => {
-  const conf = { n: 2, disk: 3, ram: 2, cpu: 1, uptime: "short" } as const;
+  const conf = {
+    run_limit: 2,
+    disk: 3,
+    ram: 2,
+    cpu: 1,
+    uptime: "short",
+    user: "academic",
+  } as const;
 
   const info: PurchaseInfo = {
     type: "quota",
-    user: "academic",
+    user: conf.user,
     upgrade: "custom",
-    quantity: conf.n,
+    quantity: conf.run_limit,
     subscription: "monthly",
     start: new Date(),
     custom_ram: conf.ram,
@@ -61,31 +71,33 @@ const hobby: Item = (() => {
   return {
     title: "Hobbyist",
     icon: "battery-quarter",
-    projects: conf.n,
+    projects: conf.run_limit,
     shared_ram: conf.ram,
     shared_cores: conf.cpu,
     disk: conf.disk,
     academic: true,
     uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
-    monthly: round2(priceM.discounted_cost),
-    yearly: round2(priceY.discounted_cost),
+    monthly: priceM.discounted_cost,
+    yearly: priceY.discounted_cost,
+    conf,
   };
 })();
 
 const academic: Item = (() => {
   const conf = {
-    n: 3,
+    run_limit: 3,
     disk: 10,
     ram: 5,
     cpu: 2,
     uptime: "day",
+    user: "academic",
   } as const;
 
   const info: PurchaseInfo = {
     type: "quota",
-    user: "academic",
+    user: conf.user,
     upgrade: "custom",
-    quantity: conf.n,
+    quantity: conf.run_limit,
     subscription: "monthly",
     start: new Date(),
     custom_ram: conf.ram,
@@ -103,32 +115,34 @@ const academic: Item = (() => {
   return {
     title: "Academic Researcher Group",
     icon: "battery-half",
-    projects: conf.n,
+    projects: conf.run_limit,
     shared_ram: conf.ram,
     shared_cores: conf.cpu,
     disk: conf.disk,
     dedicated_cores: 0,
     academic: true,
     uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
-    monthly: round2(priceM.discounted_cost),
-    yearly: round2(priceY.discounted_cost),
+    monthly: priceM.discounted_cost,
+    yearly: priceY.discounted_cost,
+    conf,
   };
 })();
 
 const business: Item = (() => {
   const conf = {
-    n: 5,
+    run_limit: 5,
     disk: 5,
     ram: 4,
     cpu: 1,
     uptime: "medium",
+    user: "business",
   } as const;
 
   const info: PurchaseInfo = {
     type: "quota",
-    user: "business",
+    user: conf.user,
     upgrade: "custom",
-    quantity: conf.n,
+    quantity: conf.run_limit,
     subscription: "monthly",
     start: new Date(),
     custom_ram: conf.ram,
@@ -146,14 +160,15 @@ const business: Item = (() => {
   return {
     title: "Business Working Group",
     icon: "battery-full",
-    projects: conf.n,
+    projects: conf.run_limit,
     shared_ram: conf.ram,
     shared_cores: conf.cpu,
     disk: conf.disk,
     academic: false,
     uptime: LicenseIdleTimeouts[conf.uptime].labelShort,
-    monthly: round2(priceM.discounted_cost),
-    yearly: round2(priceY.discounted_cost),
+    monthly: priceM.discounted_cost,
+    yearly: priceY.discounted_cost,
+    conf,
   };
 })();
 
@@ -255,10 +270,10 @@ export default function Subscriptions({ customize }) {
                       style={{
                         fontWeight: "bold",
                         fontSize: "18pt",
-                        color: "#555",
+                        color: COLORS.GRAY_DD,
                       }}
                     >
-                      ${item.monthly}
+                      {money(item.monthly, true)}
                     </span>{" "}
                     / month
                   </div>
@@ -267,13 +282,14 @@ export default function Subscriptions({ customize }) {
                       style={{
                         fontWeight: "bold",
                         fontSize: "18pt",
-                        color: "#555",
+                        color: COLORS.GRAY_DD,
                       }}
                     >
-                      ${item.yearly}
+                      {money(item.yearly, true)}
                     </span>{" "}
                     / year
                   </div>
+                  <LinkToStore conf={item.conf} />
                 </PricingItem>
               )}
             />


### PR DESCRIPTION
# Description

- I discovered hardcoded price values on these pages, which are certainly wrong.
- added "select" links for course and subscription examples to the store/site-license
- expanding on-prem descriptions and remove the "kubernetes" option
- also fixed broken links

testing:
- regarding the hardcoded prices, a neat test is to look at the price examples for subscriptions and courses and then click on the select button to check if the price matches. it might be off a bit for courses, but overall it is very close to the real number.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
