### PR TITLE
frontend: check if free project in restricted country is allowed to run

### DIFF
--- a/src/packages/frontend/client/project.ts
+++ b/src/packages/frontend/client/project.ts
@@ -380,7 +380,7 @@ export class ProjectClient {
     const state = redux.getStore("projects")?.get_state(project_id);
     if (!(state == null && redux.getStore("account")?.get("is_admin"))) {
       // not trying to view project as admin so do some checks
-      if (!allow_project_to_run(project_id)) return;
+      if (!await allow_project_to_run(project_id)) return;
       if (!this.client.is_signed_in()) {
         // silently ignore if not signed in
         return;

--- a/src/packages/frontend/project/client-side-throttle.ts
+++ b/src/packages/frontend/project/client-side-throttle.ts
@@ -3,7 +3,10 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { redux } from "../app-framework";
+import { join } from "path";
+
+import { redux } from "@cocalc/frontend/app-framework";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 
 /*
 Client-side throttling of running projects in blocked countries.  This may or may not be the
@@ -17,6 +20,7 @@ We allow a project to run if any of these conditions is satisfied:
    - admin member upgrade
    - is a project in a course (don't interfere with instructors/students)
    - project already running or starting for some reason
+   - last chance: it's a blocked country but the limit of trial project has not been reached
 */
 
 function not_in_blocked_country() {
@@ -29,7 +33,28 @@ function not_in_blocked_country() {
   return !nonfree_countries.contains(country);
 }
 
-export function allow_project_to_run(project_id: string): boolean {
+async function too_many_free_projects(): Promise<boolean> {
+  // there are never too many free projects if we're NOT on cocalc.com
+  if (not_in_blocked_country()) return false;
+
+  try {
+    const statsRaw = await fetch(join(appBasePath, "stats"));
+    const stats: {
+      running_projects?: { free?: number };
+    } = await statsRaw.json();
+    const running_projects = stats?.running_projects?.free ?? 0;
+    const free_limit =
+      redux.getStore("customize")?.get("max_trial_projects") ?? 0;
+    return free_limit > 0 && running_projects >= free_limit;
+  } catch (err) {
+    console.error("error fetching stats", err);
+    return false; // we assume it is ok to run a project
+  }
+}
+
+export async function allow_project_to_run(
+  project_id: string
+): Promise<boolean> {
   function log(..._args) {
     // console.log("allow_project_to_run", project_id, ..._args);
   }
@@ -75,6 +100,12 @@ export function allow_project_to_run(project_id: string): boolean {
   // maybe there is a license (valid or not -- we won't check at this point)
   if (store.get_site_license_ids(project_id).length > 0) {
     log("a license is applied");
+    return true;
+  }
+
+  // last chance: if the limit of trial projects has not been reached, allow it.
+  if (!(await too_many_free_projects())) {
+    log("there are not too many free projects running");
     return true;
   }
 

--- a/src/packages/frontend/project/client-side-throttle.ts
+++ b/src/packages/frontend/project/client-side-throttle.ts
@@ -5,7 +5,7 @@
 
 import { join } from "path";
 
-import { redux } from "@cocalc/frontend/app-framework";
+import { redux, useEffect, useState } from "@cocalc/frontend/app-framework";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 
 /*
@@ -111,4 +111,19 @@ export async function allow_project_to_run(
 
   // got nothing:
   return false;
+}
+
+export function useAllowedFreeProjectToRun(
+  project_id: string
+): boolean | undefined {
+  const [allowed, setAllowed] = useState<boolean | undefined>(undefined);
+  useEffect(() => {
+    allow_project_to_run(project_id)
+      .then(setAllowed)
+      .catch((err) => {
+        console.error("error in useAllowedFreeProjectToRun", err);
+        setAllowed(true); // we assume it is ok to run a project
+      });
+  }, [project_id]);
+  return allowed;
 }

--- a/src/packages/frontend/project/start-button.tsx
+++ b/src/packages/frontend/project/start-button.tsx
@@ -12,6 +12,9 @@ It's really more than just that button, since it gives info as starting/stopping
 happens, and also when the system is heavily loaded.
 */
 
+import { Alert, Button } from "antd";
+import { CSSProperties, useRef } from "react";
+
 import {
   React,
   redux,
@@ -27,9 +30,7 @@ import {
   VisibleMDLG,
 } from "@cocalc/frontend/components";
 import { server_seconds_ago } from "@cocalc/util/misc";
-import { Alert, Button } from "antd";
-import { CSSProperties, useEffect, useRef, useState } from "react";
-import { allow_project_to_run } from "./client-side-throttle";
+import { useAllowedFreeProjectToRun } from "./client-side-throttle";
 import { DOC_TRIAL } from "./trial-banner";
 
 interface Props {
@@ -51,18 +52,7 @@ export const StartButton: React.FC<Props> = ({ project_id }) => {
   const connected = project_websockets?.get(project_id) == "online";
   const project_map = useTypedRedux("projects", "project_map");
   const lastNotRunningRef = useRef<null | number>(null);
-  const [allowed, setAllowed] = useState<boolean | undefined>(undefined);
-
-  useEffect(() => {
-    const check_allowed = async () => {
-      setAllowed(await allow_project_to_run(project_id));
-    };
-
-    check_allowed().catch((err) => {
-      console.error("unable to check if project is allowed to run", err);
-      setAllowed(true); // assume it is allowed
-    });
-  }, []);
+  const allowed = useAllowedFreeProjectToRun(project_id);
 
   const state = useMemo(() => {
     const state = project_map?.getIn([project_id, "state"]);

--- a/src/packages/frontend/project/trial-banner.tsx
+++ b/src/packages/frontend/project/trial-banner.tsx
@@ -12,18 +12,18 @@ import {
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { A, Icon } from "@cocalc/frontend/components";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 import { server_time } from "@cocalc/frontend/frame-editors/generic/client";
 import {
   SiteLicenseInput,
   useManagedLicenses,
 } from "@cocalc/frontend/site-licenses/input";
+import { LICENSE_MIN_PRICE } from "@cocalc/util/consts/billing";
 import { Alert } from "antd";
 import humanizeList from "humanize-list";
 import { join } from "path";
-import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
-import { allow_project_to_run } from "./client-side-throttle";
+import { useAllowedFreeProjectToRun } from "./client-side-throttle";
 import { applyLicense } from "./settings/site-license";
-import { LICENSE_MIN_PRICE } from "@cocalc/util/consts/billing";
 
 export const DOC_TRIAL = "https://doc.cocalc.com/trial.html";
 
@@ -156,6 +156,7 @@ const TrialBannerComponent: React.FC<BannerProps> = React.memo(
 
     const [showAddLicense, setShowAddLicense] = useState<boolean>(false);
     const managedLicenses = useManagedLicenses();
+    const allow_run = useAllowedFreeProjectToRun(project_id);
 
     const age_ms: number = server_time().getTime() - proj_created;
     const ageDays = age_ms / (24 * 60 * 60 * 1000);
@@ -192,8 +193,7 @@ const TrialBannerComponent: React.FC<BannerProps> = React.memo(
         </>
       );
 
-      const allow_run = allow_project_to_run(project_id);
-      if (!allow_run) {
+      if (allow_run === false) {
         return (
           <span>
             {trial_project} - There are too many free trial projects running

--- a/src/packages/frontend/projects/actions.ts
+++ b/src/packages/frontend/projects/actions.ts
@@ -893,7 +893,7 @@ export class ProjectsActions extends Actions<ProjectsState> {
 
   // return true, if it actually started the project
   public async start_project(project_id: string): Promise<boolean> {
-    if (!allow_project_to_run(project_id)) {
+    if (!(await allow_project_to_run(project_id))) {
       return false;
     }
     const state = store.get_state(project_id);
@@ -970,7 +970,7 @@ export class ProjectsActions extends Actions<ProjectsState> {
   }
 
   public async restart_project(project_id: string): Promise<void> {
-    if (!allow_project_to_run(project_id)) {
+    if (!(await allow_project_to_run(project_id))) {
       return;
     }
     this.project_log(project_id, {


### PR DESCRIPTION
# Description

The `too_many_free_projects` function was removed, hence free projects in restricted countries can't really do anything any more. This re-introduces this check, at the very end of the chain, by calling the endpoint directly.

~~What's left to do is to make this check an effect, such that a promise can be used.~~ Also, maybe add some caching, but I think that's not really necessary.

OK, what's left is testing. This is a hook and I think I found all usages and properly "await"ed them.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
