### PR TITLE
Jupyter tweak insert bar

### DIFF
--- a/src/packages/frontend/jupyter/_jupyter.sass
+++ b/src/packages/frontend/jupyter/_jupyter.sass
@@ -62,24 +62,37 @@
 .cocalc-jupyter-btn-interrupt
   +smooth-background-color
 
+$fadeOutDelay: 0.3s
+$fadeOutSpeed: 0.1s
+
 .cocalc-jupyter-insert-cell
   margin-top: 5px
   margin-bottom: 7px
   height: 8px
   cursor: pointer
   text-align: center
+  transition-delay: $fadeOutDelay
+  transition-property: background-color
+  transition-timing-function: ease-out
+  transition-duration: $fadeOutSpeed
   &:hover
     background-color: $COL_FG_BLUE
+    transition: background-color 0s linear
   &:hover .cocalc-jupyter-insert-cell-controls
-    display: block
+    visibility: visible
+    opacity: 1
+    transition: opacity 0s linear, visibility 0s linear
 
 .cocalc-jupyter-insert-cell-controls
-  display: none
+  visibility: hidden
+  opacity: 0
   z-index: 1
   position: relative
   top: -6px
-  &:hover
-    display: block
+  transition-delay: $fadeOutDelay
+  transition-property: background-color, visibility, opacity
+  transition-timing-function: ease-out
+  transition-duration: $fadeOutSpeed
 
 .cocalc-jupyter-insert-cell-btn
   background-color: $COL_FG_BLUE

--- a/src/packages/frontend/jupyter/_jupyter.sass
+++ b/src/packages/frontend/jupyter/_jupyter.sass
@@ -62,12 +62,12 @@
 .cocalc-jupyter-btn-interrupt
   +smooth-background-color
 
-$fadeOutDelay: 0.3s
+$fadeOutDelay: 0.25s
 $fadeOutSpeed: 0.1s
 
 .cocalc-jupyter-insert-cell
-  margin-top: 5px
-  margin-bottom: 7px
+  margin-top: 6px
+  margin-bottom: 10px
   height: 8px
   cursor: pointer
   text-align: center
@@ -82,6 +82,14 @@ $fadeOutSpeed: 0.1s
     visibility: visible
     opacity: 1
     transition: opacity 0s linear, visibility 0s linear
+  &.cocalc-jupyter-insert-cell-below
+    margin-top: 20px
+    height: 5px
+    background-color: $COL_GRAY_L
+    > .cocalc-jupyter-insert-cell-controls
+      top: -8px
+    &:hover
+      background-color: $COL_FG_BLUE
 
 .cocalc-jupyter-insert-cell-controls
   visibility: hidden
@@ -96,6 +104,11 @@ $fadeOutSpeed: 0.1s
 
 .cocalc-jupyter-insert-cell-btn
   background-color: $COL_FG_BLUE
+  &:hover
+    background-color: $COL_BLUE_DD
+
+.cocalc-jupyter-insert-cell-btn-below
+  background-color: $COL_GRAY_L
   &:hover
     background-color: $COL_BLUE_DD
 

--- a/src/packages/frontend/jupyter/insert-cell.tsx
+++ b/src/packages/frontend/jupyter/insert-cell.tsx
@@ -156,10 +156,14 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
       children?: React.ReactNode;
     }) {
       const { type, children } = props;
+      const className =
+        position === "below"
+          ? "cocalc-jupyter-insert-cell-btn-below"
+          : "cocalc-jupyter-insert-cell-btn";
       return (
         <Button
           style={TINY_BTN_STYLE}
-          className="cocalc-jupyter-insert-cell-btn"
+          className={className}
           size={"small"}
           onClick={(e) => btnClick(e, type)}
         >
@@ -169,11 +173,16 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
     }
 
     function renderControls() {
+      const style: CSS =
+        showChatGPT || position === "below"
+          ? {
+              visibility: "visible",
+              opacity: 1,
+            }
+          : {};
+
       return (
-        <div
-          className="cocalc-jupyter-insert-cell-controls"
-          style={showChatGPT ? { visibility: "visible", opacity: 1 } : {}}
-        >
+        <div className="cocalc-jupyter-insert-cell-controls" style={style}>
           <Space size="large">
             <TinyButton type="code">
               <Icon name="code" /> Code
@@ -342,9 +351,14 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
     const style: CSS =
       position === "below" ? { marginBottom: `${BTN_HEIGHT}px` } : {};
 
+    const classNames = ["cocalc-jupyter-insert-cell"];
+    if (position === "below") {
+      classNames.push("cocalc-jupyter-insert-cell-below");
+    }
+
     return (
       <div
-        className="cocalc-jupyter-insert-cell"
+        className={classNames.join(" ")}
         style={{
           ...style,
           ...(showChatGPT ? { backgroundColor: COLORS.FG_BLUE } : {}),

--- a/src/packages/frontend/jupyter/insert-cell.tsx
+++ b/src/packages/frontend/jupyter/insert-cell.tsx
@@ -172,7 +172,7 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
       return (
         <div
           className="cocalc-jupyter-insert-cell-controls"
-          style={showChatGPT ? { display: "block" } : {}}
+          style={showChatGPT ? { visibility: "visible", opacity: 1 } : {}}
         >
           <Space size="large">
             <TinyButton type="code">

--- a/src/packages/frontend/jupyter/insert-cell.tsx
+++ b/src/packages/frontend/jupyter/insert-cell.tsx
@@ -71,10 +71,11 @@ export const InsertCell: React.FC<InsertCellProps> = React.memo(
     const [querying, setQuerying] = useState<boolean>(false);
     const inputRef = React.useRef<any>(null);
 
-    if (IS_TOUCH) {
+    if (IS_TOUCH && position === "above") {
       // TODO: Inserting cells via hover and click does not make sense
       // for a touch device, since no notion of hover, and is just confusing and results
       // in many false inserts.
+      // Exception: last "bottom" insert bar, because it is always visible
       return <div style={{ height: "6px" }}></div>;
     }
 


### PR DESCRIPTION
# Description

- during hover out, it stays around a bit longer
- at the bottom, a less dominantly styled bar stays around all the time
   - the one at the bottom is now also visible for touch devices (the others ones are still not there at all)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
