### PR TITLE
project: optionally run an init script

### DIFF
--- a/src/packages/project/init-kucalc.ts
+++ b/src/packages/project/init-kucalc.ts
@@ -9,6 +9,7 @@ import * as projectSetup from "./project-setup";
 import { activate as initAutorenice } from "./autorenice";
 import * as dedicatedDisks from "./dedicated-disks";
 import * as sshd from "./sshd";
+import * as initScript from "./init-script";
 import { getLogger } from "./logger";
 
 export default async function init() {
@@ -38,4 +39,6 @@ export default async function init() {
   }
 
   await dedicatedDisks.init();
+
+  initScript.run();
 }

--- a/src/packages/project/init-program.ts
+++ b/src/packages/project/init-program.ts
@@ -14,6 +14,7 @@ interface Options {
   testFirewall: boolean;
   daemon: boolean;
   sshd: boolean;
+  init: string;
 }
 
 let options = {
@@ -24,6 +25,7 @@ let options = {
   kucalc: false,
   daemon: false,
   sshd: false,
+  init: "",
 } as Options;
 
 export { options };
@@ -52,6 +54,10 @@ program
   .option(
     "--sshd",
     "Start the SSH daemon (setup script and configuration must be present)"
+  )
+  .option(
+    "--init [string]",
+    "Runs the given script via bash and redirects output to .log and .err files."
   )
   .option(
     "--test-firewall",

--- a/src/packages/project/init-script.ts
+++ b/src/packages/project/init-script.ts
@@ -27,6 +27,12 @@ export async function run() {
 
   try {
     await access(initScript, constants.R_OK);
+  } catch {
+    info(`"${initScript}" does not exist`);
+    return;
+  }
+
+  try {
     info(`running "${initScript}"`);
 
     const out = openSync(change_filename_extension(initScript, "log"), "w");
@@ -36,7 +42,7 @@ export async function run() {
     spawn("bash", [initScript], {
       stdio: ["ignore", out, err],
     });
-  } catch {
-    info(`"${initScript}" does not exist`);
+  } catch (err) {
+    info(`Problem running "${initScript}" -- ${err}`);
   }
 }

--- a/src/packages/project/init-script.ts
+++ b/src/packages/project/init-script.ts
@@ -1,0 +1,44 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
+This runs a script configured via the --init [str] parameter.
+*/
+
+import { spawn } from "node:child_process";
+import { openSync, constants } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { access } from "node:fs/promises";
+
+import { change_filename_extension } from "@cocalc/util/misc";
+
+import { options } from "./init-program";
+import { getLogger } from "./logger";
+
+const { info } = getLogger("init-script");
+
+export async function run() {
+  if (!options.init) return;
+
+  const initScript = join(homedir(), options.init);
+
+  try {
+    await access(initScript, constants.R_OK);
+    info(`running "${initScript}"`);
+
+    const out = openSync(change_filename_extension(initScript, "log"), "a");
+    const err = openSync(change_filename_extension(initScript, "err"), "a");
+
+    const initProcess = spawn("bash", [initScript], {
+      detached: true,
+      stdio: ["ignore", out, err],
+    });
+
+    initProcess.unref();
+  } catch {
+    info(`"${initScript}" does not exist`);
+  }
+}

--- a/src/packages/project/init-script.ts
+++ b/src/packages/project/init-script.ts
@@ -29,8 +29,8 @@ export async function run() {
     await access(initScript, constants.R_OK);
     info(`running "${initScript}"`);
 
-    const out = openSync(change_filename_extension(initScript, "log"), "a");
-    const err = openSync(change_filename_extension(initScript, "err"), "a");
+    const out = openSync(change_filename_extension(initScript, "log"), "w");
+    const err = openSync(change_filename_extension(initScript, "err"), "w");
 
     const initProcess = spawn("bash", [initScript], {
       detached: true,

--- a/src/packages/project/init-script.ts
+++ b/src/packages/project/init-script.ts
@@ -32,12 +32,10 @@ export async function run() {
     const out = openSync(change_filename_extension(initScript, "log"), "w");
     const err = openSync(change_filename_extension(initScript, "err"), "w");
 
-    const initProcess = spawn("bash", [initScript], {
-      detached: true,
+    // we don't detach the process, because otherwise it stays around when restarting the project
+    spawn("bash", [initScript], {
       stdio: ["ignore", out, err],
     });
-
-    initProcess.unref();
   } catch {
     info(`"${initScript}" does not exist`);
   }

--- a/src/packages/server/projects/control/util.ts
+++ b/src/packages/server/projects/control/util.ts
@@ -83,12 +83,16 @@ export async function launchProjectDaemon(env, uid?: number): Promise<void> {
   const cwd = join(root, "packages/project");
   winston.debug(`"npx cocalc-project --daemon" from "${cwd}" with uid=${uid}`);
   await promisify((cb: Function) => {
-    const child = spawn("npx", ["cocalc-project", "--daemon"], {
-      env,
-      cwd,
-      uid,
-      gid: uid,
-    });
+    const child = spawn(
+      "npx",
+      ["cocalc-project", "--daemon", "--init", "project_init.sh"],
+      {
+        env,
+        cwd,
+        uid,
+        gid: uid,
+      }
+    );
     child.on("error", (err) => {
       winston.debug(`project daemon error ${err}`);
       cb(err);


### PR DESCRIPTION
# Description

This moves the logic of running `project_init.sh` to the project hub itself. Same behavior. However, there is also an important change: I added this parameter to the `launchProjectDaemon` function, which has implications for single and multi user project modes. So, that means we get feature parity with "kucalc" projects.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
