### PR TITLE
util/quota: avoid modifying passed in objects

### DIFF
--- a/src/packages/database/postgres/site-license/hook.test.ts
+++ b/src/packages/database/postgres/site-license/hook.test.ts
@@ -1,0 +1,210 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/**
+ * This tests the core of ./hook.ts
+ * It's not using it directly, though, because of the complex dependency of the database.
+ * The main purpose of this test is to simulate what happens, if first a partial set of licenses,
+ * and then one more license is fed through the quota function.
+ * There was a bug, where licenses were modified in place, and the second call to the quota function
+ * used the modified license, which led to very subtle but severe problems.
+ *
+ * The quota function uses a deep copy operation on all its arguments to avoid this.
+ */
+
+import { isEqual } from "lodash";
+
+import { quota_with_reasons } from "@cocalc/util/upgrades/quota";
+
+test("allow for much larger max_upgrades", () => {
+  const site_settings = {
+    default_quotas: {
+      internet: true,
+      idle_timeout: 1800,
+      mem: 2000,
+      cpu: 1,
+      cpu_oc: 20,
+      mem_oc: 10,
+    },
+    max_upgrades: {
+      disk_quota: 20000,
+      memory: 50000,
+      memory_request: 1000,
+      cores: 16,
+      network: 1,
+      cpu_shares: 1024,
+      mintime: 7776000,
+      member_host: 1,
+      ephemeral_state: 1,
+      ephemeral_disk: 1,
+      always_running: 1,
+    },
+    kucalc: "onprem",
+    datastore: true,
+  };
+
+  const site_licenses = {
+    a: {
+      quota: { cpu: 2, ram: 13 },
+    },
+    b: {
+      quota: { cpu: 3, ram: 32 },
+    },
+  };
+
+  const q1 = quota_with_reasons(
+    {},
+    { userX: {} },
+    { a: site_licenses.a },
+    site_settings
+  );
+  expect(q1).toEqual({
+    quota: {
+      network: true,
+      member_host: false,
+      privileged: false,
+      memory_request: 1000,
+      cpu_request: 0.1,
+      disk_quota: 3000,
+      memory_limit: 13000,
+      cpu_limit: 2,
+      idle_timeout: 1800,
+      always_running: false,
+      dedicated_vm: false,
+      dedicated_disks: [],
+    },
+    reasons: {},
+  });
+
+  const q2 = quota_with_reasons(
+    {},
+    { userX: {} },
+    site_licenses,
+    site_settings
+  );
+  expect(q2).toEqual({
+    quota: {
+      always_running: false,
+      cpu_limit: 5,
+      cpu_request: 0.25,
+      dedicated_disks: [],
+      dedicated_vm: false,
+      disk_quota: 3000,
+      idle_timeout: 1800,
+      member_host: false,
+      memory_limit: 45000,
+      memory_request: 1000,
+      network: true,
+      privileged: false,
+    },
+    reasons: {},
+  });
+});
+
+test("two licenses", () => {
+  const site_settings = {
+    default_quotas: {
+      internet: true,
+      idle_timeout: 1800,
+      mem: 2000,
+      cpu: 1,
+      cpu_oc: 20,
+      mem_oc: 10,
+    },
+    max_upgrades: {
+      disk_quota: 20000,
+      memory: 50000,
+      memory_request: 1000,
+      cores: 16,
+      network: 1,
+      cpu_shares: 1024,
+      mintime: 7776000,
+      member_host: 1,
+      ephemeral_state: 1,
+      ephemeral_disk: 1,
+      always_running: 1,
+    },
+    kucalc: "onprem",
+    datastore: true,
+  };
+
+  const site_licenses = {
+    a: {
+      quota: { cpu: 1, ram: 13 },
+    },
+    b: {
+      quota: { cpu: 3, ram: 32 },
+    },
+  };
+
+  const q1 = quota_with_reasons(
+    {},
+    { userX: {} },
+    { a: site_licenses.a },
+    site_settings
+  );
+  expect(q1).toEqual({
+    quota: {
+      network: true,
+      member_host: false,
+      privileged: false,
+      memory_request: 1000,
+      cpu_request: 0.05,
+      disk_quota: 3000,
+      memory_limit: 13000,
+      cpu_limit: 1,
+      idle_timeout: 1800,
+      always_running: false,
+      dedicated_vm: false,
+      dedicated_disks: [],
+    },
+    reasons: {},
+  });
+
+  const q2 = quota_with_reasons(
+    {},
+    { userX: {} },
+    site_licenses,
+    site_settings
+  );
+  expect(q1).toEqual({
+    quota: {
+      network: true,
+      member_host: false,
+      privileged: false,
+      memory_request: 1000,
+      cpu_request: 0.05,
+      disk_quota: 3000,
+      memory_limit: 13000,
+      cpu_limit: 1,
+      idle_timeout: 1800,
+      always_running: false,
+      dedicated_vm: false,
+      dedicated_disks: [],
+    },
+    reasons: {},
+  });
+
+  expect(q2).toEqual({
+    quota: {
+      always_running: false,
+      cpu_limit: 4,
+      cpu_request: 0.2,
+      dedicated_disks: [],
+      dedicated_vm: false,
+      disk_quota: 3000,
+      idle_timeout: 1800,
+      member_host: false,
+      memory_limit: 45000,
+      memory_request: 1000,
+      network: true,
+      privileged: false,
+    },
+    reasons: {},
+  });
+
+  // in particular, this implies that the second license indeed HAS an effect and hence will be used.
+  expect(isEqual(q1, q2)).toBe(false);
+});

