### PR TITLE
frontend/flyout: round 4 of fixes

### DIFF
--- a/src/packages/frontend/project/page/file-tab.tsx
+++ b/src/packages/frontend/project/page/file-tab.tsx
@@ -9,7 +9,7 @@ A single tab in a project.
    - There is ALSO one for each of the fixed tabs -- files, new, log, search, settings.
 */
 
-import { Button, Popover, Space } from "antd";
+import { Popover } from "antd";
 import { CSSProperties, ReactNode } from "react";
 
 import {
@@ -20,22 +20,18 @@ import {
 } from "@cocalc/frontend/app-framework";
 import { HiddenXSSM, Icon, IconName } from "@cocalc/frontend/components";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
-import { ServerLink } from "@cocalc/frontend/project/named-server-panel";
 import track from "@cocalc/frontend/user-tracking";
 import { filename_extension, path_split, path_to_tab } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { PROJECT_INFO_TITLE } from "../info";
-import { TITLE as SERVERS_TITLE } from "../servers";
-import { RestartProject } from "../settings/restart-project";
-import { StopProject } from "../settings/stop-project";
-import { ChatGPTGenerateNotebookButton } from "./home-page/chatgpt-generate-jupyter";
-import { HomeRecentFiles } from "./home-page/recent-files";
-import { FilesFlyout } from "./flyouts/files";
 import { ProjectSearchBody } from "../search/body";
-import { NewFlyout } from "./flyouts/new";
-import { ProjectInfoFlyout } from "./flyouts/info";
+import { TITLE as SERVERS_TITLE } from "../servers";
 import { SettingsFlyout } from "./flyouts/control";
+import { FilesFlyout } from "./flyouts/files";
+import { ProjectInfoFlyout } from "./flyouts/info";
 import { LogFlyout } from "./flyouts/log";
+import { NewFlyout } from "./flyouts/new";
+import { ServersFlyout } from "./flyouts/servers";
 
 const { file_options } = require("@cocalc/frontend/editor");
 
@@ -78,14 +74,14 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
     label: "New",
     flyoutTitle: "New file",
     icon: "plus-circle",
-    tooltip: NewPopover,
+    tooltip: "Create new files",
     flyout: NewFlyout,
     noAnonymous: false,
   },
   log: {
     label: "Log",
     icon: "history",
-    tooltip: LogPopover,
+    tooltip: "Project activity log",
     flyout: LogFlyout,
     flyoutTitle: "Recent Files",
     noAnonymous: false,
@@ -100,8 +96,7 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
   servers: {
     label: SERVERS_TITLE,
     icon: "server",
-    tooltip: ServersPopover,
-    flyout: ({ project_id }) => ServersPopover({ project_id, flyout: true }),
+    flyout: ({ project_id }) => ServersFlyout({ project_id }),
     noAnonymous: false,
   },
   info: {
@@ -114,7 +109,7 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
   settings: {
     label: "Settings",
     icon: "wrench",
-    tooltip: SettingsPopover,
+    tooltip: "Project settings and controls",
     flyout: SettingsFlyout,
     noAnonymous: false,
     flyoutTitle: "Status and controls",
@@ -410,64 +405,6 @@ function DisplayedLabel({ path, label, inline = true }) {
         {label}
         <span style={{ color: COLORS.FILE_EXT }}>{ext}</span>
       </span>
-    </div>
-  );
-}
-
-function NewPopover({ project_id }) {
-  return (
-    <div>
-      Create or Upload New Files (click for more...)
-      <hr />
-      <ChatGPTGenerateNotebookButton project_id={project_id} />
-    </div>
-  );
-}
-
-function LogPopover({ project_id }) {
-  return (
-    <div>
-      Project Activity Log (click for more...)
-      <hr />
-      <HomeRecentFiles project_id={project_id} style={{ maxHeight: "125px" }} />
-    </div>
-  );
-}
-
-function SettingsPopover({ project_id }) {
-  return (
-    <div>
-      Project settings and controls (click for more...)
-      <hr />
-      <Button.Group>
-        <RestartProject project_id={project_id} />
-        <StopProject project_id={project_id} />
-      </Button.Group>
-    </div>
-  );
-}
-
-function ServersPopover({ project_id, flyout = false }) {
-  const servers = [
-    <ServerLink key="jupyterlab" name="jupyterlab" project_id={project_id} />,
-    <ServerLink key="jupyter" name="jupyter" project_id={project_id} />,
-    <ServerLink key="code" name="code" project_id={project_id} />,
-    <ServerLink key="pluto" name="pluto" project_id={project_id} />,
-  ].filter((s) => s != null);
-
-  return (
-    <div>
-      Launch servers
-      {!flyout ? ": Jupyter, Pluto, VS Code (click for more details..." : ""}
-      <hr />
-      <Space direction="vertical">
-        {servers}
-        {servers.length == 0 && (
-          <>
-            No available server has been detected in this project environment.
-          </>
-        )}
-      </Space>
     </div>
   );
 }

--- a/src/packages/frontend/project/page/flyouts/control.tsx
+++ b/src/packages/frontend/project/page/flyouts/control.tsx
@@ -59,6 +59,9 @@ export function SettingsFlyout(_): JSX.Element {
     "all_projects_have_been_loaded"
   );
 
+  const active_top_tab = useTypedRedux("page", "active_top_tab");
+  const projectIsVisible = active_top_tab === project_id;
+
   function renderState() {
     const s = state?.get("state");
     const iconName = COMPUTE_STATES[s]?.icon;
@@ -90,7 +93,8 @@ export function SettingsFlyout(_): JSX.Element {
     }
   }
 
-  function renderStatus(): JSX.Element {
+  function renderStatus(): JSX.Element | undefined {
+    if (!projectIsVisible) return;
     return (
       <>
         <Title level={4}>

--- a/src/packages/frontend/project/page/flyouts/servers.tsx
+++ b/src/packages/frontend/project/page/flyouts/servers.tsx
@@ -1,0 +1,35 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Space } from "antd";
+
+import { Paragraph } from "@cocalc/frontend/components";
+import { ServerLink } from "@cocalc/frontend/project/named-server-panel";
+
+export function ServersFlyout({ project_id }) {
+  const servers = [
+    <ServerLink key="jupyterlab" name="jupyterlab" project_id={project_id} />,
+    <ServerLink key="jupyter" name="jupyter" project_id={project_id} />,
+    <ServerLink key="code" name="code" project_id={project_id} />,
+    <ServerLink key="pluto" name="pluto" project_id={project_id} />,
+  ].filter((s) => s != null);
+
+  return (
+    <div style={{ padding: "5px" }}>
+      <Paragraph>
+        When launched, these servers run inside this project. They should open
+        up in a new browser tab, and get access all files in this project.
+      </Paragraph>
+      <Space direction="vertical">
+        {servers}
+        {servers.length === 0 && (
+          <Paragraph>
+            No available server has been detected in this project environment.
+          </Paragraph>
+        )}
+      </Space>
+    </div>
+  );
+}

--- a/src/packages/frontend/project/page/home-page/button.tsx
+++ b/src/packages/frontend/project/page/home-page/button.tsx
@@ -44,6 +44,7 @@ export default function HomePageButton({ project_id, active, width }) {
         borderRadius: "0",
         fontSize: "24px",
         color: active ? COLORS.ANTD_LINK_BLUE : COLORS.FILE_ICON,
+        transitionDuration: "0s",
       }}
       onClick={() => {
         actions?.set_active_tab("home");

--- a/src/packages/frontend/project/page/page.tsx
+++ b/src/packages/frontend/project/page/page.tsx
@@ -21,6 +21,7 @@ import {
   FrameContext,
   defaultFrameContext,
 } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
+import { EDITOR_PREFIX, path_to_tab } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { useAppState } from "../../app/context";
 import { AnonymousName } from "../anonymous-name";
@@ -44,8 +45,6 @@ import HomePageButton from "./home-page/button";
 import { useProjectStatus } from "./project-status-hook";
 import { SoftwareEnvUpgrade } from "./software-env-upgrade";
 import Tabs, { FIXED_TABS_BG_COLOR, VerticalFixedTabs } from "./tabs";
-import { path_to_tab } from "@cocalc/util/misc";
-import { EDITOR_PREFIX } from "@cocalc/util/misc";
 //import FirstSteps from "@cocalc/frontend/project/explorer/file-listing/first-steps";
 
 const PAGE_STYLE: React.CSSProperties = {

--- a/src/packages/frontend/project/page/tabs.tsx
+++ b/src/packages/frontend/project/page/tabs.tsx
@@ -6,8 +6,8 @@
 /*
 Tabs in a particular project.
 */
-import { Switch, Tooltip } from "antd";
 
+import { Switch, Tooltip } from "antd";
 import { debounce, throttle } from "lodash";
 import { ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
 
@@ -134,8 +134,10 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
     const observer = new ResizeObserver(
       debounce(
         () => {
-          if (parent.current == null) return;
-          setHomePageButtonWidth(parent.current.scrollWidth);
+          const width = parent.current?.offsetWidth;
+          // we ignore zero width, which happens when not visible
+          if (width == null || width == 0) return;
+          setHomePageButtonWidth(width);
         },
         50,
         { trailing: true, leading: false }

--- a/src/packages/frontend/project/settings/run-quota/hooks.tsx
+++ b/src/packages/frontend/project/settings/run-quota/hooks.tsx
@@ -110,7 +110,10 @@ function pct(val, total, unit) {
   };
 }
 
-export function useCurrentUsage({ project_id }): CurrentUsage {
+export function useCurrentUsage({
+  project_id,
+  shortStr = false,
+}): CurrentUsage {
   const project_status = useTypedRedux({ project_id }, "status");
 
   const project_map = useTypedRedux("projects", "project_map");
@@ -158,7 +161,8 @@ export function useCurrentUsage({ project_id }): CurrentUsage {
     const pct = usage.cpu_pct;
     if (typeof cpu === "number" && typeof pct === "number") {
       const hms = seconds2hms(cpu, false, true);
-      const txt = `${pct}% (${hms})`;
+      // In a flyout, hms overlaps with the quota value column next to it
+      const txt = `${pct}%${shortStr ? "" : ` (${hms})`}`;
       return {
         element: <PercentBar percent={pct} format={() => txt} />,
         display: `${pct}% (in total ${hms} of CPU time)`,

--- a/src/packages/frontend/project/settings/run-quota/misc.ts
+++ b/src/packages/frontend/project/settings/run-quota/misc.ts
@@ -43,9 +43,12 @@ export interface QuotaData {
   usage: Usage;
 }
 
-export function renderValueUnit(val, unit): string {
-  val = round2(val);
-  return `${val} ${plural(val, unit)}`;
+export function renderValueUnit(val: number, unit: string): string {
+  if (unit === "MB" && val >= 1000) {
+    return `${round2(val / 1000)} GB`;
+  } else {
+    return `${round2(val)} ${plural(val, unit)}`;
+  }
 }
 
 export function booleanValueStr(quota) {

--- a/src/packages/frontend/project/settings/run-quota/run-quota.tsx
+++ b/src/packages/frontend/project/settings/run-quota/run-quota.tsx
@@ -52,7 +52,7 @@ export const RunQuota: React.FC<Props> = React.memo(
     const isFlyout = mode === "flyout";
     const projectIsRunning = project_state === "running";
     //const projectStatus = project.get("status");
-    const currentUsage = useCurrentUsage({ project_id });
+    const currentUsage = useCurrentUsage({ project_id, shortStr: isFlyout });
     const kucalc = useTypedRedux("customize", "kucalc");
     const cocalcCom = kucalc === KUCALC_COCALC_COM;
     const runQuota = useRunQuota(project_id, null);


### PR DESCRIPTION
# Description

- [x] if project not visible, do not render the status to avoid showing the floating restart confirmation popup
- [x] switching between projects causes the width of the home button to flicker, a component is measured as zero width
- [x] removing the settings/quota cpu usage time, since it overlaps with the next quota column
  - also convert MB→GB to save width
- [x] getting rid of the vertical bar popover with complex controls ... flyouts replace them



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
