### PR TITLE
Tweak servers jupyterlab issue 6492

### DIFF
--- a/src/packages/frontend/project/page/file-tab.tsx
+++ b/src/packages/frontend/project/page/file-tab.tsx
@@ -73,7 +73,7 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
   servers: {
     label: SERVERS_TITLE,
     icon: "server",
-    tooltip: "Servers running in this project (e.g., Jupyter, Pluto, …)",
+    tooltip: "Launch servers: e.g., Jupyter, Pluto, …",
     noAnonymous: true,
   },
   info: {

--- a/src/packages/project/named-servers/list.ts
+++ b/src/packages/project/named-servers/list.ts
@@ -36,25 +36,57 @@ I also saw almost exactly this happen in the JupyterLab weekly meeting
 with the latest beta in early November (that was even worse, since refreshing
 maybe didn't even work).
 */
-const JUPYTERLAB_RTC = false;
+
+// If you want to enable it, set the environment variable in Project Settings {"COCALC_JUPYTERLAB_RTC": "true"}
+const JUPYTERLAB_RTC = process.env.COCALC_JUPYTERLAB_RTC === "true";
+
+// iopub params for jupyter notebook
+const JUPYTERNB_DATA =
+  process.env.COCALC_JUPYTER_NOTEBOOK_iopub_data_rate_limit ?? 2000000;
+const JUPYTERNB_MSGS =
+  process.env.COCALC_JUPYTER_NOTEBOOK_iopub_msg_rate_limit ?? 50;
+
+// iopub params for jupyter lab
+const JUPYTERLAB_DATA =
+  process.env.COCALC_JUPYTER_LAB_iopub_data_rate_limit ?? 2000000;
+const JUPYTERLAB_MSGS =
+  process.env.COCALC_JUPYTER_LAB_iopub_msg_rate_limit ?? 50;
 
 const SPEC: { [name in NamedServerName]: CommandFunction } = {
   code: (ip: string, port: number) =>
     `code-server --bind-addr=${ip}:${port} --auth=none`,
   jupyter: (ip: string, port: number, basePath: string) =>
-    `jupyter notebook --port-retries=0 --no-browser --NotebookApp.iopub_data_rate_limit=${
-      process.env.COCALC_JUPYTER_NOTEBOOK_iopub_data_rate_limit ?? 2000000
-    } --NotebookApp.iopub_msg_rate_limit=${
-      process.env.COCALC_JUPYTER_NOTEBOOK_iopub_msg_rate_limit ?? 50
-    } --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_remote_access=True --NotebookApp.mathjax_url=/cdn/mathjax/MathJax.js --NotebookApp.base_url=${basePath} --ip=${ip} --port=${port}`,
+    [
+      `jupyter notebook`,
+      `--port-retries=0`,
+      `--no-browser`,
+      `--NotebookApp.iopub_data_rate_limit=${JUPYTERNB_DATA}`,
+      `--NotebookApp.iopub_msg_rate_limit=${JUPYTERNB_MSGS}`,
+      // we run Jupyter NB without authentication, because everything is proxied through CoCalc anyway
+      `--NotebookApp.token='' --NotebookApp.password=''`,
+      `--NotebookApp.allow_remote_access=True`,
+      `--NotebookApp.mathjax_url=/cdn/mathjax/MathJax.js`,
+      `--NotebookApp.base_url=${basePath} --ip=${ip} --port=${port}`,
+    ].join(" "),
   jupyterlab: (ip: string, port: number, basePath: string) =>
-    `jupyter lab --port-retries=0 --no-browser --NotebookApp.iopub_data_rate_limit=${
-      process.env.COCALC_JUPYTER_LAB_iopub_data_rate_limit ?? 2000000
-    } --NotebookApp.iopub_msg_rate_limit=${
-      process.env.COCALC_JUPYTER_LAB_iopub_msg_rate_limit ?? 50
-    } --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_remote_access=True --NotebookApp.mathjax_url=/cdn/mathjax/MathJax.js --NotebookApp.base_url=${basePath} --ip=${ip} --port=${port} ${
-      JUPYTERLAB_RTC ? "--collaborative" : ""
-    }`,
+    [
+      "jupyter lab",
+      `--port-retries=0`, // don't try another port, only the one we specified will work
+      `--no-browser`, // don't open a browser – the UI does this if appliable
+      `--NotebookApp.iopub_data_rate_limit=${JUPYTERLAB_DATA}`,
+      `--NotebookApp.iopub_msg_rate_limit=${JUPYTERLAB_MSGS}`,
+      // we run Jupyter Lab without authentication, because everything is proxied through CoCalc anyway
+      `--NotebookApp.token='' --NotebookApp.password=''`,
+      // additionally to the above, and since several Jupyter Lab across projects might interfere with each other, we disable XSRF protection
+      // see https://github.com/sagemathinc/cocalc/issues/6492
+      `--ServerApp.disable_check_xsrf=True`, // Ref: https://jupyter-server.readthedocs.io/en/latest/other/full-config.html
+      `--NotebookApp.allow_remote_access=True`,
+      `--NotebookApp.mathjax_url=/cdn/mathjax/MathJax.js`,
+      `--NotebookApp.base_url=${basePath}`,
+      `--ip=${ip}`,
+      `--port=${port}`,
+      `${JUPYTERLAB_RTC ? "--collaborative" : ""}`,
+    ].join(" "),
   pluto: (ip: string, port: number) =>
     `echo 'import Pluto; Pluto.run(launch_browser=false, require_secret_for_access=false, host="${ip}", port=${port})' | julia`,
 } as const;


### PR DESCRIPTION
# Description

- fix #6492 by disabling it
- make jupyter lab's RTC configurable (env var)
- make the command more readable by splitting it, and adding some comments about what they are
- fix #6490 

Testing: what I checked was starting both jupyter servers in my dev project. Not sure how to trigger the xsrf cookie problem … but well, I added a link to the docs in the sources, which imply this will fix it :man_shrugging: 


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
