### PR TITLE
ssh gateway custom domain

### DIFF
--- a/src/packages/frontend/account/ssh-keys/ssh-key-adder.tsx
+++ b/src/packages/frontend/account/ssh-keys/ssh-key-adder.tsx
@@ -76,13 +76,11 @@ interface Props {
   add_ssh_key: Function;
   toggleable?: boolean;
   style?: React.CSSProperties;
+  extra?: JSX.Element;
 }
 
-export const SSHKeyAdder: React.FC<Props> = ({
-  add_ssh_key,
-  toggleable,
-  style,
-}) => {
+export const SSHKeyAdder: React.FC<Props> = (props: Props) => {
+  const { add_ssh_key, toggleable, style, extra } = props;
   const [key_title, set_key_title] = useState<string>("");
   const [key_value, set_key_value] = useState<string>("");
   const [show_panel, set_show_panel] = useState<boolean>(false);
@@ -133,6 +131,7 @@ export const SSHKeyAdder: React.FC<Props> = ({
         }
         style={style}
       >
+        {extra && extra}
         <form onSubmit={submit_form}>
           <FormGroup>
             Title

--- a/src/packages/frontend/admin/site-settings.tsx
+++ b/src/packages/frontend/admin/site-settings.tsx
@@ -3,61 +3,54 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { alert_message } from "@cocalc/frontend/alerts";
 import {
   Button,
-  FormGroup,
   FormControl,
+  FormGroup,
   Well,
 } from "@cocalc/frontend/antd-bootstrap";
-import { alert_message } from "../alerts";
-import humanizeList from "humanize-list";
 import {
-  React,
   Component,
-  Rendered,
-  ReactDOM,
-  rtypes,
   rclass,
+  React,
+  ReactDOM,
   redux,
-} from "../app-framework";
-
-import { query } from "../frame-editors/generic/client";
-import { copy, deep_copy, keys, unreachable } from "@cocalc/util/misc";
-import { SERVER_SETTINGS_ENV_PREFIX } from "@cocalc/util/consts";
+  Rendered,
+  rtypes,
+} from "@cocalc/frontend/app-framework";
+import {
+  CopyToClipBoard,
+  ErrorDisplay,
+  Icon,
+  LabeledRow,
+  Markdown,
+  Space /*, Tip*/,
+} from "@cocalc/frontend/components";
 import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
+import { query } from "@cocalc/frontend/frame-editors/generic/client";
+import { SERVER_SETTINGS_ENV_PREFIX } from "@cocalc/util/consts";
+import {
+  Config,
+  ConfigValid,
+  RowType,
+} from "@cocalc/util/db-schema/site-defaults";
+import { EXTRAS } from "@cocalc/util/db-schema/site-settings-extras";
+import { copy, deep_copy, keys, unreachable } from "@cocalc/util/misc";
 import { site_settings_conf } from "@cocalc/util/schema";
-import { ON_PREM_DEFAULT_QUOTAS } from "@cocalc/util/upgrade-spec";
-import { upgrades } from "@cocalc/util/upgrade-spec";
+import { version } from "@cocalc/util/smc-version";
+import { COLORS } from "@cocalc/util/theme";
+import { ON_PREM_DEFAULT_QUOTAS, upgrades } from "@cocalc/util/upgrade-spec";
+import { Input, InputRef } from "antd";
+import humanizeList from "humanize-list";
+import { isEqual } from "lodash";
+
 const MAX_UPGRADES = upgrades.max_per_project;
 
 const FIELD_DEFAULTS = {
   default_quotas: ON_PREM_DEFAULT_QUOTAS,
   max_upgrades: MAX_UPGRADES,
 } as const;
-
-import { EXTRAS } from "@cocalc/util/db-schema/site-settings-extras";
-import {
-  ConfigValid,
-  Config,
-  RowType,
-} from "@cocalc/util/db-schema/site-defaults";
-
-import { isEqual } from "lodash";
-
-import { COLORS } from "@cocalc/util/theme";
-
-import { Input, InputRef } from "antd";
-
-import {
-  CopyToClipBoard,
-  Icon,
-  Markdown,
-  ErrorDisplay,
-  LabeledRow,
-  Space /*, Tip*/,
-} from "../components";
-
-import { version } from "@cocalc/util/smc-version";
 
 // We use this for now since antd's rewriting their components
 // in such a way that ReactDOM.findDOMNode no longer applies,

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -40,7 +40,7 @@ import {
   KUCALC_ON_PREMISES,
   site_settings_conf,
 } from "@cocalc/util/db-schema/site-defaults";
-import { dict, YEAR } from "@cocalc/util/misc";
+import { deep_copy, dict, YEAR } from "@cocalc/util/misc";
 import { sanitizeSoftwareEnv } from "@cocalc/util/sanitize-software-envs";
 import * as theme from "@cocalc/util/theme";
 import { DefaultQuotaSetting, Quota } from "@cocalc/util/upgrades/quota";
@@ -86,6 +86,7 @@ export type SoftwareEnvironments = TypedMap<{
 export interface CustomizeState {
   is_commercial: boolean;
   ssh_gateway: boolean;
+  ssh_gateway_dns: string; // e.g. "ssh.cocalc.com"
   account_creation_email_instructions: string;
   commercial: boolean;
   default_quotas: TypedMap<DefaultQuotaSetting>;
@@ -207,11 +208,10 @@ function process_kucalc(obj) {
 }
 
 function process_customize(obj) {
+  const obj_orig = deep_copy(obj);
   for (const k in site_settings_conf) {
     const v = site_settings_conf[k];
-    obj[k] = obj[k] ? obj[k] : v.to_val?.(v.default) ?? v.default;
-    // the "to_val" processing already happened server-side for obj[k],
-    // but NOT for v.default!
+    obj[k] = obj[k] ? obj[k] : v.to_val?.(v.default, obj_orig) ?? v.default;
   }
   set_customize(obj);
 }

--- a/src/packages/frontend/project/settings/ssh.tsx
+++ b/src/packages/frontend/project/settings/ssh.tsx
@@ -5,11 +5,14 @@
 
 import { SSHKeyAdder } from "@cocalc/frontend/account/ssh-keys/ssh-key-adder";
 import { SSHKeyList } from "@cocalc/frontend/account/ssh-keys/ssh-key-list";
-import { React, redux } from "@cocalc/frontend/app-framework";
-import { Icon } from "@cocalc/frontend/components";
+import { React, redux, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { A, Icon } from "@cocalc/frontend/components";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { replace } from "lodash";
 import { Project } from "./types";
+import { Typography } from "antd";
+
+const { Text, Paragraph } = Typography;
 
 interface Props {
   project: Project;
@@ -18,6 +21,8 @@ interface Props {
 
 export const SSHPanel: React.FC<Props> = React.memo((props: Props) => {
   const { project } = props;
+
+  const ssh_gateway_dns = useTypedRedux("customize", "ssh_gateway_dns");
 
   const project_id = project.get("project_id");
 
@@ -28,19 +33,32 @@ export const SSHPanel: React.FC<Props> = React.memo((props: Props) => {
 
   function render_ssh_notice() {
     const user = replace(project_id, /-/g, "");
-    const addr = `${user}@ssh.cocalc.com`;
+    const text = `${user}@${ssh_gateway_dns}`;
     return (
-      <div>
-        <span>Use the following username@host to connect to this project:</span>
-        <pre>{addr}</pre>
-        <a
-          href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key"
-          target="_blank"
-          rel="noopener"
+      <>
+        <hr />
+        <Paragraph>
+          Use the following <Text code>username@host</Text> to connect to this
+          project:
+        </Paragraph>
+        <Paragraph
+          copyable={{ text }}
+          style={{
+            whiteSpace: "nowrap",
+            overflowX: "auto",
+            textAlign: "center",
+          }}
         >
-          <Icon name="life-ring" /> How to create SSH keys
-        </a>
-      </div>
+          <Text strong code>
+            {text}
+          </Text>
+        </Paragraph>
+        <Paragraph>
+          <A href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key">
+            <Icon name="life-ring" /> How to create SSH keys
+          </A>
+        </Paragraph>
+      </>
     );
   }
 
@@ -51,27 +69,31 @@ export const SSHPanel: React.FC<Props> = React.memo((props: Props) => {
   ]);
 
   return (
-      <SSHKeyList ssh_keys={ssh_keys} project_id={project.get("project_id")}>
-        <div>
+    <SSHKeyList ssh_keys={ssh_keys} project_id={project.get("project_id")}>
+      <>
+        <p>
+          Easily access this project directly via SSH by adding an ssh public
+          key here.
+        </p>
+        <p>
+          The project <Text strong>must be running</Text> in order to be able to
+          connect and any changes take <Text strong>about 30 seconds</Text> to
+          take effect.
+        </p>
+      </>
+      <SSHKeyAdder
+        add_ssh_key={add_ssh_key}
+        toggleable={true}
+        style={{ marginBottom: "10px" }}
+        extra={
           <p>
-            Easily access this project directly via ssh by adding an ssh public
-            key here.
-          </p>
-          <p>
-            It takes <b>about 30 seconds</b> for any changes to take effect.
-          </p>
-          <p>
-            If you want to use the same ssh key for all your projects, add a key
+            If you want to use the same SSH key for all your projects, add it
             using the "SSH keys" tab under Account Settings. If you have done
-            that, there is no need to also configure an ssh key here.
+            that, there is no need to also configure an SSH key here.
           </p>
-        </div>
-        <SSHKeyAdder
-          add_ssh_key={add_ssh_key}
-          toggleable={true}
-          style={{ marginBottom: "10px" }}
-        />
-        {render_ssh_notice()}
-      </SSHKeyList>
+        }
+      />
+      {render_ssh_notice()}
+    </SSHKeyList>
   );
 });

--- a/src/packages/server/settings/customize.ts
+++ b/src/packages/server/settings/customize.ts
@@ -24,6 +24,7 @@ export interface Customize {
   isCommercial?: boolean;
   kucalc?: KucalcValues;
   sshGateway?: boolean;
+  sshGatewayDNS?: string;
   logoSquareURL?: string;
   logoRectangularURL?: string;
   splashImage?: string;
@@ -87,6 +88,7 @@ export default async function getCustomize(): Promise<Customize> {
 
     kucalc: settings.kucalc,
     sshGateway: settings.ssh_gateway,
+    sshGatewayDNS: settings.ssh_gateway_dns,
 
     anonymousSignup: settings.anonymous_signup,
     emailSignup: settings.email_signup,


### PR DESCRIPTION
# Description

1. new `ssh_gateway_dns` setting
2. use it in the ssh box in the project settings
3. I also tweaked the UI a little bit and mentioned, that projects need to run

deployment: update frontend first (also "util"). if there is no value set via the customization endpoint, it falls back to `ssh.${dns}`, which is fine for prod and test.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
