### PR TITLE
next: reduce size of assets

### DIFF
--- a/src/packages/next/lib/landing/consts.ts
+++ b/src/packages/next/lib/landing/consts.ts
@@ -3,10 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { fromPairs } from "lodash";
-
-import { EnvData } from "./types";
-
 export const LANGUAGE_NAMES = [
   "python",
   "R",
@@ -20,21 +16,3 @@ export const LANGUAGE_NAMES = [
 export const SOFTWARE_ENV_NAMES = ["22.04", "20.04", "18.04"] as const;
 export const SOFTWARE_ENV_DEFAULT = "20.04";
 export type SoftwareEnvNames = typeof SOFTWARE_ENV_NAMES[number];
-
-export const SOFTWARE_URLS: { [key in SoftwareEnvNames]: string } = fromPairs(
-  SOFTWARE_ENV_NAMES.map((name) => [
-    name,
-    `https://storage.googleapis.com/cocalc-compute-environment/software-inventory-${name}.json`,
-  ])
-);
-
-import SOFTWARE_1804 from "dist/software-inventory/18.04.json";
-import SOFTWARE_2004 from "dist/software-inventory/20.04.json";
-import SOFTWARE_2204 from "dist/software-inventory/22.04.json";
-
-// Note: we need to be explicit with these rougher types, because TS can't infer them from the JSON files since they're too large.
-export const SOFTWARE_FALLBACK: { [key in SoftwareEnvNames]: EnvData } = {
-  "18.04": SOFTWARE_1804 as EnvData,
-  "20.04": SOFTWARE_2004 as EnvData,
-  "22.04": SOFTWARE_2204 as EnvData,
-} as const;

--- a/src/packages/next/lib/landing/landing.test.ts
+++ b/src/packages/next/lib/landing/landing.test.ts
@@ -5,7 +5,8 @@
 
 import { toPairs } from "lodash";
 
-import { SOFTWARE_ENV_NAMES, SOFTWARE_FALLBACK, SOFTWARE_URLS } from "./consts";
+import { SOFTWARE_ENV_NAMES } from "./consts";
+import { SOFTWARE_FALLBACK, SOFTWARE_URLS } from "./software-data";
 import { EnvData } from "./types";
 
 test("3 known software environments", () => {

--- a/src/packages/next/lib/landing/software-data.ts
+++ b/src/packages/next/lib/landing/software-data.ts
@@ -1,0 +1,29 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// NOTE: this pulls in a lot of data. Make sure to never load it indirectly from a page.
+
+import { fromPairs } from "lodash";
+
+import { SoftwareEnvNames, SOFTWARE_ENV_NAMES } from "./consts";
+import { EnvData } from "./types";
+
+import SOFTWARE_1804 from "dist/software-inventory/18.04.json";
+import SOFTWARE_2004 from "dist/software-inventory/20.04.json";
+import SOFTWARE_2204 from "dist/software-inventory/22.04.json";
+
+export const SOFTWARE_URLS: { [key in SoftwareEnvNames]: string } = fromPairs(
+  SOFTWARE_ENV_NAMES.map((name) => [
+    name,
+    `https://storage.googleapis.com/cocalc-compute-environment/software-inventory-${name}.json`,
+  ])
+);
+
+// Note: we need to be explicit with these rougher types, because TS can't infer them from the JSON files since they're too large.
+export const SOFTWARE_FALLBACK: { [key in SoftwareEnvNames]: EnvData } = {
+  "18.04": SOFTWARE_1804 as EnvData,
+  "20.04": SOFTWARE_2004 as EnvData,
+  "22.04": SOFTWARE_2204 as EnvData,
+} as const;

--- a/src/packages/next/lib/landing/software-specs.ts
+++ b/src/packages/next/lib/landing/software-specs.ts
@@ -10,12 +10,8 @@ import { basename } from "node:path";
 
 import { hours_ago } from "@cocalc/util/relative-time";
 import withCustomize from "lib/with-customize";
-import {
-  SoftwareEnvNames,
-  SOFTWARE_ENV_NAMES,
-  SOFTWARE_FALLBACK,
-  SOFTWARE_URLS,
-} from "./consts";
+import { SoftwareEnvNames, SOFTWARE_ENV_NAMES } from "./consts";
+import { SOFTWARE_FALLBACK, SOFTWARE_URLS } from "./software-data";
 import {
   ComputeComponents,
   ComputeInventory,


### PR DESCRIPTION
# Description

I noticed performance issues upon loading the pages. This split next/landing/consts up to avoid loading the software fallback data. There are probably other such silly details going on as well. This should also help with next.js development, because there is less client code to keep track of.

next.js full build on master:

```
Route (pages)                                    Size     First Load JS
┌ λ /                                            8.8 kB         4.96 MB
```

after the first commit:

```
Route (pages)                                    Size     First Load JS
┌ λ /                                            8.8 kB          1.3 MB
```

… I looked further, and what I saw are many embedded source maps. I don't know if they're also in production, because the files looks different from  my build. Well, could be something for another investigation. 


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
