### PR TITLE
next/npm: do not call build-dev twice from build target

### DIFF
--- a/src/packages/next/package.json
+++ b/src/packages/next/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "build": "pnpm build-dev && npx next telemetry disable && rm -rf .next && pnpm build-dev && NODE_OPTIONS='--max_old_space_size=8000' next build",
+    "build": "npx next telemetry disable && rm -rf .next && pnpm build-dev && NODE_OPTIONS='--max_old_space_size=8000' next build",
     "build-dev": "rm -rf dist && pnpm software && npx tsc --build tsconfig-dist.json",
     "tsc": "npx tsc --build tsconfig-dist.json -w --pretty --preserveWatchOutput ",
     "software": "bash ./software-inventory/setup.sh",


### PR DESCRIPTION
# Description

This is just tiny, and we discussed this and forgot about it. I think that build-dev step (the first one of two) in next's build target is pointless. I was wondering if this should be "build-deps" instead, but well, I don't think so. We always call make-dev (and that workspaces script). So, with that change it's more straight to the point.

Why the change? Running build-dev twice wastes a lot of time.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
