### PR TITLE
frontend/trial-banner: make it dismissable in the first month

### DIFF
--- a/src/packages/frontend/project/no-internet-banner.tsx
+++ b/src/packages/frontend/project/no-internet-banner.tsx
@@ -13,7 +13,7 @@ import {
   useState,
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
-import { A, Icon, VisibleMDLG } from "@cocalc/frontend/components";
+import { A, Icon, Text, VisibleMDLG } from "@cocalc/frontend/components";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 import {
   ALERT_STYLE,
@@ -65,10 +65,10 @@ export const NoInternetBanner: React.FC<NoInternetBannerProps> = React.memo(
     function renderDescription(): JSX.Element {
       return (
         <div style={{ display: "flex", flexDirection: "row" }}>
-          <div style={{ flex: "1 1 auto" }}>
-            <span style={{ fontSize: ALERT_STYLE.fontSize }}>
+          <div style={{ flex: "1 1 auto", marginTop: "4px" }}>
+            <Text style={{ fontSize: ALERT_STYLE.fontSize }}>
               {renderMessage()}
-            </span>
+            </Text>
           </div>
           <div>
             <Button

--- a/src/packages/frontend/project/project-banner.tsx
+++ b/src/packages/frontend/project/project-banner.tsx
@@ -83,10 +83,6 @@ export const ProjectWarningBanner: React.FC<Props> = React.memo(
 
     switch (showBanner()) {
       case "trial":
-        // timestamp, when this project was created. won't change over time.
-        const projCreatedTS =
-          project_map?.getIn([project_id, "created"]) ?? new Date(0);
-
         // list of all licenses applied to this project
         const projectSiteLicenses =
           project_map?.get(project_id)?.get("site_license")?.keySeq().toJS() ??
@@ -96,7 +92,7 @@ export const ProjectWarningBanner: React.FC<Props> = React.memo(
           <TrialBanner
             project_id={project_id}
             projectSiteLicenses={projectSiteLicenses}
-            proj_created={projCreatedTS.getTime()}
+            projectCreatedTS={project_map?.getIn([project_id, "created"])}
             host={host}
             internet={internet}
             projectIsRunning={projectIsRunning}

--- a/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
+++ b/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
@@ -3,21 +3,30 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Button, Space } from "antd";
+import { join } from "path";
+
+import { CSS, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components/icon";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 import { open_new_tab } from "@cocalc/frontend/misc";
 import { is_valid_uuid_string } from "@cocalc/util/misc";
-import { Button, Space } from "antd";
-import { join } from "path";
-import { useTypedRedux } from "../../app-framework";
 
 interface Props {
   project_id?: string;
+  text?: string;
+  asLink?: boolean;
+  showVoucherButton?: boolean;
+  style?: CSS;
 }
 
-export const BuyLicenseForProject: React.FC<Props> = (props: Props) => {
-  const { project_id } = props;
-
+export const BuyLicenseForProject: React.FC<Props> = ({
+  project_id,
+  text = "Buy a license",
+  asLink = false,
+  showVoucherButton = true,
+  style,
+}: Props) => {
   const commercial = useTypedRedux("customize", "commercial");
 
   function url(path): string {
@@ -32,19 +41,29 @@ export const BuyLicenseForProject: React.FC<Props> = (props: Props) => {
   if (!commercial) {
     return null;
   }
-  return (
-    <Space>
+
+  function renderBuyButton() {
+    return (
       <Button
-        size="large"
-        icon={<Icon name="shopping-cart" />}
+        size={asLink ? undefined : "large"}
+        type={asLink ? "link" : "default"}
+        icon={asLink ? undefined : <Icon name="shopping-cart" />}
+        style={style}
         onClick={() => {
           open_new_tab(url("store/site-license"));
         }}
       >
-        Buy a license
+        {text}
       </Button>
+    );
+  }
+
+  function renderVoucherButton() {
+    return (
       <Button
-        size="large"
+        size={asLink ? undefined : "large"}
+        type={asLink ? "link" : "default"}
+        style={style}
         icon={<Icon name="gift2" />}
         onClick={() => {
           open_new_tab(url("redeem"));
@@ -52,6 +71,17 @@ export const BuyLicenseForProject: React.FC<Props> = (props: Props) => {
       >
         Redeem a voucher
       </Button>
-    </Space>
-  );
+    );
+  }
+
+  if (showVoucherButton === false) {
+    return renderBuyButton();
+  } else {
+    return (
+      <Space>
+        {renderBuyButton()}
+        {renderVoucherButton()}
+      </Space>
+    );
+  }
 };

--- a/src/packages/util/consts/billing.ts
+++ b/src/packages/util/consts/billing.ts
@@ -9,4 +9,8 @@ export const AVG_YEAR_DAYS = 12 * AVG_MONTH_DAYS;
 export const ONE_MONTH_MS = AVG_MONTH_DAYS * ONE_DAY_MS;
 
 // throughout the UI, we show this price as the minimum (per month)
-export const LICENSE_MIN_PRICE = "less than $4/month";
+export const LICENSE_MIN_PRICE = "about $4/month";
+
+// Trial Banner in the UI
+export const EVALUATION_PERIOD_DAYS = 10;
+export const BANNER_NON_DISMISSABLE_DAYS = 30;


### PR DESCRIPTION
# Description

Tweaking the trial banner

1. dismissable in the first month
2. smaller in the beginning
3. the "with a license" buy link uses the same component, as we use for the buy button. i.e. this triggers automatic application of the license to the project.
4. explicitly mention "internet access" is missing
5. Welcome → "Hello :hand:" and a link to the documentation (main index page)

Initially

![Screenshot from 2023-05-04 17-02-52](https://user-images.githubusercontent.com/207405/236248489-980f4e70-7ad1-4bbe-a2c9-a6fe88f8bfe2.png)

After 10 days, a bit more prominent but dismissable

![Screenshot from 2023-05-04 17-02-33](https://user-images.githubusercontent.com/207405/236248643-3c391ceb-3400-4a12-a1db-bca9d2aa93c0.png)


After 30 days

![Screenshot from 2023-05-04 17-01-51](https://user-images.githubusercontent.com/207405/236248446-05bfd70d-7957-4cb9-be43-a858f71e65a5.png)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
