### PR TITLE
project/jupyter-pool: configure from env vars + respect env vars

### DIFF
--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -1223,6 +1223,9 @@ importers:
       '@types/node':
         specifier: ^18.11.18
         version: 18.11.18
+      '@types/node-cleanup':
+        specifier: ^2.1.2
+        version: 2.1.2
       coffeescript:
         specifier: ^2.5.1
         version: 2.7.0
@@ -1883,7 +1886,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/core@7.21.4:
+  /@babel/core@7.21.4(supports-color@9.3.1):
     resolution: {integrity: sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -1892,13 +1895,13 @@ packages:
       '@babel/generator': 7.21.4
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
       '@babel/helper-module-transforms': 7.21.2(supports-color@9.3.1)
-      '@babel/helpers': 7.21.0
+      '@babel/helpers': 7.21.0(supports-color@9.3.1)
       '@babel/parser': 7.21.4
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4(supports-color@9.3.1)
       '@babel/types': 7.21.4
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -1980,7 +1983,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.21.4
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.5
       lru-cache: 5.1.1
@@ -2190,7 +2193,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helpers@7.21.0:
+  /@babel/helpers@7.21.0(supports-color@9.3.1):
     resolution: {integrity: sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -2509,7 +2512,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2518,7 +2521,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2535,7 +2538,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2637,7 +2640,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2654,7 +2657,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2674,7 +2677,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2691,7 +2694,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2708,7 +2711,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2725,7 +2728,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2742,7 +2745,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2759,7 +2762,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2776,7 +2779,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2824,7 +2827,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2834,7 +2837,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -3738,7 +3741,7 @@ packages:
     resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.17
       babel-plugin-istanbul: 6.1.1
@@ -4948,6 +4951,10 @@ packages:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: false
 
+  /@types/node-cleanup@2.1.2:
+    resolution: {integrity: sha512-HTksao/sZs9nqxKD/vWOR3WxSrQsyJlBPEFFCgq9lMmhRsuQF+2p6hy+7FaCYn6lOeiDc3ywI8jDQ2bz5y6m8w==}
+    dev: true
+
   /@types/node-zendesk@2.0.9:
     resolution: {integrity: sha512-AKnAXd0SsTx2pGzL6UcjJLGzF8Gi5FLx0AnZsnREvPaa0/s/CeDr8l199oIT9FPU4HZTvvE48AqKw18akcDNJw==}
     dependencies:
@@ -5949,7 +5956,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@jest/transform': 29.5.0
       '@types/babel__core': 7.20.0
       babel-plugin-istanbul: 6.1.1
@@ -5968,7 +5975,7 @@ packages:
       '@babel/core': ^7.12.0
       webpack: '>=5'
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
       webpack: 5.75.0(@swc/core@1.3.3)(webpack-cli@5.0.1)
@@ -6040,7 +6047,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
     dev: false
 
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.21.4):
@@ -6048,7 +6055,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.4)
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.21.4)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.4)
@@ -6069,7 +6076,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       babel-plugin-jest-hoist: 29.5.0
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.21.4)
     dev: true
@@ -9795,7 +9802,7 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/parser': 7.21.4
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
@@ -9916,7 +9923,7 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@jest/test-sequencer': 29.5.0
       '@jest/types': 29.5.0
       '@types/node': 18.11.18
@@ -10194,7 +10201,7 @@ packages:
     resolution: {integrity: sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       '@babel/generator': 7.21.4
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.4)
       '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.21.4)
@@ -11486,7 +11493,7 @@ packages:
   /next-remove-imports@1.0.11(webpack@5.75.0):
     resolution: {integrity: sha512-i+L8kcP1hM3nOCNv8NWhtJGWwkEDtej0BaRlCzcZDQeXCT3cwaJo4VyD9x4449sbJwj9xt/wmqlH8fg5g8RaYg==}
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       babel-loader: 9.1.2(@babel/core@7.21.4)(webpack@5.75.0)
       babel-plugin-transform-remove-imports: 1.7.0(@babel/core@7.21.4)
     transitivePeerDependencies:
@@ -14851,7 +14858,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       client-only: 0.0.1
       react: 18.2.0
     dev: false
@@ -15211,7 +15218,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.4(supports-color@9.3.1)
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.5.0(@types/node@18.11.18)

--- a/src/packages/project/init-kucalc.ts
+++ b/src/packages/project/init-kucalc.ts
@@ -11,6 +11,7 @@ import * as dedicatedDisks from "./dedicated-disks";
 import * as sshd from "./sshd";
 import * as initScript from "./init-script";
 import { getLogger } from "./logger";
