### PR TITLE
next/index: "fake" logo for on-prem has a closing bracket

### DIFF
--- a/src/packages/next/components/logo.tsx
+++ b/src/packages/next/components/logo.tsx
@@ -80,7 +80,6 @@ export default function Logo(props: Props) {
             width: "50%",
           }}
         />
-        )
         <div>
           <Image
             src={logoRectangularURL}


### PR DESCRIPTION
# Description

I guess by mistake, 5088bddeb4584dbceed5c6c19c3cd4d4799c403c introduced a closing bracket, which is visible on the HTML page

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
