### PR TITLE
next/billing/subscriptions: fix the "cost" column

### DIFF
--- a/src/packages/next/components/billing/subscriptions.tsx
+++ b/src/packages/next/components/billing/subscriptions.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { Icon } from "@cocalc/frontend/components/icon";
 import { capitalize, cmp, planInterval, stripeAmount } from "@cocalc/util/misc";
 import License from "components/licenses/license";
-import { CSS, Paragraph, Title } from "components/misc";
+import { CSS, Paragraph, Text, Title } from "components/misc";
 import A from "components/misc/A";
 import HelpEmail from "components/misc/help-email";
 import Timestamp from "components/misc/timestamp";
@@ -18,16 +18,36 @@ import apiPost from "lib/api/post";
 import useAPI from "lib/hooks/api";
 import useIsMounted from "lib/hooks/mounted";
 import { Details as LicenseLoader } from "../licenses/license";
+import { InvoicesData } from "@cocalc/util/types/stripe";
 
-function Description(props) {
+const DESCR_STYLE: CSS = {
+  wordWrap: "break-word",
+  wordBreak: "break-word",
+} as const;
+
+function getInvoiceById(invoices, id) {
+  for (const invoice of invoices.data ?? []) {
+    if (invoice.id == id) return invoice;
+  }
+  return null;
+}
+
+interface DescriptionProps {
+  latest_invoice: string;
+  metadata?: { license_id: string };
+  invoices: InvoicesData;
+}
+
+function Description(props: DescriptionProps) {
   const { latest_invoice, metadata, invoices } = props;
-  const style: CSS = { wordWrap: "break-word", wordBreak: "break-word" };
-  for (const invoice of invoices.data) {
-    if (latest_invoice != invoice.id) continue;
-    const cnt = invoice.lines?.total_count ?? 1;
+
+  const invoice = getInvoiceById(invoices, latest_invoice);
+
+  if (invoice?.lines != null) {
+    const cnt = invoice.lines.total_count ?? 1;
     const url = invoice.hosted_invoice_url;
     return (
-      <div style={style}>
+      <div style={DESCR_STYLE}>
         {invoice.lines.data[0].description}
         {cnt > 1 && ", etc."}
         {url && (
@@ -45,10 +65,11 @@ function Description(props) {
       </div>
     );
   }
+
   // in case the above didn't return, i.e. invoice was not found in the invoices.data array, we try to load it:
   if (metadata?.license_id) {
     return (
-      <div style={style}>
+      <div style={DESCR_STYLE}>
         <LicenseLoader license_id={metadata.license_id} condensed={true} />
         License: <License license_id={metadata.license_id} />
       </div>
@@ -80,26 +101,50 @@ function Status({ status }) {
   return <>{capitalize(status)}</>;
 }
 
-function Cost({ plan }) {
-  return (
-    <>
-      {stripeAmount(plan.amount, plan.currency)} for{" "}
-      {planInterval(plan.interval, plan.interval_count)}
-    </>
-  );
+interface CostProps {
+  latest_invoice: string;
+  plan: {
+    amount: number;
+    currency: string;
+    interval: string;
+    interval_count: number;
+  };
+  invoices: InvoicesData;
+  metadata?: { license_id: string };
 }
 
-function Cancel({
-  cancel_at_period_end,
-  cancel_at,
-  id,
-  onChange,
-}: {
+function Cost({ latest_invoice, plan, invoices, metadata }: CostProps) {
+  const invoice = getInvoiceById(invoices, latest_invoice);
+  if (invoice != null) {
+    const unitCount = invoice.lines?.data?.[0].quantity ?? 1;
+    return (
+      <>
+        {stripeAmount(plan.amount, plan.currency, unitCount)} for{" "}
+        {planInterval(plan.interval, plan.interval_count)}
+      </>
+    );
+    // since no invoice has been not found in the invoices.data array, we try to load it:
+  } else if (metadata?.license_id) {
+    return (
+      <LicenseLoader
+        license_id={metadata.license_id}
+        type={"cost"}
+        plan={plan}
+      />
+    );
+  }
+  return <Text type="secondary">no data available</Text>;
+}
+
+interface CancelProps {
   cancel_at_period_end: boolean;
   cancel_at: number | null;
   id: string;
   onChange: () => void;
-}) {
+}
+
+function Cancel(props: CancelProps) {
+  const { cancel_at_period_end, cancel_at, id, onChange } = props;
   const [error, setError] = useState<string>("");
   const [canceling, setCanceling] = useState<boolean>(false);
   const isMounted = useIsMounted();
@@ -166,7 +211,7 @@ function columns(invoices, onChange) {
           <br />
           Period: <Period {...sub} />
           <br />
-          Cost: <Cost {...sub} />
+          Cost: <Cost {...sub} invoices={invoices} />
           <br />
           <Cancel {...sub} onChange={onChange} />
         </div>
@@ -195,7 +240,7 @@ function columns(invoices, onChange) {
       responsive: ["sm"],
       title: "Cost",
       sorter: { compare: (a, b) => cmp(a.plan.amount, b.plan.amount) },
-      render: (_, sub) => <Cost {...sub} />,
+      render: (_, sub) => <Cost {...sub} invoices={invoices} />,
     },
     {
       responsive: ["sm"],

--- a/src/packages/server/billing/get-invoices-and-receipts.ts
+++ b/src/packages/server/billing/get-invoices-and-receipts.ts
@@ -1,9 +1,10 @@
 import { StripeClient } from "@cocalc/server/stripe/client";
 import { isValidUUID } from "@cocalc/util/misc";
+import { InvoicesData } from "@cocalc/util/types/stripe";
 
 export default async function getInvoicesAndReceipts(
   account_id: string
-): Promise<object> {
+): Promise<InvoicesData> {
   if (!isValidUUID(account_id)) {
     throw Error("invalid uuid");
   }

--- a/src/packages/server/stripe/client.ts
+++ b/src/packages/server/stripe/client.ts
@@ -5,21 +5,22 @@
 
 import { reuseInFlight } from "async-await-utils/hof";
 import { callback } from "awaiting";
-import { callback2 } from "@cocalc/util/async-utils";
-import * as message from "@cocalc/util/message";
-import { available_upgrades, get_total_upgrades } from "@cocalc/util/upgrades";
-import type { PostgreSQL } from "@cocalc/database/postgres/types";
-import {
-  setStripeCustomerId,
-  getStripeCustomerId,
-} from "@cocalc/database/postgres/stripe";
-import stripeName from "@cocalc/util/stripe/name";
-import { db } from "@cocalc/database";
 import Stripe from "stripe";
 export { Stripe };
-import getPrivateProfile from "@cocalc/server/accounts/profile/private";
-import { syncCustomer } from "@cocalc/database/postgres/stripe";
 
+import { db } from "@cocalc/database";
+import {
+  getStripeCustomerId,
+  setStripeCustomerId,
+  syncCustomer,
+} from "@cocalc/database/postgres/stripe";
+import type { PostgreSQL } from "@cocalc/database/postgres/types";
+import getPrivateProfile from "@cocalc/server/accounts/profile/private";
+import { callback2 } from "@cocalc/util/async-utils";
+import * as message from "@cocalc/util/message";
+import stripeName from "@cocalc/util/stripe/name";
+import { InvoicesData } from "@cocalc/util/types/stripe";
+import { available_upgrades, get_total_upgrades } from "@cocalc/util/upgrades";
 import getConn from "./connection";
 import salesTax from "./sales-tax";
 
@@ -481,7 +482,9 @@ export class StripeClient {
     return message.stripe_charges({ charges });
   }
 
-  public async mesg_get_invoices(mesg: Message): Promise<Message> {
+  public async mesg_get_invoices(
+    mesg: Message
+  ): Promise<{ invoices: InvoicesData }> {
     const dbg = this.dbg("mesg_get_invoices");
     dbg("get a list of invoices for this customer");
     const options = await this.stripe_api_pager_options(mesg);

--- a/src/packages/util/misc.ts
+++ b/src/packages/util/misc.ts
@@ -1715,12 +1715,16 @@ export function to_money(n: number): string {
   return n.toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, "$1,");
 }
 
-export function stripeAmount(units: number, currency: string): string {
+export function stripeAmount(
+  unitPrice: number,
+  currency: string,
+  units = 1
+): string {
   // input is in pennies
   if (currency !== "usd") {
     throw Error(`not-implemented currency ${currency}`);
   }
-  let s = `$${to_money(units / 100)} USD`;
+  let s = `$${to_money((units * unitPrice) / 100)} USD`;
   return s;
 }
 

--- a/src/packages/util/types/stripe.ts
+++ b/src/packages/util/types/stripe.ts
@@ -1,0 +1,14 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// used by next/v2 api
+
+export type InvoicesData = {
+  data?: {
+    id: string;
+    lines?: { data: { description: string }[]; total_count?: number };
+    hosted_invoice_url: string;
+  }[];
+};


### PR DESCRIPTION
# Description

Right now, the "Cost" column in the overview of subscriptions only lists the cost for a single unit. I.e. run limit/quantity is not taken into account. This was a bit tricky, because the info is actually in the license data, but that isn't always available (like, it is for the description column as well). In any case, here are two rows from my dev project, shows the actual cost in the cost column.

(I'm also adding some typing to have less surprises about which field is where, etc.)

![Screenshot from 2023-03-09 11-19-00](https://user-images.githubusercontent.com/207405/223994706-bd5cc418-5146-47ce-ba01-339b2bd51a4d.png)

![Screenshot from 2023-03-09 11-18-39](https://user-images.githubusercontent.com/207405/223994775-f82c856a-ff54-4262-b606-eaca33039a47.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
