### PR TITLE
frontend/jupyter/snippets: disable insert if there is no target notebook

### DIFF
--- a/src/packages/frontend/frame-editors/jupyter-editor/snippets/main.tsx
+++ b/src/packages/frontend/frame-editors/jupyter-editor/snippets/main.tsx
@@ -226,6 +226,7 @@ export const JupyterSnippets: React.FC<Props> = React.memo((props: Props) => {
         size={"small"}
         icon={<LeftSquareOutlined />}
         type={link ? "link" : "default"}
+        disabled={jupyterFrameID == null}
         onClick={(e) => {
           insert_snippet({ code, descr });
           e.stopPropagation();


### PR DESCRIPTION
# Description

see #6472. this disables the insert link and pick button.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
