### PR TITLE
fix ChatGPT settings

### DIFF
--- a/src/packages/util/db-schema/site-settings-extras.ts
+++ b/src/packages/util/db-schema/site-settings-extras.ts
@@ -53,6 +53,8 @@ const pii_retention_display = (retention: string) => {
   }
 };
 
+const openai_enabled = (conf) => to_bool(conf.openai_enabled);
+
 export type SiteSettingsExtrasKeys =
   | "pii_retention"
   | "stripe_heading"
@@ -93,6 +95,20 @@ export type SettingsExtras = Record<SiteSettingsExtrasKeys, Config>;
 
 // not public, but admins can edit them
 export const EXTRAS: SettingsExtras = {
+  openai_section: {
+    name: "OpenAI Configuration",
+    desc: "",
+    default: "",
+    show: openai_enabled,
+    type: "header",
+  },
+  openai_api_key: {
+    name: "OpenAI API Key",
+    desc: "Your OpenAI API Key from https://platform.openai.com/account/api-keys.  This key is needed to support functionality that uses OpenAI's API.",
+    default: "",
+    password: true,
+    show: openai_enabled,
+  },
   pii_retention: {
     name: "PII Retention",
     desc: "How long to keep personally identifiable information, after which the server automatically deletes certain database entries that contain PII.",
@@ -200,20 +216,6 @@ export const EXTRAS: SettingsExtras = {
   github_token: {
     name: "GitHub Token",
     desc: "This is a Personal Access token for the above GitHub account.  You can get one at https://github.com/settings/tokens -- you do not have to enable any scopes -- it used only to increase rate limits from 60/hour to 5000/hour.",
-    default: "",
-    password: true,
-    show: () => true,
-  },
-  openai_section: {
-    name: "OpenAI Configuration",
-    desc: "",
-    default: "",
-    show: only_commercial,
-    type: "header",
-  },
-  openai_api_key: {
-    name: "OpenAI API Key",
-    desc: "Your OpenAI API Key from https://platform.openai.com/account/api-keys.  This key is needed to support functionality that uses OpenAI's API.",
     default: "",
     password: true,
     show: () => true,


### PR DESCRIPTION

# Description

- show ChatGPT api key in all UI modes
- make the API key config appear only if enabled
- hackish workaround: reorg it, to make them appear next to each other

![Screenshot from 2023-03-24 11-09-43](https://user-images.githubusercontent.com/207405/227492770-7142d9c0-5729-45f2-98f4-33e69135d3cd.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
