### PR TITLE
util/quota: edge case of non member hosting + dedicated disk

### DIFF
--- a/src/packages/util/quota.test.ts
+++ b/src/packages/util/quota.test.ts
@@ -2039,4 +2039,36 @@ describe("boost", () => {
       dedicated_vm: false,
     });
   });
+
+  it("treats edge case correctly", () => {
+    const site_licenses: SiteLicenses = {
+      license1: {
+        quota: {
+          cpu: 2,
+          ram: 8,
+          disk: 5,
+          user: "academic",
+          boost: false,
+          member: false, // no member hosting!
+          idle_timeout: "short", // this should set it to 30 mins idle timeout, not 10!
+          dedicated_cpu: 0,
+          dedicated_ram: 0,
+          always_running: false,
+        },
+        status: "active",
+      },
+      disk1: {
+        quota: {
+          member: true, // for unknown reasons, this field sneaks in
+          idle_timeout: "short",
+          dedicated_disk: {
+            name: "disk1234",
+            speed: "standard",
+            size_gb: 32,
+          },
+        },
+        status: "active",
+      },
+    };
+  });
 });


### PR DESCRIPTION
# Description

- one license has no member hosting, but idle time set … and quota upgrades
- another one a disk upgrade, which for yet unknown reasons has member hosting set to true
- expected result: 30 mins idle, not 10; no member hosting; disk attached; quotas configured



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
