### PR TITLE
admin config for "datastore" and FC-ing settings body

### DIFF
--- a/src/packages/frontend/account/types.ts
+++ b/src/packages/frontend/account/types.ts
@@ -15,7 +15,7 @@ export interface AccountState {
   active_page: string;
   user_type: string;
   account_id: string;
-  groups?: string[];
+  groups?: List<string>;
   terminal: Map<string, any>;
   first_name?: string;
   last_name?: string;

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -85,6 +85,7 @@ export type SoftwareEnvironments = TypedMap<{
 
 export interface CustomizeState {
   is_commercial: boolean;
+  datastore: boolean;
   ssh_gateway: boolean;
   ssh_gateway_dns: string; // e.g. "ssh.cocalc.com"
   ssh_gateway_fingerprint: string; // e.g. "SHA256:a8284..."
@@ -212,7 +213,8 @@ function process_customize(obj) {
   const obj_orig = deep_copy(obj);
   for (const k in site_settings_conf) {
     const v = site_settings_conf[k];
-    obj[k] = obj[k] ? obj[k] : v.to_val?.(v.default, obj_orig) ?? v.default;
+    obj[k] =
+      obj[k] != null ? obj[k] : v.to_val?.(v.default, obj_orig) ?? v.default;
   }
   set_customize(obj);
 }

--- a/src/packages/frontend/project/settings/body.tsx
+++ b/src/packages/frontend/project/settings/body.tsx
@@ -22,7 +22,10 @@ import { Project } from "./types";
 import { SSHPanel } from "./ssh";
 import { Environment } from "./environment";
 import { Datastore } from "./datastore";
-import { KUCALC_COCALC_COM } from "@cocalc/util/db-schema/site-defaults";
+import {
+  KUCALC_COCALC_COM,
+  KUCALC_ON_PREMISES,
+} from "@cocalc/util/db-schema/site-defaults";
 import { SettingBox } from "../../components";
 import { AddCollaborators } from "../../collaborators";
 
@@ -56,6 +59,7 @@ interface ReduxProps {
   // from customize
   kucalc: string;
   ssh_gateway: boolean;
+  datastore: boolean;
 
   // from projects
   get_course_info: Function;
@@ -82,6 +86,7 @@ export const Body = rclass<ReactProps>(
         customize: {
           kucalc: rtypes.string,
           ssh_gateway: rtypes.bool,
+          datastore: rtypes.bool,
         },
         projects: {
           get_course_info: rtypes.func,
@@ -143,6 +148,9 @@ export const Body = rclass<ReactProps>(
       const have_jupyter_lab = available.jupyter_lab;
       const have_jupyter_notebook = available.jupyter_notebook;
       const student = getStudentProjectFunctionality(this.props.project_id);
+      const showDatastore =
+        this.props.kucalc === KUCALC_COCALC_COM ||
+        (this.props.kucalc === KUCALC_ON_PREMISES && this.props.datastore);
       return (
         <div>
           {commercial &&
@@ -225,7 +233,7 @@ export const Body = rclass<ReactProps>(
                 key="environment"
                 project_id={this.props.project_id}
               />
-              {this.props.kucalc === KUCALC_COCALC_COM && (
+              {showDatastore && (
                 <Datastore key="datastore" project_id={this.props.project_id} />
               )}
               <ProjectCapabilities

--- a/src/packages/frontend/project/settings/body.tsx
+++ b/src/packages/frontend/project/settings/body.tsx
@@ -20,6 +20,7 @@ import {
   KUCALC_ON_PREMISES,
 } from "@cocalc/util/db-schema/site-defaults";
 import { is_different } from "@cocalc/util/misc";
+import { List } from "immutable";
 import React from "react";
 import { Col, Row } from "react-bootstrap";
 import { Icon, SettingBox } from "../../components";
@@ -62,7 +63,7 @@ export const Body: React.FC<ReactProps> = React.memo((props: ReactProps) => {
     props;
 
   const get_total_upgrades = redux.getStore("account").get_total_upgrades;
-  const groups = useTypedRedux("account", "groups") ?? [];
+  const groups = useTypedRedux("account", "groups") ?? List<string>();
 
   const kucalc = useTypedRedux("customize", "kucalc");
   const ssh_gateway = useTypedRedux("customize", "ssh_gateway");
@@ -160,7 +161,7 @@ export const Body: React.FC<ReactProps> = React.memo((props: ReactProps) => {
             project={project}
             actions={redux.getActions("projects")}
             user_map={user_map}
-            account_groups={groups}
+            account_groups={groups.toJS()}
             upgrades_you_can_use={upgrades_you_can_use}
             upgrades_you_applied_to_all_projects={
               upgrades_you_applied_to_all_projects

--- a/src/packages/frontend/project/settings/body.tsx
+++ b/src/packages/frontend/project/settings/body.tsx
@@ -3,42 +3,41 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import React from "react";
-import * as misc from "@cocalc/util/misc";
-import { Icon } from "../../components";
-import { NonMemberProjectWarning } from "../warnings/non-member";
-import { NoNetworkProjectWarning } from "../warnings/no-network";
-import { redux, rtypes, rclass } from "../../app-framework";
-import { CurrentCollaboratorsPanel } from "../../collaborators";
-import { NamedServerPanel } from "../named-server-panel";
-import { AboutBox } from "./about-box";
-import { UpgradeUsage } from "./upgrade-usage";
-import { HideDeleteBox } from "./hide-delete-box";
-import { SagewsControl } from "./sagews-control";
-import { ProjectCapabilities } from "./project-capabilites";
-import { ProjectControl } from "./project-control";
-import { Customer, ProjectMap, UserMap } from "@cocalc/frontend/todo-types";
-import { Project } from "./types";
-import { SSHPanel } from "./ssh";
-import { Environment } from "./environment";
-import { Datastore } from "./datastore";
+import { redux, useTypedRedux } from "@cocalc/frontend/app-framework";
 import {
-  KUCALC_COCALC_COM,
-  KUCALC_ON_PREMISES,
-} from "@cocalc/util/db-schema/site-defaults";
-import { SettingBox } from "../../components";
-import { AddCollaborators } from "../../collaborators";
-
-import { webapp_client } from "../../webapp-client";
-import { Col, Row } from "react-bootstrap";
-
+  AddCollaborators,
+  CurrentCollaboratorsPanel,
+} from "@cocalc/frontend/collaborators";
+import { getStudentProjectFunctionality } from "@cocalc/frontend/course";
 import { commercial } from "@cocalc/frontend/customize";
 import {
   is_available,
   ProjectConfiguration,
 } from "@cocalc/frontend/project_configuration";
-import { getStudentProjectFunctionality } from "@cocalc/frontend/course";
+import { Customer, ProjectMap, UserMap } from "@cocalc/frontend/todo-types";
+import {
+  KUCALC_COCALC_COM,
+  KUCALC_ON_PREMISES,
+} from "@cocalc/util/db-schema/site-defaults";
+import { is_different } from "@cocalc/util/misc";
+import React from "react";
+import { Col, Row } from "react-bootstrap";
+import { Icon, SettingBox } from "../../components";
+import { webapp_client } from "../../webapp-client";
+import { NamedServerPanel } from "../named-server-panel";
+import { NoNetworkProjectWarning } from "../warnings/no-network";
+import { NonMemberProjectWarning } from "../warnings/non-member";
+import { AboutBox } from "./about-box";
+import { Datastore } from "./datastore";
+import { Environment } from "./environment";
+import { HideDeleteBox } from "./hide-delete-box";
+import { ProjectCapabilities } from "./project-capabilites";
+import { ProjectControl } from "./project-control";
+import { SagewsControl } from "./sagews-control";
 import SavingProjectSettingsError from "./saving-project-settings-error";
+import { SSHPanel } from "./ssh";
+import { Project } from "./types";
+import { UpgradeUsage } from "./upgrade-usage";
 
 interface ReactProps {
   project_id: string;
@@ -51,232 +50,183 @@ interface ReactProps {
   name: string;
 }
 
-interface ReduxProps {
-  // from account
-  get_total_upgrades: Function;
-  groups: string[];
+const is_same = (prev: ReactProps, next: ReactProps) => {
+  return !(
+    is_different(prev, next, ["project", "user_map", "project_map"]) ||
+    (next.customer != null && !next.customer.equals(prev.customer))
+  );
+};
 
-  // from customize
-  kucalc: string;
-  ssh_gateway: boolean;
-  datastore: boolean;
+export const Body: React.FC<ReactProps> = React.memo((props: ReactProps) => {
+  const { project_id, account_id, project, user_map, email_address, name } =
+    props;
 
-  // from projects
-  get_course_info: Function;
-  get_total_upgrades_you_have_applied: Function;
-  get_upgrades_you_applied_to_project: Function;
-  get_total_project_quotas: Function;
-  get_upgrades_to_project: Function;
-  compute_images: Map<string, any>;
-  all_projects_have_been_loaded: boolean;
+  const get_total_upgrades = redux.getStore("account").get_total_upgrades;
+  const groups = useTypedRedux("account", "groups") ?? [];
 
-  // context specific
-  configuration: ProjectConfiguration;
-  available_features: object;
-}
+  const kucalc = useTypedRedux("customize", "kucalc");
+  const ssh_gateway = useTypedRedux("customize", "ssh_gateway");
+  const datastore = useTypedRedux("customize", "datastore");
 
-export const Body = rclass<ReactProps>(
-  class Body extends React.Component<ReactProps & ReduxProps> {
-    public static reduxProps({ name }) {
-      return {
-        account: {
-          get_total_upgrades: rtypes.func,
-          groups: rtypes.array,
-        },
-        customize: {
-          kucalc: rtypes.string,
-          ssh_gateway: rtypes.bool,
-          datastore: rtypes.bool,
-        },
-        projects: {
-          get_course_info: rtypes.func,
-          get_total_upgrades_you_have_applied: rtypes.func,
-          get_upgrades_you_applied_to_project: rtypes.func,
-          get_total_project_quotas: rtypes.func,
-          get_upgrades_to_project: rtypes.func,
-          compute_images: rtypes.immutable.Map,
-          all_projects_have_been_loaded: rtypes.bool,
-        },
-        [name]: {
-          configuration: rtypes.immutable,
-          available_features: rtypes.object,
-        },
-      };
-    }
+  const projects_store = redux.getStore("projects");
+  const {
+    get_course_info,
+    get_total_upgrades_you_have_applied,
+    get_upgrades_you_applied_to_project,
+    get_total_project_quotas,
+    get_upgrades_to_project,
+  } = projects_store;
 
-    shouldComponentUpdate(props) {
-      return (
-        misc.is_different(this.props, props, [
-          "project",
-          "user_map",
-          "project_map",
-          "compute_images",
-          "configuration",
-          "available_features",
-          "all_projects_have_been_loaded",
-        ]) ||
-        (props.customer != undefined &&
-          !props.customer.equals(this.props.customer))
-      );
-    }
+  const all_projects_have_been_loaded = useTypedRedux(
+    "projects",
+    "all_projects_have_been_loaded"
+  );
 
-    render() {
-      // get the description of the share, in case the project is being shared
-      const id = this.props.project_id;
+  const configuration: ProjectConfiguration | undefined = useTypedRedux(
+    { project_id },
+    "configuration"
+  );
 
-      const upgrades_you_can_use = this.props.get_total_upgrades();
+  // get the description of the share, in case the project is being shared
+  const id = project_id;
 
-      const course_info = this.props.get_course_info(this.props.project_id);
-      const upgrades_you_applied_to_all_projects =
-        this.props.get_total_upgrades_you_have_applied();
-      const upgrades_you_applied_to_this_project =
-        this.props.get_upgrades_you_applied_to_project(id);
-      const total_project_quotas = this.props.get_total_project_quotas(id); // only available for non-admin for now.
-      const all_upgrades_to_this_project =
-        this.props.get_upgrades_to_project(id);
-      const store = redux.getStore("projects");
-      const site_license_upgrades =
-        store.get_total_site_license_upgrades_to_project(this.props.project_id);
-      const site_license_ids: string[] = store.get_site_license_ids(
-        this.props.project_id
-      );
-      const dedicated_resources = store.get_total_site_license_dedicated(
-        this.props.project_id
-      );
+  const upgrades_you_can_use = get_total_upgrades();
 
-      const available = is_available(this.props.configuration);
-      const have_jupyter_lab = available.jupyter_lab;
-      const have_jupyter_notebook = available.jupyter_notebook;
-      const student = getStudentProjectFunctionality(this.props.project_id);
-      const showDatastore =
-        this.props.kucalc === KUCALC_COCALC_COM ||
-        (this.props.kucalc === KUCALC_ON_PREMISES && this.props.datastore);
-      return (
-        <div>
-          {commercial &&
-          total_project_quotas != undefined &&
-          !total_project_quotas.member_host ? (
-            <NonMemberProjectWarning
-              upgrade_type="member_host"
-              upgrades_you_can_use={upgrades_you_can_use}
-              upgrades_you_applied_to_all_projects={
-                upgrades_you_applied_to_all_projects
-              }
-              course_info={course_info}
-              account_id={webapp_client.account_id}
-              email_address={this.props.email_address}
+  const course_info = get_course_info(project_id);
+  const upgrades_you_applied_to_all_projects =
+    get_total_upgrades_you_have_applied();
+  const upgrades_you_applied_to_this_project =
+    get_upgrades_you_applied_to_project(id);
+  const total_project_quotas = get_total_project_quotas(id); // only available for non-admin for now.
+  const all_upgrades_to_this_project = get_upgrades_to_project(id);
+  const store = redux.getStore("projects");
+  const site_license_upgrades =
+    store.get_total_site_license_upgrades_to_project(project_id);
+  const site_license_ids: string[] = store.get_site_license_ids(project_id);
+  const dedicated_resources =
+    store.get_total_site_license_dedicated(project_id);
+
+  const available = is_available(configuration);
+  const have_jupyter_lab = available.jupyter_lab;
+  const have_jupyter_notebook = available.jupyter_notebook;
+  const student = getStudentProjectFunctionality(project_id);
+  const showDatastore =
+    kucalc === KUCALC_COCALC_COM ||
+    (kucalc === KUCALC_ON_PREMISES && datastore);
+
+  return (
+    <div>
+      {commercial &&
+      total_project_quotas != undefined &&
+      !total_project_quotas.member_host ? (
+        <NonMemberProjectWarning
+          upgrade_type="member_host"
+          upgrades_you_can_use={upgrades_you_can_use}
+          upgrades_you_applied_to_all_projects={
+            upgrades_you_applied_to_all_projects
+          }
+          course_info={course_info}
+          account_id={webapp_client.account_id}
+          email_address={email_address}
+        />
+      ) : undefined}
+      {commercial &&
+      total_project_quotas != undefined &&
+      !total_project_quotas.network ? (
+        <NoNetworkProjectWarning
+          upgrade_type="network"
+          upgrades_you_can_use={upgrades_you_can_use}
+          upgrades_you_applied_to_all_projects={
+            upgrades_you_applied_to_all_projects
+          }
+        />
+      ) : undefined}
+      <h1 style={{ marginTop: "0px" }}>
+        <Icon name="wrench" /> Project Settings
+      </h1>
+      <SavingProjectSettingsError project_id={project_id} />
+      <Row>
+        <Col sm={6}>
+          <AboutBox
+            project_id={id}
+            project_title={project.get("title") ?? ""}
+            description={project.get("description") ?? ""}
+            created={project.get("created")}
+            name={project.get("name")}
+            actions={redux.getActions("projects")}
+          />
+          <UpgradeUsage
+            project_id={id}
+            project={project}
+            actions={redux.getActions("projects")}
+            user_map={user_map}
+            account_groups={groups}
+            upgrades_you_can_use={upgrades_you_can_use}
+            upgrades_you_applied_to_all_projects={
+              upgrades_you_applied_to_all_projects
+            }
+            upgrades_you_applied_to_this_project={
+              upgrades_you_applied_to_this_project
+            }
+            total_project_quotas={total_project_quotas}
+            all_upgrades_to_this_project={all_upgrades_to_this_project}
+            all_projects_have_been_loaded={all_projects_have_been_loaded}
+            site_license_upgrades={site_license_upgrades}
+            site_license_ids={site_license_ids}
+            dedicated_resources={dedicated_resources}
+          />
+
+          <HideDeleteBox
+            key="hidedelete"
+            project={project}
+            actions={redux.getActions("projects")}
+          />
+          {!student.disableSSH &&
+          (ssh_gateway || kucalc === KUCALC_COCALC_COM) ? (
+            <SSHPanel
+              key="ssh-keys"
+              project={project}
+              account_id={account_id}
             />
           ) : undefined}
-          {commercial &&
-          total_project_quotas != undefined &&
-          !total_project_quotas.network ? (
-            <NoNetworkProjectWarning
-              upgrade_type="network"
-              upgrades_you_can_use={upgrades_you_can_use}
-              upgrades_you_applied_to_all_projects={
-                upgrades_you_applied_to_all_projects
-              }
-            />
-          ) : undefined}
-          <h1 style={{ marginTop: "0px" }}>
-            <Icon name="wrench" /> Project Settings
-          </h1>
-          <SavingProjectSettingsError project_id={this.props.project_id} />
-          <Row>
-            <Col sm={6}>
-              <AboutBox
-                project_id={id}
-                project_title={this.props.project.get("title") ?? ""}
-                description={this.props.project.get("description") ?? ""}
-                created={this.props.project.get("created")}
-                name={this.props.project.get("name")}
-                actions={redux.getActions("projects")}
-              />
-              <UpgradeUsage
-                project_id={id}
-                project={this.props.project}
-                actions={redux.getActions("projects")}
-                user_map={this.props.user_map}
-                account_groups={this.props.groups}
-                upgrades_you_can_use={upgrades_you_can_use}
-                upgrades_you_applied_to_all_projects={
-                  upgrades_you_applied_to_all_projects
-                }
-                upgrades_you_applied_to_this_project={
-                  upgrades_you_applied_to_this_project
-                }
-                total_project_quotas={total_project_quotas}
-                all_upgrades_to_this_project={all_upgrades_to_this_project}
-                all_projects_have_been_loaded={
-                  this.props.all_projects_have_been_loaded
-                }
-                site_license_upgrades={site_license_upgrades}
-                site_license_ids={site_license_ids}
-                dedicated_resources={dedicated_resources}
-              />
-
-              <HideDeleteBox
-                key="hidedelete"
-                project={this.props.project}
-                actions={redux.getActions("projects")}
-              />
-              {!student.disableSSH &&
-              (this.props.ssh_gateway ||
-                this.props.kucalc === KUCALC_COCALC_COM) ? (
-                <SSHPanel
-                  key="ssh-keys"
-                  project={this.props.project}
-                  account_id={this.props.account_id}
-                />
-              ) : undefined}
-              <Environment
-                key="environment"
-                project_id={this.props.project_id}
-              />
-              {showDatastore && (
-                <Datastore key="datastore" project_id={this.props.project_id} />
-              )}
-              <ProjectCapabilities
-                name={this.props.name}
-                key={"capabilities"}
-                project={this.props.project}
-                project_id={this.props.project_id}
-              />
-            </Col>
-            <Col sm={6}>
-              <CurrentCollaboratorsPanel
-                key="current-collabs"
-                project={this.props.project}
-                user_map={this.props.user_map}
-              />
-              {!student.disableCollaborators && (
-                <SettingBox
-                  title="Add new collaborators"
-                  icon="UserAddOutlined"
-                >
-                  <AddCollaborators
-                    project_id={this.props.project.get("project_id")}
-                  />
-                </SettingBox>
-              )}
-              <ProjectControl key="control" project={this.props.project} />
-              <SagewsControl key="worksheet" project={this.props.project} />
-              {have_jupyter_notebook && (
-                <NamedServerPanel project_id={id} name={"jupyter"} />
-              )}
-              {have_jupyter_lab && (
-                <NamedServerPanel project_id={id} name={"jupyterlab"} />
-              )}
-              {available.vscode && (
-                <NamedServerPanel project_id={id} name={"code"} />
-              )}
-              {available.julia && (
-                <NamedServerPanel project_id={id} name={"pluto"} />
-              )}
-            </Col>
-          </Row>
-        </div>
-      );
-    }
-  }
-);
+          <Environment key="environment" project_id={project_id} />
+          {showDatastore && (
+            <Datastore key="datastore" project_id={project_id} />
+          )}
+          <ProjectCapabilities
+            name={name}
+            key={"capabilities"}
+            project={project}
+            project_id={project_id}
+          />
+        </Col>
+        <Col sm={6}>
+          <CurrentCollaboratorsPanel
+            key="current-collabs"
+            project={project}
+            user_map={user_map}
+          />
+          {!student.disableCollaborators && (
+            <SettingBox title="Add new collaborators" icon="UserAddOutlined">
+              <AddCollaborators project_id={project.get("project_id")} />
+            </SettingBox>
+          )}
+          <ProjectControl key="control" project={project} />
+          <SagewsControl key="worksheet" project={project} />
+          {have_jupyter_notebook && (
+            <NamedServerPanel project_id={id} name={"jupyter"} />
+          )}
+          {have_jupyter_lab && (
+            <NamedServerPanel project_id={id} name={"jupyterlab"} />
+          )}
+          {available.vscode && (
+            <NamedServerPanel project_id={id} name={"code"} />
+          )}
+          {available.julia && (
+            <NamedServerPanel project_id={id} name={"pluto"} />
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+}, is_same);

--- a/src/packages/frontend/project/settings/body.tsx
+++ b/src/packages/frontend/project/settings/body.tsx
@@ -8,6 +8,7 @@ import {
   AddCollaborators,
   CurrentCollaboratorsPanel,
 } from "@cocalc/frontend/collaborators";
+import { Icon, SettingBox } from "@cocalc/frontend/components";
 import { getStudentProjectFunctionality } from "@cocalc/frontend/course";
 import { commercial } from "@cocalc/frontend/customize";
 import {
@@ -15,6 +16,7 @@ import {
   ProjectConfiguration,
 } from "@cocalc/frontend/project_configuration";
 import { Customer, ProjectMap, UserMap } from "@cocalc/frontend/todo-types";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import {
   KUCALC_COCALC_COM,
   KUCALC_ON_PREMISES,
@@ -23,8 +25,6 @@ import { is_different } from "@cocalc/util/misc";
 import { List } from "immutable";
 import React from "react";
 import { Col, Row } from "react-bootstrap";
-import { Icon, SettingBox } from "../../components";
-import { webapp_client } from "../../webapp-client";
 import { NamedServerPanel } from "../named-server-panel";
 import { NoNetworkProjectWarning } from "../warnings/no-network";
 import { NonMemberProjectWarning } from "../warnings/non-member";

--- a/src/packages/frontend/project/settings/datastore.tsx
+++ b/src/packages/frontend/project/settings/datastore.tsx
@@ -675,9 +675,6 @@ export const Datastore: React.FC<Props> = React.memo((props: Props) => {
       <>
         <span>
           Cloud storage & remote file-systems
-          <sup>
-            <i>beta</i>
-          </sup>
         </span>
         <Button
           icon={<ReloadOutlined />}

--- a/src/packages/frontend/project/settings/quota-console.tsx
+++ b/src/packages/frontend/project/settings/quota-console.tsx
@@ -31,7 +31,7 @@ interface Props {
   project_state?: "opened" | "running" | "starting" | "stopping"; //  -- only show memory usage when project_state == 'running'
   user_map: object;
   quota_params: object; // from the schema
-  account_groups: any[];
+  account_groups: string[];
   total_project_quotas?: object; // undefined if viewing as admin
   site_license_upgrades?: object;
   all_upgrades_to_this_project?: object;

--- a/src/packages/frontend/project/settings/upgrade-usage.tsx
+++ b/src/packages/frontend/project/settings/upgrade-usage.tsx
@@ -25,7 +25,10 @@ import { KUCALC_DISABLED } from "@cocalc/util/db-schema/site-defaults";
 import { is_zero_map, plural, round2, to_human_list } from "@cocalc/util/misc";
 import { PROJECT_UPGRADES } from "@cocalc/util/schema";
 import { COLORS } from "@cocalc/util/theme";
-import { DedicatedDisk,  DedicatedResources } from "@cocalc/util/types/dedicated";
+import {
+  DedicatedDisk,
+  DedicatedResources,
+} from "@cocalc/util/types/dedicated";
 import { PRICES } from "@cocalc/util/upgrades/dedicated";
 import { dedicatedDiskDisplay } from "@cocalc/util/upgrades/utils";
 import { Button, Card, Typography } from "antd";

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -34,6 +34,7 @@ export type SiteSettingsKeys =
   | "google_analytics"
   | "kucalc"
   | "dns"
+  | "datastore"
   | "ssh_gateway"
   | "ssh_gateway_dns"
   | "ssh_gateway_fingerprint"
@@ -107,7 +108,8 @@ export const show_theming_vars = (conf): boolean =>
   to_bool(fallback(conf, "theming"));
 export const only_commercial = (conf): boolean =>
   to_bool(fallback(conf, "commercial"));
-export const to_bool = (val): boolean => val === "true" || val === "yes";
+export const to_bool = (val): boolean =>
+  val === "true" || val === "yes" || (typeof val === "boolean" && val);
 export const to_trimmed_str = (val?: string): string => (val ?? "").trim();
 export const only_booleans = ["yes", "no"]; // we also understand true and false
 export const to_int = (val): number => parseInt(val);
@@ -366,6 +368,14 @@ export const site_settings_conf: SiteSettings = {
     default: "",
     to_val: split_strings,
     show: only_cocalc_com,
+  },
+  datastore: {
+    name: "Datastore",
+    desc: "Show the 'Cloud storage & remote file-systems' panel in the project settings",
+    default: "yes",
+    valid: only_booleans,
+    show: only_onprem,
+    to_val: to_bool,
   },
   onprem_quota_heading: {
     name: "On-prem Quotas",


### PR DESCRIPTION
# Description

- for onprem mode, a toggle to show the "datastore" config panel in the settings
- there was a problem when the default value is true, i.e. the frontend didn't check properly if it should use a default fallback for an undefined value. also made the conversion to a boolean idempotent.
- I also noticed that the body for the settings isn't a React FC yet, so I fixed that as well.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
