### PR TITLE
project/jupyter tweaks/debugging

### DIFF
--- a/src/packages/project/jupyter/execute-code.ts
+++ b/src/packages/project/jupyter/execute-code.ts
@@ -274,6 +274,7 @@ export class CodeExecutionEmitter
     this.state = "running";
     log.silly("_execute_code", this.code);
     if (this.kernel.get_state() === "closed") {
+      log.silly("_execute_code", "kernel.get_state() is closed");
       this.close();
       cb("closed");
       return;

--- a/src/packages/project/jupyter/execute-code.ts
+++ b/src/packages/project/jupyter/execute-code.ts
@@ -159,6 +159,9 @@ export class CodeExecutionEmitter
 
   _handle_shell(mesg: any): void {
     if (mesg.parent_header.msg_id !== this._message.header.msg_id) {
+      log.silly(
+        `_handle_shell: msg_id mismatch: ${mesg.parent_header.msg_id} != ${this._message.header.msg_id}`
+      );
       return;
     }
     log.silly("_handle_shell: got SHELL message -- ", mesg);
@@ -174,6 +177,11 @@ export class CodeExecutionEmitter
     } else if (mesg.content?.status == "ok") {
       this._push_mesg(mesg);
       this.set_shell_done(true);
+    } else {
+      log.warn(
+        `_handle_shell: got unexpected status: ${mesg.content?.status}`,
+        mesg
+      );
     }
   }
 

--- a/src/packages/project/jupyter/jupyter.ts
+++ b/src/packages/project/jupyter/jupyter.ts
@@ -258,14 +258,9 @@ export class JupyterKernel
       _jupyter_kernels[this._path].close();
     }
     _jupyter_kernels[this._path] = this;
-    const dbg = this.dbg("constructor");
-    dbg();
-    process.on("exit", () => {
-      if (this._kernel != null) {
-        killKernel(this._kernel);
-      }
-    });
     this.setMaxListeners(100);
+    const dbg = this.dbg("constructor");
+    dbg("done");
   }
 
   public get_path() {
@@ -518,7 +513,6 @@ export class JupyterKernel
       delete _jupyter_kernels[this._path];
     }
     this.removeAllListeners();
-    process.removeListener("exit", this.close);
     if (this._kernel != null) {
       killKernel(this._kernel);
       delete this._kernel;

--- a/src/packages/project/jupyter/jupyter.ts
+++ b/src/packages/project/jupyter/jupyter.ts
@@ -567,7 +567,7 @@ export class JupyterKernel
     if (this._kernel?.initCode != null) {
       for (const code of this._kernel?.initCode ?? []) {
         dbg("initCode ", code);
-        new CodeExecutionEmitter(this, { code }).go();
+        await new CodeExecutionEmitter(this, { code }).go();
       }
     }
     if (!this.has_ensured_running) {


### PR DESCRIPTION
# Description

I'm going through code and logs, ultimate goal is to figure out why nbgrader stalls. I also made #6696 and addressed it here. Not sure if this is fine this way or not – I think it's ok.

In any case, I contemplated about where it could stall, and added an `else` check for an unexpected content status. Log says this:

```
2023-05-11T10:14:10.582Z: cocalc:warn:jupyter:execute-code _handle_shell: got unexpected status: aborted {"header":{"msg_id":"49bfeb81-9d8c08c27f6640acedd36696_46","msg_type":"execute_reply","username":"user","session":"49bfeb81-9d8c08c27f6640acedd36696","date":"2023-05-11T10:14:10.579182Z","version":"5.3"},"parent_header":{"msg_id":"execute_dbd3b8de-455b-48c7-aea5-2d6b60f8353a","username":"user","session":"8c7f450d-a6c7-4b6d-850d-8314786e8f0a","msg_type":"execute_request","version":"5.3","date":"2023-05-11T10:14:10.574000Z"},"metadata":{"started":"2023-05-11T10:14:10.579152Z","dependencies_met":true,"engine":"32bc6c4c-3ee2-453a-9734-a568fdba3c4f","status":"aborted"},"content":{"status":"aborted"},"buffers":[],"channel":"shell"}
```

I don't know much about jupyter, in particular what the specs for all of this are. There is clearly no typing to restrict what states there are. What I'll do is to rewrite this in such a way, that only an expected and "actionable" `content.status` triggers an action, while everything else is the "abort-or-whatever-else" case.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
