### PR TITLE
frontend/trial banner: voucher redeem + buy button

### DIFF
--- a/src/packages/frontend/project/trial-banner.tsx
+++ b/src/packages/frontend/project/trial-banner.tsx
@@ -133,8 +133,8 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
         <>
           <BuyLicenseForProject
             project_id={project_id}
-            text={"with a license"}
-            showVoucherButton={false}
+            buyText={"with a license"}
+            voucherText={"a voucher"}
             asLink={true}
             style={{ padding: 0, fontSize: style.fontSize, ...a_style }}
           />
@@ -320,6 +320,9 @@ export const BannerApplySiteLicense: React.FC<ApplyLicenseProps> = (
             applyLicense({ project_id, license_id });
           }}
           onCancel={() => setShowAddLicense(false)}
+          extraButtons={
+            <BuyLicenseForProject project_id={project_id} size={"middle"} />
+          }
         />
       </div>
     </>

--- a/src/packages/frontend/site-licenses/input.tsx
+++ b/src/packages/frontend/site-licenses/input.tsx
@@ -10,7 +10,7 @@ import {
   React,
   redux,
   useEffect,
-  useTypedRedux
+  useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
 import SelectLicense, { License } from "./select-license";
@@ -33,6 +33,7 @@ interface Props {
   exclude?: string[];
   style?: CSS;
   extra?: React.ReactNode;
+  extraButtons?: React.ReactNode;
 }
 
 export const SiteLicenseInput: React.FC<Props> = (props: Props) => {
@@ -44,6 +45,7 @@ export const SiteLicenseInput: React.FC<Props> = (props: Props) => {
     style,
     confirmLabel = "Apply License",
     extra,
+    extraButtons,
   } = props;
 
   const managedLicenses = useManagedLicenses();
@@ -60,6 +62,7 @@ export const SiteLicenseInput: React.FC<Props> = (props: Props) => {
       confirmLabel={confirmLabel}
       style={style}
       extra={extra}
+      extraButtons={extraButtons}
     />
   );
 };

--- a/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
+++ b/src/packages/frontend/site-licenses/purchase/buy-license-for-project.tsx
@@ -14,18 +14,20 @@ import { is_valid_uuid_string } from "@cocalc/util/misc";
 
 interface Props {
   project_id?: string;
-  text?: string;
+  buyText?: string;
+  voucherText?: string;
   asLink?: boolean;
-  showVoucherButton?: boolean;
   style?: CSS;
+  size?: "small" | "middle" | "large";
 }
 
 export const BuyLicenseForProject: React.FC<Props> = ({
   project_id,
-  text = "Buy a license",
+  buyText = "Buy a license",
+  voucherText = "Redeem a voucher",
   asLink = false,
-  showVoucherButton = true,
   style,
+  size = "large",
 }: Props) => {
   const commercial = useTypedRedux("customize", "commercial");
 
@@ -45,7 +47,7 @@ export const BuyLicenseForProject: React.FC<Props> = ({
   function renderBuyButton() {
     return (
       <Button
-        size={asLink ? undefined : "large"}
+        size={asLink ? undefined : size}
         type={asLink ? "link" : "default"}
         icon={asLink ? undefined : <Icon name="shopping-cart" />}
         style={style}
@@ -53,7 +55,7 @@ export const BuyLicenseForProject: React.FC<Props> = ({
           open_new_tab(url("store/site-license"));
         }}
       >
-        {text}
+        {buyText}
       </Button>
     );
   }
@@ -61,21 +63,25 @@ export const BuyLicenseForProject: React.FC<Props> = ({
   function renderVoucherButton() {
     return (
       <Button
-        size={asLink ? undefined : "large"}
+        size={asLink ? undefined : size}
         type={asLink ? "link" : "default"}
         style={style}
-        icon={<Icon name="gift2" />}
+        icon={asLink ? undefined : <Icon name="gift2" />}
         onClick={() => {
           open_new_tab(url("redeem"));
         }}
       >
-        Redeem a voucher
+        {voucherText}
       </Button>
     );
   }
 
-  if (showVoucherButton === false) {
-    return renderBuyButton();
+  if (asLink) {
+    return (
+      <>
+        {renderBuyButton()} or {renderVoucherButton()}
+      </>
+    );
   } else {
     return (
       <Space>

--- a/src/packages/frontend/site-licenses/select-license.tsx
+++ b/src/packages/frontend/site-licenses/select-license.tsx
@@ -34,6 +34,7 @@ interface Props {
   confirmLabel?: ReactNode;
   style?: CSS;
   extra?: ReactNode; // plain-text node is ok
+  extraButtons?: ReactNode;
 }
 
 export default function SelectLicense(props: Props) {
@@ -47,6 +48,7 @@ export default function SelectLicense(props: Props) {
     confirmLabel,
     style,
     extra,
+    extraButtons,
   } = props;
   const isBlurredRef = useRef<boolean>(true);
   const [licenseId, setLicenseId] = useState<string>(defaultLicenseId ?? "");
@@ -136,6 +138,9 @@ export default function SelectLicense(props: Props) {
             </Button>
           )}
         {onCancel && <Button onClick={onCancel}>Cancel</Button>}
+        {extraButtons != null ? (
+          <span style={{ paddingLeft: "20px" }}>{extraButtons}</span>
+        ) : null}
       </Space>
     );
   }


### PR DESCRIPTION
# Description

A little tweak to the trial banner, showing the link to redeem a voucher and when applying a license, buy+redeem buttons.

![Screenshot from 2023-05-17 10-39-14](https://github.com/sagemathinc/cocalc/assets/207405/711e620a-7313-48dd-8947-59153696aff9)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
