### PR TITLE
frontend/project/new filename: make ymd_semantic the default 

### DIFF
--- a/src/packages/frontend/account/default-file-name-generator.ts
+++ b/src/packages/frontend/account/default-file-name-generator.ts
@@ -5,21 +5,17 @@
 
 // Return a default filename with the given ext (or not extension if ext not given)
 // this is just a wrapper for backwards compatibility
-import { NewFilenames, NewFilenameTypes } from "../project/utils";
-import { NEW_FILENAMES } from "@cocalc/util/db-schema";
-
-import { redux } from "../app-framework";
+import { redux } from "@cocalc/frontend/app-framework";
+import { DEFAULT_NEW_FILENAMES, NEW_FILENAMES } from "@cocalc/util/db-schema";
+import { NewFilenames } from "../project/utils";
 
 const new_filenames_generator = new NewFilenames(undefined, true);
 
-export const default_filename = function (
-  ext?: string,
-  project_id?: string
-): string {
+export function default_filename(ext?: string, project_id?: string): string {
   const account_store = redux.getStore("account");
-  const type: any = account_store // [j3] I have absolutely no idea why this won't type properly.
-    ? account_store.getIn(["other_settings", NEW_FILENAMES])
-    : (NewFilenames.default_family as NewFilenameTypes);
+  const type =
+    account_store?.getIn(["other_settings", NEW_FILENAMES]) ??
+    DEFAULT_NEW_FILENAMES;
   new_filenames_generator.set_ext(ext);
 
   if (project_id != undefined) {
@@ -30,4 +26,4 @@ export const default_filename = function (
   } else {
     return new_filenames_generator.gen(type);
   }
-};
+}

--- a/src/packages/frontend/account/other-settings.tsx
+++ b/src/packages/frontend/account/other-settings.tsx
@@ -3,22 +3,23 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Component, Rendered, redux } from "../app-framework";
-import { Map } from "immutable";
-import { webapp_client } from "../webapp-client";
-import { Checkbox, Panel } from "../antd-bootstrap";
 import { Card, InputNumber } from "antd";
