### PR TITLE
frontend/jupyter: improve quick insert bar

### DIFF
--- a/src/packages/frontend/components/paste-button.tsx
+++ b/src/packages/frontend/components/paste-button.tsx
@@ -1,0 +1,35 @@
+import { CSSProperties, useState } from "react";
+import { Button } from "antd";
+
+import { Icon } from "@cocalc/frontend/components/icon";
+import { alert_message } from "@cocalc/frontend/alerts";
+
+interface Props {
+  style?: CSSProperties;
+  paste: (text: string) => any;
+}
+
+export default function PasteButton({ style, paste }: Props) {
+  const [pasted, setPasted] = useState<boolean>(false);
+
+  async function onClick() {
+    try {
+      const text = await navigator.clipboard.readText();
+      paste(text);
+      setPasted(true);
+    } catch (err) {
+      alert_message({
+        type: "error",
+        title: "Permission denied",
+        message: `You have to enable clipboard access to make pasting from the clipboard work.\n${err}`,
+      });
+    }
+  }
+
+  return (
+    <Button size="small" type="text" style={style} onClick={onClick}>
+      <Icon name={pasted ? "check" : "paste"} />
+      {pasted ? "Pasted" : "Paste"}
+    </Button>
+  );
+}

--- a/src/packages/frontend/frame-editors/chatgpt/title-bar-button.tsx
+++ b/src/packages/frontend/frame-editors/chatgpt/title-bar-button.tsx
@@ -19,6 +19,7 @@ import {
   VisibleMDLG,
 } from "@cocalc/frontend/components";
 import OpenAIAvatar from "@cocalc/frontend/components/openai-avatar";
+import { COLORS } from "@cocalc/util/theme";
 
 interface Preset {
   command: string;
@@ -189,7 +190,7 @@ export default function ChatGPT({
               setError("");
             }}
             type="text"
-            style={{ float: "right", color: "#666" }}
+            style={{ float: "right", color: COLORS.GRAY_M }}
           >
             <Icon name="times" />
           </Button>

--- a/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
@@ -299,6 +299,7 @@ export class NotebookFrameActions {
       this.move_cursor(1);
     }
   }
