### PR TITLE
frontend/trial banner: remove "Trial" if internet accessible

### DIFF
--- a/src/packages/frontend/project/no-internet-banner.tsx
+++ b/src/packages/frontend/project/no-internet-banner.tsx
@@ -74,7 +74,7 @@ export const NoInternetBanner: React.FC<NoInternetBannerProps> = React.memo(
           <div>
             <Button
               size="small"
-              type="primary"
+              type="default"
               icon={<Icon name="times-circle" />}
               onClick={() => actions?.close_project_no_internet_warning()}
             >

--- a/src/packages/frontend/project/settings/quota-console.tsx
+++ b/src/packages/frontend/project/settings/quota-console.tsx
@@ -5,17 +5,9 @@
 
 // TODO: Remove `as any`s in this file.
 // Refer to https://github.com/microsoft/TypeScript/issues/13948
-import React, { useEffect, useState } from "react";
+
 import * as immutable from "immutable";
-import { Rendered, usePrevious } from "../../app-framework";
-import { LabeledRow, Tip, Icon, Space, Loading } from "../../components";
-import { alert_message } from "../../alerts";
-import { ProjectSettings, ProjectStatus } from "./types";
-import * as misc from "@cocalc/util/misc";
-const { User } = require("../../users"); // TODO fix typing error when importing properly
-import { webapp_client } from "../../webapp-client";
-import { PROJECT_UPGRADES } from "@cocalc/util/schema";
-import { KUCALC_DISABLED } from "@cocalc/util/db-schema/site-defaults";
+import React, { useEffect, useState } from "react";
 const {
   Checkbox,
   Row,
@@ -23,6 +15,22 @@ const {
   ButtonToolbar,
   Button,
 } = require("react-bootstrap");
+
+import { alert_message } from "@cocalc/frontend/alerts";
+import { Rendered, usePrevious } from "@cocalc/frontend/app-framework";
+import {
+  Icon,
+  LabeledRow,
+  Loading,
+  Space,
+  Tip,
+} from "@cocalc/frontend/components";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import { KUCALC_DISABLED } from "@cocalc/util/db-schema/site-defaults";
+import * as misc from "@cocalc/util/misc";
+import { PROJECT_UPGRADES } from "@cocalc/util/schema";
+import { ProjectSettings, ProjectStatus } from "./types";
+const { User } = require("@cocalc/frontend/users"); // TODO fix typing error when importing properly
 
 interface Props {
   project_id: string;
@@ -106,7 +114,7 @@ export const QuotaConsole: React.FC<Props> = (props: Props) => {
 
   function render_quota_row(
     name: keyof QuotaParams,
-    quota: { edit: string; view: string },
+    quota: { edit: string; view: string } | undefined,
     base_value: number,
     upgrades: QuotaParams,
     params_data: {
@@ -117,6 +125,8 @@ export const QuotaConsole: React.FC<Props> = (props: Props) => {
     },
     site_license: number
   ): Rendered {
+    if (quota == null) return;
+
     if (
       kucalc == KUCALC_DISABLED &&
       name != "mintime" &&
@@ -126,6 +136,7 @@ export const QuotaConsole: React.FC<Props> = (props: Props) => {
       // NONE of the other quotas are.
       return;
     }
+
     // if always_running is true, don't show idle timeout row, since not relevant
     if (
       name == "mintime" &&

--- a/src/packages/frontend/project/trial-banner.tsx
+++ b/src/packages/frontend/project/trial-banner.tsx
@@ -82,20 +82,23 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
     // when to show the more intimidating red banner:
     // after $ELEVATED_DAYS days
     // but not if there are already any licenses applied to the project
-    // and also if user manages at least one license
-    const elevated =
-      ageDays >= ELEVATED_DAYS &&
-      projectSiteLicenses.length === 0 &&
-      managedLicenses?.size === 0;
+    // or if user manages at least one license
+    const no_licenses =
+      projectSiteLicenses.length === 0 && managedLicenses?.size === 0;
+    const elevated = ageDays >= ELEVATED_DAYS && no_licenses;
+
     const style = elevated ? ALERT_STYLE_ELEVATED : ALERT_STYLE;
     const a_style = elevated ? A_STYLE_ELEVATED : A_STYLE;
 
-    const trial_project = (
+    // If user has any licenses or there is a license applied to the project (even when expired), we no longer call this a "Trial"
+    const trial_project = no_licenses ? (
       <strong>
         <A href={DOC_TRIAL} style={a_style}>
           Free Trial (Day {Math.floor(ageDays)})
         </A>
       </strong>
+    ) : (
+      <strong>No upgrades</strong>
     );
 
     function renderMessage(): JSX.Element | undefined {
@@ -132,7 +135,7 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
       } else if (host) {
         return (
           <span>
-            {trial_project} – upgrade to{" "}
+            <strong>Low-grade hosting</strong> – upgrade to{" "}
             <A href={MEMBER_QUOTA} style={a_style}>
               <u>Member Hosting</u>
             </A>{" "}
@@ -172,9 +175,13 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
       );
     }
 
+    // allow users to close the banner, if there is either internet or host upgrade – or if user has licenses (past customer, upgrades by someone else, etc.)
+    const closable = !host || !internet || !no_licenses;
+
     return (
       <Alert
         type="warning"
+        closable={closable}
         style={style}
         icon={
           <Icon


### PR DESCRIPTION
# Description

- if there is internet access, there must be a license applied ... this means it's not a trial any more.
- it's also not a trial project, if there is a license somewhere – i.e. it assumes users are beyond trial testing.
– in these cases, this makes the banner dismissable as well
- saw a crash when there is no quota set for the admin quota editor

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
