### PR TITLE
database/pool test: fix off-by-one

### DIFF
--- a/src/packages/database/pool/util.test.ts
+++ b/src/packages/database/pool/util.test.ts
@@ -10,7 +10,8 @@ test("use the timeInSeconds code gen function", () => {
 import { expireTime } from "./util";
 
 test("using expireTime to compute a time in the future", () => {
-  const now = new Date().valueOf();
-  const now10 = expireTime(10).valueOf();
-  expect(now10 - now).toBeCloseTo(10000);
+  const now = new Date().getTime();
+  const now10 = expireTime(10).getTime();
+  // sometimes, this is off by one. expect.toBeCloseTo only checks after the decimal point
+  expect(Math.abs(now10 - now - 10000)).toBeLessThanOrEqual(1);
 });


### PR DESCRIPTION
# Description

- occasionally, there is a +/- 1 difference and "close to" is only for fractions of one after the decimal point
- `valueOf` is somehow discouraged since [mdn docs say](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf#description) "This method is usually called internally by JavaScript and not explicitly in code."


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
