### PR TITLE
project: optionally launch the sshd server

### DIFF
--- a/src/packages/project/data.ts
+++ b/src/packages/project/data.ts
@@ -20,6 +20,8 @@ export const projectPidFile = join(data, "project.pid");
 export const startTimestampFile = join(data, "start-timestamp.txt");
 export const sessionIDFile = join(data, "session-id.txt");
 export const rootSymlink = join(data, "root");
+export const SSH_LOG = join(data, "sshd.log");
+export const SSH_ERR = join(data, "sshd.err");
 export const secretToken =
   process.env.COCALC_SECRET_TOKEN ?? join(data, "secret_token");
 

--- a/src/packages/project/init-kucalc.ts
+++ b/src/packages/project/init-kucalc.ts
@@ -8,6 +8,7 @@ const kucalc = require("./kucalc");
 import * as projectSetup from "./project-setup";
 import { activate as initAutorenice } from "./autorenice";
 import * as dedicatedDisks from "./dedicated-disks";
+import * as sshd from "./sshd";
 import { getLogger } from "./logger";
 
 export default async function init() {
@@ -31,5 +32,10 @@ export default async function init() {
 
   projectSetup.configure();
   projectSetup.set_extra_env();
+
+  if (options.sshd) {
+    sshd.init();
+  }
+
   await dedicatedDisks.init();
 }

--- a/src/packages/project/init-program.ts
+++ b/src/packages/project/init-program.ts
@@ -13,6 +13,7 @@ interface Options {
   kucalc: boolean;
   testFirewall: boolean;
   daemon: boolean;
+  sshd: boolean;
 }
 
 let options = {
@@ -22,6 +23,7 @@ let options = {
   testFirewall: false,
   kucalc: false,
   daemon: false,
+  sshd: false,
 } as Options;
 
 export { options };
@@ -47,6 +49,10 @@ program
     options.hostname
   )
   .option("--kucalc", "Running in the kucalc environment")
+  .option(
+    "--sshd",
+    "Start the SSH daemon (setup script and configuration must be present)"
+  )
   .option(
     "--test-firewall",
     "Abort and exit w/ code 99 if internal GCE information *is* accessible"

--- a/src/packages/project/sshd.ts
+++ b/src/packages/project/sshd.ts
@@ -1,0 +1,31 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
+This starts an sshd server used for accessing the project via an ssh gateway server
+
+Ref.: https://nodejs.org/docs/latest-v16.x/api/child_process.html#optionsdetached
+*/
+
+import { spawn } from "node:child_process";
+import { openSync } from "node:fs";
+import { getLogger } from "./logger";
+import { SSH_LOG, SSH_ERR } from "./data";
+
+const { info } = getLogger("sshd");
+
+export async function init() {
+  info("starting sshd");
+
+  const out = openSync(SSH_LOG, "a");
+  const err = openSync(SSH_ERR, "a");
+
+  const sshd = spawn("bash", ["/cocalc/kucalc-start-sshd.sh"], {
+    detached: true,
+    stdio: ["ignore", out, err],
+  });
+
+  sshd.unref();
+}


### PR DESCRIPTION
# Description

this moves the sshd server launch to the project, i.e. instead of doing this in the init.sh file. later, we can figure out if we ever want to customize this, get rid of the start script, etc.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
