### PR TITLE
server/sso: additional heuristic if no first and last name in profile

### DIFF
--- a/src/packages/server/auth/sso/openid-parser.ts
+++ b/src/packages/server/auth/sso/openid-parser.ts
@@ -3,6 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { firstLetterUppercase } from "@cocalc/util/misc";
 import { Profile } from "passport";
 import { PassportTypes } from "./types";
 
@@ -30,17 +31,28 @@ export function parseOpenIdProfile(
     // realname usually have form  «FirstName MiddleName… LastName»
     const [first, ...last] = json.realname.split(" ");
     profile.name = {
-        givenName: first,
-        familyName: last.join(" "), // Or we should get last[-1]?
-    };
-  } else if (json.email) { // no name? we use the email address
-    // don't include dots, because our "spam protection" rejects domain-like patterns
-    const emailacc = json.email.split("@")[0].split(".");
-    const [first, ...last] = emailacc; // last is always at least []
-    profile.name = {
       givenName: first,
-      familyName: last.join(" "),
+      familyName: last.join(" "), // Or we should get last[-1]?
     };
+  } else if (json.email) {
+    // no name? we use the email address
+    // don't include dots, because our "spam protection" rejects domain-like patterns
+    const emailacc = json.email
+      .split("@")[0]
+      .split(".")
+      .map(firstLetterUppercase);
+    if (emailacc.length > 1) {
+      const [first, ...last] = emailacc;
+      profile.name = {
+        givenName: first,
+        familyName: last.join(" "),
+      };
+    } else {
+      profile.name = {
+        givenName: "",
+        familyName: emailacc.join(" "),
+      };
+    }
   }
 
   if (json.email) {

--- a/src/packages/server/auth/sso/passport-login.ts
+++ b/src/packages/server/auth/sso/passport-login.ts
@@ -126,7 +126,7 @@ export class PassportLogin {
       locals.cookies.set(API_KEY_COOKIE_NAME);
     }
 
-    sanitizeProfile(this.opts);
+    sanitizeProfile(this.opts, logger.extend("sanitizeProfile").debug);
 
     // L({ locals, opts }); // DANGER -- do not uncomment except for debugging due to SECURITY
 

--- a/src/packages/server/auth/sso/sanitize-profile.ts
+++ b/src/packages/server/auth/sso/sanitize-profile.ts
@@ -3,14 +3,17 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { is_valid_email_address } from "@cocalc/util/misc";
 import { PassportLoginOpts } from "@cocalc/server/auth/sso/types";
+import {
+  firstLetterUppercase,
+  is_valid_email_address,
+} from "@cocalc/util/misc";
 
 // this processes the profile, based on our general experience
 // in particular, an interesting detail to add would be to derive a "name" if
 // there is just an email address given. (there are workarounds for OAuth2 elsewhere)
 
-export function sanitizeProfile(opts: PassportLoginOpts): void {
+export function sanitizeProfile(opts: PassportLoginOpts, L: Function): void {
   if (
     opts.full_name != null &&
     opts.first_name == null &&
@@ -38,5 +41,26 @@ export function sanitizeProfile(opts: PassportLoginOpts): void {
     opts.emails = email_arr
       .filter((x) => typeof x === "string" && is_valid_email_address(x))
       .map((x) => x.toLowerCase());
+  }
+
+  // Heuristic: even though there is this "parseOpenIdProfile" function,
+  // in some cases it isn't called properly or there is just an error querying the userinfo endpoint.
+  // In any case, this tries to extract the name from the email address.
+  if (!opts.first_name && !opts.last_name) {
+    const email = opts.emails?.[0]; // from the above, we know this is valid or there is no email at all
+    L(`No name, trying to extract from email address '${email}'`);
+    if (email) {
+      // don't include dots, because our "spam protection" rejects domain-like patterns
+      const emailacc = email.split("@")[0].split(".").map(firstLetterUppercase);
+      if (emailacc.length > 1) {
+        // last is always at least an array with the part before @
+        const [first, ...last] = emailacc;
+        opts.first_name = first;
+        opts.last_name = last.join(" ");
+      } else {
+        opts.first_name = "";
+        opts.last_name = emailacc.join(" ");
+      }
+    }
   }
 }

--- a/src/packages/util/misc.test.ts
+++ b/src/packages/util/misc.test.ts
@@ -127,3 +127,13 @@ describe("json patch test", () => {
     expect(j([{ op: "replacce", path: "/biscuits/0/name" }])).toBe(false);
   });
 });
+
+test("firstLetterUppercase", () => {
+  const s = misc.firstLetterUppercase;
+  expect(s(undefined)).toBe("");
+  expect(s("")).toBe("");
+  expect(s("a")).toBe("A");
+  expect(s("abc")).toBe("Abc");
+  expect(s("ABC")).toBe("ABC");
+  expect(s("aBC")).toBe("ABC");
+});

--- a/src/packages/util/misc.ts
+++ b/src/packages/util/misc.ts
@@ -2378,3 +2378,8 @@ export function rowBackground({
     return "white";
   }
 }
+
+export function firstLetterUppercase(str: string | undefined) {
+  if (str == null) return "";
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
# Description

There is a stupid edge case,where querying the OAuth2 endpoint for the userinfo does not work (no idea why) and still no name info comes back. This adds the same heuristic that would clean up the profile to the general `sanitizeProfile` function, i.e. that `if (!opts.first_name && !opts.last_name) {` case.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
