### PR TITLE
next/config: fixing style, adding email verification, ...

### DIFF
--- a/src/packages/database/postgres/account-queries.ts
+++ b/src/packages/database/postgres/account-queries.ts
@@ -136,7 +136,7 @@ export async function set_email_address_verified(
   const { db, account_id, email_address } = opts;
   assert_valid_account_id(account_id);
   assert_valid_email_address(email_address);
-  return await db.async_query({
+  await db.async_query({
     query: "UPDATE accounts",
     jsonb_set: { email_address_verified: { [email_address]: new Date() } },
     where: { "account_id = $::UUID": account_id },

--- a/src/packages/database/postgres/passport.ts
+++ b/src/packages/database/postgres/passport.ts
@@ -16,7 +16,6 @@ import {
   set_email_address_verified,
 } from "./account-queries";
 import {
-  CB,
   CreatePassportOpts,
   DeletePassportOpts,
   PassportExistsOpts,
@@ -25,6 +24,7 @@ import {
 } from "./types";
 import { PassportStrategyDB } from "@cocalc/server/auth/sso/types";
 import { isBlockedUnlinkStrategy } from "@cocalc/server/auth/sso/unlink-strategy";
+import { CB } from "@cocalc/util/types/database";
 
 export async function set_passport_settings(
   db: PostgreSQL,
@@ -68,7 +68,7 @@ export async function get_all_passport_settings(
   db: PostgreSQL
 ): Promise<PassportStrategyDB[]> {
   return (
-    await db.async_query({
+    await db.async_query<PassportStrategyDB>({
       query: "SELECT strategy, conf, info FROM passport_settings",
     })
   ).rows;

--- a/src/packages/database/postgres/passport.ts
+++ b/src/packages/database/postgres/passport.ts
@@ -5,26 +5,26 @@
 
 // DEVELOPMENT: use scripts/auth/gen-sso.py to generate some test data
 
+import { PassportStrategyDB } from "@cocalc/server/auth/sso/types";
+import { isBlockedUnlinkStrategy } from "@cocalc/server/auth/sso/unlink-strategy";
 import {
   getPassportsCached,
-  setPassportsCached,
+  setPassportsCached
 } from "@cocalc/server/settings/server-settings";
 import { to_json } from "@cocalc/util/misc";
+import { CB } from "@cocalc/util/types/database";
 import {
   set_account_info_if_different,
   set_account_info_if_not_set,
-  set_email_address_verified,
+  set_email_address_verified
 } from "./account-queries";
 import {
   CreatePassportOpts,
   DeletePassportOpts,
   PassportExistsOpts,
   PostgreSQL,
-  UpdateAccountInfoAndPassportOpts,
+  UpdateAccountInfoAndPassportOpts
 } from "./types";
-import { PassportStrategyDB } from "@cocalc/server/auth/sso/types";
-import { isBlockedUnlinkStrategy } from "@cocalc/server/auth/sso/unlink-strategy";
-import { CB } from "@cocalc/util/types/database";
 
 export async function set_passport_settings(
   db: PostgreSQL,
@@ -52,7 +52,7 @@ export async function set_passport_settings(
 
 export async function get_passport_settings(
   db: PostgreSQL,
-  opts: { strategy: string; cb?: CB }
+  opts: { strategy: string; cb?: (data: object) => void }
 ): Promise<any> {
   const { rows } = await db.async_query({
     query: "SELECT conf, info FROM passport_settings",

--- a/src/packages/database/postgres/project-and-user-tracker.ts
+++ b/src/packages/database/postgres/project-and-user-tracker.ts
@@ -171,9 +171,9 @@ export class ProjectAndUserTracker extends EventEmitter {
     dbg(new_val);
     // users on a project changed or project created
     const { project_id } = new_val;
-    let users: QueryResult[];
+    let users: QueryResult<{ account_id: string }>[];
     try {
-      users = await query(this.db, {
+      users = await query<{ account_id: string }>(this.db, {
         query: "SELECT jsonb_object_keys(users) AS account_id FROM projects",
         where: { "project_id = $::UUID": project_id },
       });
@@ -490,9 +490,9 @@ function all_query(db: PostgreSQL, opts: QueryOptions, cb: Function): void {
   db._query(opts);
 }
 
-async function query(
+async function query<T>(
   db: PostgreSQL,
   opts: QueryOptions
-): Promise<QueryResult[]> {
+): Promise<QueryResult<T>[]> {
   return await callback(all_query, db, opts);
 }

--- a/src/packages/database/postgres/registration-tokens.ts
+++ b/src/packages/database/postgres/registration-tokens.ts
@@ -1,4 +1,5 @@
 import { callback2 } from "@cocalc/util/async-utils";
+import { PostgreSQL } from "./types";
 
 function isDelete(options: { delete?: boolean }[]) {
   return options.some((v) => v?.delete === true);
@@ -13,7 +14,7 @@ interface Query {
 }
 
 export default async function registrationTokensQuery(
-  db: { _query: Function },
+  db: PostgreSQL,
   options: { delete?: boolean }[],
   query: Query
 ) {

--- a/src/packages/database/postgres/site-license/search.ts
+++ b/src/packages/database/postgres/site-license/search.ts
@@ -55,7 +55,7 @@ export async function matching_site_licenses(
 ): Promise<{ id: string }[]> {
   if (is_valid_uuid_string(search)) {
     return (
-      await db.async_query({
+      await db.async_query<{id :string}>({
         cache: true,
         query: "SELECT id FROM site_licenses WHERE id=$1",
         params: [search],

--- a/src/packages/database/postgres/types.ts
+++ b/src/packages/database/postgres/types.ts
@@ -3,12 +3,21 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import type { Stripe } from "@cocalc/server/stripe/client";
 import { EventEmitter } from "events";
-import { Changes } from "./changefeed";
 import { Client } from "pg";
+
 import { PassportStrategyDB } from "@cocalc/server/auth/sso/types";
-import { CB } from "@cocalc/util/types/database";
+import type { Stripe } from "@cocalc/server/stripe/client";
+import {
+  CB,
+  CBDB,
+  QueryResult,
+  QueryRows,
+  UntypedQueryResult,
+} from "@cocalc/util/types/database";
+import { Changes } from "./changefeed";
+
+export type { QueryResult };
 
 export type QuerySelect = object;
 
@@ -17,8 +26,6 @@ export type QueryWhere =
   | { [field: string]: any }[]
   | string
   | string[];
-
-type UntypedQueryResult = { [key: string]: any };
 
 // There are many more options still -- add them as needed.
 export interface QueryOptions<T = UntypedQueryResult> {
@@ -43,9 +50,6 @@ export interface QueryOptions<T = UntypedQueryResult> {
 
 export interface AsyncQueryOptions<T = UntypedQueryResult>
   extends Omit<QueryOptions<T>, "cb"> {}
-
-export type QueryRows<T = UntypedQueryResult> = { rows: QueryResult<T>[] };
-export type QueryResult<T = { [key: string]: any }> = T;
 
 export interface ChangefeedOptions {
   table: string; // Name of the table
@@ -105,7 +109,9 @@ export interface PostgreSQL extends EventEmitter {
 
   get_site_settings(opts: { cb: CB }): void;
 
-  async_query<T = any>(opts: AsyncQueryOptions): Promise<QueryRows<T>>;
+  async_query<T = UntypedQueryResult>(
+    opts: AsyncQueryOptions
+  ): Promise<QueryRows<T>>;
 
   _listen(table: string, select: QuerySelect, watch: string[], cb: CB): void;
 
@@ -119,7 +125,7 @@ export interface PostgreSQL extends EventEmitter {
     account_id?: string;
     email_address?: string;
     columns?: string[];
-    cb: CB;
+    cb: CBDB;
   }): void;
 
   add_user_to_project(opts: {
@@ -212,7 +218,7 @@ export interface PostgreSQL extends EventEmitter {
   get_project_ids_with_user(opts: {
     account_id: string;
     is_owner?: boolean;
-    cb: CB;
+    cb: CBDB;
   }): void;
 
   get_remember_me(opts: { hash: string; cb: CB });

--- a/src/packages/database/postgres/types.ts
+++ b/src/packages/database/postgres/types.ts
@@ -42,7 +42,10 @@ export interface AsyncQueryOptions extends Omit<QueryOptions, "cb"> {}
 
 export type QueryResult = { [key: string]: any };
 
-export type CB = (err: string | Error | null | undefined, result?: any) => any;
+export type CB<T = any> = (
+  err: string | Error | null | undefined,
+  result?: T
+) => any;
 
 export interface ChangefeedOptions {
   table: string; // Name of the table
@@ -313,4 +316,12 @@ export interface PostgreSQL extends EventEmitter {
   projects_that_need_to_be_started(): Promise<string[]>;
 
   is_connected(): boolean;
+
+  verify_email_create_token(opts: {
+    account_id: string;
+    cb: CB<{
+      token: string;
+      email_address: string;
+    }>;
+  }): Promise<void>;
 }

--- a/src/packages/frontend/client/client.ts
+++ b/src/packages/frontend/client/client.ts
@@ -23,6 +23,7 @@ import { IdleClient } from "./idle";
 import { version } from "@cocalc/util/smc-version";
 import { start_metrics } from "../prom-client";
 import { setup_global_cocalc } from "./console";
+import { Query } from "@cocalc/sync/table";
 
 export type AsyncCall = (opts: object) => Promise<any>;
 
@@ -70,7 +71,7 @@ export interface WebappClient extends EventEmitter {
   dbg: (str: string) => Function;
   is_project: () => boolean;
   is_connected: () => boolean;
-  query: Function;
+  query: Query; // TODO typing
   query_cancel: Function;
   is_deleted: Function;
   set_deleted: Function;
@@ -144,7 +145,7 @@ class Client extends EventEmitter implements WebappClient {
   send: Function;
   call: Function;
   is_connected: () => boolean;
-  query: Function;
+  query: typeof QueryClient.prototype.query;
   query_cancel: Function;
 
   is_deleted: Function;

--- a/src/packages/frontend/client/query.ts
+++ b/src/packages/frontend/client/query.ts
@@ -6,6 +6,7 @@
 import * as message from "@cocalc/util/message";
 import { is_array } from "@cocalc/util/misc";
 import { validate_client_query } from "@cocalc/util/schema-validate";
+import { CB } from "@cocalc/util/types/database";
 
 declare const $: any; // jQuery
 
@@ -37,7 +38,7 @@ export class QueryClient {
     no_post?: boolean; // DEPRECATED -- didn't turn out to be worth it.
     ignore_response?: boolean; // if true, be slightly efficient by not waiting for any response or
     // error (just assume it worked; don't care about response)
-    cb?: Function; // used for changefeed outputs if changes is true
+    cb?: CB; // used for changefeed outputs if changes is true
   }): Promise<any> {
     if (opts.options != null && !is_array(opts.options)) {
       // should never happen...

--- a/src/packages/frontend/client/stripe.ts
+++ b/src/packages/frontend/client/stripe.ts
@@ -10,9 +10,10 @@ stripe payments api via backend hub
 import { callback2 } from "@cocalc/util/async-utils";
 import * as message from "@cocalc/util/message";
 import { PurchaseInfo } from "@cocalc/util/licenses/purchase/types";
+import { HubClient } from "./hub";
 
 export class StripeClient {
-  private call_api: Function;
+  private call_api: typeof HubClient.prototype.call;
 
   constructor(call_api) {
     this.call_api = call_api;

--- a/src/packages/frontend/components/time-ago.tsx
+++ b/src/packages/frontend/components/time-ago.tsx
@@ -8,9 +8,10 @@
  * TODO: internationalize this formatter -- see https://www.npmjs.com/package/react-timeago
  */
 
-import { default as UpstreamTimeAgo } from "react-timeago";
 import React, { CSSProperties as CSS } from "react";
-import { useTypedRedux } from "../app-framework";
+import { default as UpstreamTimeAgo } from "react-timeago";
+
+import { useTypedRedux } from "@cocalc/frontend/app-framework";
 import { is_date, is_different as misc_is_different } from "@cocalc/util/misc";
 import { Tip } from "./tip";
 
@@ -149,7 +150,16 @@ interface TimeAgoProps {
 
 export const TimeAgo: React.FC<TimeAgoProps> = React.memo(
   (props: TimeAgoElementProps) => {
-    const { popover, placement, tip, live, style, date, minPeriod, time_ago_absolute } = props;
+    const {
+      popover,
+      placement,
+      tip,
+      live,
+      style,
+      date,
+      minPeriod,
+      time_ago_absolute,
+    } = props;
 
     const other_settings = useTypedRedux("account", "other_settings");
     if (date == null) return <></>;
@@ -161,7 +171,9 @@ export const TimeAgo: React.FC<TimeAgoProps> = React.memo(
         placement={placement}
         tip={tip}
         live={live}
-        time_ago_absolute={time_ago_absolute ?? other_settings.get("time_ago_absolute") ?? false}
+        time_ago_absolute={
+          time_ago_absolute ?? other_settings.get("time_ago_absolute") ?? false
+        }
         style={style}
         minPeriod={minPeriod}
       />

--- a/src/packages/hub/auth.ts
+++ b/src/packages/hub/auth.ts
@@ -840,12 +840,12 @@ export async function verify_email_send_token(opts: VerifyEmailOpts) {
   });
 
   try {
-    const { token, email_address } = await cb2(
-      opts.database.verify_email_create_token,
-      {
-        account_id: opts.account_id,
-      }
-    );
+    const { token, email_address } = await cb2<{
+      token: string;
+      email_address: string;
+    }>(opts.database.verify_email_create_token, {
+      account_id: opts.account_id,
+    });
     const settings = await cb2(opts.database.get_server_settings_cached);
     await cb2(welcome_email, {
       to: email_address,

--- a/src/packages/hub/auth.ts
+++ b/src/packages/hub/auth.ts
@@ -822,7 +822,14 @@ export async function is_password_correct(
   }
 }
 
-export async function verify_email_send_token(opts) {
+interface VerifyEmailOpts {
+  database: PostgreSQL;
+  account_id: string;
+  only_verify: boolean;
+  cb: (err?) => void;
+}
+
+export async function verify_email_send_token(opts: VerifyEmailOpts) {
   opts = defaults(opts, {
     database: required,
     account_id: required,

--- a/src/packages/hub/auth.ts
+++ b/src/packages/hub/auth.ts
@@ -782,14 +782,16 @@ export async function is_password_correct(
     cb: required,
   });
 
+  const { account_id, email_address } = opts;
+
   if (opts.password_hash != null) {
     const r = verifyPassword(opts.password, opts.password_hash);
     opts.cb(undefined, r);
-  } else if (opts.account_id != null || opts.email_address != null) {
+  } else if (account_id != null || email_address != null) {
     try {
       const account = await cb2(opts.database.get_account, {
-        account_id: opts.account_id,
-        email_address: opts.email_address,
+        account_id,
+        email_address,
         columns: ["password_hash"],
       });
 

--- a/src/packages/next/components/account/config/account/api.tsx
+++ b/src/packages/next/components/account/config/account/api.tsx
@@ -1,11 +1,17 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Alert, Button, Input, Popconfirm, Space } from "antd";
 import { useState } from "react";
 
-import register from "../register";
-import { Alert, Button, Input, Popconfirm, Space } from "antd";
-import useAPI from "lib/hooks/api";
+import A from "components/misc/A";
 import Loading from "components/share/loading";
 import apiPost from "lib/api/post";
-import A from "components/misc/A";
+import useAPI from "lib/hooks/api";
+import register from "../register";
+import { Paragraph, Text } from "components/misc";
 
 register({
   path: "account/api",
@@ -107,21 +113,23 @@ register({
       body = (
         <Space direction="vertical">
           API Key:
-          <Input value={apiKey} readOnly style={{ width: "60ex" }} />
+          <Text code strong style={{ fontSize: "150%" }} copyable>
+            {apiKey}
+          </Text>
           <br />
           <A href="https://doc.cocalc.com/api/">Learn about the API...</A>
           <br />
           <Popconfirm
             title={
-              <div style={{ maxWidth: "50ex" }}>
-                Are you sure you want to delete your API key?{" "}
-                <b>
-                  <i>
-                    Anything using the current API key will stop working until
-                    you create and enter a new key.
-                  </i>
-                </b>
-              </div>
+              <>
+                <Paragraph style={{ maxWidth: "50ex" }}>
+                  Are you sure you want to delete your API key?
+                </Paragraph>
+                <Paragraph type="danger">
+                  Anything using the current API key will stop working until you
+                  create and enter a new key.
+                </Paragraph>
+              </>
             }
             onConfirm={() => apiAction("delete")}
             okText={"Yes, delete my key"}

--- a/src/packages/next/components/account/config/account/avatar.tsx
+++ b/src/packages/next/components/account/config/account/avatar.tsx
@@ -23,7 +23,6 @@ import gravatarUrl from "@cocalc/frontend/account/gravatar-url";
 import { ColorPicker } from "@cocalc/frontend/colorpicker";
 import { Icon } from "@cocalc/frontend/components/icon";
 import imageToDataURL from "@cocalc/frontend/misc/image-to-data";
-import { COLORS } from "@cocalc/util/theme";
 import { DisplayAvatar } from "components/account/avatar";
 import Code from "components/landing/code";
 import { Paragraph, Title } from "components/misc";

--- a/src/packages/next/components/account/config/account/avatar.tsx
+++ b/src/packages/next/components/account/config/account/avatar.tsx
@@ -1,20 +1,23 @@
+import { Alert, Checkbox, Col, Radio, Row, Space, Upload } from "antd";
 import { useEffect, useState } from "react";
-import register from "../register";
-import { Alert, Checkbox, Col, Row, Radio, Space, Upload } from "antd";
-import Loading from "components/share/loading";
-import useEditTable from "lib/hooks/edit-table";
-import { ColorPicker } from "@cocalc/frontend/colorpicker";
-import { Icon } from "@cocalc/frontend/components/icon";
-import A from "components/misc/A";
-import { DisplayAvatar } from "components/account/avatar";
-import useProfile from "lib/hooks/profile";
-import useCustomize from "lib/use-customize";
+
+import { InboxOutlined } from "@ant-design/icons";
+import ImgCrop from "@cocalc/antd-img-crop";
 import { avatar_fontcolor } from "@cocalc/frontend/account/avatar/font-color";
 import gravatarUrl from "@cocalc/frontend/account/gravatar-url";
-import ImgCrop from "@cocalc/antd-img-crop";
-import { InboxOutlined } from "@ant-design/icons";
-import Code from "components/landing/code";
+import { ColorPicker } from "@cocalc/frontend/colorpicker";
+import { Icon } from "@cocalc/frontend/components/icon";
 import imageToDataURL from "@cocalc/frontend/misc/image-to-data";
+import { COLORS } from "@cocalc/util/theme";
+import { DisplayAvatar } from "components/account/avatar";
+import Code from "components/landing/code";
+import { Paragraph, Title } from "components/misc";
+import A from "components/misc/A";
+import Loading from "components/share/loading";
+import useEditTable from "lib/hooks/edit-table";
+import useProfile from "lib/hooks/profile";
+import useCustomize from "lib/use-customize";
+import register from "../register";
 
 interface Data {
   email_address?: string;
@@ -63,7 +66,7 @@ register({
         <Row>
           <Col md={6} sm={24}>
             <div style={{ marginRight: "15px" }}>
-              <h3 style={{ marginTop: "10px" }}>
+              <Title level={3} style={{ marginTop: "10px" }}>
                 <DisplayAvatar
                   style={{ marginRight: "10px" }}
                   size={40}
@@ -72,7 +75,7 @@ register({
                   letter={profile?.first_name?.[0]}
                 />
                 Preview
-              </h3>
+              </Title>
               <br />
               {profile && (
                 <span
@@ -96,31 +99,31 @@ register({
               />
               <br />
               <br />
-              <div style={{ fontSize: "10px", color: "#666" }}>
+              <Paragraph style={{ fontSize: "10px", color: COLORS.GRAY }}>
                 (It will take a while for your avatar to update at the top of
                 the page, even after you save it.)
-              </div>
+              </Paragraph>
             </div>
           </Col>
           <Col md={18} sm={24}>
             <Space direction="vertical">
-              <h3>
+              <Title level={3}>
                 <Icon name="colors" /> Color
-              </h3>
-              <div>
+              </Title>
+              <Paragraph>
                 {desc.color}{" "}
                 <A href="/config/account/name">Change your name.</A>
-              </div>
-              <div style={{ width: "100%" }}>
+              </Paragraph>
+              <div style={{ margin: "20px 0" }}>
                 <ColorPicker
                   color={edited.profile.color}
-                  style={{ width: "200px", margin: "auto" }}
+                  style={{ width: "100%" }}
                   onChange={(color) => setEdited(color, "profile.color")}
                 />
               </div>
-              <h3>
+              <Title level={3}>
                 <Icon name="image" /> Image
-              </h3>
+              </Title>
               {desc.image}
               <Checkbox
                 checked={useImage}
@@ -186,12 +189,12 @@ function EditImage({ value, email_address, onChange }) {
           type="info"
           style={{ maxWidth: "500px" }}
           message={
-            <>
+            <Paragraph>
               Gravatar is a service for using a common avatar across websites.
               Go to the{" "}
               <A href="https://gravatar.com">Wordpress Gravatar site</A> and
               sign in (or create an account) using <Code>{email_address}</Code>.
-            </>
+            </Paragraph>
           }
         />
       )}

--- a/src/packages/next/components/account/config/account/avatar.tsx
+++ b/src/packages/next/components/account/config/account/avatar.tsx
@@ -1,4 +1,19 @@
-import { Alert, Checkbox, Col, Radio, Row, Space, Upload } from "antd";
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import {
+  Alert,
+  Checkbox,
+  Col,
+  Divider,
+  List,
+  Radio,
+  Row,
+  Space,
+  Upload,
+} from "antd";
 import { useEffect, useState } from "react";
 
 import { InboxOutlined } from "@ant-design/icons";
@@ -62,21 +77,16 @@ register({
 
     return (
       <Space direction="vertical">
-        <Save />
-        <Row>
+        <Row gutter={[20, 30]}>
+          <Col md={24} sm={24}>
+            <Save />
+          </Col>
           <Col md={6} sm={24}>
-            <div style={{ marginRight: "15px" }}>
-              <Title level={3} style={{ marginTop: "10px" }}>
-                <DisplayAvatar
-                  style={{ marginRight: "10px" }}
-                  size={40}
-                  color={edited.profile.color}
-                  image={edited.profile.image}
-                  letter={profile?.first_name?.[0]}
-                />
-                Preview
-              </Title>
-              <br />
+            <Title level={3}>
+              <Icon name="solution" /> Preview
+            </Title>
+            <List>
+              <Paragraph type="secondary">Name</Paragraph>
               {profile && (
                 <span
                   style={{
@@ -89,27 +99,37 @@ register({
                   {profile?.first_name} {profile?.last_name}
                 </span>
               )}
-              <br />
-              <br />
+              <Divider plain />
+              <Paragraph type="secondary">Small</Paragraph>
+              <DisplayAvatar
+                style={{ marginRight: "10px" }}
+                size={40}
+                color={edited.profile.color}
+                image={edited.profile.image}
+                letter={profile?.first_name?.[0]}
+              />
+              <Divider plain />
+              <Paragraph type="secondary">Large</Paragraph>
               <DisplayAvatar
                 size={120}
                 color={edited.profile.color}
                 image={edited.profile.image}
                 letter={profile?.first_name?.[0]}
               />
-              <br />
-              <br />
-              <Paragraph style={{ fontSize: "10px", color: COLORS.GRAY }}>
+              <Paragraph
+                type="secondary"
+                style={{ fontSize: "10px", marginTop: "20px" }}
+              >
                 (It will take a while for your avatar to update at the top of
                 the page, even after you save it.)
               </Paragraph>
-            </div>
+            </List>
           </Col>
           <Col md={18} sm={24}>
-            <Space direction="vertical">
-              <Title level={3}>
-                <Icon name="colors" /> Color
-              </Title>
+            <Title level={3}>
+              <Icon name="colors" /> Color
+            </Title>
+            <Space direction="vertical" size="middle">
               <Paragraph>
                 {desc.color}{" "}
                 <A href="/config/account/name">Change your name.</A>

--- a/src/packages/next/components/account/config/account/delete-account.tsx
+++ b/src/packages/next/components/account/config/account/delete-account.tsx
@@ -1,12 +1,19 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Alert, Button, Input, Space } from "antd";
-import { Icon } from "@cocalc/frontend/components/icon";
-import apiPost from "lib/api/post";
-import { useRouter } from "next/router";
-import A from "components/misc/A";
 import { useEffect, useState } from "react";
-import useCustomize from "lib/use-customize";
-import useDatabase from "lib/hooks/database";
+
+import { Icon } from "@cocalc/frontend/components/icon";
+import { Paragraph, Title } from "components/misc";
+import A from "components/misc/A";
 import Loading from "components/share/loading";
+import apiPost from "lib/api/post";
+import useDatabase from "lib/hooks/database";
+import useCustomize from "lib/use-customize";
+import { useRouter } from "next/router";
 import register from "../register";
 
 register({
@@ -40,23 +47,23 @@ register({
 
     return (
       <Space direction="vertical">
-        <h2>
-          Are you sure you want to <b>delete your {siteName} account</b>?
-        </h2>
-        <p>
+        <Title level={3}>
+          Are you sure you want to <i>delete your {siteName} account</i>?
+        </Title>
+        <Paragraph>
           You will immediately lose access to all of{" "}
           <A external href="/projects">
             your projects
           </A>
           , and any purchased subscriptions will be canceled.
-        </p>
-        <p>
+        </Paragraph>
+        <Paragraph>
           Do NOT delete your account if you are{" "}
           <A href="https://github.com/sagemathinc/cocalc/issues/3243">
             a current student in a course...
           </A>
-        </p>
-        <p>
+        </Paragraph>
+        <Paragraph>
           To <b>DELETE YOUR ACCOUNT</b>, first type your full name "{fullName}"
           below (without quotes):
           <br />
@@ -69,7 +76,7 @@ register({
               return false;
             }}
           />
-        </p>
+        </Paragraph>
         <Button
           disabled={name != fullName || deleting}
           type="primary"

--- a/src/packages/next/components/account/config/account/email.tsx
+++ b/src/packages/next/components/account/config/account/email.tsx
@@ -31,7 +31,7 @@ addresses, and your email address is never revealed to other users.)`;
 
 const verificationDesc = `Your email is considered verified,
 if we either sent you a verification email and you clicked on the link with a secret token to open that link,
-or if you did sign up using a registered single-sign-on provider (e.g., Google/Gmail or your university).`;
+or if you did sign up using a registered single-sign-on provider (e.g. Google/Gmail or your university).`;
 
 const EMAIL_ACCOUNT_Q = {
   accounts: { email_address: null, email_address_verified: null },

--- a/src/packages/next/components/account/config/account/email.tsx
+++ b/src/packages/next/components/account/config/account/email.tsx
@@ -1,13 +1,19 @@
-import { useEffect, useState } from "react";
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Alert, Input, Space } from "antd";
-import useDatabase from "lib/hooks/database";
-import Loading from "components/share/loading";
-import SaveButton from "components/misc/save-button";
-import apiPost from "lib/api/post";
-import register from "../register";
-import useAPI from "lib/hooks/api";
+import { useEffect, useState } from "react";
+
 import { is_valid_email_address as isValidEmailAddress } from "@cocalc/util/misc";
-import { Paragraph } from "components/misc";
+import { Paragraph, Text } from "components/misc";
+import SaveButton from "components/misc/save-button";
+import Loading from "components/share/loading";
+import apiPost from "lib/api/post";
+import useAPI from "lib/hooks/api";
+import useDatabase from "lib/hooks/database";
+import register from "../register";
 
 interface Data {
   email_address?: string;
@@ -72,7 +78,7 @@ export function ChangeEmailAddress(props: Props) {
         >
           {!embedded && (
             <Paragraph>
-              <b>Your email address</b> {emailDesc}
+              <Text strong>Your email address</Text> {emailDesc}
             </Paragraph>
           )}
           <Input

--- a/src/packages/next/components/account/config/account/email.tsx
+++ b/src/packages/next/components/account/config/account/email.tsx
@@ -3,17 +3,20 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Alert, Input, Space } from "antd";
-import { useEffect, useState } from "react";
+import { Alert, Button, Input, Space } from "antd";
+import { useEffect, useMemo, useState } from "react";
 
+import { Icon } from "@cocalc/frontend/components/icon";
 import { is_valid_email_address as isValidEmailAddress } from "@cocalc/util/misc";
-import { Paragraph, Text } from "components/misc";
+import { Paragraph, Text, Title } from "components/misc";
 import SaveButton from "components/misc/save-button";
+import Timestamp from "components/misc/timestamp";
 import Loading from "components/share/loading";
 import apiPost from "lib/api/post";
 import useAPI from "lib/hooks/api";
 import useDatabase from "lib/hooks/database";
 import register from "../register";
+import { useCustomize } from "lib/customize";
 
 interface Data {
   email_address?: string;
@@ -26,22 +29,30 @@ can add you as collaborators to projects by searching for your exact
 email address. (There is no way to do a search for partial email
 addresses, and your email address is never revealed to other users.)`;
 
+const verificationDesc = `Your email is considered verified,
+if we either sent you a verification email and you clicked on the link with a secret token to open that link,
+or if you did sign up using a registered single-sign-on provider (e.g., Google/Gmail or your university).`;
+
+const EMAIL_ACCOUNT_Q = {
+  accounts: { email_address: null, email_address_verified: null },
+} as const;
 interface Props {
-  embedded?: boolean;
+  embedded?: boolean; // set to true if this is used elsewhere to set/change email address
   onSuccess?: () => void;
 }
 
 export function ChangeEmailAddress(props: Props) {
   const { embedded = false, onSuccess } = props;
 
+  const { verifyEmailAddresses } = useCustomize();
   const hasPassword = useAPI("auth/has-password");
-  const { loading, value } = useDatabase({
-    accounts: { email_address: null },
-  });
+
+  const { loading, value, query } = useDatabase(EMAIL_ACCOUNT_Q);
   const [password, setPassword] = useState<string>("");
   const [lastSuccess, setLastSuccess] = useState<string>("");
   const [original, setOriginal] = useState<Data | undefined>(undefined);
   const [edited, setEdited] = useState<Data | undefined>(undefined);
+  const [emailChanged, setEmailChanged] = useState<boolean>(false);
 
   useEffect(() => {
     if (!loading && original === undefined && value.accounts != null) {
@@ -56,6 +67,8 @@ export function ChangeEmailAddress(props: Props) {
     if (!lastSuccess) return;
 
     if (lastSuccess == password + edited.email_address) {
+      setEmailChanged(true);
+      query(EMAIL_ACCOUNT_Q);
       onSuccess?.();
     }
   }, [lastSuccess, edited?.email_address, password]);
@@ -119,11 +132,165 @@ export function ChangeEmailAddress(props: Props) {
               message={"Email address and password successfully saved."}
             />
           )}
+          {!embedded && verifyEmailAddresses && (
+            <EmailVerification
+              loading={loading}
+              emailChanged={emailChanged}
+              account={value?.accounts}
+            />
+          )}
         </Space>
       </form>
     </div>
   );
 }
+
+interface VeryProps {
+  loading?: boolean;
+  emailChanged?: boolean; // if true, email has been changed and verification email has been sent already
+  account?: {
+    email_address?: string;
+    email_address_verified?: { [key: string]: string /* an ISO date */ };
+  };
+}
+
+const EmailVerification: React.FC<VeryProps> = (props: VeryProps) => {
+  const { loading, account, emailChanged = false } = props;
+  const [emailSent, setEmailSent] = useState<boolean>(false);
+  const [emailSentSuccess, setEmailSentSuccess] = useState<boolean>(false);
+  const [emailSentError, setEmaiSentError] = useState<string | undefined>();
+
+  const isVerified = useMemo((): Date | boolean => {
+    if (account == null) return false;
+    const { email_address, email_address_verified } = account;
+    if (email_address == null) return false;
+    const when = email_address_verified?.[email_address];
+    if (when) {
+      try {
+        return new Date(when);
+      } catch (err) {
+        console.warn(
+          `Error converting verified email time: ${when} – considering it as verified, though.`
+        );
+        return true;
+      }
+    }
+    return false;
+  }, [account, loading]);
+
+  async function sendVerificationEmail() {
+    setEmailSent(true);
+    try {
+      apiPost("/accounts/send-verification-email", {
+        email_address: account?.email_address,
+      });
+      setEmailSentSuccess(true);
+    } catch (err) {
+      setEmaiSentError(err.messaage);
+    }
+  }
+
+  function renderStatus(status: boolean): JSX.Element {
+    return (
+      <Paragraph strong>
+        Status:{" "}
+        {status ? (
+          <Text strong type="success">
+            <Icon name="check" /> Verified
+          </Text>
+        ) : (
+          <Text strong type="danger">
+            <Icon name="times" /> Not Verified
+          </Text>
+        )}
+      </Paragraph>
+    );
+  }
+
+  function renderVerify() {
+    if (loading) return <Loading />;
+    if (isVerified) {
+      return (
+        <>
+          {renderStatus(true)}
+          <Paragraph>
+            Your email address has been verified
+            {isVerified instanceof Date && (
+              <>
+                {" "}
+                <Timestamp datetime={isVerified} />
+              </>
+            )}
+            .
+          </Paragraph>
+        </>
+      );
+    }
+    if (account == null) return;
+    const { email_address } = account;
+    if (email_address == null) {
+      return (
+        <>
+          {renderStatus(false)}
+          <Paragraph>
+            There is no email address to verify. Please set one above!
+          </Paragraph>
+        </>
+      );
+    }
+    return (
+      <>
+        {renderStatus(false)}
+        <Paragraph>
+          To verify your email address, we sent you an email with a link to
+          click on. You can also{" "}
+          <Button
+            disabled={emailChanged || emailSent}
+            size="small"
+            type="primary"
+            onClick={sendVerificationEmail}
+          >
+            resend the verification email
+          </Button>
+          .
+        </Paragraph>
+        {(emailSentSuccess || emailChanged) && (
+          <Alert
+            type="success"
+            message={
+              <>
+                <Icon name="mail" /> Verification email sent to{" "}
+                <code>{email_address}</code>. Please check your inbox and click
+                on the link in that email!
+              </>
+            }
+          />
+        )}
+        {emailSentError && (
+          <Alert
+            type="error"
+            message={
+              <>
+                <Icon name="times" /> Error sending verification email:{" "}
+                <code>{emailSentError}</code>
+              </>
+            }
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <br />
+      <Title level={3}>Verified Email Address</Title>
+      <Paragraph>{verificationDesc}</Paragraph>
+      {/* <pre>{JSON.stringify(account, null, 2)}</pre> */}
+      {renderVerify()}
+    </>
+  );
+};
 
 register({
   path: "account/email",

--- a/src/packages/next/components/account/config/account/name.tsx
+++ b/src/packages/next/components/account/config/account/name.tsx
@@ -7,7 +7,7 @@ import { Alert, Checkbox, Input, Space } from "antd";
 import { useEffect, useState } from "react";
 
 import { Icon } from "@cocalc/frontend/components/icon";
-import { Paragraph } from "components/misc";
+import { Paragraph, Text } from "components/misc";
 import A from "components/misc/A";
 import SaveButton from "components/misc/save-button";
 import Loading from "components/share/loading";
@@ -102,64 +102,58 @@ function ConfigureName() {
             />
             <br />
             <Paragraph>
-              <Paragraph strong>First Name</Paragraph>
-              <Paragraph type="secondary">{firstNameDesc}</Paragraph>
-              <Input
-                addonBefore={"First name"}
-                defaultValue={get.value.accounts.first_name}
-                onChange={onChange("first_name")}
-              />
+              <Text strong>First Name</Text> {firstNameDesc}
             </Paragraph>
+            <Input
+              addonBefore={"First name"}
+              defaultValue={get.value.accounts.first_name}
+              onChange={onChange("first_name")}
+            />
             <br />
             <Paragraph>
-              <Paragraph strong>Last Name</Paragraph>
-              <Paragraph type="secondary">{lastNameDesc}</Paragraph>
-              <Input
-                addonBefore={"Last name"}
-                defaultValue={get.value.accounts.last_name}
-                onChange={onChange("last_name")}
-              />
+              <Text strong>Last Name</Text> {lastNameDesc}
             </Paragraph>
+            <Input
+              addonBefore={"Last name"}
+              defaultValue={get.value.accounts.last_name}
+              onChange={onChange("last_name")}
+            />
             <br />
             <Paragraph>
-              <Paragraph strong>Username</Paragraph>
-              <Paragraph type="secondary">
-                Your username provides a{" "}
-                {edited.name ? (
-                  <A external href={`/${edited.name}`}>
-                    nice URL
-                  </A>
-                ) : (
-                  "nice URL"
-                )}{" "}
-                for content you share publicly.
-                {original.name && (
-                  <>
-                    {" "}
-                    (Changing your name could break links that you have shared.)
-                  </>
-                )}
-              </Paragraph>
-              <Input
-                addonBefore={"Name"}
-                defaultValue={get.value.accounts.name}
-                onChange={onChange("name")}
-              />
+              <Text strong>Username</Text> Your username provides a{" "}
+              {edited.name ? (
+                <A external href={`/${edited.name}`}>
+                  nice URL
+                </A>
+              ) : (
+                "nice URL"
+              )}{" "}
+              for content you share publicly.
+              {original.name && (
+                <>
+                  {" "}
+                  (Changing your name could break links that you have shared.)
+                </>
+              )}
             </Paragraph>
+            <Input
+              addonBefore={"Name"}
+              defaultValue={get.value.accounts.name}
+              onChange={onChange("name")}
+            />
             <br />
-
             <Paragraph>
-              <Paragraph strong>
+              <Text strong>
                 <Icon name="user-secret" /> Unlisted
-              </Paragraph>
-              <Paragraph type="secondary">{unlistedDesc}</Paragraph>
-              <Checkbox
-                defaultChecked={get.value.accounts.unlisted}
-                onChange={onChange("unlisted", "checked")}
-              >
-                Unlisted
-              </Checkbox>
+              </Text>{" "}
+              {unlistedDesc}
             </Paragraph>
+            <Checkbox
+              defaultChecked={get.value.accounts.unlisted}
+              onChange={onChange("unlisted", "checked")}
+            >
+              Unlisted
+            </Checkbox>
           </Space>
         </form>
       )}

--- a/src/packages/next/components/account/config/account/name.tsx
+++ b/src/packages/next/components/account/config/account/name.tsx
@@ -3,14 +3,16 @@ Very bad experimental first account name configuration page.
 This is extremely preliminary and just for experimentation.
 */
 
-import { useEffect, useState } from "react";
 import { Alert, Checkbox, Input, Space } from "antd";
+import { useEffect, useState } from "react";
+
+import { Icon } from "@cocalc/frontend/components/icon";
+import { Paragraph } from "components/misc";
+import A from "components/misc/A";
+import SaveButton from "components/misc/save-button";
 import Loading from "components/share/loading";
 import useDatabase from "lib/hooks/database";
-import SaveButton from "components/misc/save-button";
-import A from "components/misc/A";
 import register from "../register";
-import { Icon } from "@cocalc/frontend/components/icon";
 
 interface Data {
   first_name?: string;
@@ -99,54 +101,65 @@ function ConfigureName() {
               table="accounts"
             />
             <br />
-            <b>First Name</b> {firstNameDesc}
-            <Input
-              addonBefore={"First name"}
-              defaultValue={get.value.accounts.first_name}
-              onChange={onChange("first_name")}
-            />
+            <Paragraph>
+              <Paragraph strong>First Name</Paragraph>
+              <Paragraph type="secondary">{firstNameDesc}</Paragraph>
+              <Input
+                addonBefore={"First name"}
+                defaultValue={get.value.accounts.first_name}
+                onChange={onChange("first_name")}
+              />
+            </Paragraph>
             <br />
-            <b>Last Name</b> {lastNameDesc}
-            <Input
-              addonBefore={"Last name"}
-              defaultValue={get.value.accounts.last_name}
-              onChange={onChange("last_name")}
-            />
+            <Paragraph>
+              <Paragraph strong>Last Name</Paragraph>
+              <Paragraph type="secondary">{lastNameDesc}</Paragraph>
+              <Input
+                addonBefore={"Last name"}
+                defaultValue={get.value.accounts.last_name}
+                onChange={onChange("last_name")}
+              />
+            </Paragraph>
             <br />
-            <b>Username</b>
-            <div>
-              Your username provides a{" "}
-              {edited.name ? (
-                <A external href={`/${edited.name}`}>
-                  nice URL
-                </A>
-              ) : (
-                "nice URL"
-              )}{" "}
-              for content you share publicly.
-              {original.name && (
-                <>
-                  {" "}
-                  (Changing your name could break links that you have shared.)
-                </>
-              )}
-            </div>
-            <Input
-              addonBefore={"Name"}
-              defaultValue={get.value.accounts.name}
-              onChange={onChange("name")}
-            />
+            <Paragraph>
+              <Paragraph strong>Username</Paragraph>
+              <Paragraph type="secondary">
+                Your username provides a{" "}
+                {edited.name ? (
+                  <A external href={`/${edited.name}`}>
+                    nice URL
+                  </A>
+                ) : (
+                  "nice URL"
+                )}{" "}
+                for content you share publicly.
+                {original.name && (
+                  <>
+                    {" "}
+                    (Changing your name could break links that you have shared.)
+                  </>
+                )}
+              </Paragraph>
+              <Input
+                addonBefore={"Name"}
+                defaultValue={get.value.accounts.name}
+                onChange={onChange("name")}
+              />
+            </Paragraph>
             <br />
-            <b>
-              <Icon name="user-secret" /> Unlisted
-            </b>
-            <div>{unlistedDesc}</div>
-            <Checkbox
-              defaultChecked={get.value.accounts.unlisted}
-              onChange={onChange("unlisted", "checked")}
-            >
-              Unlisted
-            </Checkbox>
+
+            <Paragraph>
+              <Paragraph strong>
+                <Icon name="user-secret" /> Unlisted
+              </Paragraph>
+              <Paragraph type="secondary">{unlistedDesc}</Paragraph>
+              <Checkbox
+                defaultChecked={get.value.accounts.unlisted}
+                onChange={onChange("unlisted", "checked")}
+              >
+                Unlisted
+              </Checkbox>
+            </Paragraph>
           </Space>
         </form>
       )}

--- a/src/packages/next/components/account/config/account/password.tsx
+++ b/src/packages/next/components/account/config/account/password.tsx
@@ -1,9 +1,16 @@
-import { useState } from "react";
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Alert, Button, Input, Space } from "antd";
-import register from "../register";
+import { useState } from "react";
+
+import { Title, Text, Paragraph } from "components/misc";
 import A from "components/misc/A";
 import Loading from "components/share/loading";
 import apiPost from "lib/api/post";
+import register from "../register";
 
 register({
   path: "account/password",
@@ -36,38 +43,41 @@ register({
 
     return (
       <Space direction="vertical">
-        <h2>Change Password</h2>
+        <Title level={3}>Change Password</Title>
         {error && (
           <Alert
             type="error"
             message={
               <>
-                {error}{" "}
-                <A href="/auth/password-reset">Reset password...</A>
+                {error} <A href="/auth/password-reset">Reset password...</A>
               </>
             }
             showIcon
           />
         )}
-        <b>Current password:</b>
-        <Input.Password
-          disabled={changing}
-          placeholder="Current password..."
-          value={currentPassword}
-          onChange={(e) => setCurrentPassword(e.target.value)}
-        />
-        (leave blank if you have not set a password)
-        <b>New password:</b>
-        <Input.Password
-          disabled={changing}
-          placeholder="New password..."
-          value={newPassword}
-          onChange={(e) => {
-            setNewPassword(e.target.value);
-          }}
-          onPressEnter={resetPassword}
-        />
-        (at least 6 characters)
+        <Paragraph>
+          <Text strong>Current password:</Text>
+          <Input.Password
+            disabled={changing}
+            placeholder="Current password..."
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+          />
+          (leave blank if you have not set a password)
+        </Paragraph>
+        <Paragraph>
+          <Text strong>New password:</Text>
+          <Input.Password
+            disabled={changing}
+            placeholder="New password..."
+            value={newPassword}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+            }}
+            onPressEnter={resetPassword}
+          />
+          (at least 6 characters)
+        </Paragraph>
         <Button
           type="primary"
           disabled={
@@ -92,11 +102,11 @@ register({
           />
         )}
         <br />
-        <h2>Reset Password</h2>
-        <div>
+        <Title level={3}>Reset Password</Title>
+        <Paragraph>
           You can also <A href="/auth/password-reset">reset your password</A>,
           in case you don't remember it.
-        </div>
+        </Paragraph>
       </Space>
     );
   },

--- a/src/packages/next/components/account/config/account/sign-out.tsx
+++ b/src/packages/next/components/account/config/account/sign-out.tsx
@@ -1,9 +1,16 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+
 import { Button, Space } from "antd";
+
 import { Icon } from "@cocalc/frontend/components/icon";
+import { Paragraph } from "components/misc";
 import apiPost from "lib/api/post";
 import { useRouter } from "next/router";
 import register from "../register";
-import { Paragraph } from "components/misc";
 
 register({
   path: "account/sign-out",

--- a/src/packages/next/components/account/config/account/sign-out.tsx
+++ b/src/packages/next/components/account/config/account/sign-out.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@cocalc/frontend/components/icon";
 import apiPost from "lib/api/post";
 import { useRouter } from "next/router";
 import register from "../register";
+import { Paragraph } from "components/misc";
 
 register({
   path: "account/sign-out",
@@ -13,7 +14,7 @@ register({
     const router = useRouter();
     return (
       <Space direction="vertical">
-        Sign out of your account:
+        <Paragraph>Sign out of your account:</Paragraph>
         <Button
           type="primary"
           onClick={async () => {
@@ -24,7 +25,7 @@ register({
           <Icon name="sign-out-alt" /> Sign Out
         </Button>
         <br />
-        Sign out on all devices that are authenticated:
+        <Paragraph>Sign out on all devices that are authenticated:</Paragraph>
         <Button
           onClick={async () => {
             await apiPost("/accounts/sign-out", { all: true });

--- a/src/packages/next/components/account/config/account/sso.tsx
+++ b/src/packages/next/components/account/config/account/sso.tsx
@@ -5,9 +5,11 @@
 
 import { Icon } from "@cocalc/frontend/components/icon";
 import { len } from "@cocalc/util/misc";
+import { COLORS } from "@cocalc/util/theme";
 import { Strategy } from "@cocalc/util/types/sso";
 import { Alert, Button, Popconfirm, Space } from "antd";
 import { StrategyAvatar } from "components/auth/sso";
+import { Paragraph } from "components/misc";
 import A from "components/misc/A";
 import Loading from "components/share/loading";
 import SiteName from "components/share/site-name";
@@ -77,68 +79,72 @@ register({
     );
 
     return (
-      <div style={{ color: "#555" }}>
+      <div style={{ color: COLORS.GRAY_D }}>
         {error && <Alert showIcon type="error" message={error} />}
-        {unlinking && (
-          <Loading style={{ fontSize: "16pt" }}>
-            Unlinking your passport...
-          </Loading>
-        )}
-        {len(passports) > 0 && (
-          <>
-            <Heading title="Your account is linked with" />
-            <Unlink
-              passports={passports}
-              strategies={strategies.result}
-              onUnlink={async (name: string, strategy: Strategy) => {
-                if (unlinking) return;
-                if (len(passports) == 1 && !hasPassword.result.hasPassword) {
-                  setError(
-                    <>
-                      You cannot unlink sign on using {strategy.display}, since
-                      you would then have no way to sign into your account!
-                      Please add another SSO method first or{" "}
-                      <A href="/config/account/email">set an email address</A>{" "}
-                      and <A href="/config/account/password">a password</A>, or{" "}
-                      <A href="/config/account/delete">delete your account</A>.
-                    </>
-                  );
-                  return;
-                }
-
-                try {
-                  setError(null);
-                  setUnlinking(true);
-                  await apiPost("/auth/unlink-strategy", { name });
-                } catch (err) {
-                  setError(err.message);
-                  return;
-                } finally {
-                  setUnlinking(false);
-                }
-
-                const passports0 = edited?.passports;
-                if (!passports0) return;
-                for (const x in passports0) {
-                  if (x == name) {
-                    delete passports0[x];
-                    break;
+        <Space direction="vertical">
+          {unlinking && (
+            <Loading style={{ fontSize: "16pt" }}>
+              Unlinking your passport...
+            </Loading>
+          )}
+          {len(passports) > 0 && (
+            <>
+              <Heading title="Your account is linked with" />
+              <Unlink
+                passports={passports}
+                strategies={strategies.result}
+                onUnlink={async (name: string, strategy: Strategy) => {
+                  if (unlinking) return;
+                  if (len(passports) == 1 && !hasPassword.result.hasPassword) {
+                    setError(
+                      <>
+                        You cannot unlink sign on using {strategy.display},
+                        since you would then have no way to sign into your
+                        account! Please add another SSO method first or{" "}
+                        <A href="/config/account/email">set an email address</A>{" "}
+                        and <A href="/config/account/password">a password</A>,
+                        or{" "}
+                        <A href="/config/account/delete">delete your account</A>
+                        .
+                      </>
+                    );
+                    return;
                   }
-                }
-                setEdited({ passports: passports0 });
-              }}
-            />
-            <br />
-            <br />
-          </>
-        )}
 
-        {strategies.result.length > 0 && (
-          <>
-            <Heading title="Click to link your account" />
-            <Link strategies={strategies.result} linked={linkedNames} />
-          </>
-        )}
+                  try {
+                    setError(null);
+                    setUnlinking(true);
+                    await apiPost("/auth/unlink-strategy", { name });
+                  } catch (err) {
+                    setError(err.message);
+                    return;
+                  } finally {
+                    setUnlinking(false);
+                  }
+
+                  const passports0 = edited?.passports;
+                  if (!passports0) return;
+                  for (const x in passports0) {
+                    if (x == name) {
+                      delete passports0[x];
+                      break;
+                    }
+                  }
+                  setEdited({ passports: passports0 });
+                }}
+              />
+              <br />
+              <br />
+            </>
+          )}
+
+          {strategies.result.length > 0 && (
+            <>
+              <Heading title="Click to link your account" />
+              <Link strategies={strategies.result} linked={linkedNames} />
+            </>
+          )}
+        </Space>
       </div>
     );
   },
@@ -195,7 +201,7 @@ function Link({
   // link to the page for additional non-public institutional SSOs
   function hidden() {
     return (
-      <div style={{ marginTop: "1rem" }}>
+      <Paragraph style={{ marginTop: "1rem" }}>
         or other{" "}
         <Button
           type="link"
@@ -205,7 +211,7 @@ function Link({
           institutional SSO options
         </Button>
         .
-      </div>
+      </Paragraph>
     );
   }
 

--- a/src/packages/next/components/account/config/anonymous/index.tsx
+++ b/src/packages/next/components/account/config/anonymous/index.tsx
@@ -1,4 +1,9 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
 The config page for anonymous users.  An anonymous user *is* signed in using a full account.
 This page does belong in configuration -- it's about taking the steps to convert their
 anonymous account into a full account so they won't lose their work.  Most important
@@ -6,9 +11,11 @@ is an email address or SSO sign on link.
 
 Non-anonymous users get the layout page.
 */
-import SiteName from "components/share/site-name";
 import { Button, Popconfirm } from "antd";
+
 import { Icon } from "@cocalc/frontend/components/icon";
+import { Paragraph, Title } from "components/misc";
+import SiteName from "components/share/site-name";
 import apiPost from "lib/api/post";
 import { useRouter } from "next/router";
 import Upgrade from "./upgrade";
@@ -42,11 +49,13 @@ export default function Anonymous() {
           <Icon name="sign-out-alt" /> Sign Out
         </Button>
       </Popconfirm>
-      <h2>
+      <Title level={3}>
         Thank you for trying <SiteName /> anonymously!
-      </h2>
-      Signing up for an account will prevent losing your work, and unlock
-      additional features.
+      </Title>
+      <Paragraph>
+        Signing up for an account will prevent losing your work, and unlock
+        additional features.
+      </Paragraph>
       <Upgrade style={{ margin: "15px 0px" }} />
     </div>
   );

--- a/src/packages/next/components/account/config/anonymous/upgrade.tsx
+++ b/src/packages/next/components/account/config/anonymous/upgrade.tsx
@@ -1,12 +1,19 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Alert, Button, Input, Space } from "antd";
+import { delay } from "awaiting";
 import { CSSProperties, useState } from "react";
+
+import { Icon } from "@cocalc/frontend/components/icon";
+import { is_valid_email_address as isValidEmailAddress } from "@cocalc/util/misc";
 import { TermsCheckbox } from "components/auth/sign-up";
 import SSO from "components/auth/sso";
-import { is_valid_email_address as isValidEmailAddress } from "@cocalc/util/misc";
-import { Icon } from "@cocalc/frontend/components/icon";
+import { Title } from "components/misc";
 import apiPost from "lib/api/post";
 import { useRouter } from "next/router";
-import { delay } from "awaiting";
 
 interface Props {
   style: CSSProperties;
@@ -24,10 +31,8 @@ export default function Upgrade({ style }: Props) {
       <br />
       {terms && (
         <SSO
-          style={{ margin: "5px 0" }}
-          header={
-            <h3 style={{ marginBottom: "10px" }}>Or Use Single Sign On</h3>
-          }
+          style={{ margin: "30px 0" }}
+          header={<Title level={3}>Or Use Single Sign On</Title>}
         />
       )}
     </div>
@@ -59,7 +64,7 @@ function EmailPassword() {
   }
   return (
     <>
-      <h3>Set an Email Address and Password</h3>
+      <Title level={3}>Set an Email Address and Password</Title>
       {error && (
         <Alert
           type="error"

--- a/src/packages/next/components/account/config/editor/appearance.tsx
+++ b/src/packages/next/components/account/config/editor/appearance.tsx
@@ -10,6 +10,7 @@ import CodeMirror from "components/share/codemirror";
 import Loading from "components/share/loading";
 import useEditTable from "lib/hooks/edit-table";
 import register from "../register";
+import { Title } from "components/misc";
 
 interface Data {
   font_size: number;
@@ -64,10 +65,12 @@ register({
     }
 
     return (
-      <Space direction="vertical" style={{ width: "100%" }}>
-        <Row>
-          <Col md={14} sm={24} style={{ paddingRight: "15px" }}>
-            <Save />
+      <Row gutter={[20, 30]}>
+        <Col md={24}>
+          <Save />
+        </Col>
+        <Col md={14} sm={24}>
+          <Space direction="vertical" size="large">
             <EditNumber
               path="font_size"
               icon="text-height"
@@ -94,23 +97,23 @@ register({
               path="editor_settings.line_numbers"
               desc={desc.line_numbers}
             />
-          </Col>
-          <Col md={10} sm={24}>
-            <h3 style={{ marginTop: "10px" }}>Preview</h3>
-            <CodeMirror
-              content={EXAMPLE}
-              filename="a.py"
-              fontSize={edited.font_size}
-              options={{
-                // @ts-ignore
-                theme: edited.editor_settings.theme,
-                lineNumbers: edited.editor_settings.line_numbers,
-                lineWrapping: edited.editor_settings.line_wrapping,
-              }}
-            />
-          </Col>
-        </Row>
-      </Space>
+          </Space>
+        </Col>
+        <Col md={10} sm={24}>
+          <Title level={3}>Preview</Title>
+          <CodeMirror
+            content={EXAMPLE}
+            filename="a.py"
+            fontSize={edited.font_size}
+            options={{
+              // @ts-ignore
+              theme: edited.editor_settings.theme,
+              lineNumbers: edited.editor_settings.line_numbers,
+              lineWrapping: edited.editor_settings.line_wrapping,
+            }}
+          />
+        </Col>
+      </Row>
     );
   },
 });

--- a/src/packages/next/components/account/config/editor/appearance.tsx
+++ b/src/packages/next/components/account/config/editor/appearance.tsx
@@ -1,9 +1,15 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Col, Row, Space } from "antd";
-import Loading from "components/share/loading";
-import register from "../register";
-import useEditTable from "lib/hooks/edit-table";
+
 import { EDITOR_COLOR_SCHEMES } from "@cocalc/util/db-schema/accounts";
 import CodeMirror from "components/share/codemirror";
+import Loading from "components/share/loading";
+import useEditTable from "lib/hooks/edit-table";
+import register from "../register";
 
 interface Data {
   font_size: number;

--- a/src/packages/next/components/account/config/editor/jupyter.tsx
+++ b/src/packages/next/components/account/config/editor/jupyter.tsx
@@ -41,7 +41,7 @@ register({
     }
 
     return (
-      <Space direction="vertical" style={{ width: "100%" }}>
+      <Space direction="vertical" size="large">
         <Save />
         <EditBoolean
           icon="list-ol"
@@ -56,7 +56,7 @@ register({
           title="New Notebook Kernel"
           desc={desc.ask_jupyter_kernel}
           label="Ask which kernel to use"
-        />{" "}
+        />
         <EditBoolean
           icon="list"
           path="editor_settings.disable_jupyter_virtualization"
@@ -64,12 +64,12 @@ register({
           desc={desc.disable_jupyter_virtualization}
           label={
             <>
-              No virtualization -- render entire notebook rather than
-              rendering just the visible part of it using{" "}
+              No virtualization -- render entire notebook rather than rendering
+              just the visible part of it using{" "}
               <A href="https://virtuoso.dev/">react-virtuoso</A>.
             </>
           }
-        />{" "}
+        />
         <EditBoolean
           icon="ipynb"
           path="editor_settings.jupyter_classic"
@@ -88,7 +88,7 @@ register({
             </>
           }
           label="Use Jupyter classic"
-        />{" "}
+        />
       </Space>
     );
   },

--- a/src/packages/next/components/account/config/editor/keyboard.tsx
+++ b/src/packages/next/components/account/config/editor/keyboard.tsx
@@ -38,7 +38,7 @@ register({
     }
 
     return (
-      <Space direction="vertical" style={{ width: "100%" }}>
+      <Space direction="vertical" size="large">
         <Save />
         <EditSelect
           path="editor_settings.bindings"

--- a/src/packages/next/components/account/config/editor/options.tsx
+++ b/src/packages/next/components/account/config/editor/options.tsx
@@ -1,8 +1,14 @@
-import register from "../register";
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Space } from "antd";
+
+import A from "components/misc/A";
 import Loading from "components/share/loading";
 import useEditTable from "lib/hooks/edit-table";
-import A from "components/misc/A";
+import register from "../register";
 
 const desc = {
   code_folding: `Enable the code folding plugin.  When enabled, you can fold or unfold all
@@ -29,7 +35,7 @@ as { and } in C-like languages, cause the current line to be reindented.`,
   build_on_save: `Trigger a build of LaTex, Rmd, etc. files whenever they are saved to disk, instead of only building when you click the Build button. This is fine for small documents, but can be annoying for large documents, especially if you are a "compulsive saver".`,
   show_exec_warning:
     "Show a warning if you hit shift+enter (or other keys) when editing certain files, e.g., Python code, that is not directly executable.  This is just to avoid confusion if you create a .py file and think it is a Jupyter notebook.",
-};
+} as const;
 
 register({
   path: "editor/options",
@@ -47,7 +53,7 @@ register({
     }
 
     return (
-      <Space direction="vertical" style={{ width: "100%" }}>
+      <Space direction="vertical" size="large">
         <Save />
         <EditBoolean
           icon="caret-down"
@@ -145,7 +151,7 @@ register({
           path="editor_settings.show_exec_warning"
           desc={desc.show_exec_warning}
         />
-        <br/>
+        <br />
         <Save />
       </Space>
     );

--- a/src/packages/next/components/account/config/editor/terminal.tsx
+++ b/src/packages/next/components/account/config/editor/terminal.tsx
@@ -1,11 +1,18 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Col, Row, Space } from "antd";
-import Loading from "components/share/loading";
-import register from "../register";
-import useEditTable from "lib/hooks/edit-table";
+
 import {
-  theme_desc,
   example,
+  theme_desc,
 } from "@cocalc/frontend/frame-editors/terminal-editor/theme-data";
+import Loading from "components/share/loading";
+import useEditTable from "lib/hooks/edit-table";
+import register from "../register";
+import { Paragraph, Title } from "components/misc";
 
 interface Data {
   terminal: {
@@ -19,7 +26,7 @@ const desc = {
 for a particular terminal at any time.`,
   color_scheme: `The color scheme used for terminals.`,
   font: `The CoCalc terminal uses your browser's fixed-width font, which you can change in your browser's preferences.`,
-};
+} as const;
 
 register({
   path: "editor/terminal",
@@ -38,10 +45,12 @@ register({
     }
 
     return (
-      <Space direction="vertical" style={{ width: "100%" }}>
-        <Row>
-          <Col md={14} sm={24} style={{paddingRight:'15px'}}>
-            <Save />
+      <Row gutter={[20, 30]}>
+        <Col md={24} sm={24}>
+          <Save />
+        </Col>
+        <Col md={14} sm={24}>
+          <Space direction="vertical" size="large">
             <EditNumber
               path="terminal.font_size"
               title="Terminal Font Size"
@@ -58,23 +67,27 @@ register({
               options={theme_desc}
               style={{ width: "30ex" }}
             />
-            <h3 style={{ marginTop: "15px" }}>Font</h3>
-            {desc.font}
-          </Col>
-          <Col md={10} sm={24}>
-            <h3 style={{ marginTop: "10px" }}>Preview</h3>
-            <div
-              style={{
-                fontSize: `${edited.terminal.font_size}px`,
-                overflow: "hidden",
-              }}
-              dangerouslySetInnerHTML={{
-                __html: example(edited.terminal.color_scheme),
-              }}
-            />
-          </Col>
-        </Row>
-      </Space>
+            <Space direction="vertical">
+              <Title level={2} style={{ marginTop: "15px" }}>
+                Font
+              </Title>
+              <Paragraph>{desc.font}</Paragraph>
+            </Space>
+          </Space>
+        </Col>
+        <Col md={10} sm={24}>
+          <h3 style={{ marginTop: "10px" }}>Preview</h3>
+          <div
+            style={{
+              fontSize: `${edited.terminal.font_size}px`,
+              overflow: "hidden",
+            }}
+            dangerouslySetInnerHTML={{
+              __html: example(edited.terminal.color_scheme),
+            }}
+          />
+        </Col>
+      </Row>
     );
   },
 });

--- a/src/packages/next/components/account/config/layout.tsx
+++ b/src/packages/next/components/account/config/layout.tsx
@@ -127,6 +127,7 @@ export default function ConfigLayout({ page }: Props) {
           padding: "0",
           backgroundColor: "white",
           color: COLORS.GRAY_D,
+          maxWidth: "1200px",
         }}
       >
         {content}

--- a/src/packages/next/components/account/config/layout.tsx
+++ b/src/packages/next/components/account/config/layout.tsx
@@ -36,7 +36,11 @@ export default function ConfigLayout({ page }: Props) {
   const isBrowser = useIsBrowser();
   const profile = useProfile({ noCache: true });
   if (!profile) {
-    return <Loading />;
+    return (
+      <div style={{ textAlign: "center", minHeight: "400px", paddingTop: "100px" }}>
+        <Loading large />
+      </div>
+    );
   }
   const { account_id, is_anonymous } = profile;
 

--- a/src/packages/next/components/account/config/layout.tsx
+++ b/src/packages/next/components/account/config/layout.tsx
@@ -69,9 +69,9 @@ export default function ConfigLayout({ page }: Props) {
       style={{
         padding: 24,
         margin: 0,
-        minHeight: 280,
+        minHeight: 500,
         ...(info?.danger
-          ? { color: "#ff4d4f", backgroundColor: "#fff1f0" }
+          ? { color: "#ff4d4f", backgroundColor: COLORS.ATND_BG_RED_L }
           : undefined),
       }}
     >
@@ -124,7 +124,7 @@ export default function ConfigLayout({ page }: Props) {
       </Sider>
       <Layout
         style={{
-          padding: "0 24px 24px",
+          padding: "0",
           backgroundColor: "white",
           color: COLORS.GRAY_D,
         }}

--- a/src/packages/next/components/account/config/layout.tsx
+++ b/src/packages/next/components/account/config/layout.tsx
@@ -1,25 +1,34 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Alert, Divider, Layout, Space } from "antd";
-import Config from "components/account/config";
-import A from "components/misc/A";
 import { join } from "path";
-import basePath from "lib/base-path";
-import ConfigMenu from "./menu";
-import useIsBrowser from "lib/hooks/is-browser";
-import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
-import { menu } from "./register";
+
 import { Icon } from "@cocalc/frontend/components/icon";
-import Search from "./search/component";
-import Avatar from "components/account/avatar";
-import useProfile from "lib/hooks/profile";
 import { capitalize } from "@cocalc/util/misc";
+import Avatar from "components/account/avatar";
+import Config from "components/account/config";
+import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
+import A from "components/misc/A";
 import Loading from "components/share/loading";
+import basePath from "lib/base-path";
+import useIsBrowser from "lib/hooks/is-browser";
+import useProfile from "lib/hooks/profile";
 import { useRouter } from "next/router";
 import Anonymous from "./anonymous";
+import ConfigMenu from "./menu";
+import { menu } from "./register";
+import Search from "./search/component";
+import { Paragraph, Text, Title } from "components/misc";
+import { COLORS } from "@cocalc/util/theme";
+import SiteName from "components/share/site-name";
 
 const { Content, Sider } = Layout;
 
 interface Props {
-  page: string;
+  page: string[]; // e.g. ["account", "name"]
 }
 
 export default function ConfigLayout({ page }: Props) {
@@ -66,38 +75,24 @@ export default function ConfigLayout({ page }: Props) {
           : undefined),
       }}
     >
-      <div style={{ float: "right", marginBottom: "15px" }}>
-        <Alert
-          showIcon
-          type="info"
-          message={
-            <>
-              This is the account configuration page.{" "}
-              <A href={join(basePath, "settings")} external>
-                You can also adjust key preferences in the main app...
-              </A>
-            </>
-          }
-        />
-      </div>
       <Space style={{ marginBottom: "15px" }}>
         <Avatar account_id={account_id} style={{ marginRight: "15px" }} />
-        <div style={{ color: "#666" }}>
-          <b style={{ fontSize: "13pt" }}>
+        <div style={{ color: COLORS.GRAY }}>
+          <Text strong style={{ fontSize: "13pt" }}>
             {profile?.first_name} {profile?.last_name}
             {profile.name ? ` (@${profile.name})` : ""}
-          </b>
+          </Text>
           <div>Your account</div>
         </div>
       </Space>
       {main != "search" && <Search />}
       {info && (
         <>
-          <h2>
+          <Title level={2}>
             <Icon name={info.icon} style={{ marginRight: "5px" }} />{" "}
             {capitalize(main)} - {info.title}
-          </h2>
-          {info.desc}
+          </Title>
+          <Paragraph type="secondary">{info.desc}</Paragraph>
           <Divider />
         </>
       )}
@@ -106,14 +101,14 @@ export default function ConfigLayout({ page }: Props) {
           style={{ margin: "15px auto", maxWidth: "600px" }}
           message={<b>Under Constructions</b>}
           description={
-            <>
-              This page is under construction. To configure your CoCalc account,
-              visit{" "}
+            <Paragraph>
+              This page is under construction. To configure your <SiteName />{" "}
+              account, visit{" "}
               <A href={join(basePath, "settings")} external>
                 Account Preferences
               </A>
               .
-            </>
+            </Paragraph>
           }
           type="warning"
           showIcon
@@ -131,7 +126,7 @@ export default function ConfigLayout({ page }: Props) {
         style={{
           padding: "0 24px 24px",
           backgroundColor: "white",
-          color: "#555",
+          color: COLORS.GRAY_D,
         }}
       >
         {content}

--- a/src/packages/next/components/account/config/menu.tsx
+++ b/src/packages/next/components/account/config/menu.tsx
@@ -1,34 +1,16 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Menu } from "antd";
+import { useEffect, useMemo, useState } from "react";
+
 import { Icon } from "@cocalc/frontend/components/icon";
-import { useRouter } from "next/router";
-import { ReactNode, useEffect, useState } from "react";
-import { menu, topIcons } from "./register";
 import { capitalize } from "@cocalc/util/misc";
-
-const { SubMenu } = Menu;
-
-function menuBody() {
-  const v: ReactNode[] = [];
-  for (const main in menu) {
-    const title = capitalize(main);
-    const icon = topIcons[main] ?? "gear";
-    const w: ReactNode[] = [];
-    for (const sub in menu[main]) {
-      const { title, icon, danger } = menu[main][sub];
-      w.push(
-        <Menu.Item key={main + "/" + sub} danger={danger}>
-          <Icon name={icon} style={{ marginRight: "5px" }} /> {title}
-        </Menu.Item>
-      );
-    }
-    v.push(
-      <SubMenu key={main} icon={<Icon name={icon} />} title={title}>
-        {w}
-      </SubMenu>
-    );
-  }
-  return v;
-}
+import { menuItem, MenuItems } from "components/antd-menu-items";
+import { useRouter } from "next/router";
+import { menu, topIcons } from "./register";
 
 export default function ConfigMenu({ main, sub }) {
   const router = useRouter();
@@ -42,6 +24,21 @@ export default function ConfigMenu({ main, sub }) {
       setOpenKeys(openKeys.concat([main]));
     }
   }, [main]);
+
+  const items: MenuItems = useMemo(
+    () =>
+      Object.keys(menu).map((main) => {
+        const sub = Object.keys(menu[main]).map((sub) => {
+          const { title, icon, danger } = menu[main][sub];
+          return menuItem(`${main}/${sub}`, title, icon, undefined, danger);
+        });
+
+        const title = capitalize(main);
+        const icon = topIcons[main] ?? "gear";
+        return menuItem(main, title, <Icon name={icon} />, sub);
+      }),
+    []
+  );
 
   return (
     <Menu
@@ -57,8 +54,7 @@ export default function ConfigMenu({ main, sub }) {
           scroll: false,
         });
       }}
-    >
-      {menuBody()}
-    </Menu>
+      items={items}
+    />
   );
 }

--- a/src/packages/next/components/account/config/register.ts
+++ b/src/packages/next/components/account/config/register.ts
@@ -1,8 +1,13 @@
-import { register as registerSearch } from "./search/entries";
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { IconName } from "@cocalc/frontend/components/icon";
 import { capitalize } from "@cocalc/util/misc";
+import { register as registerSearch } from "./search/entries";
 
-export const components: any = {};
+export const components: { [main: string]: { [sub: string]: Function } } = {};
 
 interface Options {
   path: string;
@@ -14,34 +19,33 @@ interface Options {
   search?: string | object;
 }
 
+interface Entry {
+  title: string;
+  icon?: IconName;
+  desc?: string;
+  danger?: boolean;
+}
+
 export const menu: {
   [main: string]: {
-    [sub: string]: {
-      title: string;
-      icon?: IconName;
-      desc?: string;
-      danger?: boolean;
-    };
+    [sub: string]: Entry;
   };
 } = {};
 
 export default function register(opts: Options) {
-  let { path, title, icon, desc, Component, danger, search } = opts;
+  const { path, icon, desc = "", Component, danger, search } = opts;
   const [main, sub] = path.split("/");
-  if(!title) {
-    title = capitalize(sub);
-  }
-  if (!desc) {
-    desc = '';
-  }
+  const title = opts.title ?? capitalize(sub);
+
   if (components[main] == null) {
-    components[main] = { [sub]: Component };
-  } else {
-    components[main][sub] = Component;
+    components[main] = {};
   }
+  components[main][sub] = Component;
+
   if (desc || search) {
     registerSearch({ path, title, desc, icon, search });
   }
+
   if (menu[main] == null) {
     menu[main] = {};
   }
@@ -56,4 +60,4 @@ export const topIcons: { [key: string]: IconName } = {
   licenses: "key",
   purchases: "credit-card",
   support: "support",
-};
+} as const;

--- a/src/packages/next/components/account/config/search/component.tsx
+++ b/src/packages/next/components/account/config/search/component.tsx
@@ -1,13 +1,18 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Input, List } from "antd";
+import { join } from "path";
 import { useState } from "react";
-import { Info } from "./entries";
-import register from "../register";
-import { search } from "./entries";
-import A from "components/misc/A";
+
 import { Icon } from "@cocalc/frontend/components/icon";
 import { capitalize } from "@cocalc/util/misc";
+import A from "components/misc/A";
 import { useRouter } from "next/router";
-import { join } from "path";
+import register from "../register";
+import { Info, search } from "./entries";
 
 interface Props {
   allowEmpty?: boolean; // if true allow empty search
@@ -75,6 +80,7 @@ function SearchResults({
       bordered
       itemLayout="horizontal"
       dataSource={results}
+      locale={{ emptyText: <>No results</> }}
       renderItem={(item) => {
         const top = item.path.split("/")[0];
         return (

--- a/src/packages/next/components/account/config/search/entries.ts
+++ b/src/packages/next/components/account/config/search/entries.ts
@@ -1,5 +1,10 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { IconName } from "@cocalc/frontend/components/icon";
-import { search_split, search_match } from "@cocalc/util/misc";
+import { search_match, search_split } from "@cocalc/util/misc";
 
 interface Info0 {
   path: string;

--- a/src/packages/next/components/account/navtab.tsx
+++ b/src/packages/next/components/account/navtab.tsx
@@ -1,8 +1,23 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 /* The "Account" navigation tab in the bar at the top. */
-import { Icon, isIconName } from "@cocalc/frontend/components/icon";
+
 import type { MenuProps } from "antd";
 import { Dropdown } from "antd";
+import { join } from "path";
+import { CSSProperties } from "react";
+
+import { Icon } from "@cocalc/frontend/components/icon";
 import Avatar from "components/account/avatar";
+import {
+  menuGroup,
+  menuItem,
+  MenuItem,
+  MenuItems,
+} from "components/antd-menu-items";
 import { LinkStyle } from "components/landing/header";
 import A from "components/misc/A";
 import apiPost from "lib/api/post";
@@ -10,40 +25,6 @@ import basePath from "lib/base-path";
 import { useCustomize } from "lib/customize";
 import useProfile from "lib/hooks/profile";
 import { useRouter } from "next/router";
-import { join } from "path";
-import { CSSProperties } from "react";
-
-type MenuItem = Required<MenuProps>["items"][number];
-
-function makeItem(
-  key: React.Key,
-  label: React.ReactNode,
-  icon?: React.ReactNode | string,
-  children?: MenuItem[]
-): MenuItem {
-  if (typeof icon === "string" && isIconName(icon)) {
-    icon = <Icon name={icon} />;
-  }
-  return {
-    key,
-    icon,
-    children,
-    label,
-  } as MenuItem;
-}
-
-function makeGroup(
-  key: React.Key,
-  label: React.ReactNode,
-  children: MenuItem[]
-): MenuItem {
-  return {
-    key,
-    children,
-    label,
-    type: "group",
-  } as MenuItem;
-}
 
 const DIVIDER = {
   type: "divider",
@@ -64,7 +45,7 @@ export default function AccountNavTab({ style }: Props) {
 
   const profile_url = name ? `/${name}` : `/share/accounts/${account_id}`;
 
-  const signedIn = makeItem(
+  const signedIn = menuItem(
     "signed-in",
     <A href={is_anonymous ? "/config/search/input" : profile_url}>
       Signed into {siteName} as
@@ -76,7 +57,7 @@ export default function AccountNavTab({ style }: Props) {
     </A>
   );
 
-  const docs = makeItem(
+  const docs = menuItem(
     "docs",
     <A href="https://doc.cocalc.com" external>
       Documentation
@@ -84,7 +65,7 @@ export default function AccountNavTab({ style }: Props) {
     "book"
   );
 
-  const configuration = makeGroup(
+  const configuration = menuGroup(
     "configuration",
     <A href="/config/search/input">
       <span style={{ color: "#a4acb3" }}>
@@ -92,13 +73,13 @@ export default function AccountNavTab({ style }: Props) {
       </span>
     </A>,
     [
-      makeItem("account", <A href="/config/account/name">Account</A>, "user"),
-      makeItem(
+      menuItem("account", <A href="/config/account/name">Account</A>, "user"),
+      menuItem(
         "editor",
         <A href="/config/editor/appearance">Editor</A>,
         "edit"
       ),
-      makeItem(
+      menuItem(
         "system",
         <A href="/config/system/appearance">System</A>,
         "gear"
@@ -108,11 +89,11 @@ export default function AccountNavTab({ style }: Props) {
 
   function profileItems() {
     if (!profile) return [];
-    const ret: MenuItem[] = [];
+    const ret: MenuItems = [];
     ret.push(signedIn);
     if (is_anonymous) {
       ret.push(
-        makeItem(
+        menuItem(
           "sign-up",
           <A href="/config/search/input">
             <b>Sign Up (save your work)!</b>
@@ -123,7 +104,7 @@ export default function AccountNavTab({ style }: Props) {
     }
     ret.push(docs);
     if (isCommercial) {
-      ret.push(makeItem("store", <A href="/store">Store</A>, "shopping-cart"));
+      ret.push(menuItem("store", <A href="/store">Store</A>, "shopping-cart"));
     }
     ret.push(DIVIDER);
     ret.push(configuration);
@@ -134,7 +115,7 @@ export default function AccountNavTab({ style }: Props) {
   function yourPages(): MenuItem[] {
     const yours: MenuItem[] = [];
     yours.push(
-      makeItem(
+      menuItem(
         "projects",
         <A href={join(basePath, "projects")} external>
           {is_anonymous ? "Project" : "Projects"}
@@ -144,16 +125,16 @@ export default function AccountNavTab({ style }: Props) {
     );
 
     if (!is_anonymous) {
-      yours.push(makeItem("licenses", <A href="/licenses">Licenses</A>, "key"));
+      yours.push(menuItem("licenses", <A href="/licenses">Licenses</A>, "key"));
 
       if (isCommercial) {
         yours.push(
-          makeItem("billing", <A href="/billing">Billing</A>, "credit-card")
+          menuItem("billing", <A href="/billing">Billing</A>, "credit-card")
         );
       }
       if (sshGateway) {
         yours.push(
-          makeItem(
+          menuItem(
             "ssh",
             <A href={join(basePath, "settings", "ssh-keys")} external>
               SSH keys
@@ -165,7 +146,7 @@ export default function AccountNavTab({ style }: Props) {
 
       if (shareServer) {
         yours.push(
-          makeItem(
+          menuItem(
             "shared",
             <A
               href={
@@ -180,13 +161,13 @@ export default function AccountNavTab({ style }: Props) {
         );
 
         yours.push(
-          makeItem("stars", <A href="/stars">Stars</A>, "star-filled")
+          menuItem("stars", <A href="/stars">Stars</A>, "star-filled")
         );
       }
     }
 
     return [
-      makeGroup(
+      menuGroup(
         "your",
         <A href={join(basePath, "app")} external>
           <span style={{ color: "#a4acb3" }}>
@@ -202,7 +183,7 @@ export default function AccountNavTab({ style }: Props) {
     if (!is_admin) return [];
     return [
       DIVIDER,
-      makeItem(
+      menuItem(
         "admin",
         <A href={join(basePath, "admin")} external>
           Site Administration
@@ -214,7 +195,7 @@ export default function AccountNavTab({ style }: Props) {
 
   const signout: MenuItem[] = [
     DIVIDER,
-    makeItem(
+    menuItem(
       "sign-out",
       <A
         onClick={async () => {

--- a/src/packages/next/components/antd-menu-items.tsx
+++ b/src/packages/next/components/antd-menu-items.tsx
@@ -1,0 +1,46 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import type { MenuProps } from "antd";
+
+import { Icon, isIconName } from "@cocalc/frontend/components/icon";
+import { ReactNode } from "react";
+
+export type MenuItem = Required<MenuProps>["items"][number];
+export type MenuItems = MenuItem[];
+
+export function menuItem(
+  key: React.Key,
+  label: React.ReactNode,
+  icon?: React.ReactNode | string,
+  children?: MenuItem[],
+  danger?: boolean
+): MenuItem {
+  if (typeof icon === "string" && isIconName(icon)) {
+    icon = <Icon name={icon} />;
+  }
+  return {
+    key,
+    icon,
+    children,
+    label,
+    danger,
+  } as MenuItem;
+}
+
+export function menuGroup(
+  key: React.Key,
+  label: React.ReactNode,
+  children: MenuItem[],
+  icon?: ReactNode
+): MenuItem {
+  return {
+    key,
+    children,
+    label,
+    type: "group",
+    icon,
+  } as MenuItem;
+}

--- a/src/packages/next/lib/hooks/database.ts
+++ b/src/packages/next/lib/hooks/database.ts
@@ -1,4 +1,10 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { useEffect, useState } from "react";
+
 import apiPost from "lib/api/post";
 import useIsMounted from "./mounted";
 import { removeNulls } from "@cocalc/util/misc";

--- a/src/packages/next/lib/hooks/edit-table.tsx
+++ b/src/packages/next/lib/hooks/edit-table.tsx
@@ -41,6 +41,21 @@ interface Options {
   noSave?: boolean;
 }
 
+interface HeadingProps {
+  path?: string;
+  title?: string;
+  desc?: ReactNode;
+  icon?: IconName;
+}
+
+interface EditBooleanProps {
+  path: string;
+  title?: string;
+  desc?: ReactNode;
+  label?: ReactNode;
+  icon?: IconName;
+}
+
 export default function useEditTable<T extends object>(
   query: object,
   options?: Options
@@ -89,17 +104,8 @@ export default function useEditTable<T extends object>(
     );
   }
 
-  function Heading({
-    path,
-    title,
-    icon,
-    desc,
-  }: {
-    path?: string;
-    title?: string;
-    desc?: ReactNode;
-    icon?: IconName;
-  }) {
+  function Heading(props: HeadingProps) {
+    const { path, title, icon, desc } = props;
     return (
       <>
         <Title level={3}>
@@ -111,19 +117,8 @@ export default function useEditTable<T extends object>(
     );
   }
 
-  function EditBoolean({
-    path,
-    title,
-    desc,
-    label,
-    icon,
-  }: {
-    path: string;
-    title?: string;
-    desc?: ReactNode;
-    label?: ReactNode;
-    icon?: IconName;
-  }) {
+  function EditBoolean(props: EditBooleanProps) {
+    const { path, title, desc, label, icon } = props;
     return (
       <Space direction="vertical" style={{ marginTop: "15px" }}>
         <Heading path={path} title={title} icon={icon} desc={desc} />

--- a/src/packages/next/lib/hooks/edit-table.tsx
+++ b/src/packages/next/lib/hooks/edit-table.tsx
@@ -1,3 +1,10 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Space } from "antd";
+import { cloneDeep, get, keys, set } from "lodash";
 import {
   CSSProperties,
   ReactNode,
@@ -6,16 +13,16 @@ import {
   useRef,
   useState,
 } from "react";
-import useDatabase from "lib/hooks/database";
-import SaveButton from "components/misc/save-button";
-import { get, set, cloneDeep, keys } from "lodash";
-import { Space } from "antd";
-import { SCHEMA } from "@cocalc/util/schema";
-import Checkbox from "components/misc/checkbox";
-import IntegerSlider from "components/misc/integer-slider";
-import SelectWithDefault from "components/misc/select-with-default";
+
 import { Icon, IconName } from "@cocalc/frontend/components/icon";
 import { capitalize } from "@cocalc/util/misc";
+import { SCHEMA } from "@cocalc/util/schema";
+import { Paragraph, Title } from "components/misc";
+import Checkbox from "components/misc/checkbox";
+import IntegerSlider from "components/misc/integer-slider";
+import SaveButton from "components/misc/save-button";
+import SelectWithDefault from "components/misc/select-with-default";
+import useDatabase from "lib/hooks/database";
 
 /*
 WARNING: the code below is some pretty complicated use of React hooks,
@@ -34,7 +41,10 @@ interface Options {
   noSave?: boolean;
 }
 
-export default function useEditTable<T extends object>(query: object, options?: Options) {
+export default function useEditTable<T extends object>(
+  query: object,
+  options?: Options
+) {
   const { loading, value } = useDatabase(query);
   const [original, setOriginal] = useState<T | undefined>(undefined);
   const [edited, setEdited0] = useState<T | undefined>(undefined);
@@ -92,11 +102,11 @@ export default function useEditTable<T extends object>(query: object, options?: 
   }) {
     return (
       <>
-        <h3>
+        <Title level={3}>
           {icon && <Icon name={icon} style={{ marginRight: "10px" }} />}
           {getTitle(path, title)}
-        </h3>
-        {desc && <div>{desc}</div>}
+        </Title>
+        {desc && <Paragraph>{desc}</Paragraph>}
       </>
     );
   }

--- a/src/packages/next/pages/api/v2/accounts/send-verification-email.ts
+++ b/src/packages/next/pages/api/v2/accounts/send-verification-email.ts
@@ -1,0 +1,27 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
+Send verification email
+*/
+
+import sendEmailVerification from "@cocalc/server/accounts/send-email-verification";
+import getAccountId from "lib/account/get-account";
+import getParams from "lib/api/get-params";
+
+export default async function handle(req, res) {
+  const account_id = await getAccountId(req);
+  if (account_id == null) {
+    res.json({ error: "must be signed in" });
+    return;
+  }
+  const { email_address } = getParams(req);
+  try {
+    const msg = await sendEmailVerification(account_id, email_address);
+    res.json({ error: msg });
+  } catch (err) {
+    res.json({ error: err.message });
+  }
+}

--- a/src/packages/next/pages/api/v2/accounts/set-email-address.ts
+++ b/src/packages/next/pages/api/v2/accounts/set-email-address.ts
@@ -1,4 +1,9 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+/*
 Set email address for an existing account.
 
 You must include both the email address and password.  If there is no password

--- a/src/packages/next/pages/billing/[[...page]].tsx
+++ b/src/packages/next/pages/billing/[[...page]].tsx
@@ -3,8 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { capitalize } from "@cocalc/util/misc";
 import { Layout } from "antd";
+
+import { capitalize } from "@cocalc/util/misc";
 import { MainPages, MainPagesType } from "components/billing/consts";
 import BillingLayout from "components/billing/layout";
 import Footer from "components/landing/footer";

--- a/src/packages/next/pages/config/[...page].tsx
+++ b/src/packages/next/pages/config/[...page].tsx
@@ -1,18 +1,48 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Layout } from "antd";
-import Header from "components/landing/header";
+import { join } from "path";
+
+import ConfigLayout from "components/account/config/layout";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
-import ConfigLayout from "components/account/config/layout";
+import Header from "components/landing/header";
+import { Paragraph } from "components/misc";
+import A from "components/misc/A";
+import basePath from "lib/base-path";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
 
 export default function Preferences({ customize, page }) {
+  function noteAboutConfig() {
+    return (
+      <Paragraph
+        type="secondary"
+        style={{
+          padding: "15px",
+          margin: 0,
+          textAlign: "center",
+          borderTop: `1px solid lightgray`,
+        }}
+      >
+        This is the account configuration page.{" "}
+        <A href={join(basePath, "settings")} external>
+          You can also adjust key preferences in the main app...
+        </A>
+      </Paragraph>
+    );
+  }
+
   return (
     <Customize value={customize}>
       <Head title="Configuration" />
       <Layout>
         <Header />
         <ConfigLayout page={page} />
+        {noteAboutConfig()}
         <Footer />
       </Layout>
     </Customize>
@@ -20,7 +50,13 @@ export default function Preferences({ customize, page }) {
 }
 
 export async function getServerSideProps(context) {
-  const { page } = context.params;
+  const { params, res } = context;
+  const { page = [] } = params;
+
+  const [_, sub] = page;
+  if (sub == null) {
+    return res.redirect(307, "./search/input");
+  }
 
   return await withCustomize({ context, props: { page } });
 }

--- a/src/packages/next/pages/config/index.tsx
+++ b/src/packages/next/pages/config/index.tsx
@@ -1,4 +1,10 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { Layout } from "antd";
+
 import Header from "components/landing/header";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";

--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -825,6 +825,7 @@ importers:
     specifiers:
       '@cocalc/backend': workspace:*
       '@cocalc/database': workspace:*
+      '@cocalc/hub': workspace:*
       '@cocalc/server': workspace:*
       '@cocalc/util': workspace:*
       '@passport-next/passport-google-oauth2': ^1.0.0
@@ -866,6 +867,7 @@ importers:
     dependencies:
       '@cocalc/backend': link:../backend
       '@cocalc/database': link:../database
+      '@cocalc/hub': link:../hub
       '@cocalc/server': 'link:'
       '@cocalc/util': link:../util
       '@passport-next/passport-google-oauth2': 1.0.0
@@ -1383,7 +1385,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.18.13
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
@@ -1395,7 +1397,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.20.10
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       lru-cache: 5.1.1
@@ -1456,7 +1458,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.1.0
 
@@ -1762,7 +1764,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.18.13:
@@ -1771,7 +1773,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.18.13
@@ -1895,7 +1897,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-do-expressions': 7.18.6_@babel+core@7.18.13
     dev: false
@@ -1906,7 +1908,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.13
 
@@ -1916,7 +1918,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-default-from': 7.18.6_@babel+core@7.18.13
     dev: false
@@ -1927,7 +1929,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.18.13
 
@@ -1937,7 +1939,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-function-bind': 7.18.6_@babel+core@7.18.13
     dev: false
@@ -1976,7 +1978,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.13
 
@@ -1986,7 +1988,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.13
 
@@ -1996,7 +1998,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.13
 
@@ -2006,7 +2008,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.13
 
@@ -2017,7 +2019,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.20.10
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.18.13
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.13
@@ -2029,7 +2031,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.13
 
@@ -2039,7 +2041,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.13
@@ -2050,7 +2052,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-pipeline-operator': 7.18.6_@babel+core@7.18.13
     dev: false
@@ -2115,7 +2117,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-throw-expressions': 7.18.6_@babel+core@7.18.13
     dev: false
@@ -2126,7 +2128,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.13
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -2135,7 +2137,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.20.12:
@@ -2161,7 +2163,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.20.12:
@@ -2179,7 +2181,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-decorators/7.18.6_@babel+core@7.18.13:
@@ -2188,7 +2190,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2198,7 +2200,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2207,7 +2209,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-export-default-from/7.18.6_@babel+core@7.18.13:
@@ -2216,7 +2218,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2225,7 +2227,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-function-bind/7.18.6_@babel+core@7.18.13:
@@ -2234,7 +2236,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2244,7 +2246,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2254,7 +2256,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.18.13:
@@ -2262,7 +2264,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2280,7 +2282,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.20.12:
@@ -2317,7 +2319,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.20.12:
@@ -2334,7 +2336,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.20.12:
@@ -2351,7 +2353,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.20.12:
@@ -2368,7 +2370,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.20.12:
@@ -2385,7 +2387,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.20.12:
@@ -2402,7 +2404,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.20.12:
@@ -2420,7 +2422,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2430,7 +2432,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-throw-expressions/7.18.6_@babel+core@7.18.13:
@@ -2439,7 +2441,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -2449,7 +2451,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.20.12:
@@ -2478,7 +2480,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.18.13:
@@ -2514,7 +2516,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-block-scoping/7.18.9_@babel+core@7.18.13:
@@ -2523,7 +2525,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-classes/7.18.9_@babel+core@7.18.13:
@@ -2569,7 +2571,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-destructuring/7.18.13_@babel+core@7.18.13:
@@ -2578,7 +2580,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.18.13:
@@ -2587,7 +2589,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.13
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -2597,7 +2599,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.18.13:
@@ -2606,7 +2608,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -2616,7 +2618,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.18.13:
@@ -2625,7 +2627,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.18.13
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
@@ -2636,7 +2638,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.18.13:
@@ -2645,7 +2647,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-modules-amd/7.18.6_@babel+core@7.18.13:
@@ -2766,7 +2768,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.13
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -2776,7 +2778,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.18.13:
@@ -2810,7 +2812,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.18.13:
@@ -2819,7 +2821,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-react-jsx/7.20.7_@babel+core@7.18.13:
@@ -2842,7 +2844,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.0
 
@@ -2852,7 +2854,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.18.13:
@@ -2861,7 +2863,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-spread/7.18.9_@babel+core@7.18.13:
@@ -2870,7 +2872,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
 
@@ -2880,7 +2882,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.18.13:
@@ -2889,7 +2891,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.18.13:
@@ -2898,7 +2900,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.18.13:
@@ -2907,7 +2909,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.18.13:
@@ -2916,7 +2918,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.13
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -3104,7 +3106,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.13
+      '@babel/core': 7.18.13_supports-color@9.3.1
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.18.13
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.18.13

--- a/src/packages/server/accounts/send-email-verification.ts
+++ b/src/packages/server/accounts/send-email-verification.ts
@@ -3,6 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { db } from "@cocalc/database";
 import { verify_email_send_token } from "@cocalc/hub/auth";
 import { callback2 as cb2 } from "@cocalc/util/async-utils";
 import { isValidUUID, is_valid_email_address } from "@cocalc/util/misc";
@@ -23,6 +24,7 @@ export default async function sendEmailVerification(
       account_id,
       email_address,
       only_verify: true,
+      database: db(),
     });
   } catch (err) {
     return err.message;

--- a/src/packages/server/accounts/send-email-verification.ts
+++ b/src/packages/server/accounts/send-email-verification.ts
@@ -1,0 +1,30 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { verify_email_send_token } from "@cocalc/hub/auth";
+import { callback2 as cb2 } from "@cocalc/util/async-utils";
+import { isValidUUID, is_valid_email_address } from "@cocalc/util/misc";
+
+export default async function sendEmailVerification(
+  account_id: string,
+  email_address: string
+): Promise<string | undefined> {
+  if (!isValidUUID(account_id)) {
+    throw Error("account_id is not valid");
+  }
+  if (!is_valid_email_address(email_address)) {
+    throw Error("email address is not valid");
+  }
+
+  try {
+    await cb2(verify_email_send_token, {
+      account_id,
+      email_address,
+      only_verify: true,
+    });
+  } catch (err) {
+    return err.message;
+  }
+}

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -36,6 +36,7 @@
     "@cocalc/database": "workspace:*",
     "@cocalc/server": "workspace:*",
     "@cocalc/util": "workspace:*",
+    "@cocalc/hub": "workspace:*",
     "@passport-next/passport-google-oauth2": "^1.0.0",
     "@passport-next/passport-oauth2": "^2.1.4",
     "@sendgrid/mail": "^7.5.0",

--- a/src/packages/server/settings/customize.ts
+++ b/src/packages/server/settings/customize.ts
@@ -44,6 +44,7 @@ export interface Customize {
   policies_html?: string;
   reCaptchaKey?: string;
   sandboxProjectId?: string;
+  verifyEmailAddresses?: boolean;
   strategies: Strategy[];
 }
 
@@ -138,6 +139,8 @@ export default async function getCustomize(): Promise<Customize> {
 
     // public info about SSO strategies
     strategies,
+
+    verifyEmailAddresses: settings.verify_emails && settings.email_enabled,
   } as Customize;
 
   return cachedCustomize;

--- a/src/packages/sync/table/synctable.ts
+++ b/src/packages/sync/table/synctable.ts
@@ -33,15 +33,15 @@ import { assert_uuid, copy, is_array, is_object, len } from "@cocalc/util/misc";
 import * as schema from "@cocalc/util/schema";
 import mergeDeep from "./immutable-deep-merge";
 
-export type Query = any; // todo
-export type QueryOptions = any[]; // todo
+export type Query = any; // TODO typing
+export type QueryOptions = any[]; // TODO typing
 
 // What we need the client below to implement so we can use
 // it to support a table.
 export interface Client extends EventEmitter {
   is_project: () => boolean;
   dbg: (str: string) => Function;
-  query: Function;
+  query: Query; // TODO typing
   query_cancel: Function;
   server_time: Function;
   alert_message?: Function;

--- a/src/packages/util/async-utils.ts
+++ b/src/packages/util/async-utils.ts
@@ -114,6 +114,7 @@ export async function retry_until_success<T>(
 }
 
 import { EventEmitter } from "events";
+import { CB } from "./types/database";
 
 /* Wait for an event emitter to emit any event at all once.
    Returns array of args emitted by that event.
@@ -169,10 +170,14 @@ async function once_with_timeout(
 
 // Alternative to callback_opts that behaves like the
 // callback defined in awaiting.
-export async function callback2(f: Function, opts: any = {}): Promise<any> {
-  function g(cb): void {
-    opts.cb = cb;
-    f(opts);
+export async function callback2<T = any>(
+  f: (opts: T & { cb: CB }) => void,
+  opts?: T
+): Promise<any> {
+  const optsCB: T & { cb: CB } = (opts ?? {}) as any;
+  function g(cb: CB): void {
+    optsCB.cb = cb;
+    f(optsCB);
   }
   return await awaiting.callback(g);
 }

--- a/src/packages/util/async-utils.ts
+++ b/src/packages/util/async-utils.ts
@@ -168,14 +168,14 @@ async function once_with_timeout(
   return val;
 }
 
-// Alternative to callback_opts that behaves like the
-// callback defined in awaiting.
-export async function callback2<T = any>(
-  f: (opts: T & { cb: CB }) => void,
-  opts?: T
-): Promise<any> {
-  const optsCB: T & { cb: CB } = (opts ?? {}) as any;
-  function g(cb: CB): void {
+// Alternative to callback_opts that behaves like the callback defined in awaiting.
+// Pass in the type of the returned value, and it will be inferred.
+export async function callback2<R = any>(
+  f: (opts) => void,
+  opts?: object
+): Promise<R> {
+  const optsCB = (opts ?? {}) as typeof opts & { cb: CB<R> };
+  function g(cb: CB<R>): void {
     optsCB.cb = cb;
     f(optsCB);
   }

--- a/src/packages/util/types/database.ts
+++ b/src/packages/util/types/database.ts
@@ -3,8 +3,15 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-// Use this type to type the callback used for the database callback2 calls.
+export type UntypedQueryResult = { [key: string]: any };
+export type QueryResult<T = UntypedQueryResult> = T;
+export type QueryRows<T = UntypedQueryResult> = { rows: QueryResult<T>[] };
+
+// Use this type to type the callback which is e.g. used in callback 2
 export type CB<T = any> = (
   err?: string | Error | null | undefined,
   result?: T
 ) => any;
+
+// and this for callbacks related to database queries
+export type CBDB<T = UntypedQueryResult> = CB<QueryRows<T>>;

--- a/src/packages/util/types/database.ts
+++ b/src/packages/util/types/database.ts
@@ -1,0 +1,10 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// Use this type to type the callback used for the database callback2 calls.
+export type CB<T = any> = (
+  err?: string | Error | null | undefined,
+  result?: T
+) => any;


### PR DESCRIPTION
# Description

- next/config: name, etc.
- next/config: account
- I saw email verification is still missing, and I added it. screenshot from  config/account/email:
     ![Screenshot from 2023-01-25 15-47-12](https://user-images.githubusercontent.com/207405/214594219-392678d8-4138-4dd1-a801-04833b99234f.png)
-  This depends on the hub, so, I added this as a reference. I believe that's against the overall plan, but well, there are already warnings about circular dependencies, and this only adds a bit more of these. In any case, this works.
- While implementing the above, I struggled with some postgres typing. Being more specific with some types opened up a can of worms. e.g. now it is possible to specify the expected type of a query/async_query. So, many additional touches to files, but none of them should have any impact (famous last words :shrug:)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
