### PR TITLE
next/news: show most recent one on landing page

### DIFF
--- a/src/packages/database/postgres/news.ts
+++ b/src/packages/database/postgres/news.ts
@@ -3,7 +3,11 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { NewsItem, NewsPrevNext } from "@cocalc/util/types/news";
+import {
+  NewsItem,
+  NewsPrevNext,
+  RecentHeadline,
+} from "@cocalc/util/types/news";
 import { LRUQueryCache } from "./util";
 
 const C = new LRUQueryCache({ ttl_s: 10 * 60 });
@@ -105,4 +109,19 @@ export async function getIndex(
   offset: number
 ): Promise<NewsItem[]> {
   return await C.query<NewsItem>(Q_INDEX, [limit, offset]);
+}
+
+// get the most recent news item
+const Q_MOST_RECENT = `
+SELECT
+  id, channel, title, tags,
+  extract(epoch from date::timestamptz)::INTEGER as date
+FROM news
+WHERE date <= NOW()
+  AND hide IS NOT TRUE
+ORDER BY date DESC
+LIMIT 1`;
+
+export async function getMostRecentNews(): Promise<RecentHeadline | null> {
+  return await C.queryOne<NewsItem>(Q_MOST_RECENT);
 }

--- a/src/packages/next/components/landing/news-banner.tsx
+++ b/src/packages/next/components/landing/news-banner.tsx
@@ -1,0 +1,73 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Icon, IconName } from "@cocalc/frontend/components/icon";
+import { slugURL } from "@cocalc/util/news";
+import { COLORS } from "@cocalc/util/theme";
+import { CHANNELS_ICONS, RecentHeadline } from "@cocalc/util/types/news";
+import { Paragraph, Text } from "components/misc";
+import A from "components/misc/A";
+import { NewsTags } from "components/news/news";
+import { useDateStr } from "components/news/useDateStr";
+import { MAX_WIDTH } from "lib/config";
+
+const PADDING = "15px";
+const FONT_SIZE = "16px";
+
+// This is similar to the "BannerWithLinks" component, but showing recent news
+export function NewsBanner({
+  recentHeadline,
+}: {
+  recentHeadline: RecentHeadline | null;
+}) {
+  if (recentHeadline == null) return null;
+
+  const { channel, title, tags } = recentHeadline;
+  const permalink = slugURL(recentHeadline);
+  const dateStr = useDateStr(recentHeadline);
+
+  function renderHeadline() {
+    return (
+      <span style={{ paddingLeft: PADDING }}>
+        <Icon name={CHANNELS_ICONS[channel] as IconName} /> {dateStr}{" "}
+        <A
+          href={permalink}
+          style={{ paddingLeft: PADDING, fontWeight: "bold" }}
+        >
+          {title}
+        </A>{" "}
+        <NewsTags
+          tags={tags}
+          style={{ paddingLeft: PADDING }}
+          styleTag={{ fontSize: FONT_SIZE }}
+        />
+      </span>
+    );
+  }
+
+  return (
+    <div style={{ backgroundColor: COLORS.YELL_LL }}>
+      <Paragraph
+        style={{
+          margin: "0 auto",
+          padding: "10px",
+          textAlign: "center",
+          maxWidth: MAX_WIDTH,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: FONT_SIZE,
+          }}
+        >
+          {renderHeadline()}
+          <span style={{ paddingLeft: PADDING }}>
+            <A href={"/news"}>All news...</A>
+          </span>
+        </Text>
+      </Paragraph>
+    </div>
+  );
+}

--- a/src/packages/next/components/news/news.tsx
+++ b/src/packages/next/components/news/news.tsx
@@ -52,7 +52,6 @@ export function News(props: Props) {
   const { id, url, tags, title, date, channel, text, future, hide } = news;
   const dateStr = useDateStr(news, historyMode);
   const permalink = slugURL(news);
-  const router = useRouter();
   const { kucalc, dns } = useCustomize();
   const isCoCalcCom = kucalc === KUCALC_COCALC_COM;
   const showShareLinks = typeof dns === "string" && isCoCalcCom;
@@ -196,26 +195,8 @@ export function News(props: Props) {
     }
   }
 
-  function onTagClickStandalone(tag: string) {
-    router.push(`/news?tag=${tag}`);
-  }
-
   function renderTags() {
-    if (tags == null || !Array.isArray(tags) || tags.length === 0) return;
-    return (
-      <Space size={[0, 4]} wrap>
-        {tags.sort().map((tag) => (
-          <Tag
-            color={getRandomColor(tag)}
-            key={tag}
-            style={{ cursor: "pointer" }}
-            onClick={() => (onTagClick ?? onTagClickStandalone)(tag)}
-          >
-            {tag}
-          </Tag>
-        ))}
-      </Space>
-    );
+    return <NewsTags tags={tags} onTagClick={onTagClick} />;
   }
 
   function extra() {
@@ -337,4 +318,36 @@ export function News(props: Props) {
       </>
     );
   }
+}
+
+interface NewsTagsProps {
+  tags?: string[];
+  onTagClick?: (tag: string) => void;
+  style?: CSS;
+  styleTag?: CSS;
+}
+
+export function NewsTags({ tags, onTagClick, style, styleTag }: NewsTagsProps) {
+  if (tags == null || !Array.isArray(tags) || tags.length === 0) return null;
+
+  const router = useRouter();
+
+  function onTagClickStandalone(tag: string) {
+    router.push(`/news?tag=${tag}`);
+  }
+
+  return (
+    <Space size={[0, 4]} wrap style={style}>
+      {tags.sort().map((tag) => (
+        <Tag
+          color={getRandomColor(tag)}
+          key={tag}
+          style={{ cursor: "pointer", ...styleTag }}
+          onClick={() => (onTagClick ?? onTagClickStandalone)(tag)}
+        >
+          {tag}
+        </Tag>
+      ))}
+    </Space>
+  );
 }

--- a/src/packages/next/components/news/useDateStr.ts
+++ b/src/packages/next/components/news/useDateStr.ts
@@ -8,7 +8,10 @@ import { useMemo } from "react";
 
 import { NewsItem } from "@cocalc/util/types/news";
 
-export function useDateStr(news: NewsItem, minutes = false): string {
+export function useDateStr(
+  news: Omit<NewsItem, "text">,
+  minutes = false
+): string {
   const f = minutes ? "YYYY-MM-DD HH:mm" : "YYYY-MM-DD";
   return useMemo(
     () =>

--- a/src/packages/util/types/news.ts
+++ b/src/packages/util/types/news.ts
@@ -22,6 +22,9 @@ export interface NewsItem extends NewsProto {
   };
 }
 
+// NewsProto but without hide, text, and url
+export type RecentHeadline = Omit<NewsProto, "hide" | "text" | "url">;
+
 // This is what the frontend gets from the backend
 export interface NewsItemWebapp {
   id: string;
@@ -38,7 +41,7 @@ export const CHANNELS = [
   "about",
 ] as const;
 
-export type Channel = typeof CHANNELS[number];
+export type Channel = (typeof CHANNELS)[number];
 
 export const CHANNELS_DESCRIPTIONS: { [name in Channel]: string } = {
   announcement: "Major announcements, important upcoming changes",


### PR DESCRIPTION
# Description

This replaces the static yellow banner on the index page with the most recent news item + link to all news.

![Screenshot from 2023-04-26 11-04-34](https://user-images.githubusercontent.com/207405/234532143-a994a5fb-5fe6-4671-9beb-759ba81c80d8.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