+import { init as initJupyterPoolParams } from "./jupyter/pool-params";
 
 export default async function init() {
   const winston = getLogger("init kucalc");
@@ -37,6 +38,9 @@ export default async function init() {
   if (options.sshd) {
     sshd.init(envVars);
   }
+
+  // this must come after projectSetup.set_extra_env !
+  initJupyterPoolParams();
 
   await dedicatedDisks.init();
 

--- a/src/packages/project/init-kucalc.ts
+++ b/src/packages/project/init-kucalc.ts
@@ -12,6 +12,7 @@ import * as sshd from "./sshd";
 import * as initScript from "./init-script";
 import { getLogger } from "./logger";
 import { init as initJupyterPoolParams } from "./jupyter/pool-params";
+import { init as initJupyterPool } from "./jupyter/pool";
 
 export default async function init() {
   const winston = getLogger("init kucalc");
@@ -45,4 +46,7 @@ export default async function init() {
   await dedicatedDisks.init();
 
   initScript.run();
+
+  // this has to come after setting env vars and intializing the pool params
+  initJupyterPool();
 }

--- a/src/packages/project/jupyter/pool-params.ts
+++ b/src/packages/project/jupyter/pool-params.ts
@@ -16,15 +16,18 @@ const L = getLogger("jupyter:pool-params").debug;
 // read env vars with that prefix
 const PREFIX = "COCALC_JUPYTER_POOL";
 
-// fallback defaults
+// the defaults
 const CONFIG_FN = "cocalc-jupyter-pool";
 const CONFIG_DIR = join(homedir(), ".config");
 const CONFIG = join(CONFIG_DIR, CONFIG_FN);
+const SIZE = 1; // size of pool, set to 0 to disable it
+const TIMEOUT_S = 3600; // after that time, clean up old kernels in the pool
+const LAUNCH_DELAY_MS = 7500; // additional delay before spawning an additional kernel
 
 const PARAMS = {
-  SIZE: 1,
-  TIMEOUT_S: 3600,
-  LAUNCH_DELAY_MS: 7500,
+  SIZE,
+  TIMEOUT_S,
+  LAUNCH_DELAY_MS,
   CONFIG_FN,
   CONFIG_DIR,
   CONFIG,
@@ -55,7 +58,22 @@ export function init() {
   PARAMS.CONFIG = join(PARAMS.CONFIG_DIR, PARAMS.CONFIG_FN);
 }
 
-export function getParams() {
-  // we make a copy, just to make sure pool.ts gets a consistent view of the params, no matter what
-  return { ...PARAMS } as const;
+export function getSize(): number {
+  return PARAMS.SIZE;
+}
+
+export function getTimeoutS(): number {
+  return PARAMS.TIMEOUT_S;
+}
+
+export function getLaunchDelayMS(): number {
+  return PARAMS.LAUNCH_DELAY_MS;
+}
+
+export function getConfig(): string {
+  return PARAMS.CONFIG;
+}
+
+export function getConfigDir(): string {
+  return PARAMS.CONFIG_DIR;
 }

--- a/src/packages/project/jupyter/pool-params.ts
+++ b/src/packages/project/jupyter/pool-params.ts
@@ -1,0 +1,61 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// Parameters for the Jupyter Pool
+// They're loaded right after custom env variables are set, such that not only admins of the platform,
+// but also users on their own can tune them.
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import { getLogger } from "../logger";
+const L = getLogger("jupyter:pool-params").debug;
+
+// read env vars with that prefix
+const PREFIX = "COCALC_JUPYTER_POOL";
+
+// fallback defaults
+const CONFIG_FN = "cocalc-jupyter-pool";
+const CONFIG_DIR = join(homedir(), ".config");
+const CONFIG = join(CONFIG_DIR, CONFIG_FN);
+
+const PARAMS = {
+  SIZE: 1,
+  TIMEOUT_S: 3600,
+  LAUNCH_DELAY_MS: 7500,
+  CONFIG_FN,
+  CONFIG_DIR,
+  CONFIG,
+};
+
+export function init() {
+  // at this point, project-setup::set_extra_env has already been called.
+  // hence process.env contains global env vars set in init.sh and user specified env vars
+  const env = process.env;
+  for (const key in PARAMS) {
+    // we derive the full path, see end of this function
+    if (key === "CONFIG") continue;
+    const varName = `${PREFIX}_${key}`;
+    if (varName in env) {
+      const val = env[varName];
+      if (val === "") continue; // ignore empty values
+      // if val can be converted to a number, use the integer value
+      const num = Number(val);
+      if (!Number.isNaN(num)) {
+        L(`setting ${key} to ${num} (converted from '${val}')`);
+        PARAMS[key] = num;
+      } else {
+        L(`setting ${key} to '${val}'`);
+        PARAMS[key] = val;
+      }
+    }
+  }
+  PARAMS.CONFIG = join(PARAMS.CONFIG_DIR, PARAMS.CONFIG_FN);
+}
+
+export function getParams() {
+  // we make a copy, just to make sure pool.ts gets a consistent view of the params, no matter what
+  return { ...PARAMS } as const;
+}

--- a/src/packages/project/package.json
+++ b/src/packages/project/package.json
@@ -83,6 +83,7 @@
     "@types/express": "^4.17.13",
     "@types/jquery": "^3.5.5",
     "@types/node": "^18.11.18",
+    "@types/node-cleanup": "^2.1.2",
     "coffeescript": "^2.5.1"
   },
   "scripts": {

--- a/src/packages/project/project-setup.ts
+++ b/src/packages/project/project-setup.ts
@@ -7,10 +7,10 @@
 This configures the project hub based on an environment variable or other data.
 */
 
-import { existsSync } from "fs";
-import { setPriority } from "os";
-import { getLogger } from "@cocalc/project/logger";
+import { existsSync } from "node:fs";
+import { setPriority } from "node:os";
 
+import { getLogger } from "@cocalc/project/logger";
 const L = getLogger("project:project-setup");
 
 // 19 is the minimum, we keep it 1 above that.


### PR DESCRIPTION
# Description

- jupyter pool parameters can be tuned by either the admin or by the user via project env vars.
- also: respect env vars by initializing that juypter pool **after** env vars are set.
- installing @types/node-cleanup for development, can't hurt

What I tested:

Setting this in my dev project's env variables:

```
{
   "ASDFASDF": "12345",
   "COCALC_JUPYTER_POOL_SIZE": "3"
}
```

and then after restarting the notebook (and well, earlier there was a python3 notebook) it did spawn 3:

```
cocalc:debug:jupyter:pool replenishPool {"name":"python3","opts":{"env":{"COCALC_JUPYTER_KERNELNAME":"python3","PLOTLY_RENDERER":"colab"}}} {"size":3,"timeout_s":3600}
```

Then, setting the size to 0 and restarting, there were no extra kernels in my processes list.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
