### PR TITLE
frontend/project/home: show recently active files on home page

### DIFF
--- a/src/packages/frontend/_projects.sass
+++ b/src/packages/frontend/_projects.sass
@@ -109,3 +109,8 @@
     font-size: 110%
   h6
     font-size: 105%
+
+li.cc-project-home-recent-files
+  cursor: pointer
+  &:hover
+    background-color: $COL_GRAY_LLL

--- a/src/packages/frontend/components/path-link.tsx
+++ b/src/packages/frontend/components/path-link.tsx
@@ -36,16 +36,6 @@ export const PathLink: React.FC<Props> = (props: Props) => {
     link = true,
   } = props;
 
-  function handle_click(e): void {
-    e.preventDefault();
-    const switch_to = should_open_in_foreground(e);
-    redux.getProjectActions(project_id).open_file({
-      path,
-      foreground: switch_to,
-      foreground_project: switch_to,
-    });
-  }
-
   function render_link(text): JSX.Element {
     let s;
     if (!endswith(text, "/")) {
@@ -66,8 +56,8 @@ export const PathLink: React.FC<Props> = (props: Props) => {
     if (link) {
       return (
         <a
-          onClick={handle_click}
-          style={{ color: COLORS.GRAY_M, fontWeight: "bold", ...style }}
+          onClick={(e) => handle_log_click(e, path, project_id)}
+          style={{ color: COLORS.GRAY_D, fontWeight: "bold", ...style }}
         >
           {s}
         </a>
@@ -97,3 +87,13 @@ export const PathLink: React.FC<Props> = (props: Props) => {
     return render_link(name);
   }
 };
+
+export function handle_log_click(e, path, project_id): void {
+  e.preventDefault();
+  const switch_to = should_open_in_foreground(e);
+  redux.getProjectActions(project_id).open_file({
+    path,
+    foreground: switch_to,
+    foreground_project: switch_to,
+  });
+}

--- a/src/packages/frontend/components/path-link.tsx
+++ b/src/packages/frontend/components/path-link.tsx
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { redux } from "../app-framework";
+import { redux } from "@cocalc/frontend/app-framework";
 import {
   endswith,
   path_split,
@@ -12,6 +12,7 @@ import {
   trunc_middle,
 } from "@cocalc/util/misc";
 import { Tip } from "./tip";
+import { COLORS } from "@cocalc/util/theme";
 
 interface Props {
   path: string;
@@ -24,12 +25,22 @@ interface Props {
 }
 
 // Component to attempt opening a cocalc path in a project
-export const PathLink: React.FC<Props> = (props) => {
+export const PathLink: React.FC<Props> = (props: Props) => {
+  const {
+    path,
+    project_id,
+    full = false,
+    trunc,
+    display_name,
+    style = {},
+    link = true,
+  } = props;
+
   function handle_click(e): void {
     e.preventDefault();
     const switch_to = should_open_in_foreground(e);
-    redux.getProjectActions(props.project_id).open_file({
-      path: props.path,
+    redux.getProjectActions(project_id).open_file({
+      path,
       foreground: switch_to,
       foreground_project: switch_to,
     });
@@ -52,33 +63,30 @@ export const PathLink: React.FC<Props> = (props) => {
     } else {
       s = text;
     }
-    if (props.link) {
+    if (link) {
       return (
         <a
           onClick={handle_click}
-          style={{ color: "#777", fontWeight: "bold", ...props.style }}
+          style={{ color: COLORS.GRAY_M, fontWeight: "bold", ...style }}
         >
           {s}
         </a>
       );
     } else {
-      return <span style={props.style}>{s}</span>;
+      return <span style={style}>{s}</span>;
     }
   }
 
-  const name = props.full ? props.path : path_split(props.path).tail;
+  const name = full ? path : path_split(path).tail;
   if (
-    (props.trunc != null && name.length > props.trunc) ||
-    (props.display_name != null && props.display_name !== name)
+    (trunc != null && name.length > trunc) ||
+    (display_name != null && display_name !== name)
   ) {
     let text;
-    if (props.trunc != null) {
-      text = trunc_middle(
-        props.display_name != null ? props.display_name : name,
-        props.trunc
-      );
+    if (trunc != null) {
+      text = trunc_middle(display_name != null ? display_name : name, trunc);
     } else {
-      text = props.display_name != null ? props.display_name : name;
+      text = display_name != null ? display_name : name;
     }
     return (
       <Tip title="" tip={name}>
@@ -88,10 +96,4 @@ export const PathLink: React.FC<Props> = (props) => {
   } else {
     return render_link(name);
   }
-};
-
-PathLink.defaultProps = {
-  style: {},
-  full: false,
-  link: true,
 };

--- a/src/packages/frontend/project/history/log.tsx
+++ b/src/packages/frontend/project/history/log.tsx
@@ -4,26 +4,27 @@
  */
 
 import { List } from "immutable";
-import { rowBackground, search_split, search_match } from "@cocalc/util/misc";
+import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
+
 import {
   React,
   redux,
-  TypedMap,
   Rendered,
+  TypedMap,
   useActions,
   useEffect,
   useForceUpdate,
-  useState,
   useRef,
+  useState,
   useTypedRedux,
-} from "../../app-framework";
-import { Button } from "antd";
-import { Icon, Loading } from "../../components";
-import { LogSearch } from "./search";
-import { LogEntry } from "./log-entry";
-import { EventRecord, to_search_string } from "./types";
-import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
+} from "@cocalc/frontend/app-framework";
+import { Icon, Loading } from "@cocalc/frontend/components";
 import useVirtuosoScrollHook from "@cocalc/frontend/components/virtuoso-scroll-hook";
+import { rowBackground, search_match, search_split } from "@cocalc/util/misc";
+import { Button } from "antd";
+import { LogEntry } from "./log-entry";
+import { LogSearch } from "./search";
+import { EventRecord, to_search_string } from "./types";
 
 interface Props {
   project_id: string;

--- a/src/packages/frontend/project/page/home-page/block.tsx
+++ b/src/packages/frontend/project/page/home-page/block.tsx
@@ -3,15 +3,14 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-export function Block({
-  children,
-  onClick,
-  style,
-}: {
-  children;
-  onClick?;
-  style?;
-}) {
+interface Props {
+  children: React.ReactNode;
+  onClick?: () => void;
+  style?: React.CSSProperties;
+}
+
+export function Block(props: Props) {
+  const { children, onClick, style } = props;
   return (
     <div
       onClick={onClick}
@@ -20,6 +19,7 @@ export function Block({
         maxWidth: "800px",
         height: "500px",
         border: "1px solid #ddd",
+        borderRadius: "10px",
         overflowY: "auto",
         ...style,
       }}

--- a/src/packages/frontend/project/page/home-page/index.tsx
+++ b/src/packages/frontend/project/page/home-page/index.tsx
@@ -3,99 +3,50 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Alert, Col, Row } from "antd";
-import { useState } from "react";
+import { Col, Row } from "antd";
+// import { useState } from "react";
 
-import {
-  redux,
-  useActions,
-  useEffect,
-  useRedux,
-} from "@cocalc/frontend/app-framework";
+import { useActions, useRedux } from "@cocalc/frontend/app-framework";
 import { Title } from "@cocalc/frontend/components";
 import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
 import { ProjectLog } from "@cocalc/frontend/project/history";
-import ProjectImage from "@cocalc/frontend/project/settings/image";
 import { ProjectTitle } from "@cocalc/frontend/projects/project-title";
 import ChatGPTGenerateJupyterNotebook from "./chatgpt-generate-jupyter";
 import { Block } from "./block";
-
-/*
-import { Explorer } from "@cocalc/frontend/project/explorer";
-import { ProjectNew } from "@cocalc/frontend/project/new";
-import { ProjectInfo } from "@cocalc/frontend/project/info";
-      <Block>
-        <Explorer project_id={project_id} />
-      </Block>
-      <Block>
-        <ProjectNew project_id={project_id} />
-      </Block>
-      <Block>
-        <ProjectInfo project_id={project_id} />
-      </Block>
-      */
+import { HomeRecentFiles } from "./recent-files";
 
 export default function HomePage({ project_id }) {
   const desc = useRedux(["projects", "project_map", project_id, "description"]);
   const actions = useActions({ project_id });
-  const [error, setError] = useState<string>("");
-  const [avatarImage, setAvatarImage] = useState<string | undefined>(undefined);
-  useEffect(() => {
-    (async () => {
-      setAvatarImage(
-        await redux.getStore("projects").getProjectAvatarImage(project_id)
-      );
-    })();
-  }, []);
 
   return (
     <div style={{ margin: "15px" }}>
       <Row gutter={[30, 30]}>
-        <Col span={12} style={{ textAlign: "center" }}>
+        <Col span={12} style={{ }}>
           <Title
             level={2}
             onClick={() => actions?.set_active_tab("settings")}
-            style={{ cursor: "pointer" }}
+            style={{ cursor: "pointer" , textAlign: "center" }}
           >
             <ProjectTitle project_id={project_id} noClick />
           </Title>
-          {error && (
-            <Alert
-              style={{ marginTop: "15px" }}
-              type="error"
-              message={error}
-              showIcon
-            />
-          )}
-          <ProjectImage
-            avatarImage={avatarImage}
-            onChange={async (data) => {
-              try {
-                await redux
-                  .getActions("projects")
-                  .setProjectImage(project_id, data);
-                setAvatarImage(data.full);
-              } catch (err) {
-                setError(`Error saving project image: ${err}`);
-              }
+          <div
+            style={{
+              flex: 1,
+              cursor: "pointer",
+              maxHeight: "4em",
+              overflow: "auto",
             }}
-          />
-        </Col>
-        <Col
-          span={12}
-          style={{
-            flex: 1,
-            cursor: "pointer",
-            maxHeight: "300px",
-            overflow: "auto",
-          }}
-          onClick={() => actions?.set_active_tab("settings")}
-        >
-          <StaticMarkdown value={desc} />
+            onClick={() => actions?.set_active_tab("settings")}
+          >
+            <StaticMarkdown value={desc} />
+          </div>
+          <HomeRecentFiles project_id={project_id} />
         </Col>
         <Col span={12}>
           <ChatGPTGenerateJupyterNotebook project_id={project_id} />
         </Col>
+
         <Col span={12}>
           <Block style={{ margin: "auto" }}>
             <ProjectLog project_id={project_id} />

--- a/src/packages/frontend/project/page/home-page/index.tsx
+++ b/src/packages/frontend/project/page/home-page/index.tsx
@@ -13,6 +13,9 @@ import { ProjectTitle } from "@cocalc/frontend/projects/project-title";
 import { Block } from "./block";
 import ChatGPTGenerateJupyterNotebook from "./chatgpt-generate-jupyter";
 import { HomeRecentFiles } from "./recent-files";
+import { ProjectAvatarImage } from "@cocalc/frontend/projects/project-row";
+
+const SPAN = { md: 12, sm: 24, xs: 24 } as const;
 
 export default function HomePage({ project_id }) {
   const desc = useRedux(["projects", "project_map", project_id, "description"]);
@@ -24,16 +27,23 @@ export default function HomePage({ project_id }) {
     if (!redux.getStore("projects").hasOpenAI(project_id)) return null;
 
     return (
-      <Col span={12}>
+      <Col {...SPAN}>
         <ChatGPTGenerateJupyterNotebook project_id={project_id} />
       </Col>
     );
   }
 
   return (
-    <div style={{ margin: "15px" }}>
+    <div style={{ margin: "15px", maxWidth: "1300px" }}>
       <Row gutter={[30, 30]}>
-        <Col span={12} style={{}}>
+        <Col {...SPAN}>
+          <ProjectAvatarImage
+            project_id={project_id}
+            size={120}
+            style={{ textAlign: "center", cursor: "pointer", marginTop: "20px" }}
+            askToAddAvatar={true}
+            onClick={() => actions?.set_active_tab("settings")}
+          />
           <Title
             level={2}
             onClick={() => actions?.set_active_tab("settings")}
@@ -45,19 +55,22 @@ export default function HomePage({ project_id }) {
             style={{
               flex: 1,
               cursor: "pointer",
-              maxHeight: "4em",
+              maxHeight: "10em",
               overflow: "auto",
             }}
             onClick={() => actions?.set_active_tab("settings")}
           >
             <StaticMarkdown value={desc} />
           </div>
-          <HomeRecentFiles project_id={project_id} />
         </Col>
 
         {renderGPTGenerator()}
 
-        <Col span={12}>
+        <Col {...SPAN}>
+          <HomeRecentFiles project_id={project_id} />
+        </Col>
+
+        <Col {...SPAN}>
           <Block style={{ margin: "auto" }}>
             <ProjectLog project_id={project_id} />
           </Block>

--- a/src/packages/frontend/project/page/home-page/index.tsx
+++ b/src/packages/frontend/project/page/home-page/index.tsx
@@ -4,29 +4,40 @@
  */
 
 import { Col, Row } from "antd";
-// import { useState } from "react";
 
-import { useActions, useRedux } from "@cocalc/frontend/app-framework";
+import { redux, useActions, useRedux } from "@cocalc/frontend/app-framework";
 import { Title } from "@cocalc/frontend/components";
 import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
 import { ProjectLog } from "@cocalc/frontend/project/history";
 import { ProjectTitle } from "@cocalc/frontend/projects/project-title";
-import ChatGPTGenerateJupyterNotebook from "./chatgpt-generate-jupyter";
 import { Block } from "./block";
+import ChatGPTGenerateJupyterNotebook from "./chatgpt-generate-jupyter";
 import { HomeRecentFiles } from "./recent-files";
 
 export default function HomePage({ project_id }) {
   const desc = useRedux(["projects", "project_map", project_id, "description"]);
   const actions = useActions({ project_id });
 
+  function renderGPTGenerator() {
+    // if not available, the entire block should be gone
+    // making room for the toher blocks to move into its place
+    if (!redux.getStore("projects").hasOpenAI(project_id)) return null;
+
+    return (
+      <Col span={12}>
+        <ChatGPTGenerateJupyterNotebook project_id={project_id} />
+      </Col>
+    );
+  }
+
   return (
     <div style={{ margin: "15px" }}>
       <Row gutter={[30, 30]}>
-        <Col span={12} style={{ }}>
+        <Col span={12} style={{}}>
           <Title
             level={2}
             onClick={() => actions?.set_active_tab("settings")}
-            style={{ cursor: "pointer" , textAlign: "center" }}
+            style={{ cursor: "pointer", textAlign: "center" }}
           >
             <ProjectTitle project_id={project_id} noClick />
           </Title>
@@ -43,9 +54,8 @@ export default function HomePage({ project_id }) {
           </div>
           <HomeRecentFiles project_id={project_id} />
         </Col>
-        <Col span={12}>
-          <ChatGPTGenerateJupyterNotebook project_id={project_id} />
-        </Col>
+
+        {renderGPTGenerator()}
 
         <Col span={12}>
           <Block style={{ margin: "auto" }}>

--- a/src/packages/frontend/project/page/home-page/recent-files.tsx
+++ b/src/packages/frontend/project/page/home-page/recent-files.tsx
@@ -7,44 +7,92 @@ import {
   Loading,
   Paragraph,
   PathLink,
+  Text,
   TimeAgo,
   Title,
 } from "@cocalc/frontend/components";
-import { useTypedRedux } from "@cocalc/frontend/app-framework";
-import { User } from "../../../users";
+import { useMemo, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { EventRecordMap } from "../../history/types";
+import { User } from "@cocalc/frontend/users";
 
+interface OpenedFile {
+  filename: string;
+  time: Date;
+  account_id: string;
+}
 interface Props {
   project_id: string;
 }
 
+/**
+ * This is a distillation of the project log, showing only the most recently opened files.
+ */
 export function HomeRecentFiles(props: Props) {
   const { project_id } = props;
 
   const project_log = useTypedRedux({ project_id }, "project_log");
   const user_map = useTypedRedux("users", "user_map");
 
+  const log: OpenedFile[] = useMemo(() => {
+    if (project_log == null) return [];
+
+    const dedupe: string[] = [];
+
+    return project_log
+      .valueSeq()
+      .filter(
+        (entry: EventRecordMap) =>
+          entry.getIn(["event", "filename"]) &&
+          entry.getIn(["event", "event"]) === "open"
+      )
+      .sort((a, b) => b.get("time").getTime() - a.get("time").getTime())
+      .filter((entry: EventRecordMap) => {
+        const fn = entry.getIn(["event", "filename"]);
+        if (dedupe.includes(fn)) return false;
+        dedupe.push(fn);
+        return true;
+      })
+      .slice(0, 10)
+      .map((entry: EventRecordMap) => {
+        return {
+          filename: entry.getIn(["event", "filename"]),
+          time: entry.get("time"),
+          account_id: entry.get("account_id"),
+        };
+      })
+      .toJS();
+  }, [project_log]);
+
   function recent() {
     if (project_log == null) {
       return <Loading />;
     }
-    const log = project_log.slice(0, 5);
+
     return (
       <Paragraph>
-        {log
-          .filter((entry) => entry.event === "open")
-          .map((entry, i) => {
-            const time = entry.get("time");
-            const account_id = entry.get("account_id");
+        <ul>
+          {log.map((entry, i) => {
+            const time = entry.time;
+            const account_id = entry.account_id;
             return (
-              <div key={i}>
+              <li key={i}>
                 <>
-                  <PathLink path={entry.filename} project_id={project_id} />{" "}
-                  <User user_map={user_map} account_id={account_id} /> edited{" "}
-                  <TimeAgo date={time} />
+                  <PathLink
+                    trunc={32}
+                    full={true}
+                    style={{ fontWeight: "bold" }}
+                    path={entry.filename}
+                    project_id={project_id}
+                  />{" "}
+                  <Text type="secondary">
+                    by <User user_map={user_map} account_id={account_id} />{" "}
+                    <TimeAgo date={time} />
+                  </Text>
                 </>
-              </div>
+              </li>
             );
           })}
+        </ul>
       </Paragraph>
     );
   }

--- a/src/packages/frontend/project/page/home-page/recent-files.tsx
+++ b/src/packages/frontend/project/page/home-page/recent-files.tsx
@@ -1,0 +1,58 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import {
+  Loading,
+  Paragraph,
+  PathLink,
+  TimeAgo,
+  Title,
+} from "@cocalc/frontend/components";
+import { useTypedRedux } from "@cocalc/frontend/app-framework";
+import { User } from "../../../users";
+
+interface Props {
+  project_id: string;
+}
+
+export function HomeRecentFiles(props: Props) {
+  const { project_id } = props;
+
+  const project_log = useTypedRedux({ project_id }, "project_log");
+  const user_map = useTypedRedux("users", "user_map");
+
+  function recent() {
+    if (project_log == null) {
+      return <Loading />;
+    }
+    const log = project_log.slice(0, 5);
+    return (
+      <Paragraph>
+        {log
+          .filter((entry) => entry.event === "open")
+          .map((entry, i) => {
+            const time = entry.get("time");
+            const account_id = entry.get("account_id");
+            return (
+              <div key={i}>
+                <>
+                  <PathLink path={entry.filename} project_id={project_id} />{" "}
+                  <User user_map={user_map} account_id={account_id} /> edited{" "}
+                  <TimeAgo date={time} />
+                </>
+              </div>
+            );
+          })}
+      </Paragraph>
+    );
+  }
+
+  return (
+    <>
+      <Title level={3}>Recent files</Title>
+      {recent()}
+    </>
+  );
+}

--- a/src/packages/frontend/projects/project-row.tsx
+++ b/src/packages/frontend/projects/project-row.tsx
@@ -21,6 +21,7 @@ import { AddCollaborators } from "@cocalc/frontend/collaborators";
 import {
   Icon,
   Markdown,
+  Paragraph,
   ProjectState,
   Space,
   TimeAgo,
@@ -240,17 +241,16 @@ export const ProjectRow: React.FC<Props> = ({ project_id, index }: Props) => {
   );
 };
 
-export function ProjectAvatarImage({
-  project_id,
-  size,
-  onClick,
-  style,
-}: {
+interface ProjectAvatarImageProps {
   project_id: string;
   size?: number;
   onClick?: Function;
   style?: CSSProperties;
-}) {
+  askToAddAvatar?: boolean;
+}
+
+export function ProjectAvatarImage(props: ProjectAvatarImageProps) {
+  const { project_id, size, onClick, style, askToAddAvatar = false } = props;
   const isMounted = useIsMountedRef();
   const [avatarImage, setAvatarImage] = useState<string | undefined>(undefined);
 
@@ -264,6 +264,15 @@ export function ProjectAvatarImage({
     })();
   }, []);
 
+  function renderAdd(): JSX.Element {
+    if (!askToAddAvatar || onClick == null) return <></>;
+    return (
+      <Paragraph type="secondary" style={style} onClick={(e) => onClick(e)}>
+        (Click to add avatar image)
+      </Paragraph>
+    );
+  }
+
   return avatarImage ? (
     <div style={style} onClick={(e) => onClick?.(e)}>
       <Avatar
@@ -273,6 +282,6 @@ export function ProjectAvatarImage({
       />
     </div>
   ) : (
-    <></>
+    renderAdd()
   );
 }


### PR DESCRIPTION
# Description

- this adds a block for "recent files" (deduplicated, easy to click due to using a large list entry) for convenience
- reorgs some details with that home page, e.g. the avatar is less distracting, instead behaves like title and description
- when GPT disabled, remove GPT box entirely, such that the other boxes can move up
- max width, reactive for narrower screens
- and some small refactorings in some of the files I saw

![Screenshot from 2023-03-31 13-40-44](https://user-images.githubusercontent.com/207405/229111719-5a729526-405c-455f-99cd-34ca97a28f66.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