-import { IS_MOBILE, IS_TOUCH } from "../feature";
+import { Map } from "immutable";
+
+import { Checkbox, Panel } from "@cocalc/frontend/antd-bootstrap";
+import { Component, redux, Rendered } from "@cocalc/frontend/app-framework";
 import {
   A,
   Icon,
-  NumberInput,
   LabeledRow,
   Loading,
+  NumberInput,
   SelectorInput,
-} from "../components";
-import { NEW_FILENAMES } from "@cocalc/util/db-schema";
-import { NewFilenameFamilies, NewFilenames } from "../project/utils";
+} from "@cocalc/frontend/components";
+import { IS_MOBILE, IS_TOUCH } from "@cocalc/frontend/feature";
+import { NewFilenameFamilies } from "@cocalc/frontend/project/utils";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import { DEFAULT_NEW_FILENAMES, NEW_FILENAMES } from "@cocalc/util/db-schema";
 import { dark_mode_mins, get_dark_mode_config } from "./dark-mode";
 
 interface Props {
@@ -143,8 +144,7 @@ export class OtherSettings extends Component<Props> {
 
   private render_new_filenames(): Rendered {
     const selected =
-      this.props.other_settings.get(NEW_FILENAMES) ??
-      NewFilenames.default_family;
+      this.props.other_settings.get(NEW_FILENAMES) ?? DEFAULT_NEW_FILENAMES;
     return (
       <LabeledRow label="Generated filenames">
         <SelectorInput

--- a/src/packages/frontend/account/store.ts
+++ b/src/packages/frontend/account/store.ts
@@ -3,13 +3,14 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { List, Map } from "immutable";
 import { reduce } from "lodash";
-import { Store } from "../app-framework/Store";
-import { AccountState } from "./types";
-import { get_total_upgrades } from "@cocalc/util/upgrades";
+
+import { Store } from "@cocalc/frontend/app-framework/Store";
+import { store as customizeStore } from "@cocalc/frontend/customize";
 import { make_valid_name } from "@cocalc/util/misc";
-import { Map, List } from "immutable";
-import { store as customizeStore } from "../customize";
+import { get_total_upgrades } from "@cocalc/util/upgrades";
+import { AccountState } from "./types";
 
 // Define account store
 export class AccountStore extends Store<AccountState> {

--- a/src/packages/frontend/account/types.ts
+++ b/src/packages/frontend/account/types.ts
@@ -4,10 +4,14 @@
  */
 
 import { List, Map } from "immutable";
-import { NewFilenameTypes } from "../project/utils";
+
 import { PassportStrategyFrontend } from "@cocalc/util/types/passport-types";
-import { TypedMap } from "../app-framework";
-import { MessageInfo } from "../client/hub";
+import { TypedMap } from "@cocalc/frontend/app-framework";
+import { MessageInfo } from "@cocalc/frontend/client/hub";
+import {
+  NewFilenameTypes,
+  NEW_FILENAMES,
+} from "@cocalc/util/db-schema/defaults";
 
 // this is incomplete...
 
@@ -31,7 +35,7 @@ export interface AccountState {
   other_settings: TypedMap<{
     confirm_close: string;
     page_size?: number;
-    new_filenames?: NewFilenameTypes;
+    [NEW_FILENAMES]?: NewFilenameTypes;
     no_free_warnings?: boolean;
     time_ago_absolute: boolean;
     dark_mode: boolean;

--- a/src/packages/frontend/project/ask-filename.tsx
+++ b/src/packages/frontend/project/ask-filename.tsx
@@ -22,11 +22,8 @@ import {
 } from "@cocalc/frontend/components";
 import { file_options } from "@cocalc/frontend/editor-tmp";
 import { IS_TOUCH } from "@cocalc/frontend/feature";
-import {
-  NewFilenameFamilies,
-  NewFilenames,
-} from "@cocalc/frontend/project/utils";
-import { NEW_FILENAMES } from "@cocalc/util/db-schema";
+import { NewFilenameFamilies } from "@cocalc/frontend/project/utils";
+import { DEFAULT_NEW_FILENAMES, NEW_FILENAMES } from "@cocalc/util/db-schema";
 import { FileSpec } from "../file-associations";
 
 interface Props {
@@ -40,7 +37,7 @@ export default function AskNewFilename({ project_id }: Props) {
   const other_settings = useTypedRedux("account", "other_settings");
   const new_filename = useTypedRedux({ project_id }, "new_filename");
   const rfn = other_settings.get(NEW_FILENAMES);
-  const selected = rfn != null ? rfn : NewFilenames.default_family;
+  const selected = rfn ?? DEFAULT_NEW_FILENAMES;
 
   useEffect(() => {
     shuffle();

--- a/src/packages/frontend/project_actions.ts
+++ b/src/packages/frontend/project_actions.ts
@@ -10,6 +10,7 @@ import { join } from "path";
 import * as async from "async";
 import { isEqual } from "lodash";
 import { Set, List, fromJS, Map } from "immutable";
+
 import { client_db } from "@cocalc/util/schema";
 import {
   ConfigurationAspect,
@@ -25,7 +26,7 @@ import { callback2, retry_until_success } from "@cocalc/util/async-utils";
 import { exec } from "./frame-editors/generic/client";
 import { API } from "./project/websocket/api";
 import { in_snapshot_path, NewFilenames, normalize } from "./project/utils";
-import { NEW_FILENAMES } from "@cocalc/util/db-schema";
+import { DEFAULT_NEW_FILENAMES, NEW_FILENAMES } from "@cocalc/util/db-schema";
 import { transform_get_url } from "./project/transform-get-url";
 import { OpenFiles } from "./project/open-files";
 import { log_opened_time, open_file, log_file_open } from "./project/open-file";
@@ -291,14 +292,9 @@ export class ProjectActions extends Actions<ProjectStoreState> {
       const filenames = this.get_filenames_in_current_dir();
       // this is the type of random name generator
       const acc_store = this.redux.getStore("account") as any;
-      const dflt = NewFilenames.default_family;
-      const type = (function () {
-        if (acc_store != null) {
-          return acc_store.getIn(["other_settings", NEW_FILENAMES]);
-        } else {
-          return dflt;
-        }
-      })();
+      const type =
+        acc_store?.getIn(["other_settings", NEW_FILENAMES]) ??
+        DEFAULT_NEW_FILENAMES;
       this.new_filename_generator.set_ext(ext);
       this.setState({
         new_filename: this.new_filename_generator.gen(type, filenames),

--- a/src/packages/util/db-schema/defaults.ts
+++ b/src/packages/util/db-schema/defaults.ts
@@ -5,9 +5,18 @@
 
 export const DEFAULT_FONT_SIZE = 14;
 
+export type NewFilenameTypes =
+  | "iso"
+  | "heroku"
+  | "pet"
+  | "ymd_heroku"
+  | "ymd_pet"
+  | "semantic"
+  | "ymd_semantic";
+
 // key for new filenames algorithm in account/other_settings and associated default value
 export const NEW_FILENAMES = "new_filenames";
-export const DEFAULT_NEW_FILENAMES = "iso";
+export const DEFAULT_NEW_FILENAMES: NewFilenameTypes = "ymd_semantic";
 
 // This is used on cocalc.com, and the storage server has images named "default" and "ubuntu2004"
 // For on-prem, you have to configure the "software environment" configuration, which includes a default image name.


### PR DESCRIPTION
# Description

- change the default type of new generated file names to be `ymd_semantic` (after 4 years, instead of quote: "Change it to "semantic" after a week or two…")
- add special cases for e.g. folders and x11
- sanitize the family type
- fix the time-prefix string for python and sage files, i.e. all underscore, not just the filename tokens.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
