### PR TITLE
latex: pythontex vs pythontex3

### DIFF
--- a/src/packages/frontend/frame-editors/latex-editor/pythontex.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/pythontex.ts
@@ -31,18 +31,17 @@ export async function pythontex(
   output_directory: string | undefined
 ): Promise<ExecOutput> {
   const { base, directory } = parse_path(path);
-  const args = ["--jobs", "2"];
-  if (force) {
-    // forced build implies to run all snippets
-    args.push("--rerun=always");
-  }
-  status(`pythontex ${args.join(" ")}`);
+  const rerun = force ? "--rerun=always" : ""; // forced build implies to run all snippets
+  const args = `--jobs 2 ${rerun} '${base}'`;
+  // older ubuntu versions install both, for python2&3. Newer Ubuntu's only install "pythontex" for python3. we prefer the "version 3" variant in both cases.
+  // note: the "which" selection works, because "bash" is true
+  const command = `$(which {pythontex3,pythontex} | head -1) ${args}`;
+  status(`pythontex[3] ${args}`);
   const aggregate = time && !force ? { value: time } : undefined;
   return exec({
     timeout: 360,
     bash: true, // timeout is enforced by ulimit
-    command: "pythontex3",
-    args: args.concat(base),
+    command,
     env: { MPLBACKEND: "Agg" }, // for python plots -- https://github.com/sagemathinc/cocalc/issues/4203
     project_id: project_id,
     path: output_directory || directory,


### PR DESCRIPTION
# Description

There is a small detail with newer Ubuntu versions: `pythontex3` is what we use in 22.04 for python 3 (and we don't use `pythontex` for python 2), but newer versions only provide `pythontex` and mean python 3. 

So, this rewrites the build command to pick the "3" variant if it exists, otherwise go with the name without a "3".

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
