### PR TITLE
frontend/flyout/log: also load the complete log

### DIFF
--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -151,6 +151,7 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
   const actions = useActions({ project_id });
   const mode: FlyoutLogMode = useTypedRedux({ project_id }, "flyout_log_mode");
   const project_log = useTypedRedux({ project_id }, "project_log");
+  const project_log_all = useTypedRedux({ project_id }, "project_log_all");
   const openFiles = useTypedRedux({ project_id }, "open_files_order");
   const user_map = useTypedRedux("users", "user_map");
   const activeTab = useTypedRedux({ project_id }, "active_project_tab");
@@ -166,17 +167,18 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
   }, [activeTab]);
 
   const log: OpenedFile[] = useMemo(() => {
-    if (project_log == null) return [];
+    const log = project_log_all ?? project_log;
+    if (log == null) return [];
 
     switch (mode) {
       case "files":
-        return deriveFiles(project_log, searchTerm, max);
+        return deriveFiles(log, searchTerm, max);
       case "history":
-        return deriveHistory(project_log, searchTerm, max);
+        return deriveHistory(log, searchTerm, max);
       default:
         unreachable(mode);
     }
-  }, [project_log, searchTerm, max, mode]);
+  }, [project_log, project_log_all, searchTerm, max, mode]);
 
   function renderFileItem(entry: OpenedFile) {
     const time = entry.time;
@@ -185,7 +187,7 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
     const info = file_options(path);
     const name: IconName = info.icon ?? "file";
     const isOpened: boolean = openFiles.some((p) => p === path);
-    const isActive : boolean = activePath === path;
+    const isActive: boolean = activePath === path;
 
     return (
       <FileListItem

--- a/src/packages/frontend/project_actions.ts
+++ b/src/packages/frontend/project_actions.ts
@@ -3088,9 +3088,9 @@ export class ProjectActions extends Actions<ProjectStoreState> {
     const store = this.get_store();
     if (store == null) return; // no store
     if (store.get("project_log_all") != null) return; // already done
-    this.setState({ project_log: undefined });
+    // Dear future dev: don't delete the project_log table
+    // https://github.com/sagemathinc/cocalc/issues/6765
     store.init_table("project_log_all");
-    this.remove_table("project_log");
   }
 
   // called when project page is shown


### PR DESCRIPTION
# Description

- fixes https://github.com/sagemathinc/cocalc/issues/6765 by not deleting the table.
- there is also the recent file list for the "home" part, which doesn't use the "_all" variant. So, I'm not sure if this is a good fix or not. In general, I wasn't aware that there are two separate data sources for the activity log. I thought there is one and with that button, it just gets longer.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
