### PR TITLE
project/ssh-gateway: optionally show the ssh fingerprint

### DIFF
--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -87,6 +87,7 @@ export interface CustomizeState {
   is_commercial: boolean;
   ssh_gateway: boolean;
   ssh_gateway_dns: string; // e.g. "ssh.cocalc.com"
+  ssh_gateway_fingerprint: string; // e.g. "SHA256:a8284..."
   account_creation_email_instructions: string;
   commercial: boolean;
   default_quotas: TypedMap<DefaultQuotaSetting>;

--- a/src/packages/frontend/project/settings/ssh.tsx
+++ b/src/packages/frontend/project/settings/ssh.tsx
@@ -23,12 +23,27 @@ export const SSHPanel: React.FC<Props> = React.memo((props: Props) => {
   const { project } = props;
 
   const ssh_gateway_dns = useTypedRedux("customize", "ssh_gateway_dns");
+  const ssh_gateway_fingerprint = useTypedRedux(
+    "customize",
+    "ssh_gateway_fingerprint"
+  );
 
   const project_id = project.get("project_id");
 
   function add_ssh_key(opts) {
     opts.project_id = project_id;
     redux.getActions("projects").add_ssh_key_to_project(opts);
+  }
+
+  function render_fingerprint() {
+    // we ignore empty strings as well
+    if (!ssh_gateway_fingerprint) return;
+    return (
+      <Paragraph>
+        The server's fingerprint is: <Text code>{ssh_gateway_fingerprint}</Text>
+        .
+      </Paragraph>
+    );
   }
 
   function render_ssh_notice() {
@@ -44,15 +59,15 @@ export const SSHPanel: React.FC<Props> = React.memo((props: Props) => {
         <Paragraph
           copyable={{ text }}
           style={{
-            whiteSpace: "nowrap",
-            overflowX: "auto",
             textAlign: "center",
+            fontSize: "115%",
           }}
         >
           <Text strong code>
             {text}
           </Text>
         </Paragraph>
+        {render_fingerprint()}
         <Paragraph>
           <A href="https://github.com/sagemathinc/cocalc/wiki/AllAboutProjects#create-ssh-key">
             <Icon name="life-ring" /> How to create SSH keys

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -36,6 +36,7 @@ export type SiteSettingsKeys =
   | "dns"
   | "ssh_gateway"
   | "ssh_gateway_dns"
+  | "ssh_gateway_fingerprint"
   | "versions"
   | "version_min_project"
   | "version_min_browser"
@@ -401,6 +402,13 @@ export const site_settings_conf: SiteSettings = {
     valid: valid_dns_name,
     show: only_ssh_gateway,
     to_val: gateway_dns_to_val,
+  },
+  ssh_gateway_fingerprint: {
+    name: "SSH Gateway's Fingerprint",
+    desc: "Tell users the fingerprint of the SSH gateway server. This is used to verify that the SSH gateway server is the one they expect. E.g., `SHA256:8fa43247...`",
+    default: "",
+    show: only_ssh_gateway,
+    to_val: to_trimmed_str,
   },
   iframe_comm_hosts: {
     name: "IFrame embedding",


### PR DESCRIPTION
# Description

Add an optional server setting to show the ssh gateway's ssh fingerprint in the UI. Otherwise, users have to blindly accept. Also tweaking the name@host part a bit, just wrap the line instead of scrolling when narrow.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
