### PR TITLE
frontend/files-tab: make them wider and tweak the "more" dropdown

### DIFF
--- a/src/packages/frontend/_project_page.sass
+++ b/src/packages/frontend/_project_page.sass
@@ -19,3 +19,11 @@ dl.cc-project-settings-features
     width       : 20px
   > dd
     margin-left : 30px
+
+.cocalc-files-tabs-more
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15)
+  .ant-tabs-dropdown-menu-item
+    font-size: 14px
+    .anticon
+      font-size: 125%
+      margin-right: 10px

--- a/src/packages/frontend/components/sortable-tabs.tsx
+++ b/src/packages/frontend/components/sortable-tabs.tsx
@@ -1,3 +1,8 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import {
   DndContext,
   MouseSensor,
@@ -6,24 +11,24 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import {
-  SortableContext,
-  useSortable,
-  horizontalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import {
   restrictToHorizontalAxis,
   restrictToParentElement,
 } from "@dnd-kit/modifiers";
 import {
+  horizontalListSortingStrategy,
+  SortableContext,
+  useSortable,
+} from "@dnd-kit/sortable";
+import useMouse from "@react-hook/mouse-position";
+import {
+  createContext,
   CSSProperties,
   ReactNode,
+  useContext,
   useMemo,
   useRef,
-  createContext,
-  useContext,
 } from "react";
 import useResizeObserver from "use-resize-observer";
-import useMouse from "@react-hook/mouse-position";
 
 export { useSortable };
 
@@ -47,13 +52,8 @@ export function useItemContext() {
   return useContext(ItemContext);
 }
 
-export function SortableTabs({
-  onDragStart,
-  onDragEnd,
-  items,
-  children,
-  style,
-}: Props) {
+export function SortableTabs(props: Props) {
+  const { onDragStart, onDragEnd, items, children, style } = props;
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: {
       distance: 2,
@@ -98,7 +98,7 @@ export function SortableTabs({
     }
     const itemWidth =
       Math.max(
-        150,
+        180,
         Math.min(250 + 65, (resize?.width ?? 0) / Math.max(1, items.length))
       ) - 70; // the constant accounts for the margin and x for an antd tab.
     lastRef.current = {

--- a/src/packages/frontend/project/page/file-tabs.tsx
+++ b/src/packages/frontend/project/page/file-tabs.tsx
@@ -1,19 +1,26 @@
 /*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+
+/*
 Tabs for the open files in a project.
 */
 
-import { Tabs } from "antd";
 import type { TabsProps } from "antd";
-import { file_tab_labels } from "../file-tab-labels";
-import { FileTab } from "./file-tab";
+import { Tabs } from "antd";
+
 import { useActions } from "@cocalc/frontend/app-framework";
 import {
   renderTabBar,
   SortableTabs,
-  useSortable,
   useItemContext,
+  useSortable,
 } from "@cocalc/frontend/components/sortable-tabs";
 import { path_to_tab } from "@cocalc/util/misc";
+import { file_tab_labels } from "../file-tab-labels";
+import { FileTab } from "./file-tab";
 
 function Label({ path, project_id, label }) {
   const { width } = useItemContext();
@@ -132,6 +139,7 @@ export default function FileTabs({ openFiles, project_id, activeTab }) {
           if (actions == null) return;
           actions.set_active_tab(path_to_tab(keyToPath(key)));
         }}
+        popupClassName={"cocalc-files-tabs-more"}
       />
     </SortableTabs>
   );


### PR DESCRIPTION
# Description

This tweaks the files tab bar and the dropdown showing more.

![Screenshot from 2023-02-16 17-30-08](https://user-images.githubusercontent.com/207405/219428046-be025380-add7-47d9-9548-695b49cfccb0.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
