### PR TITLE
frontend: address Antd deprecations

### DIFF
--- a/src/packages/frontend/account/tours.tsx
+++ b/src/packages/frontend/account/tours.tsx
@@ -15,6 +15,7 @@ export default function Tours() {
   for (const name in names) {
     v.push(
       <Checkbox
+        key={name}
         checked={tours?.includes(name) || tours?.includes("all")}
         onChange={(e) => {
           const actions = redux.getActions("account");

--- a/src/packages/frontend/antd-bootstrap.tsx
+++ b/src/packages/frontend/antd-bootstrap.tsx
@@ -36,7 +36,6 @@ import {
 } from "antd";
 import { MouseEventHandler } from "react";
 
-import { Rendered } from "@cocalc/frontend/app-framework";
 import { r_join } from "@cocalc/frontend/components/r_join";
 import { Space } from "@cocalc/frontend/components/space";
 
@@ -340,27 +339,10 @@ interface TabsProps {
   tabBarExtraContent?;
   tabPosition?: "left" | "top" | "right" | "bottom";
   size?: "small";
-  items?: AntdTabItem[];
-  children?: any;
+  items: AntdTabItem[]; // This is mandatory: Tabs.TabPane (was in "Tab") is deprecated.
 }
 
-export function Tabs(props: TabsProps) {
-  const { children, items } = props;
-
-  let tabs: Rendered[] | Rendered = undefined;
-  if (items == null && children != null) {
-    tabs = [];
-    // We do this because for antd, "There must be `tab` property on children of Tabs."
-    if (Symbol.iterator in Object(props.children)) {
-      for (const x of children) {
-        if (x == null || !x.props) continue;
-        tabs.push(Tab(x.props));
-      }
-    } else {
-      tabs = Tab(children);
-    }
-  }
-
+export function Tabs(props: Readonly<TabsProps>) {
   return (
     <AntdTabs
       activeKey={props.activeKey}
@@ -370,21 +352,19 @@ export function Tabs(props: TabsProps) {
       tabBarExtraContent={props.tabBarExtraContent}
       tabPosition={props.tabPosition}
       size={props.size}
-      items={items}
-    >
-      {tabs}
-    </AntdTabs>
+      items={props.items}
+    />
   );
 }
 
 export function Tab(props: {
   id?: string;
   key?: string;
-  eventKey?: string;
+  eventKey: string;
   title: any;
   children?: any;
   style?: React.CSSProperties;
-}) {
+}): AntdTabItem {
   let title = props.title;
   if (!title) {
     // In case of useless title, some sort of fallback.
@@ -393,16 +373,18 @@ export function Tab(props: {
     title = props.eventKey ?? props.key;
     if (!title) title = "Tab";
   }
+
   // Get rid of the fade transition, which is inconsistent with
   // react-bootstrap (and also really annoying to me). See
   // https://github.com/ant-design/ant-design/issues/951#issuecomment-176291275
   const style = { ...{ transition: "0s" }, ...props.style };
 
-  return (
-    <AntdTabs.TabPane key={props.eventKey} tab={title} style={style}>
-      {props.children}
-    </AntdTabs.TabPane>
-  );
+  return {
+    key: props.key ?? props.eventKey,
+    label: title,
+    style,
+    children: props.children,
+  };
 }
 
 export function Modal(props: {

--- a/src/packages/frontend/frame-editors/latex-editor/build.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/build.tsx
@@ -176,7 +176,7 @@ export const Build: React.FC<Props> = React.memo((props) => {
 
     const items: AntdTabItem[] = [];
 
-    for (const log of Object.keys(BUILD_SPECS)) {
+    for (const log in BUILD_SPECS) {
       if (log === "clean" || log === "build") continue; // skip these
       const item = render_log(log);
       if (item) items.push(item);

--- a/src/packages/frontend/frame-editors/latex-editor/build.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/build.tsx
@@ -8,13 +8,13 @@ Show the last latex build log, i.e., output from last time we ran the LaTeX buil
 */
 
 import Ansi from "@cocalc/ansi-to-react";
-import { path_split } from "@cocalc/util/misc";
-import { React, Rendered, useRedux } from "../../app-framework";
-import { BuildCommand } from "./build-command";
+import { AntdTabItem, Tab, Tabs } from "@cocalc/frontend/antd-bootstrap";
+import { React, Rendered, useRedux } from "@cocalc/frontend/app-framework";
 import { IconName, Loading } from "@cocalc/frontend/components";
-import { Tab, Tabs } from "../../antd-bootstrap";
+import { path_split } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { BuildLogs } from "./actions";
+import { BuildCommand } from "./build-command";
 import { use_build_logs } from "./hooks";
 
 interface IBuildSpec {
@@ -108,12 +108,12 @@ export const Build: React.FC<Props> = React.memo((props) => {
   const [error_tab, set_error_tab] = React.useState(null);
   let no_errors = true;
 
-  function render_tab_body(
+  function render_tab_item(
     title: string,
     value: string,
     error?: boolean,
     time_str?: string
-  ) {
+  ): AntdTabItem {
     const style: React.CSSProperties = {
       fontFamily: "monospace",
       whiteSpace: "pre-line",
@@ -128,15 +128,21 @@ export const Build: React.FC<Props> = React.memo((props) => {
     };
     const err_style = error ? { background: COLORS.ATND_BG_RED_L } : undefined;
     const tab_button = <div style={err_style}>{title}</div>;
-    return (
-      <Tab key={title} eventKey={title} title={tab_button} style={style}>
-        {time_str && `Build time: ${time_str}\n\n`}
-        <Ansi>{value}</Ansi>
-      </Tab>
-    );
+    return Tab({
+      key: title,
+      eventKey: title,
+      title: tab_button,
+      style,
+      children: (
+        <>
+          {time_str && `Build time: ${time_str}\n\n`}
+          <Ansi>{value}</Ansi>
+        </>
+      ),
+    });
   }
 
-  function render_log(stage): Rendered {
+  function render_log(stage): AntdTabItem | undefined {
     if (build_logs == null) return;
     const x = build_logs.get(stage);
     if (!x) return;
@@ -155,18 +161,36 @@ export const Build: React.FC<Props> = React.memo((props) => {
         set_error_tab(title);
       }
     }
-    return render_tab_body(title, value, error, time_str);
+    return render_tab_item(title, value, error, time_str);
   }
 
-  function render_clean(): Rendered {
+  function render_clean(): AntdTabItem | undefined {
     const value = build_logs?.getIn(["clean", "output"]);
     if (!value) return;
     const title = "Clean Auxiliary Files";
-    return render_tab_body(title, value);
+    return render_tab_item(title, value);
   }
 
   function render_logs(): Rendered {
     if (status) return;
+
+    const items: AntdTabItem[] = [];
+
+    for (const log of Object.keys(BUILD_SPECS)) {
+      if (log === "clean" || log === "build") continue; // skip these
+      const item = render_log(log);
+      if (item) items.push(item);
+    }
+    const clean = render_clean();
+    if (clean) items.push(clean);
+
+    // check if active_tab is in the list of items.key
+    if (items.length > 0) {
+      if (!items.some((item) => item.key === active_tab)) {
+        set_active_tab(items[0].key);
+      }
+    }
+
     return (
       <Tabs
         activeKey={active_tab}
@@ -174,14 +198,8 @@ export const Build: React.FC<Props> = React.memo((props) => {
         tabPosition={"left"}
         size={"small"}
         style={{ height: "100%", overflowY: "auto" }}
-      >
-        {render_log("latex")}
-        {render_log("sagetex")}
-        {render_log("pythontex")}
-        {render_log("knitr")}
-        {render_log("bibtex")}
-        {render_clean()}
-      </Tabs>
+        items={items}
+      />
     );
   }
 

--- a/src/packages/frontend/jupyter/output-messages/widget.tsx
+++ b/src/packages/frontend/jupyter/output-messages/widget.tsx
@@ -7,23 +7,24 @@
 Widget rendering.
 */
 
-import $ from "jquery";
-import { Map, List, fromJS } from "immutable";
-import { Tabs, Tab } from "../../antd-bootstrap";
 import { Alert } from "antd";
+import { List, Map, fromJS } from "immutable";
+import $ from "jquery";
 import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
-import useIsMountedRef from "@cocalc/frontend/app-framework/is-mounted-hook";
-import useDelayedRender from "@cocalc/frontend/app-framework/delayed-render-hook";
-import { usePrevious, useRedux } from "@cocalc/frontend/app-framework";
 
-import { JupyterActions } from "../browser-actions";
-import * as pWidget from "@lumino/widgets";
-require("@jupyter-widgets/controls/css/widgets.css");
-import { CellOutputMessages } from "./message";
-import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
+import { AntdTabItem, Tab, Tabs } from "@cocalc/frontend/antd-bootstrap";
+import { usePrevious, useRedux } from "@cocalc/frontend/app-framework";
+import useDelayedRender from "@cocalc/frontend/app-framework/delayed-render-hook";
+import useIsMountedRef from "@cocalc/frontend/app-framework/is-mounted-hook";
 import { A, Loading } from "@cocalc/frontend/components";
+import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
 import getSupportURL from "@cocalc/frontend/support/url";
+import * as pWidget from "@lumino/widgets";
+import { JupyterActions } from "../browser-actions";
+import { CellOutputMessages } from "./message";
+
+require("@jupyter-widgets/controls/css/widgets.css");
 
 interface WidgetProps {
   value: Map<string, any>;
@@ -343,22 +344,23 @@ export const Widget: React.FC<WidgetProps> = React.memo(
       if (typeof react_view == "string") return;
       if (model.current == null) return;
 
-      const v: JSX.Element[] = [];
+      const v: AntdTabItem[] = [];
       let i = 0;
       for (const model_id of react_view.toJS()) {
         const key = `${i}`;
         v.push(
-          <Tab
-            eventKey={key}
-            key={key}
-            title={model.current.attributes._titles[i]}
-          >
-            <Widget
-              value={fromJS({ model_id })}
-              actions={actions}
-              name={name}
-            />
-          </Tab>
+          Tab({
+            eventKey: key,
+            key,
+            title: model.current.attributes._titles[i],
+            children: (
+              <Widget
+                value={fromJS({ model_id })}
+                actions={actions}
+                name={name}
+              />
+            ),
+          })
         );
         i += 1;
       }
@@ -370,9 +372,8 @@ export const Widget: React.FC<WidgetProps> = React.memo(
             model.current?.set_state({ selected_index });
           }}
           id={`tabs${model.current.model_id}`}
-        >
-          {v}
-        </Tabs>
+          items={v}
+        />
       );
     }
 

--- a/src/packages/frontend/project/explorer/path-navigator.tsx
+++ b/src/packages/frontend/project/explorer/path-navigator.tsx
@@ -3,11 +3,11 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { React, useTypedRedux, useActions } from "../../app-framework";
-import { trunc_middle } from "@cocalc/util/misc";
 import { HomeOutlined } from "@ant-design/icons";
+import { trunc_middle } from "@cocalc/util/misc";
 import { Breadcrumb } from "antd";
-import { PathSegmentLink } from "./path-segment-link";
+import { React, useActions, useTypedRedux } from "../../app-framework";
+import { createPathSegmentLink } from "./path-segment-link";
 
 interface Props {
   project_id: string;
@@ -21,8 +21,8 @@ export const PathNavigator: React.FC<Props> = React.memo((props: Props) => {
   const history_path = useTypedRedux({ project_id }, "history_path");
   const actions = useActions({ project_id });
 
-  function make_path(): JSX.Element[] {
-    const v: JSX.Element[] = [];
+  function make_path() {
+    const v: ReturnType<typeof createPathSegmentLink>[] = [];
 
     const current_path_depth =
       (current_path == "" ? 0 : current_path.split("/").length) - 1;
@@ -30,13 +30,7 @@ export const PathNavigator: React.FC<Props> = React.memo((props: Props) => {
     const is_root = current_path[0] === "/";
 
     v.push(
-      // yes, must be called as a normal function. The reason is
-      // because the antd Breadcrumb component requires
-      // that its children are of the type of component
-      // returned by PathSegmentLink, so we can't wrap that
-      // in a <PathSegmentLink...>.  If you don't do this,
-      // you'll get a runtime warning.
-      PathSegmentLink({
+      createPathSegmentLink({
         path: "",
         display: <HomeOutlined style={{ fontSize: style?.fontSize }} />,
         full_name: "",
@@ -52,7 +46,7 @@ export const PathNavigator: React.FC<Props> = React.memo((props: Props) => {
       const is_history = i > current_path_depth;
       v.push(
         // yes, must be called as a normal function.
-        PathSegmentLink({
+        createPathSegmentLink({
           path: history_segments.slice(0, i + 1 || undefined).join("/"),
           display: trunc_middle(segment, 15),
           full_name: segment,
@@ -69,8 +63,10 @@ export const PathNavigator: React.FC<Props> = React.memo((props: Props) => {
   // Background color is set via .cc-project-files-path-nav > nav
   // so that things look good even for multiline long paths.
   return (
-    <Breadcrumb style={style} className="cc-path-navigator">
-      {make_path()}
-    </Breadcrumb>
+    <Breadcrumb
+      style={style}
+      className="cc-path-navigator"
+      items={make_path()}
+    />
   );
 });

--- a/src/packages/frontend/project/explorer/path-segment-link.tsx
+++ b/src/packages/frontend/project/explorer/path-segment-link.tsx
@@ -4,7 +4,6 @@
  */
 
 import { Tip } from "@cocalc/frontend/components";
-import { Breadcrumb } from "antd";
 
 interface Props {
   path: string;
@@ -16,9 +15,15 @@ interface Props {
   key: number;
 }
 
+export interface PathSegmentItem {
+  key: number;
+  title: JSX.Element | string | undefined;
+  onClick: () => void;
+  className: string;
+}
+
 // One segment of the directory links at the top of the files listing.
-// this can't be a react component, because "Breadcrumb" only works with Breadcrumb.Item children!
-export function PathSegmentLink(props: Props) {
+export function createPathSegmentLink(props: Readonly<Props>): PathSegmentItem {
   const {
     path = "",
     display,
@@ -51,9 +56,10 @@ export function PathSegmentLink(props: Props) {
     }
   }
 
-  return (
-    <Breadcrumb.Item onClick={() => on_click(path)} className={cls()} key={key}>
-      {render_content()}
-    </Breadcrumb.Item>
-  );
+  return {
+    onClick: () => on_click(path),
+    className: cls(),
+    key,
+    title: render_content(),
+  };
 }

--- a/src/packages/next/components/landing/main.tsx
+++ b/src/packages/next/components/landing/main.tsx
@@ -28,13 +28,11 @@ export default function Main(props: Props) {
 
   function renderNav() {
     if (nav == null) return null;
-    return (
-      <Breadcrumb style={{ margin: "50px 0 25px 0" }}>
-        {nav.map((entry, idx) => (
-          <Breadcrumb.Item key={idx}>{entry}</Breadcrumb.Item>
-        ))}
-      </Breadcrumb>
-    );
+    const items = nav.map((entry, idx) => ({
+      key: idx,
+      title: entry,
+    }));
+    return <Breadcrumb style={{ margin: "50px 0 25px 0" }} items={items} />;
   }
 
   return (

--- a/src/packages/next/pages/news/[id].tsx
+++ b/src/packages/next/pages/news/[id].tsx
@@ -15,9 +15,9 @@ import Head from "components/landing/head";
 import Header from "components/landing/header";
 import A from "components/misc/A";
 import { News } from "components/news/news";
-import Loading from "components/share/loading";
 import { NewsWithFuture } from "components/news/types";
 import { useDateStr } from "components/news/useDateStr";
+import Loading from "components/share/loading";
 import { MAX_WIDTH, NOT_FOUND } from "lib/config";
 import { Customize, CustomizeType } from "lib/customize";
 import useProfile from "lib/hooks/profile";
@@ -62,15 +62,12 @@ export default function NewsPage(props: Props) {
   }
 
   function breadcrumb() {
-    return (
-      <Breadcrumb>
-        <Breadcrumb.Item>
-          <A href="/">{siteName}</A>
-        </Breadcrumb.Item>
-        <Breadcrumb.Item>
-          <A href="/news">News</A>
-        </Breadcrumb.Item>
-        <Breadcrumb.Item>
+    const items = [
+      { key: "/", title: <A href="/">{siteName}</A> },
+      { key: "/news", title: <A href="/news">News</A> },
+      {
+        key: "permalink",
+        title: (
           <A href={permalink}>
             {isAdmin || (!news.future && !news.hide) ? (
               <>
@@ -80,9 +77,10 @@ export default function NewsPage(props: Props) {
               "Not Authorized"
             )}
           </A>
-        </Breadcrumb.Item>
-      </Breadcrumb>
-    );
+        ),
+      },
+    ];
+    return <Breadcrumb items={items} />;
   }
 
   function olderNewer() {

--- a/src/packages/next/pages/news/[id]/[timestamp].tsx
+++ b/src/packages/next/pages/news/[id]/[timestamp].tsx
@@ -60,24 +60,20 @@ export default function NewsPage(props: Props) {
   }
 
   function breadcrumb() {
-    return (
-      <Breadcrumb>
-        <Breadcrumb.Item>
-          <A href="/">{siteName}</A>
-        </Breadcrumb.Item>
-        <Breadcrumb.Item>
-          <A href="/news">News</A>
-        </Breadcrumb.Item>
-        <Breadcrumb.Item>
-          <A href={permalink}>#{news.id}</A>
-        </Breadcrumb.Item>
-        <Breadcrumb.Item>
+    const items = [
+      { key: "/", title: <A href="/">{siteName}</A> },
+      { key: "/news", title: <A href="/news">News</A> },
+      { key: "permalink", title: <A href={permalink}>#{news.id}</A> },
+      {
+        key: "timestamp",
+        title: (
           <A href={`/news/${news.id}/${timestamp}`}>
             <TimeAgo datetime={1000 * timestamp} />
           </A>
-        </Breadcrumb.Item>
-      </Breadcrumb>
-    );
+        ),
+      },
+    ];
+    return <Breadcrumb items={items} />;
   }
 
   function up() {

--- a/src/packages/next/pages/news/edit/[id].tsx
+++ b/src/packages/next/pages/news/edit/[id].tsx
@@ -266,6 +266,12 @@ export default function EditNews(props: Props) {
 
   const title = `${siteName} / Edit News / ${isNew ? "new" : `${id}`}`;
 
+  const items = [
+    { key: "/", title: <A href="/">{siteName}</A> },
+    { key: "/news", title: <A href="/news">News</A> },
+    { key: "new", title: isNew ? "Create New" : `Edit #${id}` },
+  ];
+
   return (
     <Customize value={customize}>
       <Head title={title} />
@@ -284,17 +290,7 @@ export default function EditNews(props: Props) {
               margin: "0 auto",
             }}
           >
-            <Breadcrumb style={{ margin: "30px 0" }}>
-              <Breadcrumb.Item>
-                <A href="/">{siteName}</A>
-              </Breadcrumb.Item>
-              <Breadcrumb.Item>
-                <A href="/news">News</A>
-              </Breadcrumb.Item>
-              <Breadcrumb.Item>
-                {isNew ? "Create New" : `Edit #${id}`}
-              </Breadcrumb.Item>
-            </Breadcrumb>
+            <Breadcrumb style={{ margin: "30px 0" }} items={items} />
             {content()}
           </div>
           <Footer />


### PR DESCRIPTION
# Description

-  Antd Tabs.TabPane is deprecated
   - [x] latex build tabs
   - [x] jupyter ipywidget output with tabs
- Breadcrumb.Item
   - [x] next/news, editing, showing them, archived
   - [x] next/sso
   - [x] frontend/explorer: that home/directory quick navigate bar

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
