### PR TITLE
frontend/free project limit: cache getting stats

### DIFF
--- a/src/packages/frontend/lib/server-stats.ts
+++ b/src/packages/frontend/lib/server-stats.ts
@@ -1,0 +1,27 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { join } from "path";
+import LRU from "lru-cache";
+import { reuseInFlight } from "async-await-utils/hof";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+
+type Stats = {
+  running_projects?: { free?: number };
+};
+
+const statsCache = new LRU<"stats", Stats>({ max: 1, maxAge: 1000 * 60 * 5 });
+
+// ATTN: this might throw an exception
+export const getServerStatsCached = reuseInFlight(async (): Promise<Stats> => {
+  const stats = statsCache.get("stats");
+  if (stats != null) return stats;
+
+  const statsRaw = await fetch(join(appBasePath, "stats"));
+  const nextStats = await statsRaw.json();
+  statsCache.set("stats", nextStats);
+
+  return nextStats;
+});

--- a/src/packages/frontend/project/client-side-throttle.ts
+++ b/src/packages/frontend/project/client-side-throttle.ts
@@ -3,10 +3,8 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { join } from "path";
-
 import { redux, useEffect, useState } from "@cocalc/frontend/app-framework";
-import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { getServerStatsCached } from "@cocalc/frontend/lib/server-stats";
 
 /*
 Client-side throttling of running projects in blocked countries.  This may or may not be the
@@ -38,10 +36,7 @@ async function too_many_free_projects(): Promise<boolean> {
   if (not_in_blocked_country()) return false;
 
   try {
-    const statsRaw = await fetch(join(appBasePath, "stats"));
-    const stats: {
-      running_projects?: { free?: number };
-    } = await statsRaw.json();
+    const stats = await getServerStatsCached();
     const running_projects = stats?.running_projects?.free ?? 0;
     const free_limit =
       redux.getStore("customize")?.get("max_trial_projects") ?? 0;


### PR DESCRIPTION
# Description

follow up to that free project in restricted countries limit.

the only real change is that this caches getting the stats data (globally, can be re-used by other parts of the frontend).

I tested this locally by restricting myself (country "XX") and one free project. It works! Even double checked with the debugger.

The `/stats` endpoint is cached for 5 minutes and now this here also for 5 minutes, but ok, a certain lag is fine for this.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
