### PR TITLE
next/sso: StrategyAvatar icons referenced by an URL are cut off on the right

### DIFF
--- a/src/packages/next/components/auth/sso.tsx
+++ b/src/packages/next/components/auth/sso.tsx
@@ -3,17 +3,18 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Alert, Avatar, Tooltip, Typography } from "antd";
+import { useRouter } from "next/router";
+import { join } from "path";
+import { CSSProperties, ReactNode, useMemo } from "react";
+
 import { Icon } from "@cocalc/frontend/components/icon";
 import { checkRequiredSSO } from "@cocalc/server/auth/sso/check-required-sso";
 import { PRIMARY_SSO } from "@cocalc/util/types/passport-types";
 import { Strategy } from "@cocalc/util/types/sso";
-import { Alert, Avatar, Tooltip, Typography } from "antd";
 import Loading from "components/share/loading";
 import basePath from "lib/base-path";
 import { useCustomize } from "lib/customize";
-import { useRouter } from "next/router";
-import { join } from "path";
-import { CSSProperties, ReactNode, useMemo } from "react";
 
 const { Link: AntdLink } = Typography;
 
@@ -145,7 +146,6 @@ export function StrategyAvatar(props: AvatarProps) {
           style={{
             height: `${size - 2}px`,
             width: `${size - 2}px`,
-            marginLeft: "2.5px",
             objectFit: "contain",
           }}
         />

--- a/src/packages/next/pages/sso/index.tsx
+++ b/src/packages/next/pages/sso/index.tsx
@@ -3,8 +3,10 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { to_human_list } from "@cocalc/util/misc";
 import { Card, Col, Layout, Row, Typography } from "antd";
+import Link from "next/link";
+
+import { to_human_list } from "@cocalc/util/misc";
 import { StrategyAvatar } from "components/auth/sso";
 import Footer from "components/landing/footer";
 import Head from "components/landing/head";
@@ -15,7 +17,6 @@ import { Customize, CustomizeType } from "lib/customize";
 import { getSSO } from "lib/sso/sso";
 import { SSO } from "lib/sso/types";
 import withCustomize from "lib/with-customize";
-import Link from "next/link";
 
 const { Paragraph, Text } = Typography;
 


### PR DESCRIPTION
# Description

There is a mysterious (?) margin on the left. Removing this turns this

![Screenshot from 2023-03-23 15-48-44](https://user-images.githubusercontent.com/207405/227241323-fc5211f7-c2db-4a4c-b360-8fed9e13dfbb.png)

into 

![Screenshot from 2023-03-23 15-48-21](https://user-images.githubusercontent.com/207405/227241357-bbdb3b4a-cef1-49e0-b60a-f0ef5321fd99.png)




## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
