### PR TITLE
hub: passport manager not available right after startup

### DIFF
--- a/src/packages/hub/servers/app/customize.ts
+++ b/src/packages/hub/servers/app/customize.ts
@@ -1,6 +1,11 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { send as sendManifest } from "@cocalc/hub/manifest";
 import { WebappConfiguration } from "@cocalc/hub/webapp-configuration";
 import { database } from "../database";
-import { send as sendManifest } from "@cocalc/hub/manifest";
 
 export default function init(router, isPersonal: boolean) {
   const webappConfig = new WebappConfiguration({ db: database });

--- a/src/packages/hub/servers/express-app.ts
+++ b/src/packages/hub/servers/express-app.ts
@@ -55,6 +55,9 @@ export default async function init(opts: Options): Promise<{
   const app = express();
   app.disable("x-powered-by"); // https://github.com/sagemathinc/cocalc/issues/6101
 
+  // makes JSON (e.g. the /customize endpoint) pretty-printed
+  app.set("json spaces", 2);
+
   // healthchecks are for internal use, no basePath prefix
   // they also have to come first, since e.g. the vhost depends
   // on the DB, which could be down


### PR DESCRIPTION
# Description

Requesting the strategies right after starting the hub might throw, because the passport manager isn't available yet. This fixes this by waiting on it, essentially.

I also made it so the json sent via /customize is pretty-printed, which makes it easier to read for debugging. (that's where that strategy info is sent to the frontend)

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