+  h;
 
   public run_selected_cells(v?: string[]): void {
     this.save_input_editor();
@@ -450,6 +451,20 @@ export class NotebookFrameActions {
     const cells = this.jupyter_actions.store.get("cells");
     if (cells == null) return;
     return cells.get(id);
+  }
+
+  getPreviousCodeCellID(id: string, delta = -1): string | undefined {
+    while (true) {
+      const prevID = this.jupyter_actions.store.get_cell_id(delta, id);
+      if (prevID == null) return;
+      const prevCell = this.get_cell_by_id(prevID);
+      if (prevCell == null) return;
+      if (prevCell.get("cell_type") === "code") {
+        return prevID;
+      } else {
+        delta = delta - 1;
+      }
+    }
   }
 
   public switch_md_cell_to_edit(id: string): void {

--- a/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
@@ -712,6 +712,14 @@ export class NotebookFrameActions {
     this.jupyter_actions.set_cell_input(id, input1);
   }
 
+  public set_cell_input(id, input) {
+    this.validate({ id });
+    if (this.jupyter_actions.check_edit_protection(id)) {
+      return;
+    }
+    this.jupyter_actions.set_cell_input(id, input);
+  }
+
   // delta = -1 (above) or +1 (below)
   public insert_cell(delta: 1 | -1): string {
     const id = this.jupyter_actions.insert_cell_adjacent(

--- a/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
@@ -459,7 +459,7 @@ export class NotebookFrameActions {
       if (prevID == null) return;
       const prevCell = this.get_cell_by_id(prevID);
       if (prevCell == null) return;
-      if (prevCell.get("cell_type") === "code") {
+      if (prevCell.get("cell_type", "code") === "code") {
         return prevID;
       } else {
         delta = delta - 1;

--- a/src/packages/frontend/jupyter/_jupyter.sass
+++ b/src/packages/frontend/jupyter/_jupyter.sass
@@ -63,7 +63,9 @@
   +smooth-background-color
 
 .cocalc-jupyter-insert-cell
-  height: 6px
+  margin-top: 5px
+  margin-bottom: 7px
+  height: 8px
   cursor: pointer
   text-align: center
   &:hover
@@ -75,10 +77,15 @@
   display: none
   z-index: 1
   position: relative
-  top: -9px
+  top: -6px
   &:hover
     display: block
 
+.cocalc-jupyter-insert-cell-btn
+  background-color: $COL_FG_BLUE
+  &:hover
+    background-color: $COL_BLUE_DD
+
 .cocalc-jupyter-menu
   .ant-dropdown-trigger:hover
-      background-color: white
+    background-color: white

--- a/src/packages/frontend/jupyter/cell-input.tsx
+++ b/src/packages/frontend/jupyter/cell-input.tsx
@@ -12,12 +12,15 @@ import { useCallback, useEffect, useRef } from "react";
 import { Button, ButtonGroup } from "@cocalc/frontend/antd-bootstrap";
 import { React, Rendered } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
+import CopyButton from "@cocalc/frontend/components/copy-button";
+import PasteButton from "@cocalc/frontend/components/paste-button";
 import MarkdownInput from "@cocalc/frontend/editors/markdown-input/multimode";
 import MostlyStaticMarkdown from "@cocalc/frontend/editors/slate/mostly-static-markdown";
 import { SAVE_DEBOUNCE_MS } from "@cocalc/frontend/frame-editors/code-editor/const";
 import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
 import { FileContext, useFileContext } from "@cocalc/frontend/lib/file-context";
 import { filename_extension, startswith } from "@cocalc/util/misc";
+import { COLORS } from "@cocalc/util/theme";
 import { JupyterActions } from "./browser-actions";
 import { CellHiddenPart } from "./cell-hidden-part";
 import CellTiming from "./cell-output-time";
@@ -26,7 +29,6 @@ import { CodeMirror } from "./codemirror-component";
 import { Complete } from "./complete";
 import { InputPrompt } from "./prompt/input";
 import { get_blob_url } from "./server-urls";
-import CopyButton from "@cocalc/frontend/components/copy-button";
 
 function attachmentTransform(
   project_id: string | undefined,
@@ -393,7 +395,7 @@ export const CellInput: React.FC<CellInputProps> = React.memo(
           <div
             style={{
               display: "flex",
-              color: "#666",
+              color: COLORS.GRAY_M,
               fontSize: "11px",
             }}
           >
@@ -411,10 +413,17 @@ export const CellInput: React.FC<CellInputProps> = React.memo(
                 actions={props.actions}
               />
             )}
-            {input && (
+            {input ? (
               <CopyButton
                 value={props.cell.get("input") ?? ""}
-                style={{ fontSize: "11px", color: "#666" }}
+                style={{ fontSize: "11px", color: COLORS.GRAY_M }}
+              />
+            ) : (
+              <PasteButton
+                style={{ fontSize: "11px", color: COLORS.GRAY_M }}
+                paste={(text) =>
+                  frameActions.current?.set_cell_input(props.id, text)
+                }
               />
             )}
             {input && (

--- a/src/packages/frontend/jupyter/cell-list.tsx
+++ b/src/packages/frontend/jupyter/cell-list.tsx
@@ -96,30 +96,32 @@ interface CellListProps {
   chatgpt?;
 }
 
-export const CellList: React.FC<CellListProps> = ({
-  actions,
-  cell_list,
-  cell_toolbar,
-  cells,
-  cm_options,
-  complete,
-  cur_id,
-  directory,
-  font_size,
-  hook_offset,
-  is_focused,
-  md_edit_ids,
-  mode,
-  more_output,
-  name,
-  project_id,
-  scroll,
-  scrollTop,
-  sel_ids,
-  trust,
-  use_windowed_list,
-  chatgpt,
-}: CellListProps) => {
+export const CellList: React.FC<CellListProps> = (props: CellListProps) => {
+  const {
+    actions,
+    cell_list,
+    cell_toolbar,
+    cells,
+    cm_options,
+    complete,
+    cur_id,
+    directory,
+    font_size,
+    hook_offset,
+    is_focused,
+    md_edit_ids,
+    mode,
+    more_output,
+    name,
+    project_id,
+    scroll,
+    scrollTop,
+    sel_ids,
+    trust,
+    use_windowed_list,
+    chatgpt,
+  } = props;
+
   const cell_list_node = useRef<HTMLElement | null>(null);
   const is_mounted = useIsMountedRef();
   const frameActions = useNotebookFrameActions();
@@ -389,6 +391,7 @@ export const CellList: React.FC<CellListProps> = ({
     return (
       <InsertCell
         id={id}
+        chatgpt={chatgpt}
         key={id + "insert" + position}
         position={position}
         actions={actions}

--- a/src/packages/frontend/jupyter/chatgpt/explain.tsx
+++ b/src/packages/frontend/jupyter/chatgpt/explain.tsx
@@ -4,6 +4,7 @@ Use ChatGPT to explain what the code in a cell does.
 
 import { CSSProperties, useState } from "react";
 import { Alert, Button, Tooltip } from "antd";
+
 import OpenAIAvatar from "@cocalc/frontend/components/openai-avatar";
 import type { JupyterActions } from "../browser-actions";
 import getChatActions from "@cocalc/frontend/chat/get-actions";

--- a/src/packages/frontend/jupyter/insert-cell.tsx
+++ b/src/packages/frontend/jupyter/insert-cell.tsx
@@ -232,19 +232,18 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
       const lang = kernel_info?.get("language") ?? "python";
       const kernel_name = kernel_info?.get("display_name") ?? "Python 3";
       const fa = frameActions.current;
-      // default delta=-1 is fine, because the insert bar is usually *above* the current cell
       const prevCellID = fa.getPreviousCodeCellID(
         id,
         position === "below" ? 0 : -1
       );
       const prevCode =
         prevCellID != null
-          ? `The previous code cell is\n\n\`\`\`\n${fa.get_cell_input(
+          ? `The previous code cell is\n\n\`\`\`${lang}\n${fa.get_cell_input(
               prevCellID
             )}\n\`\`\``
           : "";
 
-      const input = `Create a new code cell for a Jupyter Notebook. Kernel: "${kernel_name}". Programming language: "${lang}". Return the entire code in a single block, enclosed in triple backticks, and comments as code comments. ${prevCode}\n\nThe new cell should do this:\n\n${prompt}`;
+      const input = `Create a new code cell for a Jupyter Notebook. Kernel: "${kernel_name}". Programming language: "${lang}". Return the entire code in a single block. Enclosed this block in triple backticks. Do not tell what the output will be. Add comments as code comments. ${prevCode}\n\nThe new cell should do this:\n\n${prompt}`;
 
       //console.log("input:\n", input);
 
@@ -254,7 +253,7 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
           input,
           project_id,
           path,
-          system: `Return only the code in the language "${lang}" enclosed in triple backticks.`,
+          system: `Return a single block in the language "${lang}" enclosed in triple backticks.`,
           tag: "generate-jupyter-cell",
         });
         //console.log("raw\n", raw);

--- a/src/packages/frontend/jupyter/insert-cell.tsx
+++ b/src/packages/frontend/jupyter/insert-cell.tsx
@@ -12,18 +12,28 @@ buttons in the hover state (even when tacking mouse moves!),
 which is confusing.
 */
 
-import { Button, Space, Tooltip } from "antd";
+import { Button, Input, Popover, Space, Tooltip } from "antd";
 
-import { CSS, React } from "@cocalc/frontend/app-framework";
+import { alert_message } from "@cocalc/frontend/alerts";
+import {
+  CSS,
+  React,
+  useFrameContext,
+  useState,
+} from "@cocalc/frontend/app-framework";
+import { Icon, Paragraph } from "@cocalc/frontend/components";
+import OpenAIAvatar from "@cocalc/frontend/components/openai-avatar";
+import ProgressEstimate from "@cocalc/frontend/components/progress-estimate";
+import { IS_TOUCH } from "@cocalc/frontend/feature";
 import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
-import { COLORS } from "@cocalc/util/theme";
-import { IS_TOUCH } from "../feature";
-import { JupyterActions } from "./browser-actions";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { unreachable } from "@cocalc/util/misc";
+import { COLORS } from "@cocalc/util/theme";
+import { JupyterActions } from "./browser-actions";
 
 type TinyButtonType = "code" | "markdown" | "paste" | "chatgpt";
 
-const BTN_HEIGHT = 12;
+const BTN_HEIGHT = 16;
 
 const TINY_BTN_STYLE: CSS = {
   margin: "0px",
@@ -31,9 +41,8 @@ const TINY_BTN_STYLE: CSS = {
   fontSize: `${BTN_HEIGHT - 2}px`,
   lineHeight: `${BTN_HEIGHT}px`,
   height: `${BTN_HEIGHT}px`,
-  borderRadius: "2px",
+  borderRadius: "4px",
   border: "none",
-  backgroundColor: COLORS.FG_BLUE,
   color: "white",
 } as const;
 
@@ -41,6 +50,7 @@ export interface InsertCellProps {
   actions: JupyterActions;
   id: string;
   position?: "above" | "below";
+  chatgpt?;
 }
 
 export interface InsertCellState {
@@ -53,8 +63,13 @@ function should_memoize(prev, next) {
 
 export const InsertCell: React.FC<InsertCellProps> = React.memo(
   (props: InsertCellProps) => {
-    const { position } = props;
+    const { position, chatgpt, actions, id } = props;
+    const haveChatGTP = chatgpt != null;
+    const { project_id, path } = useFrameContext();
     const frameActions = useNotebookFrameActions();
+    const [showChatGPT, setShowChatGPT] = useState<boolean>(false);
+    const [querying, setQuerying] = useState<boolean>(false);
+    const inputRef = React.useRef<any>(null);
 
     if (IS_TOUCH) {
       // TODO: Inserting cells via hover and click does not make sense
@@ -64,33 +79,41 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
     }
 
     function insertCell(type: "code" | "markdown", content?: string): void {
-      const { actions, id } = props;
       if (frameActions.current == null) return;
       frameActions.current.set_cur_id(id);
       const new_id = frameActions.current.insert_cell(
         position === "below" ? 1 : -1
       );
 
+      if (content) {
+        frameActions.current?.set_cell_input(new_id, content);
+      }
+
       switch (type) {
         case "markdown":
           actions.set_cell_type(new_id, "markdown");
-          frameActions.current.switch_md_cell_to_edit(new_id);
+          if (!content) {
+            frameActions.current.switch_md_cell_to_edit(new_id);
+          }
           break;
         case "code":
           frameActions.current.switch_code_cell_to_edit(new_id);
-          if (content) {
-            frameActions.current?.set_cell_input(new_id, content);
-          }
           break;
       }
     }
 
     async function pasteCell(): Promise<void> {
       try {
+        // First time around (in Chrome at least), this will require a confirmation by the user
+        // It fails with a "permission denied"
         const text = await navigator.clipboard.readText();
         insertCell("code", text);
       } catch (err) {
-        console.log("Failed to read clipboard contents: ", err);
+        alert_message({
+          type: "error",
+          title: "Permission denied",
+          message: `You have to enable clipboard access to make pasting from the clipboard work.\n${err}`,
+        });
       }
     }
 
@@ -114,7 +137,7 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
           pasteCell();
           break;
         case "chatgpt":
-          window.alert("gpt");
+          setShowChatGPT(true);
           break;
         default:
           unreachable(type);
@@ -129,6 +152,7 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
       return (
         <Button
           style={TINY_BTN_STYLE}
+          className="cocalc-jupyter-insert-cell-btn"
           size={"small"}
           onClick={(e) => btnClick(e, type)}
         >
@@ -139,15 +163,162 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
 
     function renderControls() {
       return (
-        <div className="cocalc-jupyter-insert-cell-controls">
+        <div
+          className="cocalc-jupyter-insert-cell-controls"
+          style={showChatGPT ? { display: "block" } : {}}
+        >
           <Space size="large">
-            <TinyButton type="code">Code</TinyButton>
-            <TinyButton type="markdown">Text</TinyButton>
-            <TinyButton type="paste">Paste</TinyButton>
-            <TinyButton type="chatgpt">ChatGPT</TinyButton>
+            <TinyButton type="code">
+              <Icon name="code" /> Code
+            </TinyButton>
+            <TinyButton type="markdown">
+              <Icon name="pen" /> Text
+            </TinyButton>
+            <TinyButton type="paste">
+              <Icon name="paste" /> Paste
+            </TinyButton>
+            {haveChatGTP ? (
+              <TinyButton type="chatgpt">
+                <OpenAIAvatar
+                  backgroundColor={"transparent"}
+                  size={12}
+                  style={{ marginRight: "5px" }}
+                  innerStyle={{ top: "0px" }}
+                />{" "}
+                ChatGPT
+              </TinyButton>
+            ) : undefined}
           </Space>
         </div>
       );
+    }
+
+    /**
+     * extract the code between the first and second occurance of lines starting with backticks
+     */
+    function extractCode(raw: string): {
+      content: string;
+      type: "code" | "markdown";
+    } {
+      const ret: string[] = [];
+      let inside = false;
+      for (const line of raw.split("\n")) {
+        if (line.startsWith("```")) {
+          inside = true;
+          continue;
+        }
+        if (inside) {
+          // ignore the remaining lines
+          if (line.startsWith("```")) break;
+          ret.push(line);
+        }
+      }
+
+      // if there is nothing in "ret", it probably returned a comment explaining it does not know what to do
+      if (ret.length > 0) {
+        return { content: ret.join("\n"), type: "code" };
+      } else {
+        return { content: raw, type: "markdown" };
+      }
+    }
+
+    async function queryChatGPT(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const prompt = inputRef.current?.input?.value;
+      if (frameActions.current == null || prompt == null) return;
+      const kernel_info = actions.store.get("kernel_info");
+      const lang = kernel_info?.get("language") ?? "python";
+      const kernel_name = kernel_info?.get("display_name") ?? "Python 3";
+      const fa = frameActions.current;
+      // default delta=-1 is fine, because the insert bar is usually *above* the current cell
+      const prevCellID = fa.getPreviousCodeCellID(
+        id,
+        position === "below" ? 0 : -1
+      );
+      const prevCode =
+        prevCellID != null
+          ? `The previous code cell is\n\n\`\`\`\n${fa.get_cell_input(
+              prevCellID
+            )}\n\`\`\``
+          : "";
+
+      const input = `Create a new code cell for a Jupyter Notebook. Kernel: "${kernel_name}". Programming language: "${lang}". Return the entire code in a single block, enclosed in triple backticks, and comments as code comments. ${prevCode}\n\nThe new cell should do this:\n\n${prompt}`;
+
+      //console.log("input:\n", input);
+
+      try {
+        setQuerying(true);
+        const raw = await webapp_client.openai_client.chatgpt({
+          input,
+          project_id,
+          path,
+          system: `Return only the code in the language "${lang}" enclosed in triple backticks.`,
+          tag: "generate-jupyter-cell",
+        });
+        //console.log("raw\n", raw);
+        const { content, type } = extractCode(raw);
+        insertCell(type, content);
+      } catch (err) {
+        alert_message({
+          type: "error",
+          title: "Problem generating code cell",
+          message: `${err}`,
+        });
+      } finally {
+        setQuerying(false);
+      }
+    }
+
+    function chatGPTDialogContent(): JSX.Element {
+      if (querying) {
+        return <ProgressEstimate seconds={30} />;
+      } else {
+        return (
+          <>
+            <Paragraph>
+              Describe what the next cell should do. The nearest code cell from
+              above will be sent along the query to provide context.
+            </Paragraph>
+            <Paragraph>
+              <Input
+                ref={inputRef}
+                autoFocus
+                disabled={querying}
+                placeholder="Describe the code..."
+                onChange={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onPressEnter={queryChatGPT}
+              />
+            </Paragraph>
+            <Paragraph style={{ textAlign: "center" }}>
+              <Space size="large">
+                <Button
+                  type="primary"
+                  onClick={queryChatGPT}
+                  disabled={querying}
+                >
+                  Generate
+                </Button>
+                <Button onClick={() => setShowChatGPT(false)}>Close</Button>
+              </Space>
+            </Paragraph>
+          </>
+        );
+      }
+    }
+
+    function tooltipTitle() {
+      // don't show this tooltip if we're showing the chatgpt dialog
+      if (showChatGPT) return;
+      return `Insert a new (text) cell – you can also [shift]-click on the blue bar to insert a [text] cell. Paste inserts the clipboard content into a new code cell.${
+        haveChatGTP
+          ? " ChatGPT generates a code cell based on your description."
+          : ""
+      }`;
     }
 
     const style: CSS =
@@ -156,16 +327,58 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
     return (
       <div
         className="cocalc-jupyter-insert-cell"
-        style={style}
+        style={{
+          ...style,
+          ...(showChatGPT ? { backgroundColor: COLORS.FG_BLUE } : {}),
+        }}
         onClick={barClick}
       >
-        <Tooltip
-          title="Insert a new (text) cell – you can also [shift]-click on the blue bar to insert a [text] cell"
+        <Popover
           placement="bottom"
-          mouseEnterDelay={2} // otherwise, it pops up all the time and gets really annoying
+          title={
+            <div
+              style={{ fontSize: "18px" }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              <OpenAIAvatar size={24} /> ChatGPT: Generate code cell
+              <Button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setShowChatGPT(false);
+                }}
+                type="text"
+                style={{ float: "right", color: COLORS.GRAY_M }}
+              >
+                <Icon name="times" />
+              </Button>
+            </div>
+          }
+          open={showChatGPT}
+          content={
+            <div
+              style={{ width: "400px" }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              {chatGPTDialogContent()}
+            </div>
+          }
+          trigger={[]}
         >
-          {renderControls()}
-        </Tooltip>
+          <Tooltip
+            title={tooltipTitle()}
+            placement="bottom"
+            mouseEnterDelay={2} // otherwise, it pops up all the time and gets really annoying
+          >
+            {renderControls()}
+          </Tooltip>
+        </Popover>
       </div>
     );
   },

--- a/src/packages/frontend/jupyter/output-handler.ts
+++ b/src/packages/frontend/jupyter/output-handler.ts
@@ -312,7 +312,7 @@ export class OutputHandler extends EventEmitter {
     if (output == null) {
       return;
     }
-    const value = output.getIn([`${output.size - 1}`, "value"]);
+    const value = output?.getIn([`${output.size - 1}`, "value"]);
     if (value != null) {
       let x = value;
       if (this._opts.cell.output) {

--- a/src/packages/frontend/jupyter/output-handler.ts
+++ b/src/packages/frontend/jupyter/output-handler.ts
@@ -312,7 +312,7 @@ export class OutputHandler extends EventEmitter {
     if (output == null) {
       return;
     }
-    const value = output?.getIn([`${output.size - 1}`, "value"]);
+    const value = output.getIn([`${output.size - 1}`, "value"]);
     if (value != null) {
       let x = value;
       if (this._opts.cell.output) {

--- a/src/packages/frontend/project/page/home-page/chatgpt-generate-jupyter.tsx
+++ b/src/packages/frontend/project/page/home-page/chatgpt-generate-jupyter.tsx
@@ -136,7 +136,6 @@ export default function ChatGPTGenerateJupyterNotebook({
         input,
         project_id,
         path: current_path, // mainly for analytics / metadata -- can't put the actual notebook path since the model outputs that.
-        model: "gpt-3.5-turbo",
         tag: "generate-jupyter",
       });
       await writeNotebook(raw);


### PR DESCRIPTION
# Description

The goal here is to improve that blue hover insert bar

- [x] styling/buttons
- [x] insert from clipboard
- [x] chat gpt if available: show a small box to explain what the next cell should do – context is the previous code cell. this is kind of fun to play around.

and the jupyter cell:

- [x] also adding a "paste" button, where the tiny "copy" button is, when cell is empty – then it doesn't jitter around as much any more

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
