### PR TITLE
frontend/terminal: fix showing scrollbars when narrow

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -8,6 +8,17 @@ FrameTitleBar - title bar in a frame, in the frame tree
 */
 
 import {
+  Button as AntdButton,
+  Input,
+  InputNumber,
+  Popconfirm,
+  Popover,
+} from "antd";
+import { List } from "immutable";
+import { debounce } from "lodash";
+import { ReactNode } from "react";
+
+import {
   Button as AntdBootstrapButton,
   ButtonGroup,
   ButtonStyle,
@@ -35,16 +46,6 @@ import { useStudentProjectFunctionality } from "@cocalc/frontend/course";
 import { EditorFileInfoDropdown } from "@cocalc/frontend/editors/file-info-dropdown";
 import { IS_MACOS, IS_TOUCH } from "@cocalc/frontend/feature";
 import { capitalize, copy, path_split } from "@cocalc/util/misc";
-import {
-  Input,
-  InputNumber,
-  Popconfirm,
-  Popover,
-  Button as AntdButton,
-} from "antd";
-import { List } from "immutable";
-import { debounce } from "lodash";
-import { ReactNode } from "react";
 import { Actions } from "../code-editor/actions";
 import { FORMAT_SOURCE_ICON } from "../frame-tree/config";
 import { is_safari } from "../generic/browser";
@@ -76,6 +77,7 @@ interface EditorActions extends Actions {
 }
 
 import { AvailableFeatures } from "@cocalc/frontend/project_configuration";
+import { COLORS } from "@cocalc/util/theme";
 
 const COL_BAR_BACKGROUND = "#f8f8f8";
 const COL_BAR_BACKGROUND_DARK = "#ddd";
@@ -93,14 +95,14 @@ const title_bar_style: CSS = {
 
 const TITLE_STYLE: CSS = {
   background: COL_BAR_BACKGROUND_DARK,
-  padding: "5px 5px 0 5px",
-  color: "#333",
+  padding: "8px 5px 0 5px",
+  color: COLORS.GRAY_DD,
   fontSize: "10pt",
   whiteSpace: "nowrap",
   flex: "1 1 auto",
   display: "inline-block",
   textOverflow: "ellipsis",
-  overflow: "auto",
+  overflow: "hidden",
 } as const;
 
 const CONNECTION_STATUS_STYLE: CSS = {
@@ -1574,6 +1576,7 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
 
     return (
       <div
+        title={title}
         style={{
           ...TITLE_STYLE,
           ...(is_active


### PR DESCRIPTION

# Description
- don't show scrollbars, i.e. this is ugly:

  ![Screenshot from 2023-02-07 11-08-09](https://user-images.githubusercontent.com/207405/217218162-9f67591e-3ed3-40cc-b5ab-0dd4b1d53df0.png)


- add "title to be able to see full title when hovering



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
