### PR TITLE
db: bypass "safety_check" when dropping an index

### DIFF
--- a/src/packages/database/postgres-base.coffee
+++ b/src/packages/database/postgres-base.coffee
@@ -1185,6 +1185,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                         when 'delete'
                             @_query
                                 query : "DROP INDEX #{task.name}"
+                                safety_check : false
                                 cb    : cb
                         else
                             cb("unknown action '#{task.action}")


### PR DESCRIPTION
# Description

I haven't tested this. Should not cause any problems. Resolves a problem, where an index is removed, but the safety_check in `__do_query` says this is unsafe ... i.e. this one https://github.com/sagemathinc/cocalc/blob/master/src/packages/database/postgres-base.coffee#L709

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
