### PR TITLE
frontend: add mojo file extensions support (hidden, like python)

### DIFF
--- a/src/packages/frontend/codemirror/custom-modes.ts
+++ b/src/packages/frontend/codemirror/custom-modes.ts
@@ -156,6 +156,14 @@ CodeMirror.defineMode("cython", (config) => {
   );
 });
 
+CodeMirror.defineMode("mojo", (config) => {
+  // FUTURE: need to figure out how to do this so that the name
+  // of the mode is mojo or modular
+  return (CodeMirror as any).multiplexingMode(
+    CodeMirror.getMode(config, "python")
+  );
+});
+
 CodeMirror.defineMode("sagews", function (config) {
   const options: MultiplexOption[] = [];
   const close = new RegExp(`[${MARKERS.output}${MARKERS.cell}]`);

--- a/src/packages/frontend/codemirror/mode/python.js
+++ b/src/packages/frontend/codemirror/mode/python.js
@@ -364,4 +364,9 @@
                           "readonly struct union DEF IF ELIF ELSE")
   });
 
+  CodeMirror.defineMIME("text/x-mojo", {
+    name: "python",
+    extra_keywords: words("fn struct let var borrowed inout owned Pointer"),
+  });
+
 });

--- a/src/packages/frontend/file-associations.ts
+++ b/src/packages/frontend/file-associations.ts
@@ -175,6 +175,14 @@ for (const ext in codemirror_associations) {
   };
 }
 
+file_associations["mojo"] = file_associations["🔥"] = {
+  editor: "codemirror",
+  icon: "fire",
+  opts: { mode: "python" }, // TODO: once there is a mojo codemirror mode, change it
+  name: "text/x-mojo",
+  exclude_from_menu: true,
+};
+
 // noext = means file with no extension but the given name.
 file_associations["noext-dockerfile"] = {
   editor: "codemirror",
@@ -491,9 +499,26 @@ file_associations[""] = {
   name: "",
 };
 
-for (const ext of "zip gz bz2 z lz xz lzma tgz tbz tbz2 tb2 taz tz tlz txz lzip".split(
-  " "
-)) {
+const archive_extensions = [
+  "bz2",
+  "gz",
+  "lz",
+  "lzip",
+  "lzma",
+  "taz",
+  "tb2",
+  "tbz",
+  "tbz2",
+  "tgz",
+  "tlz",
+  "txz",
+  "tz",
+  "xz",
+  "z",
+  "zip",
+] as const;
+
+for (const ext of archive_extensions) {
   file_associations[ext] = archive_association;
 }
 

--- a/src/packages/frontend/file-associations.ts
+++ b/src/packages/frontend/file-associations.ts
@@ -178,7 +178,7 @@ for (const ext in codemirror_associations) {
 file_associations["mojo"] = file_associations["🔥"] = {
   editor: "codemirror",
   icon: "fire",
-  opts: { mode: "python" }, // TODO: once there is a mojo codemirror mode, change it
+  opts: { mode: "text/x-mojo" }, // this is a custom type, similar to cython
   name: "text/x-mojo",
   exclude_from_menu: true,
 };


### PR DESCRIPTION
# Description

Just a little playful thing: adding support for mojo files, hidden in the menu, and testing if the emoji extension works. 

![Screenshot from 2023-06-06 10-05-28](https://github.com/sagemathinc/cocalc/assets/207405/9422fc89-6541-452d-bab3-9d36e707bc15)

![Screenshot from 2023-06-06 10-09-46](https://github.com/sagemathinc/cocalc/assets/207405/4ce49fcb-b8e0-4fda-9ed2-a20bd8103fec)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
