### PR TITLE
project: use getLogger everywhere

### DIFF
--- a/src/packages/project/autorenice.ts
+++ b/src/packages/project/autorenice.ts
@@ -8,14 +8,16 @@
  * It's inspired by and – http://and.sourceforge.net/
  */
 
-import debug from "debug";
-const L = debug("project:autorenice");
-import { reverse, sortBy } from "lodash";
-import { setPriority } from "os";
 import { delay } from "awaiting";
+import { reverse, sortBy } from "lodash";
+import { setPriority } from "node:os";
+
+import { getLogger } from "./logger";
 import { ProjectInfoServer, get_ProjectInfoServer } from "./project-info";
-import { ProjectInfo, Processes, Process } from "./project-info/types";
-import { is_free_project, DEFAULT_FREE_PROCS_NICENESS } from "./project-setup";
+import { Process, Processes, ProjectInfo } from "./project-info/types";
+import { DEFAULT_FREE_PROCS_NICENESS, is_free_project } from "./project-setup";
+
+const L = getLogger("autorenice").debug;
 
 const INTERVAL_S = 10;
 

--- a/src/packages/project/project-info/server.ts
+++ b/src/packages/project/project-info/server.ts
@@ -8,31 +8,32 @@ Project information server, doing the heavy lifting of telling the client
 about what's going on in a project.
 */
 
-import debug from "debug";
-const L = debug("project:project-info:server");
 import { delay } from "awaiting";
-import { join } from "path";
-import { exec } from "./utils";
+import { check as df } from "diskusage";
+import { EventEmitter } from "node:events";
+import { readFile, readdir, readlink } from "node:fs/promises";
+import { join } from "node:path";
+
 import { options } from "../init-program";
-import { promises as fsPromises } from "fs";
+import { get_kernel_by_pid } from "../jupyter/jupyter";
 import { pid2path as terminal_pid2path } from "../terminal/server";
 import { get_path_for_pid as x11_pid2path } from "../x11/server";
-import { get_kernel_by_pid } from "../jupyter/jupyter";
-const { readFile, readdir, readlink } = fsPromises;
-import { check as df } from "diskusage";
-import { EventEmitter } from "events";
 import {
+  CGroup,
+  CoCalcInfo,
   Cpu,
+  DiskUsage,
   Process,
   Processes,
   ProjectInfo,
   Stat,
   State,
-  DiskUsage,
-  CoCalcInfo,
-  CGroup,
 } from "./types";
+import { exec } from "./utils";
 //const { get_sage_path } = require("../sage_session");
+import { getLogger } from "../logger";
+
+const L = getLogger("project-info:server").debug;
 
 function is_in_dev_project() {
   return process.env.SMC_LOCAL_HUB_HOME != null;
@@ -209,19 +210,14 @@ export class ProjectInfoServer extends EventEmitter {
   // NOTE: most of this replaces kucalc.coffee
   private async cgroup({ timestamp }): Promise<CGroup | undefined> {
     if (!is_in_dev_project() && !options.kucalc && !this.testing) return;
-    const [
-      mem_stat_raw,
-      cpu_raw,
-      oom_raw,
-      cfs_quota_raw,
-      cfs_period_raw,
-    ] = await Promise.all([
-      readFile("/sys/fs/cgroup/memory/memory.stat", "utf8"),
-      readFile("/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage", "utf8"),
-      readFile("/sys/fs/cgroup/memory/memory.oom_control", "utf8"),
-      readFile("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "utf8"),
-      readFile("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "utf8"),
-    ]);
+    const [mem_stat_raw, cpu_raw, oom_raw, cfs_quota_raw, cfs_period_raw] =
+      await Promise.all([
+        readFile("/sys/fs/cgroup/memory/memory.stat", "utf8"),
+        readFile("/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage", "utf8"),
+        readFile("/sys/fs/cgroup/memory/memory.oom_control", "utf8"),
+        readFile("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "utf8"),
+        readFile("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "utf8"),
+      ]);
     const mem_stat_keys = [
       "total_rss",
       "total_cache",

--- a/src/packages/project/sync/usage-info.ts
+++ b/src/packages/project/sync/usage-info.ts
@@ -6,13 +6,15 @@
 // usage info for a specific file path, derived from the more general project info,
 // which includes all processes and other stats
 
-import debug from "debug";
-const L = debug("project:sync:usage-info");
 import { once } from "@cocalc/util/async-utils";
 import { SyncTable, SyncTableState } from "@cocalc/sync/table";
 import { close, merge } from "@cocalc/util/misc";
 import { UsageInfoServer } from "../usage-info";
 import { UsageInfo, ImmutableUsageInfo } from "../usage-info/types";
+import { getLogger } from "../logger";
+
+const logger = getLogger("sync:usage-info");
+const L = logger.debug;
 
 class UsageInfoTable {
   private readonly table?: SyncTable; // might be removed by close()
@@ -22,7 +24,7 @@ class UsageInfoTable {
 
   constructor(table: SyncTable, project_id: string) {
     this.project_id = project_id;
-    this.log = L.extend("table");
+    this.log = logger.extend("table").debug;
     this.table = table;
     this.setup_watchers();
   }
@@ -92,7 +94,7 @@ class UsageInfoTable {
   public get(path: string): ImmutableUsageInfo | undefined {
     const x = this.get_table().get(JSON.stringify([this.project_id, path]));
     if (x == null) return x;
-    return (x as unknown) as ImmutableUsageInfo;
+    return x as unknown as ImmutableUsageInfo;
     // NOTE: That we have to use JSON.stringify above is an ugly shortcoming
     // of the get method in @cocalc/sync/table/synctable.ts
     // that could probably be relatively easily fixed.

--- a/src/packages/project/usage-info/server.ts
+++ b/src/packages/project/usage-info/server.ts
@@ -11,13 +11,15 @@ for a specific "path" (e.g. the corresponding jupyter process for a notebook)
 from the ProjectInfoServer (which collects data about everything)
 */
 
-import debug from "debug";
-const L = debug("project:usage-info:server");
-import { EventEmitter } from "events";
 import { delay } from "awaiting";
+import { EventEmitter } from "node:events";
+
+import { getLogger } from "../logger";
 import { ProjectInfoServer, get_ProjectInfoServer } from "../project-info";
-import { ProjectInfo, Process } from "../project-info/types";
+import { Process, ProjectInfo } from "../project-info/types";
 import { UsageInfo } from "./types";
+
+const L = getLogger("usage-info:server").debug;
 
 function is_diff(prev: UsageInfo, next: UsageInfo, key: keyof UsageInfo) {
   // we assume a,b >= 0, hence we leave out Math.abs operations


### PR DESCRIPTION
# Description

- use getLogger instead of debug directly
- sort imports

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
