### PR TITLE
next/store: link to on-prem offerings

### DIFF
--- a/src/packages/next/components/store/dedicated.tsx
+++ b/src/packages/next/components/store/dedicated.tsx
@@ -86,16 +86,26 @@ export default function DedicatedResource(props: Props) {
           : "Buy a Dedicated Resources License"}
       </Title>
       {router.query.id == null && (
-        <Paragraph>
-          A{" "}
-          <A href="https://doc.cocalc.com/licenses.html">
-            <SiteName /> dedicated resource license
-          </A>{" "}
-          can be used to outfit your project either with additional disk storage
-          or moves your project to a much more powerful virtual machine. Create
-          a dedicated resources license below then add it to your{" "}
-          <A href="/store/cart">shopping cart</A>.
-        </Paragraph>
+        <>
+          <Paragraph>
+            A{" "}
+            <A href="https://doc.cocalc.com/licenses.html">
+              <SiteName /> dedicated resource license
+            </A>{" "}
+            can be used to outfit your project either with additional disk
+            storage or moves your project to a much more powerful virtual
+            machine. Create a dedicated resources license below then add it to
+            your <A href="/store/cart">shopping cart</A>.
+          </Paragraph>
+          <Paragraph>
+            It is also possible to run <SiteName /> on your own hardware. Check
+            out the{" "}
+            <Text strong>
+              <A href={"/pricing/onprem"}>on-premises offerings</A>
+            </Text>{" "}
+            to learn more about this.
+          </Paragraph>
+        </>
       )}
       <CreateDedicatedResource
         showInfoBar={scrollY > offsetHeader}

--- a/src/packages/next/components/store/overview.tsx
+++ b/src/packages/next/components/store/overview.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Icon } from "@cocalc/frontend/components/icon";
-import { Paragraph } from "components/misc";
+import { Paragraph, Text } from "components/misc";
 import A from "components/misc/A";
 import SiteName from "components/share/site-name";
 import {
@@ -65,6 +65,13 @@ export default function Overview() {
         If you already selected one or more items, view your{" "}
         <A href="/store/cart">shopping cart</A> or go straight to{" "}
         <A href="/store/checkout">checkout</A>.
+      </Paragraph>
+      <Paragraph>
+        It is also possible to run <SiteName /> on your own infrastructure:{" "}
+        <Text strong>
+          <A href={"/pricing/onprem"}>on-premises offerings</A>
+        </Text>
+        .
       </Paragraph>
       <Paragraph>
         You can also browse your <A href="/billing">billing records</A> or{" "}


### PR DESCRIPTION
# Description

Yesterday, Blaec mentioned to add links from the store to the on-prem offerings. This does it in two spots…

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
