### PR TITLE
[needs review] Lets dont remove user on stop project

### DIFF
--- a/src/packages/server/projects/control/multi-user.ts
+++ b/src/packages/server/projects/control/multi-user.ts
@@ -20,7 +20,7 @@ import {
   chown,
   copyPath,
   createUser,
-  deleteUser,
+//   deleteUser,
   ensureConfFilesExists,
   getEnvironment,
   getState,
@@ -138,7 +138,7 @@ class Project extends BaseProject {
     try {
       this.stateChanging = { state: "stopping" };
       await this.saveStateToDatabase(this.stateChanging);
-      await deleteUser(this.project_id);
+    //   await deleteUser(this.project_id);
       await this.wait({
         until: async () => !(await isProjectRunning(this.HOME)),
         maxTime: MAX_STOP_TIME_MS,

--- a/src/packages/server/projects/control/multi-user.ts
+++ b/src/packages/server/projects/control/multi-user.ts
@@ -30,6 +30,7 @@ import {
   launchProjectDaemon,
   mkdir,
   setupDataPath,
+  stopProjectProcesses
 } from "./util";
 import {
   BaseProject,
@@ -40,6 +41,7 @@ import {
 } from "./base";
 import getLogger from "@cocalc/backend/logger";
 import { getUid } from "@cocalc/backend/misc";
+
 
 const winston = getLogger("project-control:multi-user");
 
@@ -138,6 +140,7 @@ class Project extends BaseProject {
     try {
       this.stateChanging = { state: "stopping" };
       await this.saveStateToDatabase(this.stateChanging);
+      await stopProjectProcesses(this.project_id);
     //   await deleteUser(this.project_id);
       await this.wait({
         until: async () => !(await isProjectRunning(this.HOME)),

--- a/src/packages/server/projects/control/util.ts
+++ b/src/packages/server/projects/control/util.ts
@@ -150,7 +150,9 @@ export async function stopProjectProcesses(project_id: string): Promise<void> {
     const home_path = homePath(project_id);
     const pid = await getProjectPID(home_path);
     const scmd = `kill -9 ${pid} | true `; // | true since kill can return nonzero status. 
-    await exec(scmd); // May be here we should implement some king of GC for processes?
+    await exec(scmd); // May be here we should implement some kind of GC for processes?
+      // Just killing all processes for the user is not the solution — user can run long running tasks or services, 
+      // using tmux/rdp/etc.
 }
  
 

--- a/src/packages/server/projects/control/util.ts
+++ b/src/packages/server/projects/control/util.ts
@@ -145,6 +145,15 @@ export async function createUser(project_id: string): Promise<void> {
   );
 }
 
+
+export async function stopProjectProcesses(project_id: string): Promise<void> {
+    const home_path = homePath(project_id);
+    const pid = await getProjectPID(home_path);
+    const scmd = `kill -9 ${pid} | true `; // | true since kill can return nonzero status. 
+    await exec(scmd); // May be here we should implement some king of GC for processes?
+}
+ 
+
 export async function deleteUser(project_id: string): Promise<void> {
   const username = getUsername(project_id);
   const uid = `${getUid(project_id)}`;


### PR DESCRIPTION
# Description
Implementation of discussion 
https://github.com/sagemathinc/cocalc/discussions/6484#discussioncomment-5110002
by simplest solution «just never delete the user.».

Actually, this need little more than commenting one line (+one function), but looks it working, 
tested on production (`pnpm make`) on one of my cocalc sites.

(Also I look at Project Settings UI, <s>and it seems to me, looks like there is a lot of attributes of table `projects` that has no UI, also there may be lot of other setting that may be better store as JSON doc…</s> so I decide not to touch «Project Settings» right now, let Cocalc Architect makes this solution). 

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [*] Testing instructions are provided, if not obvious

Testing is obvious, «start»/«stop» many times any project, and on stopped state something like «sudo -u df1cc7c9fea147dd90eeb645ed32d1a4 ls . » should work.

- [*] Release instructions are provided, if not obvious

No specific deploy (DB migration, etc) is needed.