### PR TITLE
frontend/chat+slate: antd modernize @-dropdown

### DIFF
--- a/src/packages/frontend/editors/markdown-input/complete.tsx
+++ b/src/packages/frontend/editors/markdown-input/complete.tsx
@@ -10,11 +10,13 @@ for jupyter, code editors, (etc.'s) complete.  E.g., I already
 rewrote this to use the Antd dropdown, which is more dynamic.
 */
 
+import type { MenuProps } from "antd";
+import { Dropdown } from "antd";
 import { FC, ReactNode, useCallback, useEffect, useRef, useState } from "react";
 
-import { CSS, ReactDOM } from "../../app-framework";
-
-import { Dropdown, Menu } from "antd";
+import { CSS, ReactDOM } from "@cocalc/frontend/app-framework";
+import { MenuItems } from "@cocalc/frontend/components";
+import { COLORS } from "@cocalc/util/theme";
 
 export interface Item {
   label?: ReactNode;
@@ -42,13 +44,8 @@ type Props = Props1 | Props2;
 // WARNING: Complete closing when clicking outside the complete box
 // is handled in cell-list on_click.  This is ugly code (since not localized),
 // but seems to work well for now.  Could move.
-export const Complete: FC<Props> = ({
-  items,
-  onSelect,
-  onCancel,
-  offset,
-  position,
-}) => {
+export const Complete: FC<Props> = (props: Props) => {
+  const { items, onSelect, onCancel, offset, position } = props;
   const [selected, set_selected] = useState<number>(0);
   const selected_ref = useRef<number>(selected);
   useEffect(() => {
@@ -68,14 +65,6 @@ export const Complete: FC<Props> = ({
     },
     [onSelect, onCancel]
   );
-
-  function render_item({ label, value }: Item): JSX.Element {
-    return (
-      <Menu.Item key={value} style={{ fontSize: "16pt" }}>
-        {label ?? value}
-      </Menu.Item>
-    );
-  }
 
   const onKeyDown = useCallback(
     (e) => {
@@ -119,30 +108,45 @@ export const Complete: FC<Props> = ({
   // the current line instead of below it.
   selected_keys_ref.current =
     items[selected % (items.length ? items.length : 1)]?.value;
-  const menu = (
-    <div style={{ marginBottom: "15px" }}>
-      <Menu
-        selectedKeys={[selected_keys_ref.current]}
-        onClick={select}
-        style={{
-          border: "1px solid lightgrey",
-          maxHeight: "45vh", // so can always position menu above/below current line not obscuring it.
-          overflow: "auto",
-        }}
+
+  const menuItems: MenuItems = items.map(({ label, value }) => {
+    return {
+      key: value,
+      label: label ?? value,
+      style: { fontSize: "120%" },
+    };
+  });
+
+  const menu: MenuProps = {
+    selectedKeys: [selected_keys_ref.current],
+    onClick: select,
+    items: menuItems,
+    style: {
+      border: `1px solid ${COLORS.GRAY_L}`,
+      maxHeight: "45vh", // so can always position menu above/below current line not obscuring it.
+      overflow: "auto",
+    },
+  };
+
+  function renderDropdown(): JSX.Element {
+    return (
+      <Dropdown
+        menu={menu}
+        open
+        placement="topRight" // always on top, and paddingBottom makes the entire line visible
+        overlayStyle={{ paddingBottom: "1em" }}
       >
-        {items.map(render_item)}
-      </Menu>
-    </div>
-  );
+        <span />
+      </Dropdown>
+    );
+  }
 
   if (offset != null) {
     // Relative positioning of the popup (this is in the same React tree).
     return (
       <div style={{ position: "relative" }}>
         <div style={{ ...offset, position: "absolute" }}>
-          <Dropdown overlay={menu} open>
-            <span />
-          </Dropdown>
+          {renderDropdown()}
         </div>
       </div>
     );
@@ -150,11 +154,7 @@ export const Complete: FC<Props> = ({
     // Absolute position of the popup (this uses a totally different React tree)
     return (
       <Portal>
-        <div style={{ ...STYLE, ...position }}>
-          <Dropdown overlay={menu} open>
-            <span />
-          </Dropdown>
-        </div>
+        <div style={{ ...STYLE, ...position }}>{renderDropdown()}</div>
       </Portal>
     );
   } else {


### PR DESCRIPTION
# Description

This touches the "@" menu, to get rid of the deprecation, and well, I also made a font slightly smaller and made sure to popup to the top in chat (since for me, it sometimes opens up to the bottom and then I can't see or select some). I also tested this in slate markdown, works ok as well.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
