### PR TITLE
frontend: antd deprecations

### DIFF
--- a/src/packages/frontend/account/account-page.tsx
+++ b/src/packages/frontend/account/account-page.tsx
@@ -11,7 +11,7 @@ and configuration.
 */
 
 import { SignOut } from "@cocalc/frontend/account/sign-out";
-import { Col, Row, Tab, Tabs } from "@cocalc/frontend/antd-bootstrap";
+import { AntdTabItem, Col, Row, Tabs } from "@cocalc/frontend/antd-bootstrap";
 import { React, redux, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { Icon, Loading } from "@cocalc/frontend/components";
 import { LandingPage } from "@cocalc/frontend/landing-page/landing-page";
@@ -107,124 +107,98 @@ export const AccountPage: React.FC = () => {
     );
   }
 
-  function render_account_tab(): JSX.Element {
-    return (
-      <Tab
-        key="account"
-        eventKey="account"
-        title={
-          <span>
-            <Icon name="wrench" /> Preferences
-          </span>
-        }
-      >
-        {(active_page == null || active_page === "account") && (
-          <AccountPreferences />
-        )}
-      </Tab>
-    );
+  function render_account_tab(): AntdTabItem {
+    return {
+      key: "account",
+      label: (
+        <span>
+          <Icon name="wrench" /> Preferences
+        </span>
+      ),
+      children: (active_page == null || active_page === "account") && (
+        <AccountPreferences />
+      ),
+    };
   }
 
-  function render_special_tabs(): JSX.Element[] {
+  function render_special_tabs(): AntdTabItem[] {
     // adds a few conditional tabs
     if (is_anonymous) {
       // None of these make any sense for a temporary anonymous account.
       return [];
     }
-    const v: JSX.Element[] = [];
+    const items: AntdTabItem[] = [];
     if (
       kucalc === KUCALC_COCALC_COM ||
       kucalc === KUCALC_ON_PREMISES ||
       is_commercial
     ) {
-      v.push(
-        <Tab
-          key="licenses"
-          eventKey="licenses"
-          title={
-            <span>
-              <Icon name="key" /> Licenses
-            </span>
-          }
-        >
-          {active_page === "licenses" && <LicensesPage />}
-        </Tab>
-      );
+      items.push({
+        key: "licenses",
+        label: (
+          <span>
+            <Icon name="key" /> Licenses
+          </span>
+        ),
+        children: active_page === "licenses" && <LicensesPage />,
+      });
     }
+
     if (is_commercial) {
-      v.push(
-        <Tab
-          key="billing"
-          eventKey="billing"
-          title={
-            <span>
-              <Icon name="money" /> {"Purchases"}
-            </span>
-          }
-        >
-          {active_page === "billing" && <BillingPage is_simplified={false} />}
-        </Tab>
-      );
+      items.push({
+        key: "billing",
+        label: (
+          <span>
+            <Icon name="money" /> Purchases
+          </span>
+        ),
+        children: active_page === "billing" && (
+          <BillingPage is_simplified={false} />
+        ),
+      });
     }
     if (ssh_gateway || kucalc === KUCALC_COCALC_COM) {
-      v.push(
-        <Tab
-          key="ssh-keys"
-          eventKey="ssh-keys"
-          title={
-            <span>
-              <Icon name="key" /> SSH keys
-            </span>
-          }
-        >
-          {active_page === "ssh-keys" && <SSHKeysPage />}
-        </Tab>
-      );
+      items.push({
+        key: "ssh-keys",
+        label: (
+          <span>
+            <Icon name="key" /> SSH keys
+          </span>
+        ),
+        children: active_page === "ssh-keys" && <SSHKeysPage />,
+      });
     }
     if (is_commercial) {
-      v.push(
-        <Tab
-          key="support"
-          eventKey="support"
-          title={
-            <span>
-              <Icon name="medkit" /> Support
-            </span>
-          }
-        >
-          {active_page === "support" && <SupportTickets />}
-        </Tab>
-      );
+      items.push({
+        key: "support",
+        label: (
+          <span>
+            <Icon name="medkit" /> Support
+          </span>
+        ),
+        children: active_page === "support" && <SupportTickets />,
+      });
     }
-    v.push(
-      <Tab
-        key="public-files"
-        eventKey="public-files"
-        title={
-          <span>
-            <Icon name="bullhorn" /> Public files
-          </span>
-        }
-      >
-        {active_page === "public-files" && <PublicPaths />}
-      </Tab>
-    );
+    items.push({
+      key: "public-files",
+      label: (
+        <span>
+          <Icon name="bullhorn" /> Public files
+        </span>
+      ),
+      children: active_page === "public-files" && <PublicPaths />,
+    });
+    items.push({
+      key: "upgrades",
+      label: (
+        <span>
+          <Icon name="arrow-circle-up" /> Upgrades
+        </span>
+      ),
+      children: active_page === "upgrades" && <UpgradesPage />,
+    });
 
-    v.push(
-      <Tab
-        key="upgrades"
-        eventKey="upgrades"
-        title={
-          <span>
-            <Icon name="arrow-circle-up" /> Upgrades
-          </span>
-        }
-      >
-        {active_page === "upgrades" && <UpgradesPage />}
-      </Tab>
-    );
-
-    return v;
+    return items;
   }
 
   function render_logged_in_view(): JSX.Element {
@@ -242,9 +216,12 @@ export const AccountPage: React.FC = () => {
         </div>
       );
     }
-    const tabs: JSX.Element[] = [render_account_tab()].concat(
-      render_special_tabs()
-    );
+
+    const tabs: AntdTabItem[] = [
+      render_account_tab(),
+      ...render_special_tabs(),
+    ];
+
     return (
       <Row>
         <Col md={12}>
@@ -253,9 +230,8 @@ export const AccountPage: React.FC = () => {
             onSelect={handle_select}
             animation={false}
             tabBarExtraContent={<SignOut everywhere={false} highlight={true} />}
-          >
-            {tabs}
-          </Tabs>
+            items={tabs}
+          />
         </Col>
       </Row>
     );

--- a/src/packages/frontend/account/ssh-keys/ssh-key-list.tsx
+++ b/src/packages/frontend/account/ssh-keys/ssh-key-list.tsx
@@ -3,6 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Popconfirm, Typography } from "antd";
+import { Map } from "immutable";
+
 import { Button, Col, Row } from "@cocalc/frontend/antd-bootstrap";
 import { redux } from "@cocalc/frontend/app-framework";
 import {
@@ -13,17 +16,21 @@ import {
   TimeAgo,
 } from "@cocalc/frontend/components";
 import { cmp } from "@cocalc/util/misc";
-import { Popconfirm, Typography } from "antd";
-import { Map } from "immutable";
 
-// Children are rendered above the list of SSH Keys
-// Takes an optional Help string or node to render as a help modal
-export const SSHKeyList: React.FC<{
+interface SSHKeyListProps {
   ssh_keys?: Map<string, any>;
   project_id?: string;
   help?: JSX.Element;
   children?: any;
-}> = ({ ssh_keys, project_id, help, children }) => {
+}
+
+// Children are rendered above the list of SSH Keys
+// Takes an optional Help string or node to render as a help modal
+export const SSHKeyList: React.FC<SSHKeyListProps> = (
+  props: SSHKeyListProps
+) => {
+  const { ssh_keys, project_id, help, children } = props;
+
   function render_header() {
     return (
       <>

--- a/src/packages/frontend/antd-bootstrap.tsx
+++ b/src/packages/frontend/antd-bootstrap.tsx
@@ -31,6 +31,7 @@ import {
   Modal as AntdModal,
   Row as AntdRow,
   Tabs as AntdTabs,
+  TabsProps as AntdTabsProps,
   Tooltip,
 } from "antd";
 import { MouseEventHandler } from "react";
@@ -322,7 +323,9 @@ export function Col(props: {
   return <AntdCol {...props2}>{props.children}</AntdCol>;
 }
 
-export function Tabs(props: {
+export type AntdTabItem = NonNullable<AntdTabsProps["items"]>[number];
+
+interface TabsProps {
   id?: string;
   key?: string;
   activeKey: string;
@@ -332,18 +335,27 @@ export function Tabs(props: {
   tabBarExtraContent?;
   tabPosition?: "left" | "top" | "right" | "bottom";
   size?: "small";
-  children: any;
-}) {
-  // We do this because for antd, "There must be `tab` property on children of Tabs."
-  let tabs: Rendered[] | Rendered = [];
-  if (Symbol.iterator in Object(props.children)) {
-    for (const x of props.children) {
-      if (x == null || !x.props) continue;
-      tabs.push(Tab(x.props));
+  items?: AntdTabItem[];
+  children?: any;
+}
+
+export function Tabs(props: TabsProps) {
+  const { children, items } = props;
+
+  let tabs: Rendered[] | Rendered = undefined;
+  if (items == null && children != null) {
+    tabs = [];
+    // We do this because for antd, "There must be `tab` property on children of Tabs."
+    if (Symbol.iterator in Object(props.children)) {
+      for (const x of children) {
+        if (x == null || !x.props) continue;
+        tabs.push(Tab(x.props));
+      }
+    } else {
+      tabs = Tab(children);
     }
-  } else {
-    tabs = Tab(props.children);
   }
+
   return (
     <AntdTabs
       activeKey={props.activeKey}
@@ -353,6 +365,7 @@ export function Tabs(props: {
       tabBarExtraContent={props.tabBarExtraContent}
       tabPosition={props.tabPosition}
       size={props.size}
+      items={items}
     >
       {tabs}
     </AntdTabs>

--- a/src/packages/frontend/components/help-icon.tsx
+++ b/src/packages/frontend/components/help-icon.tsx
@@ -7,35 +7,44 @@
 Display a ? "help" icon, which -- when clicked -- shows a help tip
 */
 
-import { Popover } from "antd";
-import { useState } from "../app-framework";
+import { Button, Popover } from "antd";
+
+import { React, useState } from "@cocalc/frontend/app-framework";
 import { Icon } from "./icon";
+import { COLORS } from "@cocalc/util/theme";
 
 interface Props {
-  title;
-  children;
+  title: string;
+  children: React.ReactNode;
+  maxWidth?: string; // default is 50vw
 }
 
-export const HelpIcon: React.FC<Props> = ({ title, children }) => {
-  const [visible, set_visible] = useState<boolean>(false);
+export const HelpIcon: React.FC<Props> = (props: Props) => {
+  const { title, children, maxWidth = "50vw" } = props;
+
+  const [open, setOpen] = useState<boolean>(false);
 
   return (
     <Popover
-      content={children}
+      content={<div style={{ maxWidth }}>{children}</div>}
       title={
         <>
           {title}
-          <a style={{ float: "right" }} onClick={() => set_visible(false)}>
+          <Button
+            type="text"
+            style={{ float: "right", fontWeight: "bold" }}
+            onClick={() => setOpen(false)}
+          >
             Close
-          </a>
+          </Button>
         </>
       }
       trigger="click"
-      visible={visible}
-      onVisibleChange={set_visible}
+      open={open}
+      onOpenChange={setOpen}
     >
       <Icon
-        style={{ color: "#5bc0de", cursor: "pointer" }}
+        style={{ color: COLORS.BS_BLUE_TEXT, cursor: "pointer" }}
         name="question-circle"
       />
     </Popover>

--- a/src/packages/frontend/components/setting-box.tsx
+++ b/src/packages/frontend/components/setting-box.tsx
@@ -3,8 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { ReactNode, CSSProperties } from "react";
 import { Card, Typography } from "antd";
+import { CSSProperties, ReactNode } from "react";
+
 import { CloseX2 } from "./close-x2";
 import { Icon, IconName } from "./icon";
 
@@ -23,16 +24,18 @@ const STYLE = {
   marginBottom: "20px",
 } as CSSProperties;
 
-export function SettingBox({
-  icon,
-  title,
-  subtitle,
-  show_header = true,
-  close,
-  children,
-  style,
-  bodyStyle,
-}: Props) {
+export function SettingBox(props: Props) {
+  const {
+    icon,
+    title,
+    subtitle,
+    show_header = true,
+    close,
+    children,
+    style,
+    bodyStyle,
+  } = props;
+
   return (
     // type inner for the gray background in the header
     <Card

--- a/src/packages/frontend/jupyter/about.tsx
+++ b/src/packages/frontend/jupyter/about.tsx
@@ -6,14 +6,14 @@
 /*
 About dialog -- provides info about the Jupyter Notebook
 */
+import { Modal } from "antd";
 
 import Ansi from "@cocalc/ansi-to-react";
-import { Modal } from "antd";
-import { Icon, A } from "../components";
-import { ShowSupportLink } from "../support";
-import { JUPYTER_CLASSIC_MODERN } from "@cocalc/util/theme";
-import { KernelInfo } from "./types";
+import { A, Icon, Paragraph, Title } from "@cocalc/frontend/components";
+import { ShowSupportLink } from "@cocalc/frontend/support";
+import { COLORS, JUPYTER_CLASSIC_MODERN } from "@cocalc/util/theme";
 import { JupyterActions } from "./browser-actions";
+import { KernelInfo } from "./types";
 
 interface AboutProps {
   actions: JupyterActions;
@@ -21,7 +21,9 @@ interface AboutProps {
   backend_kernel_info?: KernelInfo;
 }
 
-export function About({ actions, about, backend_kernel_info }: AboutProps) {
+export function About(props: AboutProps) {
+  const { actions, about = false, backend_kernel_info } = props;
+
   function close(): void {
     actions.setState({ about: false });
     actions.focus(true);
@@ -33,7 +35,7 @@ export function About({ actions, about, backend_kernel_info }: AboutProps) {
         ? backend_kernel_info.get("nodejs_version")
         : undefined;
     if (!version) {
-      return <div>Waiting for server to be available...</div>;
+      return <Paragraph>Waiting for server to be available...</Paragraph>;
     }
     return <pre>Node.js Version {version}</pre>;
   }
@@ -44,7 +46,7 @@ export function About({ actions, about, backend_kernel_info }: AboutProps) {
         ? backend_kernel_info.get("banner")
         : undefined;
     if (banner == null) {
-      return <div>Waiting for kernel to be available...</div>;
+      return <Paragraph>Waiting for kernel to be available...</Paragraph>;
     }
     return (
       <pre>
@@ -55,113 +57,117 @@ export function About({ actions, about, backend_kernel_info }: AboutProps) {
 
   function render_faq(): JSX.Element {
     return (
-      <span>
+      <Paragraph>
         Read <A href="https://doc.cocalc.com/jupyter.html">documentation</A>
         , create a <ShowSupportLink />, or check the latest{" "}
         <A href={JUPYTER_CLASSIC_MODERN}>status of Jupyter in CoCalc.</A>
-      </span>
+      </Paragraph>
     );
   }
 
   function render_features(): JSX.Element {
     return (
-      <ul
+      <Paragraph
         style={{
-          marginTop: "10px",
+          backgroundColor: COLORS.GRAY_LLL,
           padding: "10px",
-          paddingLeft: "30px",
-          backgroundColor: "#fafafa",
-          fontSize: "11pt",
+          marginTop: "10px",
+          borderRadius: "5px",
         }}
       >
-        <li>
-          <b>Realtime sync:</b> Multiple people can simultaneously edit
-          notebooks: multiple cursors, document-wide user-specific undo and
-          redo, realtime synchronized ipywidgets
-        </li>
-        <li>
-          <b>Document split:</b> edit and see multiple parts of a large notebook
-          at once
-        </li>
-        <li>
-          <b>TimeTravel:</b> see detailed history of exactly how a notebook was
-          created
-        </li>
-        <li>
-          <b>Text/Markdown:</b> powerful graphical editor for markdown cells, so
-          you can write nicely formatted text to explain your code without
-          having to write markdown directly.
-        </li>
-        <li>
-          <b>Snippets:</b> code samples for many kernels
-        </li>
-        <li>
-          <b>Whiteboard:</b> create a whiteboard (documented ending in ".board")
-          and use Jupyter cells as part of your whiteboard
-        </li>
-        <li>
-          <b>Zoom:</b> easily change font size
-        </li>
-        <li>
-          <b>Code folding:</b> see structure of input
-        </li>
-        <li>
-          <b>Code formatting:</b> click the Format button to automatically
-          format your code and markdown.
-        </li>
-        <li>
-          <b>Modern look:</b> buttons, menus and cell execution hints that
-          better reflect state
-        </li>
-        <li>
-          <b>Large output:</b> server-side throttling, windowing, and buffering
-        </li>
-        <li>
-          <b>Background capture of output:</b> works if no user has the notebook
-          open (
-          <A href="https://github.com/jupyterlab/jupyterlab/issues/6545#issuecomment-501259211">
-            discussion
-          </A>
-          )
-        </li>
-        <li>
-          <b>Mobile support:</b> phones and tablets
-        </li>
-        <li>
-          <b>Cell creation:</b> click blue line between cells to create new
-          cells
-        </li>
-        <li>
-          <b>Share:</b> your work is visible publicly via our fast lightweight
-          notebook viewer
-        </li>
-        <li>
-          <b>LaTeX:</b> export notebook to LaTeX, then edit the generated LaTeX
-          directly in CoCalc.
-        </li>
-        <li>
-          <b>Keybindings and color schemes:</b> VIM, Emacs, and Sublime
-          keybindings, and many color schemes (in account settings)
-        </li>
-      </ul>
+        <ul>
+          <li>
+            <b>Realtime sync:</b> Multiple people can simultaneously edit
+            notebooks: multiple cursors, document-wide user-specific undo and
+            redo, realtime synchronized ipywidgets
+          </li>
+          <li>
+            <b>Document split:</b> edit and see multiple parts of a large
+            notebook at once
+          </li>
+          <li>
+            <b>TimeTravel:</b> see detailed history of exactly how a notebook
+            was created
+          </li>
+          <li>
+            <b>Text/Markdown:</b> powerful graphical editor for markdown cells,
+            so you can write nicely formatted text to explain your code without
+            having to write markdown directly.
+          </li>
+          <li>
+            <b>Snippets:</b> code samples for many kernels
+          </li>
+          <li>
+            <b>Whiteboard:</b> create a whiteboard (documented ending in
+            ".board") and use Jupyter cells as part of your whiteboard
+          </li>
+          <li>
+            <b>Zoom:</b> easily change font size
+          </li>
+          <li>
+            <b>Code folding:</b> see structure of input
+          </li>
+          <li>
+            <b>Code formatting:</b> click the Format button to automatically
+            format your code and markdown.
+          </li>
+          <li>
+            <b>Modern look:</b> buttons, menus and cell execution hints that
+            better reflect state
+          </li>
+          <li>
+            <b>Large output:</b> server-side throttling, windowing, and
+            buffering
+          </li>
+          <li>
+            <b>Background capture of output:</b> works if no user has the
+            notebook open (
+            <A href="https://github.com/jupyterlab/jupyterlab/issues/6545#issuecomment-501259211">
+              discussion
+            </A>
+            )
+          </li>
+          <li>
+            <b>Mobile support:</b> phones and tablets
+          </li>
+          <li>
+            <b>Cell creation:</b> click blue line between cells to create new
+            cells
+          </li>
+          <li>
+            <b>Share:</b> your work is visible publicly via our fast lightweight
+            notebook viewer
+          </li>
+          <li>
+            <b>LaTeX:</b> export notebook to LaTeX, then edit the generated
+            LaTeX directly in CoCalc.
+          </li>
+          <li>
+            <b>Keybindings and color schemes:</b> VIM, Emacs, and Sublime
+            keybindings, and many color schemes (in account settings)
+          </li>
+        </ul>
+      </Paragraph>
     );
   }
 
   return (
     <Modal
       width={900}
-      visible={about}
-      onCancel={close}
+      open={about}
       onOk={close}
+      onCancel={close} // for the X at the top right
+      okText={"Close"}
+      cancelButtonProps={{ style: { display: "none" } }}
       title={
-        <>
-          <Icon name="question-circle" /> About CoCalc Jupyter notebook
-        </>
+        <Title level={2}>
+          <Icon name="question-circle" /> CoCalc's Jupyter Notebook
+        </Title>
       }
     >
-      <p>You are using the CoCalc Jupyter notebook.</p>
+      <Paragraph>You are using the CoCalc Jupyter notebook.</Paragraph>
 
-      <div style={{ color: "#333", margin: "0px 45px" }}>
+      <Paragraph>
         CoCalc Jupyter notebook is a complete open source rewrite by SageMath,
         Inc. of the classical Jupyter notebook client from the{" "}
         <A href="http://jupyter.org/">Jupyter project</A>. CoCalc Jupyter
@@ -177,15 +183,15 @@ export function About({ actions, about, backend_kernel_info }: AboutProps) {
         and create a <ShowSupportLink />
         ), and some of the above is also available in classical Jupyter via
         extensions.
-      </div>
+      </Paragraph>
 
-      <h4 style={{ marginTop: "15px" }}>Questions</h4>
+      <Title level={4}>Questions</Title>
       {render_faq()}
 
-      <h4 style={{ marginTop: "15px" }}>Server Information</h4>
+      <Title level={4}>Server Information</Title>
       {render_server_info()}
 
-      <h4 style={{ marginTop: "15px" }}>Current Kernel Information</h4>
+      <Title level={4}>Current Kernel Information</Title>
       {render_kernel_info()}
     </Modal>
   );

--- a/src/packages/util/theme.ts
+++ b/src/packages/util/theme.ts
@@ -50,7 +50,7 @@ export const sign_up_id = "44ZfCImosncQhP3jwQM";
 
 // documentation
 export const JUPYTER_CLASSIC_MODERN =
-  "https://doc.cocalc.com/jupyter.html#classical-versus-cocalc";
+  "https://doc.cocalc.com/jupyter-classical-vs-cocalc.html";
 
 // this is used in packages/hub/email.coffee and hub.coffee to specify the template and ASM groups for sendgrid
 export const SENDGRID_TEMPLATE_ID = "0375d02c-945f-4415-a611-7dc3411e2a78";


### PR DESCRIPTION
# Description

- account tabs: now an array of objects  + some tweaks to the wrapper component
- ssh list: actually, that help popup icon needs some tweaks
- jupyter: modernize about modal and fix jupyter vs. classic link to docs

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
