### PR TITLE
next/software: switching software env should not switch subpage category

### DIFF
--- a/src/packages/next/components/landing/sub-nav.tsx
+++ b/src/packages/next/components/landing/sub-nav.tsx
@@ -179,15 +179,20 @@ export default function SubNav(props: Props) {
   if (p == null || isEmpty(p)) return null;
 
   function renderSoftwareEnvs() {
+    if (page != "software") return;
+
     const links = SOFTWARE_ENV_NAMES.map((name) => {
       const selected = name === softwareEnv;
       const style =
         SOFTWARE_ENV_DEFAULT === name ? { fontWeight: "bold" } : undefined;
+      // clicking on the software env link should not switch between subpages
+      const sub =
+        subPage != null && software[subPage] != null ? subPage : "executables";
       return (
         <A
           key={name}
           style={{ ...tabStyle(selected), ...style }}
-          href={`/software/executables/${name}`}
+          href={`/software/${sub}/${name}`}
         >
           {name}
         </A>
@@ -239,7 +244,7 @@ export default function SubNav(props: Props) {
   const links = (
     <>
       {r_join(tabs, SEP)}
-      {page == "software" && renderSoftwareEnvs()}
+      {renderSoftwareEnvs()}
     </>
   );
 

--- a/src/packages/next/pages/software/executables/[name].tsx
+++ b/src/packages/next/pages/software/executables/[name].tsx
@@ -4,12 +4,13 @@
  */
 
 import { Layout } from "antd";
-import { Paragraph } from "components/misc";
+
 import ExecutablesTable from "components/landing/executables-table";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
 import Image from "components/landing/image";
+import { Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
 import { Customize, CustomizeType } from "lib/customize";
 import { SoftwareEnvNames } from "lib/landing/consts";
@@ -32,9 +33,9 @@ export default function Executables(props: Props) {
   function renderInfo() {
     return (
       <div style={{ maxWidth: STYLE_PAGE.maxWidth, margin: "0 auto" }}>
-        <h1 style={{ textAlign: "center", fontSize: "32pt", color: "#444" }}>
+        <Title level={1} style={{ textAlign: "center" }}>
           Executables in CoCalc (Ubuntu {name})
-        </h1>
+        </Title>
         <div
           style={{
             width: "50%",
@@ -71,11 +72,7 @@ export default function Executables(props: Props) {
       <Head title="Executables in CoCalc" />
       <Layout>
         <Header page="software" subPage="executables" softwareEnv={name} />
-        <Layout.Content
-          style={{
-            backgroundColor: "white",
-          }}
-        >
+        <Layout.Content style={{ backgroundColor: "white" }}>
           <div style={STYLE_PAGE_WIDE}>
             {renderInfo()}
             <ExecutablesTable

--- a/src/packages/next/pages/software/index.tsx
+++ b/src/packages/next/pages/software/index.tsx
@@ -31,7 +31,7 @@ import JuliaJupyter from "/public/software/julia-jupyter.png";
 export const STYLE_PAGE: React.CSSProperties = {
   maxWidth: MAX_WIDTH,
   margin: "0 auto",
-  padding: "0 15px",
+  padding: "40px 15px 0 15px",
   backgroundColor: "white",
 } as const;
 

--- a/src/packages/next/pages/software/octave/[name].tsx
+++ b/src/packages/next/pages/software/octave/[name].tsx
@@ -4,15 +4,16 @@
  */
 
 import { Alert, Layout } from "antd";
+
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
 import Image from "components/landing/image";
 import SoftwareLibraries from "components/landing/software-libraries";
+import { Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
-import { SoftwareEnvNames } from "lib/landing/consts";
 import { Customize, CustomizeType } from "lib/customize";
-import { Paragraph } from "components/misc";
+import { SoftwareEnvNames } from "lib/landing/consts";
 import { ExecutableDescription } from "lib/landing/render-envs";
 import { withCustomizedAndSoftwareSpec } from "lib/landing/software-specs";
 import {
@@ -86,11 +87,9 @@ export default function Octave(props: Props) {
           }}
         >
           <div style={STYLE_PAGE}>
-            <h1
-              style={{ textAlign: "center", fontSize: "32pt", color: "#444" }}
-            >
+            <Title level={1} style={{ textAlign: "center" }}>
               GNU Octave Scientific Programming Packages (Ubuntu {name})
-            </h1>
+            </Title>
             {renderInfo()}
             {renderBox()}
             <ExecutableDescription spec={spec} execInfo={execInfo} />

--- a/src/packages/next/pages/software/python/[name].tsx
+++ b/src/packages/next/pages/software/python/[name].tsx
@@ -10,10 +10,10 @@ import Head from "components/landing/head";
 import Header from "components/landing/header";
 import Image from "components/landing/image";
 import SoftwareLibraries from "components/landing/software-libraries";
+import { Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
-import { SoftwareEnvNames } from "lib/landing/consts";
-import { Paragraph } from "components/misc";
 import { Customize, CustomizeType } from "lib/customize";
+import { SoftwareEnvNames } from "lib/landing/consts";
 import { ExecutableDescription } from "lib/landing/render-envs";
 import { withCustomizedAndSoftwareSpec } from "lib/landing/software-specs";
 import {
@@ -36,7 +36,8 @@ interface Props {
 }
 
 export default function Software(props: Props) {
-  const { name, customize, spec, inventory, components, execInfo, timestamp } = props;
+  const { name, customize, spec, inventory, components, execInfo, timestamp } =
+    props;
 
   function renderBox() {
     return (
@@ -65,9 +66,9 @@ export default function Software(props: Props) {
   function renderIntro() {
     return (
       <>
-        <h1 style={{ textAlign: "center", fontSize: "32pt", color: "#444" }}>
+        <Title level={1} style={{ textAlign: "center" }}>
           Installed Python Libraries (Ubuntu {name})
-        </h1>
+        </Title>
         <div style={{ width: "50%", float: "right", padding: "0 0 15px 15px" }}>
           <Image
             src={pythonScreenshot}

--- a/src/packages/next/pages/software/r/[name].tsx
+++ b/src/packages/next/pages/software/r/[name].tsx
@@ -5,12 +5,12 @@
 
 import { Alert, Layout } from "antd";
 
-import { Paragraph } from "components/misc";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
 import Image from "components/landing/image";
 import SoftwareLibraries from "components/landing/software-libraries";
+import { Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
 import { Customize, CustomizeType } from "lib/customize";
 import { SoftwareEnvNames } from "lib/landing/consts";
@@ -91,18 +91,14 @@ export default function R(props: Props) {
           }}
         >
           <div style={STYLE_PAGE}>
-            <h1
-              style={{
-                textAlign: "center",
-                fontSize: "32pt",
-                color: "#444",
-              }}
-            >
+            <Title level={1} style={{ textAlign: "center" }}>
               Installed R Statistical Software Packages (Ubuntu {name})
-            </h1>
+            </Title>
             {renderIntro()}
             {renderBox()}
-            <h2 style={{ clear: "both" }}>Available Environments</h2>
+            <Title level={2} style={{ clear: "both" }}>
+              Available Environments
+            </Title>
             <ExecutableDescription spec={spec} execInfo={execInfo} />
             <SoftwareLibraries
               timestamp={timestamp}

--- a/src/packages/next/pages/software/sagemath/[name].tsx
+++ b/src/packages/next/pages/software/sagemath/[name].tsx
@@ -4,15 +4,16 @@
  */
 
 import { Alert, Layout } from "antd";
+
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
 import Image from "components/landing/image";
 import SoftwareLibraries from "components/landing/software-libraries";
+import { Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
-import { SoftwareEnvNames } from "lib/landing/consts";
 import { Customize, CustomizeType } from "lib/customize";
-import { Paragraph } from "components/misc";
+import { SoftwareEnvNames } from "lib/landing/consts";
 import { ExecutableDescription } from "lib/landing/render-envs";
 import { withCustomizedAndSoftwareSpec } from "lib/landing/software-specs";
 import {
@@ -20,8 +21,8 @@ import {
   ComputeInventory,
   SoftwareSpec,
 } from "lib/landing/types";
-import { STYLE_PAGE } from "..";
 import sageScreenshot from "public/features/sage-worksheet.png";
+import { STYLE_PAGE } from "..";
 
 interface Props {
   name: SoftwareEnvNames;
@@ -90,11 +91,9 @@ export default function SageMath(props: Props) {
           }}
         >
           <div style={STYLE_PAGE}>
-            <h1
-              style={{ textAlign: "center", fontSize: "32pt", color: "#444" }}
-            >
+            <Title level={1} style={{ textAlign: "center" }}>
               SageMath (Ubuntu {name})
-            </h1>
+            </Title>
             {renderInfo()}
             {renderBox()}
             <ExecutableDescription spec={spec} execInfo={execInfo} />


### PR DESCRIPTION


# Description

this is just a small details that bugged me. on the next/software pages, when switching the software environment, it always jumped back to the executables sub-page. this gets rid of that behavior.

Also, a bit of title/css cosmetics.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