--- a/src/packages/util/quota.test.ts
+++ b/src/packages/util/quota.test.ts
@@ -31,6 +31,7 @@ import expect from "expect";
 // import { quota } from "./upgrades/quota";
 import {
   quota as quota0,
+  quota_with_reasons,
   quota_with_reasons as reasons0,
 } from "./upgrades/quota";
 const quota = quota0 as (a?, b?, c?, d?) => ReturnType<typeof quota0>;
@@ -725,6 +726,67 @@ describe("main quota functionality", () => {
       memory_request: 300,
       network: true,
       privileged: false,
+    });
+  });
+
+  it("allow for much larger max_upgrades /2", () => {
+    const site_settings = {
+      default_quotas: {
+        internet: true,
+        idle_timeout: 1800,
+        mem: 2000,
+        cpu: 1,
+        cpu_oc: 20,
+        mem_oc: 10,
+      },
+      max_upgrades: {
+        disk_quota: 20000,
+        memory: 50000,
+        memory_request: 1000,
+        cores: 16,
+        network: 1,
+        cpu_shares: 1024,
+        mintime: 7776000,
+        member_host: 1,
+        ephemeral_state: 1,
+        ephemeral_disk: 1,
+        always_running: 1,
+      },
+      kucalc: "onprem",
+      datastore: true,
+    };
+
+    const site_license = {
+      a: {
+        quota: { cpu: 2, ram: 13 },
+      },
+      b: {
+        quota: { cpu: 3, ram: 32 },
+      },
+    };
+
+    const q1 = quota_with_reasons(
+      {},
+      { userX: {} },
+      site_license,
+      site_settings
+    );
+    expect(q1).toEqual({
+      quota: {
+        always_running: false,
+        cpu_limit: 5,
+        cpu_request: 0.25,
+        dedicated_disks: [],
+        dedicated_vm: false,
+        disk_quota: 3000,
+        idle_timeout: 1800,
+        member_host: false,
+        memory_limit: 45000,
+        memory_request: 1000,
+        network: true,
+        privileged: false,
+      },
+      reasons: {},
     });
   });
 

--- a/src/packages/util/upgrades/quota.ts
+++ b/src/packages/util/upgrades/quota.ts
@@ -45,7 +45,7 @@ import {
   LicenseIdleTimeouts,
   LicenseIdleTimeoutsKeysOrdered,
 } from "../consts/site-license";
-import { len, test_valid_jsonpatch } from "../misc";
+import { deep_copy, len, test_valid_jsonpatch } from "../misc";
 import { SiteLicenseQuota } from "../types/site-licenses";
 // TODO how to use the logger ?
 //import { getLogger } from "@cocalc/backend/logger";
@@ -881,6 +881,13 @@ export function quota_with_reasons(
   site_licenses?: SiteLicenses,
   site_settings?: SiteSettingsQuotas
 ): { quota: Quota; reasons: { [key: string]: string } } {
+  // as a precaution (and also since we indeed ARE modifying licenses) we make deep copies of all arguments.
+  // tests to catch this are in postgres/site-license/hook.test.ts
+  settings_arg = deep_copy(settings_arg);
+  users_arg = deep_copy(users_arg);
+  site_licenses = deep_copy(site_licenses);
+  site_settings = deep_copy(site_settings);
+
   // empirically, this is sometimes a string -- we want this to be a number, though!
   if (typeof settings_arg?.disk_quota === "string") {
     settings_arg.disk_quota = to_int(settings_arg.disk_quota);


### PR DESCRIPTION
# Description

- this is a very subtle problem I have never seen before, but makes 100% sense: somewhere the quota function modifies licenses, which have unintended consequences when used again. all tests just assume a single call!
- however, the postgres/site-license/hook progressively applies licenses and in some cases, subsequent calls with modified licenses start to be incompatible.
- there is now a test applying partially and then all licenses, which trigger this problem.
- but it doesn't fail, because quota now does a deep copy of all arguments



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
