### PR TITLE
frontend/file notifications less intense

### DIFF
--- a/src/packages/frontend/app/notifications.tsx
+++ b/src/packages/frontend/app/notifications.tsx
@@ -92,7 +92,7 @@ export const Notification: React.FC<Props> = React.memo((props: Props) => {
         return (
           <Badge
             showZero
-            color={count == 0 ? COLORS.GRAY : undefined}
+            color={count == 0 ? COLORS.GRAY : COLORS.GRAY_M}
             count={count}
             className={count > 0 ? "smc-bell-notification" : ""}
           />


### PR DESCRIPTION


# Description

 instead of alert-red, this is a subtle shade of gray change

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
