### PR TITLE
frontend: small code fixes

### DIFF
--- a/src/packages/frontend/chat/chatroom.tsx
+++ b/src/packages/frontend/chat/chatroom.tsx
@@ -5,31 +5,37 @@
 
 import { debounce } from "lodash";
 import { useDebounce } from "use-debounce";
-import { history_path } from "@cocalc/util/misc";
-import { sanitize_html_safe } from "@cocalc/frontend/misc";
-import { SaveButton } from "@cocalc/frontend/frame-editors/frame-tree/save-button";
-import { Button, ButtonGroup } from "@cocalc/frontend/antd-bootstrap";
-import { ChatInput } from "./input";
-import { mark_chat_as_read_if_unseen, INPUT_HEIGHT } from "./utils";
+
+import {
+  Button,
+  ButtonGroup,
+  Col,
+  Row,
+  Well,
+} from "@cocalc/frontend/antd-bootstrap";
 import {
   React,
   redux,
   useActions,
   useEffect,
-  useRef,
   useRedux,
+  useRef,
 } from "@cocalc/frontend/app-framework";
 import {
   Icon,
   Loading,
-  Tip,
   SearchInput,
+  Tip,
   VisibleMDLG,
 } from "@cocalc/frontend/components";
-import { Col, Row, Well } from "@cocalc/frontend/antd-bootstrap";
-import { ChatLog } from "./chat-log";
-import VideoChatButton from "./video/launch-button";
 import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
