### PR TITLE
static/crash: mention to update browser

### DIFF
--- a/src/packages/static/src/crash.tsx
+++ b/src/packages/static/src/crash.tsx
@@ -1,3 +1,8 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
 import { join } from "path";
 
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
@@ -5,7 +10,7 @@ import supportURL from "@cocalc/frontend/support/url";
 import { COLORS, HELP_EMAIL } from "@cocalc/util/theme";
 import A from "./link";
 
-const STYLE = {
+const STYLE: React.CSSProperties = {
   display: "none",
   zIndex: 10000,
   position: "absolute",
@@ -21,7 +26,7 @@ const STYLE = {
   fontSize: "12pt",
   backgroundColor: "white",
   color: COLORS.GRAY_D,
-} as React.CSSProperties;
+} as const;
 
 export default function Crash() {
   const getSupport = supportURL({
@@ -30,13 +35,14 @@ export default function Crash() {
     type: "problem",
     hideExtra: true,
   });
-  const dismiss = () => {
+
+  function dismiss() {
     // Yes, this is a very non-react way to do this.  This is a
     // port of something else that didn't use React.
     const crash = document.getElementById("cocalc-react-crash");
     if (crash == null) return;
     crash.style.display = "none";
-  };
+  }
 
   return (
     <div id="cocalc-react-crash" style={STYLE}>
@@ -51,49 +57,55 @@ export default function Crash() {
         &nbsp; CoCalc Crashed
       </h1>
 
+      <div style={{ fontWeight: "bold", textAlign: "center" }}>
+        Sorry to interrupt your work. An error happened in CoCalc's web
+        application.
+        <br />
+        Don't worry, all your files are securely stored on its servers!
+      </div>
+
       <hr />
 
-      <div>
-        <p>
-          Sorry to interrupt your work. An error happened in CoCalc's web
-          application. Don't worry, all your files are securely stored on its
-          servers!
-        </p>
+      <p>
+        <strong>Browser outdated?</strong> Please check if your{" "}
+        <A
+          style={{ fontWeight: "bold" }}
+          href={"https://www.whatismybrowser.com/"}
+        >
+          browser is up to date
+        </A>
+        . CoCalc requires running a recent version of a modern browser.
+      </p>
 
-        <ul>
-          <li>
-            If you have any <strong>browser extensions</strong> enabled, they
-            can break CoCalc and there is nothing we can do about it. You may
-            want to try CoCalc in incognito mode or otherwise try disabling
-            browser extensions to see if your ad blocker (or grammar checker,
-            etc.) is breaking CoCalc.
-          </li>
-          <li>
-            <p style={{ fontWeight: "bold", fontSize: "115%" }}>
-              <a onClick={() => window.location.reload()}>
-                Reload this browser tab
-              </a>{" "}
-              in order to recover from this. You might also try{" "}
-              <a
-                href={join(
-                  appBasePath,
-                  `projects?session=${new Date().valueOf()}`
-                )}
-              >
-                a new session
-              </a>
-              .
-            </p>
-          </li>
+      <p>
+        <strong>Extensions/AdBlocker?</strong> If you have any{" "}
+        <strong>browser extensions</strong> enabled, they can break CoCalc and
+        there is nothing we can do about it. You may want to try CoCalc in
+        incognito mode or otherwise try disabling browser extensions to see if
+        your ad blocker (or grammar checker, etc.) is breaking CoCalc.
+      </p>
 
-          <li>
-            <p style={{ fontWeight: "bold", fontSize: "115%" }}>
-              <a onClick={dismiss}>Dismiss this error</a> and continue using
-              CoCalc.
-            </p>
-          </li>
-        </ul>
-      </div>
+      <ul>
+        <li>
+          <p style={{ fontWeight: "bold", fontSize: "115%" }}>
+            <a onClick={() => window.location.reload()}>
+              Reload this browser tab
+            </a>{" "}
+            in order to recover from this. You might also try{" "}
+            <a href={join(appBasePath, `projects?session=${Date.now()}`)}>
+              a new session
+            </a>
+            .
+          </p>
+        </li>
+
+        <li>
+          <p style={{ fontWeight: "bold", fontSize: "115%" }}>
+            <a onClick={dismiss}>Dismiss this error</a> and continue using
+            CoCalc.
+          </p>
+        </li>
+      </ul>
 
       <hr />
 
@@ -101,14 +113,16 @@ export default function Crash() {
 
       <div id="cocalc-error-report-startup"></div>
 
-      <p>
+      <hr />
+
+      <div>
         If this happens repeatedly for a specific file or action, please report
         all details in <A href={getSupport}>a support ticket</A>, via email to{" "}
         <A href={`mailto:${HELP_EMAIL}`}>{HELP_EMAIL}</A>, or consult our{" "}
         <A href={join(appBasePath, "info")}>other support resources</A>. Thank
         you! Unfortunately, if you don't explain how you hit this problem so we
         can reproduce it, then we probably will not be able to fix it.
-      </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
# Description

This is just a minor change to the crash box, to mention to update browser and clean this up a little bit. Motivation is that I got this crash report from an on prem installation: `SyntaxError: private fields are not currently supported` related to latex/pdfjs. Not confirmed, but the error happens for old Firefox versions: https://caniuse.com/mdn-javascript_classes_private_class_fields

So, that's why there is now a link to a page I found, which will tell you if your browser is outdated.

![Screenshot from 2023-05-12 17-14-17](https://github.com/sagemathinc/cocalc/assets/207405/1693cb64-bc4d-485c-9b52-55710e37177d)





## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
