### PR TITLE
db: set statement_timeout

### DIFF
--- a/src/packages/database/consts.ts
+++ b/src/packages/database/consts.ts
@@ -1,0 +1,21 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// Constants related to the database.
+
+import getLogger from "@cocalc/backend/logger";
+const L = getLogger("db:consts");
+
+/**
+ * this is a limit for each query, unless timeout_s is specified.
+ * https://postgresqlco.nf/en/doc/param/statement_timeout/
+ */
+export const STATEMENT_TIMEOUT_MS =
+  1000 *
+  (process.env.PG_STATEMENT_TIMEOUT_S
+    ? parseInt(process.env.PG_STATEMENT_TIMEOUT_S)
+    : 30);
+
+L.debug(`STATEMENT_TIMEOUT_MS=${STATEMENT_TIMEOUT_MS}ms`);

--- a/src/packages/database/pool/pool.ts
+++ b/src/packages/database/pool/pool.ts
@@ -3,16 +3,19 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Pool } from "pg";
+
 import {
   pgdatabase as database,
   pghost as host,
   pguser as user,
 } from "@cocalc/backend/data";
 
-import { Pool } from "pg";
+import { getLogger } from "@cocalc/backend/logger";
+import { STATEMENT_TIMEOUT_MS } from "../consts";
 import getCachedPool, { Length } from "./cached";
 import dbPassword from "./password";
-import { getLogger } from "@cocalc/backend/logger";
+
 const L = getLogger("db:pool");
 
 export * from "./util";
@@ -20,13 +23,20 @@ export * from "./util";
 let pool: Pool | undefined = undefined;
 
 export default function getPool(cacheLength?: Length): Pool {
-
   if (cacheLength != null) {
     return getCachedPool(cacheLength);
   }
   if (pool == null) {
-    L.debug(`creating a new Pool`);
-    pool = new Pool({ password: dbPassword(), user, host, database });
+    L.debug(
+      `creating a new Pool(host:${host}, database:${database}, user:${user}, statement_timeout:${STATEMENT_TIMEOUT_MS}ms)`
+    );
+    pool = new Pool({
+      password: dbPassword(),
+      user,
+      host,
+      database,
+      statement_timeout: STATEMENT_TIMEOUT_MS, // fixes https://github.com/sagemathinc/cocalc/issues/6014
+    });
   }
   return pool;
 }

--- a/src/packages/database/postgres-base.coffee
+++ b/src/packages/database/postgres-base.coffee
@@ -18,9 +18,8 @@ DEFAULT_TIMEOUT_DELAY_MS = DEFAULT_TIMEOUS_MS * 4
 
 QUERY_ALERT_THRESH_MS=5000
 
-# this is a limit for each query, unless timeout_s is specified.
-# https://postgresqlco.nf/en/doc/param/statement_timeout/
-DEFAULT_STATEMENT_TIMEOUT_S = 30
+consts = require('./consts')
+DEFAULT_STATEMENT_TIMEOUT_MS = consts.STATEMENT_TIMEOUT_MS
 
 EventEmitter = require('events')
 
@@ -252,15 +251,16 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                 dbg("create client and start connecting...")
                 locals.clients = []
 
-                # Use a function to initialize the client, to avoid any
-                # issues with scope of "client" below.
+                # Use a function to initialize the client, to avoid any issues with scope of "client" below.
+                # Ref: https://node-postgres.com/apis/client
                 init_client = (host) =>
                     client = new pg.Client
-                        user     : @_user
-                        host     : host
-                        port     : @_port
-                        password : @_password
-                        database : @_database
+                        user             : @_user
+                        host             : host
+                        port             : @_port
+                        password         : @_password
+                        database         : @_database
+                        statement_timeout: DEFAULT_STATEMENT_TIMEOUT_MS # we set a statement_timeout, to avoid queries locking up PG
                     if @_notification?
                         client.on('notification', @_notification)
                     onError = (err) =>
@@ -326,13 +326,6 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                     client.query "SELECT NOW()", (err) =>
                         clearTimeout(timeout)
                         cb?(err)
-                async.map(locals.clients, f, cb)
-            (cb) =>
-                # we set a statement_timeout, to avoid queries locking up PG
-                f = (client, cb) =>
-                    statement_timeout_ms = DEFAULT_STATEMENT_TIMEOUT_S * 1000 # in millisecs
-                    client.query "SET statement_timeout TO #{statement_timeout_ms}", (err) =>
-                        cb(err)
                 async.map(locals.clients, f, cb)
             (cb) =>
                 dbg("checking if ANY db server is in recovery, i.e., we are doing standby queries only")
@@ -783,6 +776,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                 if query_time_ms >= QUERY_ALERT_THRESH_MS
                     dbg("QUERY_ALERT_THRESH: query_time_ms=#{query_time_ms}\nQUERY_ALERT_THRESH: query='#{opts.query}'\nQUERY_ALERT_THRESH: params='#{misc.to_json(opts.params)}'")
 
+            # set a timeout for one specific query (there is a default when creating the pg.Client, see @_connect)
             if opts.timeout_s? and typeof opts.timeout_s == 'number' and opts.timeout_s >= 0
                 dbg("set query timeout to #{opts.timeout_s}secs")
                 opts.pg_params ?= {}


### PR DESCRIPTION
# Description

- this fixes #6014
- uses the `statement_timeout` parameter of `pg.Client` and `pg.Pool` → ref: https://node-postgres.com/apis/client
- makes the timeout configurable via an env variable



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