+import { SaveButton } from "@cocalc/frontend/frame-editors/frame-tree/save-button";
+import { sanitize_html_safe } from "@cocalc/frontend/misc";
+import { history_path } from "@cocalc/util/misc";
+import { ChatLog } from "./chat-log";
+import { ChatInput } from "./input";
+import { INPUT_HEIGHT, mark_chat_as_read_if_unseen } from "./utils";
+import VideoChatButton from "./video/launch-button";
 
 const PREVIEW_STYLE: React.CSSProperties = {
   background: "#f5f5f5",
@@ -39,7 +45,7 @@ const PREVIEW_STYLE: React.CSSProperties = {
   paddingBottom: "20px",
   maxHeight: "40vh",
   overflowY: "auto",
-};
+} as const;
 
 const GRID_STYLE: React.CSSProperties = {
   maxWidth: "1200px",
@@ -47,7 +53,7 @@ const GRID_STYLE: React.CSSProperties = {
   flexDirection: "column",
   width: "100%",
   margin: "auto",
-};
+} as const;
 
 const CHAT_LOG_STYLE: React.CSSProperties = {
   margin: "0",
@@ -55,7 +61,7 @@ const CHAT_LOG_STYLE: React.CSSProperties = {
   background: "white",
   flex: "1 0 auto",
   position: "relative",
-};
+} as const;
 
 interface Props {
   project_id: string;

--- a/src/packages/frontend/chat/input.tsx
+++ b/src/packages/frontend/chat/input.tsx
@@ -4,13 +4,17 @@
  */
 
 import { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
-import { redux, useRedux } from "@cocalc/frontend/app-framework";
+
+import {
+  redux,
+  useIsMountedRef,
+  useRedux,
+} from "@cocalc/frontend/app-framework";
 import MarkdownInput from "@cocalc/frontend/editors/markdown-input/multimode";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
+import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
 import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 import { useDebouncedCallback } from "use-debounce";
-import { useIsMountedRef } from "@cocalc/frontend/app-framework";
-import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
 
 interface Props {
   on_send: (value: string) => void;

--- a/src/packages/frontend/components/color-picker.tsx
+++ b/src/packages/frontend/components/color-picker.tsx
@@ -19,7 +19,11 @@ import {
 
 const { Option } = Select;
 
-import { get_local_storage, set_local_storage } from "@cocalc/frontend/misc";
+// must be imported from misc/local-storage, because otherwise the "static" build fails
+import {
+  get_local_storage,
+  set_local_storage,
+} from "@cocalc/frontend/misc/local-storage";
 import { capitalize } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { Icon } from "./icon";

--- a/src/packages/frontend/components/color-picker.tsx
+++ b/src/packages/frontend/components/color-picker.tsx
@@ -19,9 +19,10 @@ import {
 
 const { Option } = Select;
 
+import { get_local_storage, set_local_storage } from "@cocalc/frontend/misc";
 import { capitalize } from "@cocalc/util/misc";
-import { Icon } from "./icon";
 import { COLORS } from "@cocalc/util/theme";
+import { Icon } from "./icon";
 
 const Pickers = {
   circle: CirclePicker,
@@ -35,6 +36,17 @@ const Pickers = {
   slider: SliderPicker,
   compact: CompactPicker,
 };
+
+type TPickers = keyof typeof Pickers;
+
+const LS_PICKER_KEY = "defaultColorPicker";
+
+function getLocalStoragePicker(): TPickers | undefined {
+  const p = get_local_storage(LS_PICKER_KEY);
+  if (typeof p === "string" && Pickers[p] != null) {
+    return p as TPickers;
+  }
+}
 
 interface Props {
   color?: string;
@@ -53,9 +65,10 @@ export default function ColorPicker(props: Props) {
     toggle,
     justifyContent = "center",
   } = props;
+
   const [visible, setVisible] = useState<boolean>(!toggle);
-  const [picker, setPicker] = useState<keyof typeof Pickers>(
-    defaultPicker ?? localStorage["defaultColorPicker"] ?? "circle"
+  const [picker, setPicker] = useState<TPickers>(
+    defaultPicker ?? getLocalStoragePicker() ?? "circle"
   );
   const Picker = Pickers[picker];
   const v: ReactNode[] = [];
@@ -117,7 +130,7 @@ export default function ColorPicker(props: Props) {
           style={{ width: "120px", marginTop: "10px" }}
           onChange={(picker) => {
             setPicker(picker);
-            localStorage["defaultColorPicker"] = picker;
+            set_local_storage(LS_PICKER_KEY, picker);
           }}
         >
           {v}

--- a/src/packages/frontend/components/color-picker.tsx
+++ b/src/packages/frontend/components/color-picker.tsx
@@ -1,22 +1,27 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
 import { Button, Modal, Select } from "antd";
-const { Option } = Select;
-import { Icon } from "./icon";
-
 import { CSSProperties, ReactNode, useState } from "react";
 import {
-  CirclePicker,
-  ChromePicker,
-  PhotoshopPicker,
-  GithubPicker,
-  TwitterPicker,
-  SwatchesPicker,
-  SketchPicker,
   BlockPicker,
-  SliderPicker,
+  ChromePicker,
+  CirclePicker,
   CompactPicker,
+  GithubPicker,
+  PhotoshopPicker,
+  SketchPicker,
+  SliderPicker,
+  SwatchesPicker,
+  TwitterPicker,
 } from "react-color";
 
+const { Option } = Select;
+
 import { capitalize } from "@cocalc/util/misc";
+import { Icon } from "./icon";
+import { COLORS } from "@cocalc/util/theme";
 
 const Pickers = {
   circle: CirclePicker,
@@ -39,14 +44,15 @@ interface Props {
   toggle?: ReactNode;
   justifyContent?: "flex-start" | "flex-end" | "center";
 }
-export default function ColorPicker({
-  color,
-  onChange,
-  style,
-  defaultPicker,
-  toggle,
-  justifyContent = "center",
-}: Props) {
+export default function ColorPicker(props: Props) {
+  const {
+    color,
+    onChange,
+    style,
+    defaultPicker,
+    toggle,
+    justifyContent = "center",
+  } = props;
   const [visible, setVisible] = useState<boolean>(!toggle);
   const [picker, setPicker] = useState<keyof typeof Pickers>(
     defaultPicker ?? localStorage["defaultColorPicker"] ?? "circle"
@@ -101,7 +107,7 @@ export default function ColorPicker({
             float: "right",
             fontSize: "12px",
             marginTop: "20px",
-            color: "#666",
+            color: COLORS.GRAY_M,
           }}
         >
           Color Picker
@@ -128,13 +134,8 @@ interface ButtonProps {
   type?: "default" | "link" | "text" | "ghost" | "primary" | "dashed";
   onClick?: () => boolean | undefined;
 }
-export function ColorButton({
-  onChange,
-  title,
-  style,
-  type,
-  onClick,
-}: ButtonProps) {
+export function ColorButton(props: ButtonProps) {
+  const { onChange, title, style, type, onClick } = props;
   const [show, setShow] = useState<boolean>(false);
   return (
     <>
@@ -142,7 +143,7 @@ export function ColorButton({
         transitionName=""
         maskTransitionName=""
         title={title ?? "Select a Color"}
-        visible={show}
+        open={show}
         onOk={() => setShow(false)}
         onCancel={() => setShow(false)}
       >

--- a/src/packages/frontend/editors/markdown-input/multimode.tsx
+++ b/src/packages/frontend/editors/markdown-input/multimode.tsx
@@ -2,26 +2,27 @@
 Edit with either plain text input **or** WYSIWYG slate-based input.
 */
 
-import { MutableRefObject, useEffect } from "react";
 import { Radio } from "antd";
-import "@cocalc/frontend/editors/slate/elements/math/math-widget";
-import { EditableMarkdown } from "@cocalc/frontend/editors/slate/editable-markdown";
-import { MarkdownInput } from "./component";
+import { fromJS, Map as ImmutableMap } from "immutable";
+import LRU from "lru-cache";
 import {
   CSSProperties,
+  MutableRefObject,
   ReactNode,
   RefObject,
+  useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
-import { FOCUSED_STYLE, BLURED_STYLE } from "./component";
-import { fromJS, Map as ImmutableMap } from "immutable";
-import LRU from "lru-cache";
-import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
-import { FragmentId } from "@cocalc/frontend/misc/fragment-id";
+
+import { EditableMarkdown } from "@cocalc/frontend/editors/slate/editable-markdown";
+import "@cocalc/frontend/editors/slate/elements/math/math-widget";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
+import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
+import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
+import { FragmentId } from "@cocalc/frontend/misc/fragment-id";
+import { BLURED_STYLE, FOCUSED_STYLE, MarkdownInput } from "./component";
 
 // NOTE: on mobile there is very little suppport for "editor" = "slate", but
 // very good support for "markdown", hence the default below.
@@ -117,49 +118,50 @@ interface Props {
   refresh?: any;
 }
 
-export default function MultiMarkdownInput({
-  cacheId,
-  value,
-  defaultMode,
-  fixedMode,
-  onChange,
-  getValueRef,
-  onModeChange,
-  onShiftEnter,
-  placeholder,
-  fontSize,
-  height = "auto",
-  style,
-  autoFocus,
-  enableMentions,
-  enableUpload = true,
-  onUploadStart,
-  onUploadEnd,
-  submitMentionsRef,
-  extraHelp,
-  saveDebounceMs = SAVE_DEBOUNCE_MS,
-  hideHelp,
-  onBlur,
-  onFocus,
-  minimal,
-  editBarStyle,
-  onCursors,
-  cursors,
-  noVfill,
-  editorDivRef,
-  cmOptions,
-  onUndo,
-  onRedo,
-  onSave,
-  onCursorTop,
-  onCursorBottom,
-  compact,
-  isFocused,
-  registerEditor,
-  unregisterEditor,
-  modeSwitchStyle,
-  refresh,
-}: Props) {
+export default function MultiMarkdownInput(props: Props) {
+  const {
+    cacheId,
+    value,
+    defaultMode,
+    fixedMode,
+    onChange,
+    getValueRef,
+    onModeChange,
+    onShiftEnter,
+    placeholder,
+    fontSize,
+    height = "auto",
+    style,
+    autoFocus,
+    enableMentions,
+    enableUpload = true,
+    onUploadStart,
+    onUploadEnd,
+    submitMentionsRef,
+    extraHelp,
+    saveDebounceMs = SAVE_DEBOUNCE_MS,
+    hideHelp,
+    onBlur,
+    onFocus,
+    minimal,
+    editBarStyle,
+    onCursors,
+    cursors,
+    noVfill,
+    editorDivRef,
+    cmOptions,
+    onUndo,
+    onRedo,
+    onSave,
+    onCursorTop,
+    onCursorBottom,
+    compact,
+    isFocused,
+    registerEditor,
+    unregisterEditor,
+    modeSwitchStyle,
+    refresh,
+  } = props;
   const { project_id, path } = useFrameContext();
 
   function getCache() {

--- a/src/packages/frontend/editors/slate/edit-bar/color-button.tsx
+++ b/src/packages/frontend/editors/slate/edit-bar/color-button.tsx
@@ -1,8 +1,21 @@
-import { BUTTON_STYLE } from "./marks-bar";
-import { formatAction } from "../format";
-import { ColorButton } from "@cocalc/frontend/components/color-picker";
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
 
-export default function Component({ editor, color }) {
+import { ColorButton } from "@cocalc/frontend/components/color-picker";
+import { formatAction } from "../format";
+import { SlateEditor } from "../types";
+import { BUTTON_STYLE } from "./marks-bar";
+
+interface Props {
+  editor: SlateEditor;
+  color?: string;
+}
+
+export default function Component(props: Props) {
+  const { editor, color } = props;
+
   return (
     <ColorButton
       type="text"

--- a/src/packages/frontend/editors/slate/edit-bar/component.tsx
+++ b/src/packages/frontend/editors/slate/edit-bar/component.tsx
@@ -4,13 +4,13 @@
  */
 
 import React from "react";
-import { SlateEditor } from "../editable-markdown";
 
-import { MarksBar } from "./marks-bar";
-import { Marks } from "./marks";
+import { SlateEditor } from "../editable-markdown";
 import { LinkEdit } from "./link-edit";
 import { ListProperties } from "./list";
 import { ListEdit } from "./list-edit";
+import { Marks } from "./marks";
+import { MarksBar } from "./marks-bar";
 
 interface Props {
   Search: JSX.Element;
@@ -25,16 +25,18 @@ interface Props {
 
 const HEIGHT = "25px";
 
-export const EditBar: React.FC<Props> = ({
-  isCurrent,
-  Search,
-  marks,
-  linkURL,
-  listProperties,
-  editor,
-  style,
-  hideSearch,
-}) => {
+export const EditBar: React.FC<Props> = (props: Props) => {
+  const {
+    isCurrent,
+    Search,
+    marks,
+    linkURL,
+    listProperties,
+    editor,
+    style,
+    hideSearch,
+  } = props;
+
   function renderContent() {
     return (
       <>

--- a/src/packages/frontend/editors/slate/edit-bar/marks-bar.tsx
+++ b/src/packages/frontend/editors/slate/edit-bar/marks-bar.tsx
@@ -3,20 +3,22 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import React, { CSSProperties } from "react";
 import { Button, Tooltip } from "antd";
+import React, { CSSProperties } from "react";
+
 import { Icon, IconName } from "@cocalc/frontend/components";
-import { formatAction } from "../format";
+import { COLORS } from "@cocalc/util/theme";
 import { SlateEditor } from "../editable-markdown";
-import { Marks } from "./marks";
+import { formatAction } from "../format";
 import ColorButton from "./color-button";
 import FontFamily from "./font-family";
 import FontSize from "./font-size";
 import Heading from "./heading";
 import Insert from "./insert";
+import { Marks } from "./marks";
 
 export const BUTTON_STYLE = {
-  color: "#666",
+  color: COLORS.GRAY_M,
   height: "24px",
   borderLeft: "1px solid lightgray",
   borderRight: "1px solid lightgray",
@@ -73,7 +75,8 @@ const TITLES = {
   sub: "Subscript",
 };
 
-export const MarksBar: React.FC<MarksBarProps> = ({ marks, editor }) => {
+export const MarksBar: React.FC<MarksBarProps> = (props: MarksBarProps) => {
+  const { marks, editor } = props;
   const v: JSX.Element[] = [];
   v.push(<Insert key="insert" editor={editor} />);
   for (const mark of MARKS) {

--- a/src/packages/frontend/editors/slate/editable-markdown.tsx
+++ b/src/packages/frontend/editors/slate/editable-markdown.tsx
@@ -8,64 +8,60 @@
 const EXPENSIVE_DEBUG = false;
 // const EXPENSIVE_DEBUG = (window as any).cc != null && true; // EXTRA SLOW -- turn off before release!
 
-import { MutableRefObject, RefObject } from "react";
+import { delay } from "awaiting";
 import { Map } from "immutable";
-import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
-import { EditorState } from "@cocalc/frontend/frame-editors/frame-tree/types";
-import { createEditor, Descendant, Editor, Transforms } from "slate";
-import { withNonfatalRange } from "./patches";
-import { Slate, ReactEditor, Editable, withReact } from "./slate-react";
 import { debounce, isEqual, throttle } from "lodash";
+import { MutableRefObject, RefObject } from "react";
+
 import {
   CSS,
   React,
   useCallback,
   useEffect,
+  useIsMountedRef,
   useMemo,
   useRef,
   useState,
-  useIsMountedRef,
 } from "@cocalc/frontend/app-framework";
-import { Actions } from "./types";
-import { Path } from "@cocalc/frontend/frame-editors/frame-tree/path";
-import { slate_to_markdown } from "./slate-to-markdown";
-import { markdown_to_slate } from "./markdown-to-slate";
-import { Element } from "./element";
-import Leaf from "./leaf-with-cursor";
-import { withAutoFormat } from "./format";
-import { withNormalize } from "./normalize";
-import { withInsertBreakHack } from "./elements/link/editable";
-import { estimateSize } from "./elements";
-import { getHandler as getKeyboardHandler } from "./keyboard";
-import { withIsInline, withIsVoid } from "./plugins";
-import useUpload from "./upload";
-import { slateDiff } from "./slate-diff";
-import { applyOperations, preserveScrollPosition } from "./operations";
-import { getScrollState, setScrollState } from "./scroll";
-import { slatePointToMarkdownPosition } from "./sync";
-import { useMentions } from "./slate-mentions";
-import { useEmojis } from "./slate-emojis";
-import { createEmoji } from "./elements/emoji/index";
 import { mentionableUsers } from "@cocalc/frontend/editors/markdown-input/mentionable-users";
+import { submit_mentions } from "@cocalc/frontend/editors/markdown-input/mentions";
+import { EditorFunctions } from "@cocalc/frontend/editors/markdown-input/multimode";
+import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
+import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
+import { Path } from "@cocalc/frontend/frame-editors/frame-tree/path";
+import { EditorState } from "@cocalc/frontend/frame-editors/frame-tree/types";
+import { markdown_to_html } from "@cocalc/frontend/markdown";
+import Fragment, { FragmentId } from "@cocalc/frontend/misc/fragment-id";
+import { createEditor, Descendant, Editor, Transforms } from "slate";
+import { resetSelection } from "./control";
+import { useBroadcastCursors, useCursorDecorate } from "./cursors";
+import { EditBar, useLinkURL, useListProperties, useMarks } from "./edit-bar";
+import { Element } from "./element";
+import { estimateSize } from "./elements";
+import { createEmoji } from "./elements/emoji/index";
+import { withInsertBreakHack } from "./elements/link/editable";
 import { createMention } from "./elements/mention/editable";
 import { Mention } from "./elements/mention/index";
-import { submit_mentions } from "@cocalc/frontend/editors/markdown-input/mentions";
-import Fragment, { FragmentId } from "@cocalc/frontend/misc/fragment-id";
-import { useSearch, SearchHook } from "./search";
-import { EditBar, useLinkURL, useListProperties, useMarks } from "./edit-bar";
-
-import { useBroadcastCursors, useCursorDecorate } from "./cursors";
-import { resetSelection } from "./control";
-
-import { markdown_to_html } from "@cocalc/frontend/markdown";
-
-import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
-
-import { delay } from "awaiting";
-
-import { EditorFunctions } from "@cocalc/frontend/editors/markdown-input/multimode";
-
+import { withAutoFormat } from "./format";
+import { getHandler as getKeyboardHandler } from "./keyboard";
+import Leaf from "./leaf-with-cursor";
+import { markdown_to_slate } from "./markdown-to-slate";
+import { withNormalize } from "./normalize";
+import { applyOperations, preserveScrollPosition } from "./operations";
+import { withNonfatalRange } from "./patches";
+import { withIsInline, withIsVoid } from "./plugins";
+import { getScrollState, setScrollState } from "./scroll";
+import { SearchHook, useSearch } from "./search";
+import { slateDiff } from "./slate-diff";
+import { useEmojis } from "./slate-emojis";
+import { useMentions } from "./slate-mentions";
+import { Editable, ReactEditor, Slate, withReact } from "./slate-react";
+import { slate_to_markdown } from "./slate-to-markdown";
+import { slatePointToMarkdownPosition } from "./sync";
 import type { SlateEditor } from "./types";
+import { Actions } from "./types";
+import useUpload from "./upload";
+
 export type { SlateEditor };
 
 // Whether or not to use windowing by default (=only rendering visible elements).
@@ -124,8 +120,8 @@ interface Props {
   submitMentionsRef?: MutableRefObject<(fragmentId?: FragmentId) => string>; // when called this will submit all mentions in the document, and also returns current value of the document (for compat with markdown editor).  If not set, mentions are submitted when you create them.  This prop is used mainly for implementing chat, which has a clear "time of submission".
 }
 
-export const EditableMarkdown: React.FC<Props> = React.memo(
-  ({
+export const EditableMarkdown: React.FC<Props> = React.memo((props: Props) => {
+  const {
     actions: actions0,
     id: id0,
     read_only,
@@ -157,775 +153,774 @@ export const EditableMarkdown: React.FC<Props> = React.memo(
     unregisterEditor,
     getValueRef,
     submitMentionsRef,
-  }) => {
-    const { project_id, path, desc } = useFrameContext();
-    const isMountedRef = useIsMountedRef();
-    const id = id0 ?? "";
-    const actions = actions0 ?? {};
-    const font_size = font_size0 ?? desc.get("font_size") ?? 14; // so possible to use without specifying this.  TODO: should be from account settings
+  } = props;
+  const { project_id, path, desc } = useFrameContext();
+  const isMountedRef = useIsMountedRef();
+  const id = id0 ?? "";
+  const actions = actions0 ?? {};
+  const font_size = font_size0 ?? desc.get("font_size") ?? 14; // so possible to use without specifying this.  TODO: should be from account settings
 
-    const editor = useMemo(() => {
-      const ed = withNonfatalRange(
-        withInsertBreakHack(
-          withNormalize(
-            withAutoFormat(withIsInline(withIsVoid(withReact(createEditor()))))
-          )
+  const editor = useMemo(() => {
+    const ed = withNonfatalRange(
+      withInsertBreakHack(
+        withNormalize(
+          withAutoFormat(withIsInline(withIsVoid(withReact(createEditor()))))
         )
-      ) as SlateEditor;
-      actions.registerSlateEditor?.(id, ed);
+      )
+    ) as SlateEditor;
+    actions.registerSlateEditor?.(id, ed);
 
-      ed.getSourceValue = (fragment?) => {
-        return fragment ? slate_to_markdown(fragment) : ed.getMarkdownValue();
-      };
-
-      // hasUnsavedChanges is true if the children changed
-      // since last time resetHasUnsavedChanges() was called.
-      ed._hasUnsavedChanges = false;
-      ed.resetHasUnsavedChanges = () => {
-        delete ed.markdownValue;
-        ed._hasUnsavedChanges = ed.children;
-      };
-      ed.hasUnsavedChanges = () => {
-        if (ed._hasUnsavedChanges === false) {
-          // initially no unsaved changes
-          return false;
-        }
-        return ed._hasUnsavedChanges !== ed.children;
-      };
-
-      ed.markdownValue = value;
-      ed.getMarkdownValue = () => {
-        if (ed.markdownValue != null && !ed.hasUnsavedChanges()) {
-          return ed.markdownValue;
-        }
-        ed.markdownValue = slate_to_markdown(ed.children, {
-          cache: ed.syncCache,
-        });
-        return ed.markdownValue;
-      };
-
-      if (getValueRef != null) {
-        getValueRef.current = ed.getMarkdownValue;
-      }
-
-      ed.getPlainValue = (fragment?) => {
-        const markdown = ed.getSourceValue(fragment);
-        return $("<div>" + markdown_to_html(markdown) + "</div>").text();
-      };
-
-      ed.saveValue = (force?) => {
-        if (!force && !editor.hasUnsavedChanges()) {
-          return;
-        }
-        setSyncstringFromSlate();
-        actions.ensure_syncstring_is_saved?.();
-      };
-
-      ed.syncCache = {};
-      if (selectionRef != null) {
-        selectionRef.current = {
-          setSelection: (selection: any) => {
-            if (!selection) return;
-            // We confirm that the selection is valid.
-            // If not, this will throw an error.
-            const { anchor, focus } = selection;
-            Editor.node(editor, anchor);
-            Editor.node(editor, focus);
-            ed.selection = selection;
-          },
-          getSelection: () => {
-            return ed.selection;
-          },
-        };
-      }
-
-      ed.onCursorBottom = onCursorBottom;
-      ed.onCursorTop = onCursorTop;
-
-      return ed as SlateEditor;
-    }, []);
-
-    // hook up to syncstring if available:
-    useEffect(() => {
-      if (actions._syncstring == null) return;
-      const beforeChange = setSyncstringFromSlate;
-      const change = () => {
-        setEditorToValue(actions._syncstring.to_str());
-      };
-      actions._syncstring.on("before-change", beforeChange);
-      actions._syncstring.on("change", change);
-      return () => {
-        actions._syncstring.removeListener("before-change", beforeChange);
-        actions._syncstring.removeListener("change", change);
-      };
-    }, []);
-
-    useEffect(() => {
-      if (registerEditor != null) {
-        registerEditor({
-          set_cursor: ({ y }) => {
-            // This is used for navigating in Jupyter.  Of course cursors
-            // or NOT given by x,y positions in Slate, so we have to interpret
-            // this as follows, since that's what is used by our Jupyter actions.
-            //    y = 0: top of document
-            //    y = -1: bottom of document
-            let path;
-            if (y == 0) {
-              // top of doc
-              path = [0, 0];
-            } else if (y == -1) {
-              // bottom of doc
-              path = [editor.children.length - 1, 0];
-            } else {
-              return;
-            }
-            const focus = { path, offset: 0 };
-            Transforms.setSelection(editor, {
-              focus,
-              anchor: focus,
-            });
-          },
-        });
-
-        return unregisterEditor;
-      }
-    }, [registerEditor, unregisterEditor]);
-
-    useEffect(() => {
-      if (isFocused == null) return;
-      if (ReactEditor.isFocused(editor) != isFocused) {
-        if (isFocused) {
-          ReactEditor.focus(editor);
-        } else {
-          ReactEditor.blur(editor);
-        }
-      }
-    }, [isFocused]);
-
-    const [editorValue, setEditorValue] = useState<Descendant[]>(() =>
-      markdown_to_slate(value ?? "", false, editor.syncCache)
-    );
-
-    const rowSizeEstimator = useCallback((node) => {
-      return estimateSize({ node, fontSize: font_size });
-    }, []);
-
-    const mentions = useMentions({
-      editor,
-      insertMention: (editor, account_id) => {
-        Transforms.insertNodes(editor, [
-          createMention(account_id),
-          { text: " " },
-        ]);
-        if (submitMentionsRef == null) {
-          // submit immediately, since no ref for controlling this:
-          submit_mentions(project_id, path, [{ account_id, description: "" }]);
-        }
-      },
-      matchingUsers: (search) => mentionableUsers(project_id, search),
-    });
-
-    const emojis = useEmojis({
-      editor,
-      insertEmoji: (editor, content, markup) => {
-        Transforms.insertNodes(editor, [
-          createEmoji(content, markup),
-          { text: " " },
-        ]);
-      },
-    });
-
-    useEffect(() => {
-      if (submitMentionsRef != null) {
-        submitMentionsRef.current = (fragmentId?: FragmentId) => {
-          if (project_id == null || path == null) {
-            throw Error(
-              "project_id and path must be set in order to use mentions."
-            );
-          }
-          const fragment_id = Fragment.encode(fragmentId);
-
-          // No mentions in the document were already sent, so we send them now.
-          // We have to find all mentions in the document tree, and submit them.
-          const mentions: {
-            account_id: string;
-            description: string;
-            fragment_id: string;
-          }[] = [];
-          for (const [node, path] of Editor.nodes(editor, {
-            at: { path: [], offset: 0 },
-            match: (node) => node["type"] == "mention",
-          })) {
-            const [parent] = Editor.parent(editor, path);
-            mentions.push({
-              account_id: (node as Mention).account_id,
-              description: slate_to_markdown([parent]),
-              fragment_id,
-            });
-          }
-          submit_mentions(project_id, path, mentions);
-          return editor.getMarkdownValue();
-        };
-      }
-    }, [submitMentionsRef]);
-
-    const search: SearchHook = useSearch({ editor });
-
-    const { marks, updateMarks } = useMarks(editor);
-
-    const { linkURL, updateLinkURL } = useLinkURL(editor);
-
-    const { listProperties, updateListProperties } = useListProperties(editor);
-
-    const updateScrollState = useMemo(() => {
-      const { save_editor_state } = actions;
-      if (save_editor_state == null) return () => {};
-      if (disableWindowing) {
-        return throttle(() => {
-          if (!isMountedRef.current || !didRestoreScrollRef.current) return;
-          const scroll = scrollRef.current?.scrollTop;
-          if (scroll != null) {
-            save_editor_state(id, { scroll });
-          }
-        }, 250);
-      } else {
-        return throttle(() => {
-          if (!isMountedRef.current || !didRestoreScrollRef.current) return;
-          const scroll = getScrollState(editor);
-          if (scroll != null) {
-            save_editor_state(id, { scroll });
-          }
-        }, 250);
-      }
-    }, []);
-
-    const broadcastCursors = useBroadcastCursors({
-      editor,
-      broadcastCursors: (x) => actions.set_cursor_locs?.(x),
-    });
-
-    const cursorDecorate = useCursorDecorate({
-      editor,
-      cursors,
-      value: value ?? "",
-      search,
-    });
-
-    const scrollRef = useRef<HTMLDivElement | null>(null);
-    const didRestoreScrollRef = useRef<boolean>(false);
-    const restoreScroll = useMemo(() => {
-      return async () => {
-        if (didRestoreScrollRef.current) return; // so we only ever do this once.
-        try {
-          const scroll = editor_state?.get("scroll");
-          if (!scroll) return;
-
-          if (!disableWindowing) {
-            // Restore scroll for windowing
-            try {
-              await setScrollState(editor, scroll.toJS());
-            } catch (err) {
-              // could happen, e.g, if we change the format or change windowing.
-              console.log(`restoring scroll state -- ${err}`);
-            }
-            return;
-          }
-
-          // Restore scroll for no windowing.
-          // scroll = the scrollTop position, though we wrap in
-          // exception since it could be anything.
-          await new Promise(requestAnimationFrame);
-          if (scrollRef.current == null || !isMountedRef.current) {
-            return;
-          }
-          const elt = $(scrollRef.current);
-          try {
-            elt.scrollTop(scroll);
-            // scrolling after image loads
-            elt.find("img").on("load", () => {
-              if (!isMountedRef.current) return;
-              elt.scrollTop(scroll);
-            });
-          } catch (_) {}
-        } finally {
-          didRestoreScrollRef.current = true;
-          setOpacity(undefined);
-        }
-      };
-    }, []);
-
-    useEffect(() => {
-      if (actions._syncstring == null) {
-        setEditorToValue(value);
-      }
-      if (value != "Loading...") {
-        restoreScroll();
-      }
-    }, [value]);
-
-    function setSyncstringFromSlate() {
-      if (actions.set_value == null) {
-        // no way to save the value out (e.g., just beginning to test
-        // using the component).
-        return;
-      }
-      if (!editor.hasUnsavedChanges()) {
-        // there are no changes to save
-        return;
-      }
-
-      const markdown = editor.getMarkdownValue();
-      actions.set_value(markdown);
-      actions.syncstring_commit?.();
-
-      // Record that the syncstring's value is now equal to ours:
-      editor.resetHasUnsavedChanges();
-    }
-
-    // We don't want to do saveValue too much, since it presumably can be slow,
-    // especially if the document is large. By debouncing, we only do this when
-    // the user pauses typing for a moment. Also, this avoids making too many commits.
-    // For tiny documents, user can make this small or even 0 to not debounce.
-    const saveValueDebounce =
-      saveDebounceMs != null && !saveDebounceMs
-        ? () => editor.saveValue()
-        : useMemo(
-            () =>
-              debounce(
-                () => editor.saveValue(),
-                saveDebounceMs ?? SAVE_DEBOUNCE_MS
-              ),
-            []
-          );
-
-    function onKeyDown(e) {
-      if (read_only) {
-        e.preventDefault();
-        return;
-      }
-
-      mentions.onKeyDown(e);
-      emojis.onKeyDown(e);
-
-      if (e.defaultPrevented) return;
-
-      if (!ReactEditor.isFocused(editor)) {
-        // E.g., when typing into a codemirror editor embedded
-        // in slate, we get the keystrokes, but at the same time
-        // the (contenteditable) editor itself is not focused.
-        return;
-      }
-
-      const handler = getKeyboardHandler(e);
-      if (handler != null) {
-        const extra = { actions, id, search };
-        if (handler({ editor, extra })) {
-          e.preventDefault();
-          // key was handled.
-          return;
-        }
-      }
-    }
-
-    useEffect(() => {
-      if (!is_current) {
-        if (editor.hasUnsavedChanges()) {
-          // just switched from focused to not and there was
-          // an unsaved change, so save state.
-          setSyncstringFromSlate();
-          actions.ensure_syncstring_is_saved?.();
-        }
-      }
-    }, [is_current]);
-
-    const setEditorToValue = (value) => {
-      if (value == null) return;
-      if (value == editor.getMarkdownValue()) {
-        // nothing to do, and in fact doing something
-        // could be really annoying, since we don't want to
-        // autoformat via markdown everything immediately,
-        // as ambiguity is resolved while typing...
-        return;
-      }
-      const previousEditorValue = editor.children;
-
-      // we only use the latest version of the document
-      // for caching purposes.
-      editor.syncCache = {};
-      // There is an assumption here that markdown_to_slate produces
-      // a document that is properly normalized.  If that isn't the
-      // case, things will go horribly wrong, since it'll be impossible
-      // to convert the document to equal nextEditorValue.  In the current
-      // code we do nomalize the output of markdown_to_slate, so
-      // that assumption is definitely satisfied.
-      const nextEditorValue = markdown_to_slate(value, false, editor.syncCache);
-
-      try {
-        //const t = new Date();
-
-        if (
-          // length is basically changing from "Loading..."; in this case, just reset everything, rather than transforming via operations (which preserves selection, etc.)
-          previousEditorValue.length <= 1 &&
-          nextEditorValue.length >= 40 &&
-          !ReactEditor.isFocused(editor)
-        ) {
-          // This is a **MASSIVE** optimization.  E.g., for a few thousand
-          // lines markdown file with about 500 top level elements (and lots
-          // of nested lists), applying operations below starting with the
-          // empty document can take 5-10 seconds, whereas just setting the
-          // value is instant.  The drawback to directly setting the value
-          // is only that it messes up selection, and it's difficult
-          // to know where to move the selection to after changing.
-          // However, if the editor isn't focused, we don't have to worry
-          // about selection at all.  TODO: we might be able to avoid the
-          // slateDiff stuff entirely via some tricky stuff, e.g., managing
-          // the cursor on the plain text side before/after the change, since
-          // codemirror is much faster att "setValueNoJump".
-          // The main time we use this optimization here is when opening the
-          // document in the first place, in which case we're converting
-          // the document from "Loading..." to it's initial value.
-          // Also, the default config is source text focused on the left and
-          // editable text acting as a preview on the right not focused, and
-          // again this makes things fastest.
-          // DRAWBACK: this doesn't preserve scroll position and breaks selection.
-          editor.syncCausedUpdate = true;
-          // we call "onChange" instead of setEditorValue, since
-          // we want all the change handler stuff to happen, e.g.,
-          // broadcasting cursors.
-          onChange(nextEditorValue);
-          // console.log("time to set directly ", new Date() - t);
-        } else {
-          const operations = slateDiff(previousEditorValue, nextEditorValue);
-          if (operations.length == 0) {
-            // no actual change needed.
-            return;
-          }
-          // Applying this operation below will trigger
-          // an onChange, which it is best to ignore to save time and
-          // also so we don't update the source editor (and other browsers)
-          // with a view with things like loan $'s escaped.'
-          editor.syncCausedUpdate = true;
-          preserveScrollPosition(editor, operations);
-          applyOperations(editor, operations);
-          // console.log("time to set via diff", new Date() - t);
-        }
-      } finally {
-        // In all cases, now that we have transformed editor into the new value
-        // let's save the fact that we haven't changed anything yet and we
-        // know the markdown state with zero changes.  This is important, so
-        // we don't save out a change if we don't explicitly make one.
-        editor.resetHasUnsavedChanges();
-        editor.markdownValue = value;
-      }
-
-      try {
-        if (editor.selection != null) {
-          const { anchor, focus } = editor.selection;
-          Editor.node(editor, anchor);
-          Editor.node(editor, focus);
-        }
-      } catch (err) {
-        // TODO!
-        console.warn(
-          "slate - invalid selection after upstream patch. Resetting selection.",
-          err
-        );
-        // set to beginning of document -- better than crashing.
-        resetSelection(editor);
-      }
-
-      //       if ((window as any).cc?.slate != null) {
-      //         (window as any).cc.slate.eval = (s) => console.log(eval(s));
-      //       }
-
-      if (EXPENSIVE_DEBUG) {
-        const stringify = require("json-stable-stringify");
-        // We use JSON rather than isEqual here, since {foo:undefined}
-        // is not equal to {}, but they JSON the same, and this is
-        // fine for our purposes.
-        if (stringify(editor.children) != stringify(nextEditorValue)) {
-          // NOTE -- this does not 100% mean things are wrong.  One case where
-          // this is expected behavior is if you put the cursor at the end of the
-          // document, say right after a horizontal rule,  and then edit at the
-          // beginning of the document in another browser.  The discrepancy
-          // is because a "fake paragraph" is placed at the end of the browser
-          // so your cursor has somewhere to go while you wait and type; however,
-          // that space is not really part of the markdown document, and it goes
-          // away when you move your cursor out of that space.
-          console.warn(
-            "**WARNING:  slateDiff might not have properly transformed editor, though this may be fine. See window.diffBug **"
-          );
-          (window as any).diffBug = {
-            previousEditorValue,
-            nextEditorValue,
-            editorValue: editor.children,
-            stringify,
-            slateDiff,
-            applyOperations,
-            markdown_to_slate,
-            value,
-          };
-        }
-      }
+    ed.getSourceValue = (fragment?) => {
+      return fragment ? slate_to_markdown(fragment) : ed.getMarkdownValue();
     };
 
-    if ((window as any).cc != null) {
-      // This only gets set when running in cc-in-cc dev mode.
-      const { Editor, Node, Path, Range, Text } = require("slate");
-      (window as any).cc.slate = {
-        slateDiff,
-        editor,
-        actions,
-        editor_state,
-        Transforms,
-        ReactEditor,
-        Node,
-        Path,
-        Editor,
-        Range,
-        Text,
-        scrollRef,
-        applyOperations,
-        markdown_to_slate,
-        robot: async (s: string, iterations = 1) => {
-          let inserted = "";
-          let focus = editor.selection?.focus;
-          if (focus == null) throw Error("must have selection");
-          let lastOffset = focus.offset;
-          for (let n = 0; n < iterations; n++) {
-            for (const x of s) {
-              //               Transforms.setSelection(editor, {
-              //                 focus,
-              //                 anchor: focus,
-              //               });
-              editor.insertText(x);
-              focus = editor.selection?.focus;
-              if (focus == null) throw Error("must have selection");
-              inserted += x;
-              const offset = focus.offset;
-              console.log(
-                `${
-                  n + 1
-                }/${iterations}: inserted '${inserted}'; focus="${JSON.stringify(
-                  editor.selection?.focus
-                )}"`
-              );
-              if (offset != (lastOffset ?? 0) + 1) {
-                console.error("SYNC FAIL!!", { offset, lastOffset });
-                return;
-              }
-              lastOffset = offset;
-              await delay(100 * Math.random());
-              if (Math.random() < 0.2) {
-                await delay(2 * SAVE_DEBOUNCE_MS);
-              }
-            }
-          }
-          console.log("SUCCESS!");
+    // hasUnsavedChanges is true if the children changed
+    // since last time resetHasUnsavedChanges() was called.
+    ed._hasUnsavedChanges = false;
+    ed.resetHasUnsavedChanges = () => {
+      delete ed.markdownValue;
+      ed._hasUnsavedChanges = ed.children;
+    };
+    ed.hasUnsavedChanges = () => {
+      if (ed._hasUnsavedChanges === false) {
+        // initially no unsaved changes
+        return false;
+      }
+      return ed._hasUnsavedChanges !== ed.children;
+    };
+
+    ed.markdownValue = value;
+    ed.getMarkdownValue = () => {
+      if (ed.markdownValue != null && !ed.hasUnsavedChanges()) {
+        return ed.markdownValue;
+      }
+      ed.markdownValue = slate_to_markdown(ed.children, {
+        cache: ed.syncCache,
+      });
+      return ed.markdownValue;
+    };
+
+    if (getValueRef != null) {
+      getValueRef.current = ed.getMarkdownValue;
+    }
+
+    ed.getPlainValue = (fragment?) => {
+      const markdown = ed.getSourceValue(fragment);
+      return $("<div>" + markdown_to_html(markdown) + "</div>").text();
+    };
+
+    ed.saveValue = (force?) => {
+      if (!force && !editor.hasUnsavedChanges()) {
+        return;
+      }
+      setSyncstringFromSlate();
+      actions.ensure_syncstring_is_saved?.();
+    };
+
+    ed.syncCache = {};
+    if (selectionRef != null) {
+      selectionRef.current = {
+        setSelection: (selection: any) => {
+          if (!selection) return;
+          // We confirm that the selection is valid.
+          // If not, this will throw an error.
+          const { anchor, focus } = selection;
+          Editor.node(editor, anchor);
+          Editor.node(editor, focus);
+          ed.selection = selection;
+        },
+        getSelection: () => {
+          return ed.selection;
         },
       };
     }
 
-    editor.inverseSearch = async function inverseSearch(
-      force?: boolean
-    ): Promise<void> {
-      if (
-        !force &&
-        (is_fullscreen || !actions.get_matching_frame?.({ type: "cm" }))
-      ) {
-        // - if user is fullscreen assume they just want to WYSIWYG edit
-        // and double click is to select.  They can use sync button to
-        // force opening source panel.
-        // - if no source view, also don't do anything.  We only let
-        // double click do something when there is an open source view,
-        // since double click is used for selecting.
-        return;
-      }
-      // delay to give double click a chance to change current focus.
-      // This takes surprisingly long!
-      let t = 0;
-      while (editor.selection == null) {
-        await delay(1);
-        t += 50;
-        if (t > 2000) return; // give up
-      }
-      const point = editor.selection?.anchor; // using anchor since double click selects word.
-      if (point == null) {
-        return;
-      }
-      const pos = slatePointToMarkdownPosition(editor, point);
-      if (pos == null) return;
-      actions.programmatical_goto_line?.(
-        pos.line + 1, // 1 based (TODO: could use codemirror option)
-        true,
-        false, // it is REALLY annoying to switch focus to be honest, e.g., because double click to select a word is common in WYSIWYG editing.  If change this to true, make sure to put an extra always 50ms delay above due to focus even order.
-        undefined,
-        pos.ch
-      );
-    };
+    ed.onCursorBottom = onCursorBottom;
+    ed.onCursorTop = onCursorTop;
 
-    // WARNING: onChange does not fire immediately after changes occur.
-    // It is fired by react and happens in some potentialy later render
-    // loop after changes.  Thus you absolutely can't depend on it in any
-    // way for checking if the state of the editor has changed.  Instead
-    // check editor.children itself explicitly.
-    const onChange = (newEditorValue) => {
-      if (editor._hasUnsavedChanges === false) {
-        // just for initial change.
-        editor._hasUnsavedChanges = undefined;
+    return ed as SlateEditor;
+  }, []);
+
+  // hook up to syncstring if available:
+  useEffect(() => {
+    if (actions._syncstring == null) return;
+    const beforeChange = setSyncstringFromSlate;
+    const change = () => {
+      setEditorToValue(actions._syncstring.to_str());
+    };
+    actions._syncstring.on("before-change", beforeChange);
+    actions._syncstring.on("change", change);
+    return () => {
+      actions._syncstring.removeListener("before-change", beforeChange);
+      actions._syncstring.removeListener("change", change);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (registerEditor != null) {
+      registerEditor({
+        set_cursor: ({ y }) => {
+          // This is used for navigating in Jupyter.  Of course cursors
+          // or NOT given by x,y positions in Slate, so we have to interpret
+          // this as follows, since that's what is used by our Jupyter actions.
+          //    y = 0: top of document
+          //    y = -1: bottom of document
+          let path;
+          if (y == 0) {
+            // top of doc
+            path = [0, 0];
+          } else if (y == -1) {
+            // bottom of doc
+            path = [editor.children.length - 1, 0];
+          } else {
+            return;
+          }
+          const focus = { path, offset: 0 };
+          Transforms.setSelection(editor, {
+            focus,
+            anchor: focus,
+          });
+        },
+      });
+
+      return unregisterEditor;
+    }
+  }, [registerEditor, unregisterEditor]);
+
+  useEffect(() => {
+    if (isFocused == null) return;
+    if (ReactEditor.isFocused(editor) != isFocused) {
+      if (isFocused) {
+        ReactEditor.focus(editor);
+      } else {
+        ReactEditor.blur(editor);
       }
-      if (!isMountedRef.current) return;
-      broadcastCursors();
-      updateMarks();
-      updateLinkURL();
-      updateListProperties();
-      // Track where the last editor selection was,
-      // since this is very useful to know, e.g., for
-      // understanding cursor movement, format fallback, etc.
-      // @ts-ignore
-      if (editor.lastSelection == null && editor.selection != null) {
-        // initialize
-        // @ts-ignore
-        editor.lastSelection = editor.curSelection = editor.selection;
+    }
+  }, [isFocused]);
+
+  const [editorValue, setEditorValue] = useState<Descendant[]>(() =>
+    markdown_to_slate(value ?? "", false, editor.syncCache)
+  );
+
+  const rowSizeEstimator = useCallback((node) => {
+    return estimateSize({ node, fontSize: font_size });
+  }, []);
+
+  const mentions = useMentions({
+    editor,
+    insertMention: (editor, account_id) => {
+      Transforms.insertNodes(editor, [
+        createMention(account_id),
+        { text: " " },
+      ]);
+      if (submitMentionsRef == null) {
+        // submit immediately, since no ref for controlling this:
+        submit_mentions(project_id, path, [{ account_id, description: "" }]);
       }
-      // @ts-ignore
-      if (!isEqual(editor.selection, editor.curSelection)) {
-        // @ts-ignore
-        editor.lastSelection = editor.curSelection;
-        if (editor.selection != null) {
-          // @ts-ignore
-          editor.curSelection = editor.selection;
+    },
+    matchingUsers: (search) => mentionableUsers(project_id, search),
+  });
+
+  const emojis = useEmojis({
+    editor,
+    insertEmoji: (editor, content, markup) => {
+      Transforms.insertNodes(editor, [
+        createEmoji(content, markup),
+        { text: " " },
+      ]);
+    },
+  });
+
+  useEffect(() => {
+    if (submitMentionsRef != null) {
+      submitMentionsRef.current = (fragmentId?: FragmentId) => {
+        if (project_id == null || path == null) {
+          throw Error(
+            "project_id and path must be set in order to use mentions."
+          );
         }
+        const fragment_id = Fragment.encode(fragmentId);
+
+        // No mentions in the document were already sent, so we send them now.
+        // We have to find all mentions in the document tree, and submit them.
+        const mentions: {
+          account_id: string;
+          description: string;
+          fragment_id: string;
+        }[] = [];
+        for (const [node, path] of Editor.nodes(editor, {
+          at: { path: [], offset: 0 },
+          match: (node) => node["type"] == "mention",
+        })) {
+          const [parent] = Editor.parent(editor, path);
+          mentions.push({
+            account_id: (node as Mention).account_id,
+            description: slate_to_markdown([parent]),
+            fragment_id,
+          });
+        }
+        submit_mentions(project_id, path, mentions);
+        return editor.getMarkdownValue();
+      };
+    }
+  }, [submitMentionsRef]);
+
+  const search: SearchHook = useSearch({ editor });
+
+  const { marks, updateMarks } = useMarks(editor);
+
+  const { linkURL, updateLinkURL } = useLinkURL(editor);
+
+  const { listProperties, updateListProperties } = useListProperties(editor);
+
+  const updateScrollState = useMemo(() => {
+    const { save_editor_state } = actions;
+    if (save_editor_state == null) return () => {};
+    if (disableWindowing) {
+      return throttle(() => {
+        if (!isMountedRef.current || !didRestoreScrollRef.current) return;
+        const scroll = scrollRef.current?.scrollTop;
+        if (scroll != null) {
+          save_editor_state(id, { scroll });
+        }
+      }, 250);
+    } else {
+      return throttle(() => {
+        if (!isMountedRef.current || !didRestoreScrollRef.current) return;
+        const scroll = getScrollState(editor);
+        if (scroll != null) {
+          save_editor_state(id, { scroll });
+        }
+      }, 250);
+    }
+  }, []);
+
+  const broadcastCursors = useBroadcastCursors({
+    editor,
+    broadcastCursors: (x) => actions.set_cursor_locs?.(x),
+  });
+
+  const cursorDecorate = useCursorDecorate({
+    editor,
+    cursors,
+    value: value ?? "",
+    search,
+  });
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const didRestoreScrollRef = useRef<boolean>(false);
+  const restoreScroll = useMemo(() => {
+    return async () => {
+      if (didRestoreScrollRef.current) return; // so we only ever do this once.
+      try {
+        const scroll = editor_state?.get("scroll");
+        if (!scroll) return;
+
+        if (!disableWindowing) {
+          // Restore scroll for windowing
+          try {
+            await setScrollState(editor, scroll.toJS());
+          } catch (err) {
+            // could happen, e.g, if we change the format or change windowing.
+            console.log(`restoring scroll state -- ${err}`);
+          }
+          return;
+        }
+
+        // Restore scroll for no windowing.
+        // scroll = the scrollTop position, though we wrap in
+        // exception since it could be anything.
+        await new Promise(requestAnimationFrame);
+        if (scrollRef.current == null || !isMountedRef.current) {
+          return;
+        }
+        const elt = $(scrollRef.current);
+        try {
+          elt.scrollTop(scroll);
+          // scrolling after image loads
+          elt.find("img").on("load", () => {
+            if (!isMountedRef.current) return;
+            elt.scrollTop(scroll);
+          });
+        } catch (_) {}
+      } finally {
+        didRestoreScrollRef.current = true;
+        setOpacity(undefined);
       }
-
-      if (editorValue === newEditorValue) {
-        // Editor didn't actually change value so nothing to do.
-        return;
-      }
-
-      setEditorValue(newEditorValue);
-      // Update mentions state whenever editor actually changes.
-      // This may pop up the mentions selector.
-      mentions.onChange();
-      // Similar for emojis.
-      emojis.onChange();
-
-      if (!is_current) {
-        // Do not save when editor not current since user could be typing
-        // into another editor of the same underlying document.   This will
-        // cause bugs (e.g., type, switch from slate to codemirror, type, and
-        // see what you typed into codemirror disappear). E.g., this
-        // happens due to a spurious change when the editor is defocused.
-
-        return;
-      }
-      saveValueDebounce();
     };
+  }, []);
 
-    useEffect(() => {
-      editor.syncCausedUpdate = false;
-    }, [editorValue]);
+  useEffect(() => {
+    if (actions._syncstring == null) {
+      setEditorToValue(value);
+    }
+    if (value != "Loading...") {
+      restoreScroll();
+    }
+  }, [value]);
 
-    const [opacity, setOpacity] = useState<number | undefined>(0);
+  function setSyncstringFromSlate() {
+    if (actions.set_value == null) {
+      // no way to save the value out (e.g., just beginning to test
+      // using the component).
+      return;
+    }
+    if (!editor.hasUnsavedChanges()) {
+      // there are no changes to save
+      return;
+    }
 
-    let slate = (
-      <Slate editor={editor} value={editorValue} onChange={onChange}>
-        <Editable
-          placeholder={placeholder}
-          autoFocus={autoFocus}
-          className={
-            !disableWindowing && height != "auto" ? "smc-vfill" : undefined
+    const markdown = editor.getMarkdownValue();
+    actions.set_value(markdown);
+    actions.syncstring_commit?.();
+
+    // Record that the syncstring's value is now equal to ours:
+    editor.resetHasUnsavedChanges();
+  }
+
+  // We don't want to do saveValue too much, since it presumably can be slow,
+  // especially if the document is large. By debouncing, we only do this when
+  // the user pauses typing for a moment. Also, this avoids making too many commits.
+  // For tiny documents, user can make this small or even 0 to not debounce.
+  const saveValueDebounce =
+    saveDebounceMs != null && !saveDebounceMs
+      ? () => editor.saveValue()
+      : useMemo(
+          () =>
+            debounce(
+              () => editor.saveValue(),
+              saveDebounceMs ?? SAVE_DEBOUNCE_MS
+            ),
+          []
+        );
+
+  function onKeyDown(e) {
+    if (read_only) {
+      e.preventDefault();
+      return;
+    }
+
+    mentions.onKeyDown(e);
+    emojis.onKeyDown(e);
+
+    if (e.defaultPrevented) return;
+
+    if (!ReactEditor.isFocused(editor)) {
+      // E.g., when typing into a codemirror editor embedded
+      // in slate, we get the keystrokes, but at the same time
+      // the (contenteditable) editor itself is not focused.
+      return;
+    }
+
+    const handler = getKeyboardHandler(e);
+    if (handler != null) {
+      const extra = { actions, id, search };
+      if (handler({ editor, extra })) {
+        e.preventDefault();
+        // key was handled.
+        return;
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (!is_current) {
+      if (editor.hasUnsavedChanges()) {
+        // just switched from focused to not and there was
+        // an unsaved change, so save state.
+        setSyncstringFromSlate();
+        actions.ensure_syncstring_is_saved?.();
+      }
+    }
+  }, [is_current]);
+
+  const setEditorToValue = (value) => {
+    if (value == null) return;
+    if (value == editor.getMarkdownValue()) {
+      // nothing to do, and in fact doing something
+      // could be really annoying, since we don't want to
+      // autoformat via markdown everything immediately,
+      // as ambiguity is resolved while typing...
+      return;
+    }
+    const previousEditorValue = editor.children;
+
+    // we only use the latest version of the document
+    // for caching purposes.
+    editor.syncCache = {};
+    // There is an assumption here that markdown_to_slate produces
+    // a document that is properly normalized.  If that isn't the
+    // case, things will go horribly wrong, since it'll be impossible
+    // to convert the document to equal nextEditorValue.  In the current
+    // code we do nomalize the output of markdown_to_slate, so
+    // that assumption is definitely satisfied.
+    const nextEditorValue = markdown_to_slate(value, false, editor.syncCache);
+
+    try {
+      //const t = new Date();
+
+      if (
+        // length is basically changing from "Loading..."; in this case, just reset everything, rather than transforming via operations (which preserves selection, etc.)
+        previousEditorValue.length <= 1 &&
+        nextEditorValue.length >= 40 &&
+        !ReactEditor.isFocused(editor)
+      ) {
+        // This is a **MASSIVE** optimization.  E.g., for a few thousand
+        // lines markdown file with about 500 top level elements (and lots
+        // of nested lists), applying operations below starting with the
+        // empty document can take 5-10 seconds, whereas just setting the
+        // value is instant.  The drawback to directly setting the value
+        // is only that it messes up selection, and it's difficult
+        // to know where to move the selection to after changing.
+        // However, if the editor isn't focused, we don't have to worry
+        // about selection at all.  TODO: we might be able to avoid the
+        // slateDiff stuff entirely via some tricky stuff, e.g., managing
+        // the cursor on the plain text side before/after the change, since
+        // codemirror is much faster att "setValueNoJump".
+        // The main time we use this optimization here is when opening the
+        // document in the first place, in which case we're converting
+        // the document from "Loading..." to it's initial value.
+        // Also, the default config is source text focused on the left and
+        // editable text acting as a preview on the right not focused, and
+        // again this makes things fastest.
+        // DRAWBACK: this doesn't preserve scroll position and breaks selection.
+        editor.syncCausedUpdate = true;
+        // we call "onChange" instead of setEditorValue, since
+        // we want all the change handler stuff to happen, e.g.,
+        // broadcasting cursors.
+        onChange(nextEditorValue);
+        // console.log("time to set directly ", new Date() - t);
+      } else {
+        const operations = slateDiff(previousEditorValue, nextEditorValue);
+        if (operations.length == 0) {
+          // no actual change needed.
+          return;
+        }
+        // Applying this operation below will trigger
+        // an onChange, which it is best to ignore to save time and
+        // also so we don't update the source editor (and other browsers)
+        // with a view with things like loan $'s escaped.'
+        editor.syncCausedUpdate = true;
+        preserveScrollPosition(editor, operations);
+        applyOperations(editor, operations);
+        // console.log("time to set via diff", new Date() - t);
+      }
+    } finally {
+      // In all cases, now that we have transformed editor into the new value
+      // let's save the fact that we haven't changed anything yet and we
+      // know the markdown state with zero changes.  This is important, so
+      // we don't save out a change if we don't explicitly make one.
+      editor.resetHasUnsavedChanges();
+      editor.markdownValue = value;
+    }
+
+    try {
+      if (editor.selection != null) {
+        const { anchor, focus } = editor.selection;
+        Editor.node(editor, anchor);
+        Editor.node(editor, focus);
+      }
+    } catch (err) {
+      // TODO!
+      console.warn(
+        "slate - invalid selection after upstream patch. Resetting selection.",
+        err
+      );
+      // set to beginning of document -- better than crashing.
+      resetSelection(editor);
+    }
+
+    //       if ((window as any).cc?.slate != null) {
+    //         (window as any).cc.slate.eval = (s) => console.log(eval(s));
+    //       }
+
+    if (EXPENSIVE_DEBUG) {
+      const stringify = require("json-stable-stringify");
+      // We use JSON rather than isEqual here, since {foo:undefined}
+      // is not equal to {}, but they JSON the same, and this is
+      // fine for our purposes.
+      if (stringify(editor.children) != stringify(nextEditorValue)) {
+        // NOTE -- this does not 100% mean things are wrong.  One case where
+        // this is expected behavior is if you put the cursor at the end of the
+        // document, say right after a horizontal rule,  and then edit at the
+        // beginning of the document in another browser.  The discrepancy
+        // is because a "fake paragraph" is placed at the end of the browser
+        // so your cursor has somewhere to go while you wait and type; however,
+        // that space is not really part of the markdown document, and it goes
+        // away when you move your cursor out of that space.
+        console.warn(
+          "**WARNING:  slateDiff might not have properly transformed editor, though this may be fine. See window.diffBug **"
+        );
+        (window as any).diffBug = {
+          previousEditorValue,
+          nextEditorValue,
+          editorValue: editor.children,
+          stringify,
+          slateDiff,
+          applyOperations,
+          markdown_to_slate,
+          value,
+        };
+      }
+    }
+  };
+
+  if ((window as any).cc != null) {
+    // This only gets set when running in cc-in-cc dev mode.
+    const { Editor, Node, Path, Range, Text } = require("slate");
+    (window as any).cc.slate = {
+      slateDiff,
+      editor,
+      actions,
+      editor_state,
+      Transforms,
+      ReactEditor,
+      Node,
+      Path,
+      Editor,
+      Range,
+      Text,
+      scrollRef,
+      applyOperations,
+      markdown_to_slate,
+      robot: async (s: string, iterations = 1) => {
+        let inserted = "";
+        let focus = editor.selection?.focus;
+        if (focus == null) throw Error("must have selection");
+        let lastOffset = focus.offset;
+        for (let n = 0; n < iterations; n++) {
+          for (const x of s) {
+            //               Transforms.setSelection(editor, {
+            //                 focus,
+            //                 anchor: focus,
+            //               });
+            editor.insertText(x);
+            focus = editor.selection?.focus;
+            if (focus == null) throw Error("must have selection");
+            inserted += x;
+            const offset = focus.offset;
+            console.log(
+              `${
+                n + 1
+              }/${iterations}: inserted '${inserted}'; focus="${JSON.stringify(
+                editor.selection?.focus
+              )}"`
+            );
+            if (offset != (lastOffset ?? 0) + 1) {
+              console.error("SYNC FAIL!!", { offset, lastOffset });
+              return;
+            }
+            lastOffset = offset;
+            await delay(100 * Math.random());
+            if (Math.random() < 0.2) {
+              await delay(2 * SAVE_DEBOUNCE_MS);
+            }
           }
-          readOnly={read_only}
-          renderElement={Element}
-          renderLeaf={Leaf}
-          onKeyDown={onKeyDown}
-          onBlur={() => {
-            editor.saveValue();
-            updateMarks();
-            onBlur?.();
-          }}
-          onFocus={() => {
-            updateMarks();
-            onFocus?.();
-          }}
-          decorate={cursorDecorate}
-          divref={scrollRef}
-          onScroll={updateScrollState}
-          style={
-            !disableWindowing
-              ? undefined
-              : {
-                  height,
-                  position: "relative", // CRITICAL!!! Without this, editor will sometimes scroll the entire frame off the screen.  Do NOT delete position:'relative'.  5+ hours of work to figure this out!  Note that this isn't needed when using windowing above.
-                  minWidth: "80%",
-                  padding: "70px",
-                  background: "white",
-                  overflow:
-                    height == "auto"
-                      ? "hidden" /* for height='auto' we never want a scrollbar  */
-                      : "auto" /* for this overflow, see https://github.com/ianstormtaylor/slate/issues/3706 */,
-                  ...pageStyle,
-                }
-          }
-          windowing={
-            !disableWindowing
-              ? {
-                  rowStyle: {
-                    // WARNING: do *not* use margin in rowStyle.
-                    padding: "0 70px",
-                    overflow: "hidden", // CRITICAL: this makes it so the div height accounts for margin of contents (e.g., p element has margin), so virtuoso can measure it correctly.  Otherwise, things jump around like crazy.
-                    minHeight: "1px", // virtuoso can't deal with 0-height items
-                  },
-                  marginTop: "40px",
-                  marginBottom: "40px",
-                  rowSizeEstimator,
-                }
-              : undefined
-          }
-        />
-      </Slate>
+        }
+        console.log("SUCCESS!");
+      },
+    };
+  }
+
+  editor.inverseSearch = async function inverseSearch(
+    force?: boolean
+  ): Promise<void> {
+    if (
+      !force &&
+      (is_fullscreen || !actions.get_matching_frame?.({ type: "cm" }))
+    ) {
+      // - if user is fullscreen assume they just want to WYSIWYG edit
+      // and double click is to select.  They can use sync button to
+      // force opening source panel.
+      // - if no source view, also don't do anything.  We only let
+      // double click do something when there is an open source view,
+      // since double click is used for selecting.
+      return;
+    }
+    // delay to give double click a chance to change current focus.
+    // This takes surprisingly long!
+    let t = 0;
+    while (editor.selection == null) {
+      await delay(1);
+      t += 50;
+      if (t > 2000) return; // give up
+    }
+    const point = editor.selection?.anchor; // using anchor since double click selects word.
+    if (point == null) {
+      return;
+    }
+    const pos = slatePointToMarkdownPosition(editor, point);
+    if (pos == null) return;
+    actions.programmatical_goto_line?.(
+      pos.line + 1, // 1 based (TODO: could use codemirror option)
+      true,
+      false, // it is REALLY annoying to switch focus to be honest, e.g., because double click to select a word is common in WYSIWYG editing.  If change this to true, make sure to put an extra always 50ms delay above due to focus even order.
+      undefined,
+      pos.ch
     );
-    let body = (
+  };
+
+  // WARNING: onChange does not fire immediately after changes occur.
+  // It is fired by react and happens in some potentialy later render
+  // loop after changes.  Thus you absolutely can't depend on it in any
+  // way for checking if the state of the editor has changed.  Instead
+  // check editor.children itself explicitly.
+  const onChange = (newEditorValue) => {
+    if (editor._hasUnsavedChanges === false) {
+      // just for initial change.
+      editor._hasUnsavedChanges = undefined;
+    }
+    if (!isMountedRef.current) return;
+    broadcastCursors();
+    updateMarks();
+    updateLinkURL();
+    updateListProperties();
+    // Track where the last editor selection was,
+    // since this is very useful to know, e.g., for
+    // understanding cursor movement, format fallback, etc.
+    // @ts-ignore
+    if (editor.lastSelection == null && editor.selection != null) {
+      // initialize
+      // @ts-ignore
+      editor.lastSelection = editor.curSelection = editor.selection;
+    }
+    // @ts-ignore
+    if (!isEqual(editor.selection, editor.curSelection)) {
+      // @ts-ignore
+      editor.lastSelection = editor.curSelection;
+      if (editor.selection != null) {
+        // @ts-ignore
+        editor.curSelection = editor.selection;
+      }
+    }
+
+    if (editorValue === newEditorValue) {
+      // Editor didn't actually change value so nothing to do.
+      return;
+    }
+
+    setEditorValue(newEditorValue);
+    // Update mentions state whenever editor actually changes.
+    // This may pop up the mentions selector.
+    mentions.onChange();
+    // Similar for emojis.
+    emojis.onChange();
+
+    if (!is_current) {
+      // Do not save when editor not current since user could be typing
+      // into another editor of the same underlying document.   This will
+      // cause bugs (e.g., type, switch from slate to codemirror, type, and
+      // see what you typed into codemirror disappear). E.g., this
+      // happens due to a spurious change when the editor is defocused.
+
+      return;
+    }
+    saveValueDebounce();
+  };
+
+  useEffect(() => {
+    editor.syncCausedUpdate = false;
+  }, [editorValue]);
+
+  const [opacity, setOpacity] = useState<number | undefined>(0);
+
+  let slate = (
+    <Slate editor={editor} value={editorValue} onChange={onChange}>
+      <Editable
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        className={
+          !disableWindowing && height != "auto" ? "smc-vfill" : undefined
+        }
+        readOnly={read_only}
+        renderElement={Element}
+        renderLeaf={Leaf}
+        onKeyDown={onKeyDown}
+        onBlur={() => {
+          editor.saveValue();
+          updateMarks();
+          onBlur?.();
+        }}
+        onFocus={() => {
+          updateMarks();
+          onFocus?.();
+        }}
+        decorate={cursorDecorate}
+        divref={scrollRef}
+        onScroll={updateScrollState}
+        style={
+          !disableWindowing
+            ? undefined
+            : {
+                height,
+                position: "relative", // CRITICAL!!! Without this, editor will sometimes scroll the entire frame off the screen.  Do NOT delete position:'relative'.  5+ hours of work to figure this out!  Note that this isn't needed when using windowing above.
+                minWidth: "80%",
+                padding: "70px",
+                background: "white",
+                overflow:
+                  height == "auto"
+                    ? "hidden" /* for height='auto' we never want a scrollbar  */
+                    : "auto" /* for this overflow, see https://github.com/ianstormtaylor/slate/issues/3706 */,
+                ...pageStyle,
+              }
+        }
+        windowing={
+          !disableWindowing
+            ? {
+                rowStyle: {
+                  // WARNING: do *not* use margin in rowStyle.
+                  padding: "0 70px",
+                  overflow: "hidden", // CRITICAL: this makes it so the div height accounts for margin of contents (e.g., p element has margin), so virtuoso can measure it correctly.  Otherwise, things jump around like crazy.
+                  minHeight: "1px", // virtuoso can't deal with 0-height items
+                },
+                marginTop: "40px",
+                marginBottom: "40px",
+                rowSizeEstimator,
+              }
+            : undefined
+        }
+      />
+    </Slate>
+  );
+  let body = (
+    <div
+      ref={divRef}
+      className={noVfill || height == "auto" ? undefined : "smc-vfill"}
+      style={{
+        overflow: noVfill || height == "auto" ? undefined : "auto",
+        backgroundColor: "white",
+        ...style,
+        height,
+        minHeight: height == "auto" ? "50px" : undefined,
+      }}
+    >
+      {!hidePath && (
+        <Path is_current={is_current} path={path} project_id={project_id} />
+      )}
+      <EditBar
+        Search={search.Search}
+        isCurrent={is_current}
+        marks={marks}
+        linkURL={linkURL}
+        listProperties={listProperties}
+        editor={editor}
+        style={editBarStyle}
+        hideSearch={hideSearch}
+      />
       <div
-        ref={divRef}
         className={noVfill || height == "auto" ? undefined : "smc-vfill"}
         style={{
-          overflow: noVfill || height == "auto" ? undefined : "auto",
-          backgroundColor: "white",
-          ...style,
+          ...STYLE,
+          fontSize: font_size,
           height,
-          minHeight: height == "auto" ? "50px" : undefined,
+          opacity,
         }}
       >
-        {!hidePath && (
-          <Path is_current={is_current} path={path} project_id={project_id} />
-        )}
-        <EditBar
-          Search={search.Search}
-          isCurrent={is_current}
-          marks={marks}
-          linkURL={linkURL}
-          listProperties={listProperties}
-          editor={editor}
-          style={editBarStyle}
-          hideSearch={hideSearch}
-        />
-        <div
-          className={noVfill || height == "auto" ? undefined : "smc-vfill"}
-          style={{
-            ...STYLE,
-            fontSize: font_size,
-            height,
-            opacity,
-          }}
-        >
-          {mentions.Mentions}
-          {emojis.Emojis}
-          {slate}
-        </div>
+        {mentions.Mentions}
+        {emojis.Emojis}
+        {slate}
       </div>
-    );
-    return useUpload(editor, body);
-  }
-);
+    </div>
+  );
+  return useUpload(editor, body);
+});


### PR DESCRIPTION
# Description

* Antd fix modal deprecation, that "color" modal in the MD editor
* Sorting various imports along the way
* Using `localStorage` directly could cause a crash, hence using the wrapper with the LRU cache instead


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
