### PR TITLE
frontend/course: serial license distribution applies licenses to all student projects

### DIFF
--- a/src/packages/frontend/course/configuration/configuration-panel.tsx
+++ b/src/packages/frontend/course/configuration/configuration-panel.tsx
@@ -3,10 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-// CoCalc libraries
-import { webapp_client } from "@cocalc/frontend/webapp-client";
-import { contains_url, days_ago, plural } from "@cocalc/util/misc";
 import { debounce } from "lodash";
+import { Alert, Card, Row, Col } from "antd";
+
 // React libraries and Components
 import {
   React,
@@ -18,7 +17,10 @@ import {
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { Button, ButtonGroup, Checkbox } from "@cocalc/frontend/antd-bootstrap";
-import { Alert, Card, Row, Col } from "antd";
+
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import { contains_url, days_ago, plural } from "@cocalc/util/misc";
+
 // CoCalc Components
 import {
   DateTimePicker,

--- a/src/packages/frontend/course/configuration/upgrades.tsx
+++ b/src/packages/frontend/course/configuration/upgrades.tsx
@@ -5,6 +5,8 @@
 
 // Upgrading quotas for all student projects
 
+import { Alert, Card, Divider, Form, Radio, Switch, Typography } from "antd";
+
 import { alert_message } from "@cocalc/frontend/alerts";
 import {
   Button,
@@ -31,6 +33,7 @@ import {
   A,
   Icon,
   Loading,
+  Paragraph,
   Tip,
   UPGRADE_ERROR_STYLE,
 } from "@cocalc/frontend/components";
@@ -49,7 +52,7 @@ import {
   round2,
 } from "@cocalc/util/misc";
 import { PROJECT_UPGRADES } from "@cocalc/util/schema";
-import { Alert, Card, Form, Radio, Switch, Typography } from "antd";
+import { COLORS } from "@cocalc/util/theme";
 import { CourseActions } from "../actions";
 import {
   CourseSettingsRecord,
@@ -596,11 +599,12 @@ export const StudentProjectUpgrades: React.FC<Props> = (props: Props) => {
 
   function render_site_license_strategy() {
     return (
-      <div
+      <Paragraph
         style={{
-          margin: "15px",
-          border: "1px solid lightgrey",
+          margin: "0",
+          border: `1px solid ${COLORS.GRAY_L}`,
           padding: "15px",
+          borderRadius: "5px",
         }}
       >
         <b>License strategy:</b> Since you have multiple licenses, there are two
@@ -621,15 +625,27 @@ export const StudentProjectUpgrades: React.FC<Props> = (props: Props) => {
           <Radio value={"serial"} key={"serial"} style={radioStyle}>
             <b>Maximize number of covered students:</b> apply one license to
             each project associated to this course (e.g., you bought a license
-            to handle a few more students who added your course)
+            to handle a few more students who were added your course). If you
+            have more students than license seats, the first students to start
+            their projects will get the upgrades.
           </Radio>
           <Radio value={"parallel"} key={"parallel"} style={radioStyle}>
             <b>Maximize upgrades to each project:</b> apply all licenses to all
             projects associated to this course (e.g., you bought a license to
-            increase the RAM or CPU for all students)
+            increase the RAM or CPU for all students).
           </Radio>
         </Radio.Group>
-      </div>
+        <Divider type="horizontal" />
+        <Button
+          onClick={() =>
+            course_actions.configuration.configure_all_projects(true)
+          }
+          bsSize="small"
+        >
+          <Icon name="arrows" /> Redistribute licenses
+        </Button>{" "}
+        – e.g. useful if a license expired
+      </Paragraph>
     );
   }
 


### PR DESCRIPTION
# Description

I was thinking about this during a support request. IMHO it makes no real sense to bother with run limits when distributing licenses. Not all students might be active at the same time. So, what this does is to distribute the licenses in a round-robin fashion, where they're handed out proportional to the run limit. My reasoning is, this equals out the probability to get a license seat for each student.

This also adds a note about if there are more students than seats, the first one wins.

There is also a button to explicitly redistribute the licenses – e.g. if one expired, it should be removed from student projects.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
