### PR TITLE
«hub» package need deps «escape-html»

### DIFF
--- a/src/packages/hub/package.json
+++ b/src/packages/hub/package.json
@@ -38,6 +38,7 @@
     "cors": "^2.8.5",
     "debug": "^4.3.2",
     "dot-object": "^2.1.3",
+    "escape-html": "^1.0.3",
     "express": "^4.17.1",
     "express-session": "^1.10.4",
     "http-proxy": "^1.18.1",


### PR DESCRIPTION
# Description
«hub» package need deps «escape-html»
```
client.coffee
36:{ escapeHtml }       = require("escape-html")
```

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ *] Testing instructions are provided, if not obvious
- [ *] Release instructions are provided, if not obvious
