### PR TITLE
frontend/side-chat: fixing hidden slate icons

### DIFF
--- a/src/packages/frontend/chat/input.tsx
+++ b/src/packages/frontend/chat/input.tsx
@@ -4,8 +4,10 @@
  */
 
 import { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 import {
+  CSS,
   redux,
   useIsMountedRef,
   useRedux,
@@ -14,7 +16,6 @@ import MarkdownInput from "@cocalc/frontend/editors/markdown-input/multimode";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
 import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
 import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
-import { useDebouncedCallback } from "use-debounce";
 
 interface Props {
   on_send: (value: string) => void;
@@ -30,11 +31,24 @@ interface Props {
   onFocus?: () => void;
   onBlur?: () => void;
   syncdb?;
-  editBarStyle?;
+  editBarStyle?: CSS;
 }
 
-export const ChatInput: React.FC<Props> = (props) => {
-  const { syncdb } = props;
+export const ChatInput: React.FC<Props> = (props: Props) => {
+  const {
+    on_send,
+    onChange,
+    height,
+    submitMentionsRef,
+    hideHelp,
+    style,
+    cacheId,
+    onFocus,
+    onBlur,
+    syncdb,
+    editBarStyle,
+  } = props;
+
   const { project_id, path, actions } = useFrameContext();
   const font_size =
     props.font_size ?? useRedux(["font_size"], project_id, path);
@@ -54,7 +68,7 @@ export const ChatInput: React.FC<Props> = (props) => {
         ?.get("input");
       return input;
     }
-    return props.input ?? "";
+    return input ?? "";
   });
 
   const isMountedRef = useIsMountedRef();
@@ -62,7 +76,7 @@ export const ChatInput: React.FC<Props> = (props) => {
   const saveChat = useDebouncedCallback(
     (input) => {
       if (!isMountedRef.current || syncdb == null) return;
-      props.onChange(input);
+      onChange(input);
       lastSavedRef.current = input;
       // also save to syncdb, so we have undo, etc.
       // but definitely don't save (thus updating active) if
@@ -120,24 +134,24 @@ export const ChatInput: React.FC<Props> = (props) => {
     <MarkdownInput
       autoFocus
       saveDebounceMs={0}
-      onFocus={props.onFocus}
-      onBlur={props.onBlur}
-      cacheId={props.cacheId}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      cacheId={cacheId}
       value={input}
       enableUpload={true}
       onUploadStart={() => actions?.set_uploading(true)}
       onUploadEnd={() => actions?.set_uploading(false)}
       enableMentions={true}
-      submitMentionsRef={props.submitMentionsRef}
+      submitMentionsRef={submitMentionsRef}
       onChange={(input) => {
         setInput(input);
         saveChat(input);
       }}
       onShiftEnter={(input) => {
         saveChat.cancel();
-        props.on_send(input);
+        on_send(input);
       }}
-      height={props.height}
+      height={height}
       placeholder={"Type a message..."}
       extraHelp={
         IS_MOBILE
@@ -145,8 +159,8 @@ export const ChatInput: React.FC<Props> = (props) => {
           : "Double click to edit chats."
       }
       fontSize={font_size}
-      hideHelp={props.hideHelp}
-      style={props.style}
+      hideHelp={hideHelp}
+      style={style}
       onUndo={() => {
         saveChat.cancel();
         syncdb?.undo();
@@ -155,7 +169,8 @@ export const ChatInput: React.FC<Props> = (props) => {
         saveChat.cancel();
         syncdb?.redo();
       }}
-      editBarStyle={props.editBarStyle}
+      editBarStyle={editBarStyle}
+      overflowEllipsis={true}
     />
   );
 };

--- a/src/packages/frontend/chat/side-chat.tsx
+++ b/src/packages/frontend/chat/side-chat.tsx
@@ -204,7 +204,7 @@ export const SideChat: React.FC<Props> = ({ project_id, path }: Props) => {
             onChange={(value) => actions.set_input(value)}
             submitMentionsRef={submitMentionsRef}
             syncdb={actions.syncdb}
-            editBarStyle={{ overflow: "auto" }}
+            editBarStyle={{ overflow: "none" }}
           />
           <div
             style={{

--- a/src/packages/frontend/editors/markdown-input/multimode.tsx
+++ b/src/packages/frontend/editors/markdown-input/multimode.tsx
@@ -2,7 +2,7 @@
 Edit with either plain text input **or** WYSIWYG slate-based input.
 */
 
-import { Radio } from "antd";
+import { Popover, Radio } from "antd";
 import { fromJS, Map as ImmutableMap } from "immutable";
 import LRU from "lru-cache";
 import {
@@ -23,6 +23,7 @@ import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/con
 import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 import { get_local_storage, set_local_storage } from "@cocalc/frontend/misc";
 import { FragmentId } from "@cocalc/frontend/misc/fragment-id";
+import { COLORS } from "@cocalc/util/theme";
 import { BLURED_STYLE, FOCUSED_STYLE, MarkdownInput } from "./component";
 
 // NOTE: on mobile there is very little suppport for "editor" = "slate", but
@@ -125,6 +126,8 @@ interface Props {
 
   // refresh codemirror if this changes
   refresh?: any;
+
+  overflowEllipsis?: boolean; // if true, show "..." button popping up all menu entries
 }
 
 export default function MultiMarkdownInput(props: Props) {
@@ -170,8 +173,11 @@ export default function MultiMarkdownInput(props: Props) {
     unregisterEditor,
     modeSwitchStyle,
     refresh,
+    overflowEllipsis = false,
   } = props;
   const { project_id, path } = useFrameContext();
+
+  const editBar2 = useRef<JSX.Element | undefined>(undefined);
 
   function getCache() {
     return cacheId === undefined
@@ -186,6 +192,8 @@ export default function MultiMarkdownInput(props: Props) {
       getLocalStorageMode() ??
       (IS_MOBILE ? "markdown" : "editor")
   );
+
+  const [editBarPopover, setEditBarPopover] = useState<boolean>(false);
 
   useEffect(() => {
     onModeChange?.(mode);
@@ -238,6 +246,22 @@ export default function MultiMarkdownInput(props: Props) {
     };
   }, [mode]);
 
+  function toggleEditBarPopupver() {
+    setEditBarPopover(!editBarPopover);
+  }
+
+  function renderEditBarEllipsis() {
+    return (
+      <span style={{ fontWeight: 400 }}>
+        {"\u22EF"}
+        <Popover
+          open={editBarPopover}
+          content={<div>{editBar2.current}</div>}
+        />
+      </span>
+    );
+  }
+
   return (
     <div
       style={{
@@ -272,7 +296,7 @@ export default function MultiMarkdownInput(props: Props) {
           <div
             style={{
               background: "white",
-              color: "#666",
+              color: COLORS.GRAY_M,
               ...(mode == "editor" || hideHelp
                 ? {
                     position: "absolute",
@@ -285,6 +309,21 @@ export default function MultiMarkdownInput(props: Props) {
           >
             <Radio.Group
               options={[
+                ...(overflowEllipsis && mode == "editor"
+                  ? [
+                      {
+                        label: renderEditBarEllipsis(),
+                        value: "menu",
+                        style: {
+                          backgroundColor: editBarPopover
+                            ? COLORS.GRAY_L
+                            : "white",
+                          paddingLeft: 10,
+                          paddingRight: 10,
+                        },
+                      },
+                    ]
+                  : []),
                 // fontWeight is needed to undo a stupid conflict with bootstrap css, which will go away when we get rid of that ancient nonsense.
                 {
                   label: <span style={{ fontWeight: 400 }}>Text</span>,
@@ -296,7 +335,12 @@ export default function MultiMarkdownInput(props: Props) {
                 },
               ]}
               onChange={(e) => {
-                setMode(e.target.value as Mode);
+                const mode = e.target.value;
+                if (mode === "menu") {
+                  toggleEditBarPopupver();
+                } else {
+                  setMode(mode as Mode);
+                }
               }}
               value={mode}
               optionType="button"
@@ -427,6 +471,7 @@ export default function MultiMarkdownInput(props: Props) {
             unregisterEditor={unregisterEditor}
             placeholder={placeholder ?? "Type text..."}
             submitMentionsRef={submitMentionsRef}
+            editBar2={editBar2}
           />
         </div>
       )}

--- a/src/packages/frontend/editors/slate/editable-markdown.tsx
+++ b/src/packages/frontend/editors/slate/editable-markdown.tsx
@@ -118,6 +118,7 @@ interface Props {
   unregisterEditor?: () => void;
   getValueRef?: MutableRefObject<() => string>; // see comment in src/packages/frontend/editors/markdown-input/multimode.tsx
   submitMentionsRef?: MutableRefObject<(fragmentId?: FragmentId) => string>; // when called this will submit all mentions in the document, and also returns current value of the document (for compat with markdown editor).  If not set, mentions are submitted when you create them.  This prop is used mainly for implementing chat, which has a clear "time of submission".
+  editBar2?: MutableRefObject<JSX.Element | undefined>;
 }
 
 export const EditableMarkdown: React.FC<Props> = React.memo((props: Props) => {
@@ -153,6 +154,7 @@ export const EditableMarkdown: React.FC<Props> = React.memo((props: Props) => {
     unregisterEditor,
     getValueRef,
     submitMentionsRef,
+    editBar2,
   } = props;
   const { project_id, path, desc } = useFrameContext();
   const isMountedRef = useIsMountedRef();
@@ -823,6 +825,21 @@ export const EditableMarkdown: React.FC<Props> = React.memo((props: Props) => {
   }, [editorValue]);
 
   const [opacity, setOpacity] = useState<number | undefined>(0);
+
+  if (editBar2 != null) {
+    editBar2.current = (
+      <EditBar
+        Search={search.Search}
+        isCurrent={is_current}
+        marks={marks}
+        linkURL={linkURL}
+        listProperties={listProperties}
+        editor={editor}
+        style={{ ...editBarStyle, paddingRight: 0 }}
+        hideSearch={hideSearch}
+      />
+    );
+  }
 
   let slate = (
     <Slate editor={editor} value={editorValue} onChange={onChange}>


### PR DESCRIPTION
# Description

Ref #6454

With this, there is a toggleable Popover with these EditBar-buttons

![Screenshot from 2023-02-24 16-33-25](https://user-images.githubusercontent.com/207405/221219724-3e17c48c-ba80-4d0c-9711-4c5c0360e627.png)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
