### PR TITLE
github actions: newer commits abort currently running actions in the same workflow

### DIFF
--- a/.github/workflows/make-and-test.yml
+++ b/.github/workflows/make-and-test.yml
@@ -3,6 +3,11 @@
 
 name: Make all packages and run their unit tests
 
+# newer commits in the same PR abort running ones for the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["master"]

--- a/.github/workflows/sizewatcher.yml
+++ b/.github/workflows/sizewatcher.yml
@@ -1,18 +1,24 @@
 # This watches for large file size changes in PR's.
 # See https://github.com/adobe/sizewatcher#github-actions
 name: Watch for Large File Size Changes
+
+# newer commits in the same PR abort running ones for the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '18'
-    # ---------- this runs sizewatcher ------------
-    - run: npx @adobe/sizewatcher
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "18"
+      # ---------- this runs sizewatcher ------------
+      - run: npx @adobe/sizewatcher
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

with that, two quick pushes to the same repo should abort the older action runs of the same workflow. 

I got this from here, combining the last two examples: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
