### PR TITLE
frontend/antd: make dialog modals be on top of popovers -- #6467

### DIFF
--- a/src/packages/frontend/_antd_fix.sass
+++ b/src/packages/frontend/_antd_fix.sass
@@ -40,3 +40,10 @@ html
   flex-direction: column
   > .ant-alert-banner
     display: block
+
+// The frame-editor title-bar's "..." popover has a higher z-index than e.g. the "Halt" modal
+// This makes the antd modals appear on top of all other elements
+// Ref: https://github.com/sagemathinc/cocalc/issues/6467
+// I found this ticket: https://github.com/ant-design/ant-design/issues/31513
+.ant-modal-root .ant-modal-wrap
+  z-index: 1100

--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -1563,17 +1563,21 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
         content={() => {
           return (
             <div style={{ display: "flex" }}>
-              <div style={{ width: "3px" }}></div>
-              <div style={{ maxWidth: "390px" }}>
+              <div
+                style={{
+                  maxWidth: "390px",
+                  marginLeft: "3px",
+                  marginRight: "3px",
+                }}
+              >
                 {render_buttons(true, { maxHeight: "50vh" })}
               </div>
-              <div style={{ width: "3px" }}></div>
               <div>{render_types()}</div>
               <Icon
                 onClick={() => setShowMainButtonsPopover(false)}
                 name="times"
                 style={{
-                  color: "#666",
+                  color: COLORS.GRAY_M,
                   marginTop: "10px",
                   marginLeft: "10px",
                 }}


### PR DESCRIPTION
# Description

this fixes #6467

it also removes two divs, which are replaced by left and right margins :shrug: 

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
