### PR TITLE
Fix quota upgrades form

### DIFF
--- a/src/packages/util/upgrade-spec.js
+++ b/src/packages/util/upgrade-spec.js
@@ -204,8 +204,6 @@ upgrades.field_order = [
   "memory_request",
   "cores",
   "cpu_shares",
-  "ext_rw",  // cocalc-cloud only
-  "patch", // cocalc-cloud only
 ];
 
 // live_subscriptions is an array of arrays.  Each array should have length a divisor of 12.


### PR DESCRIPTION
# Description

- main idea is to get rid of the two additional fields in the `field_order`. This is used in several places and sure, this could cause problems.
- I'm only adding these two field names in the hook, specific to listing the run quotas in the project settings (without modifying that fields list)

I wasn't able to test this, since I don't know yet how to get these deprecated upgrade subscriptions. In any case, I think this is certainly of help.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
