### PR TITLE
Fix crash when OAuth1 protocol is used

### DIFF
--- a/src/packages/server/auth/sso/oauth2-user-profile-callback.ts
+++ b/src/packages/server/auth/sso/oauth2-user-profile-callback.ts
@@ -17,8 +17,12 @@ export function addUserProfileCallback(opts: UserProfileCallbackOpts) {
   strategy_instance.userProfile = function userProfile(accessToken, done) {
     L2(`userinfoURL=${userinfoURL}, accessToken=${accessToken}`);
 
-    this._oauth2.useAuthorizationHeaderforGET(true);
-    this._oauth2.get(userinfoURL, accessToken, (err, body) => {
+    var oauth_ = this._oauth;
+    if (this._oauth2) {
+        oauth_ = this._oauth2;
+        oauth_.useAuthorizationHeaderforGET(true);
+    }    
+    oauth_.get(userinfoURL, accessToken, (err, body) => {
       L2(`get->body = ${safeJsonStringify(body)}`);
 
       let json;


### PR DESCRIPTION
# Description
When OAuth1 SSO is used, here (because of hardcoding for oauth2) crash (null dereference) occured 

![image](https://user-images.githubusercontent.com/1609739/217241146-99523091-9230-4ba9-9362-72f66e44b058.png)

I am not sure that «useAuthorizationHeaderforGET» member exists for «_oauth2» (have no OAuth2 test setup), but this member definitely absent for «_oauth».

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [*] Testing instructions are provided, if not obvious
- [*] Release instructions are provided, if not obvious
