### PR TITLE
flyout: 5th round of improvements

### DIFF
--- a/src/packages/frontend/account/other-settings.tsx
+++ b/src/packages/frontend/account/other-settings.tsx
@@ -132,19 +132,6 @@ export class OtherSettings extends Component<Props> {
     );
   }
 
-  private render_hide_action_popovers(): Rendered {
-    return (
-      <Checkbox
-        checked={!!this.props.other_settings.get("hide_action_popovers")}
-        onChange={(e) =>
-          this.on_change("hide_action_popovers", e.target.checked)
-        }
-      >
-        Hide Action Button Popovers: do not show the popovers over the action
-        buttons (Explorer, New, Log, etc.)
-      </Checkbox>
-    );
-  }
 
   private render_hide_project_popovers(): Rendered {
     return (
@@ -328,7 +315,6 @@ export class OtherSettings extends Component<Props> {
         {this.render_time_ago_absolute()}
         {this.render_global_banner()}
         {this.render_mask_files()}
-        {this.render_hide_action_popovers()}
         {this.render_hide_project_popovers()}
         {this.render_hide_file_popovers()}
         {this.render_hide_button_tooltips()}

--- a/src/packages/frontend/chat/register.ts
+++ b/src/packages/frontend/chat/register.ts
@@ -3,15 +3,14 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { redux } from "@cocalc/frontend/app-framework";
-import { redux_name } from "../app-framework";
-import { webapp_client } from "../webapp-client";
-import { alert_message } from "../alerts";
-import { register_file_editor } from "../file-editors";
-import { startswith, path_split } from "@cocalc/util/misc";
-import { ChatStore } from "./store";
+import { alert_message } from "@cocalc/frontend/alerts";
+import { redux, redux_name } from "@cocalc/frontend/app-framework";
+import { register_file_editor } from "@cocalc/frontend/file-editors";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import { path_split, startswith } from "@cocalc/util/misc";
 import { ChatActions } from "./actions";
 import { ChatRoom } from "./chatroom";
+import { ChatStore } from "./store";
 
 // it is fine to call this more than once.
 export function init(project_id: string, path: string): string {

--- a/src/packages/frontend/components/copy-button.tsx
+++ b/src/packages/frontend/components/copy-button.tsx
@@ -1,24 +1,36 @@
-import { CSSProperties, useEffect, useState } from "react";
 import { Button } from "antd";
-import { Icon } from "@cocalc/frontend/components/icon";
+import { CSSProperties, useEffect, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
+
+import { Icon } from "@cocalc/frontend/components/icon";
 
 interface Props {
   style?: CSSProperties;
   value?: string;
   size?;
+  noText?: boolean;
 }
 
-export default function CopyButton({ style, value, size }: Props) {
+export default function CopyButton({
+  style,
+  value,
+  size,
+  noText = false,
+}: Props) {
   const [copied, setCopied] = useState<boolean>(false);
   useEffect(() => {
     setCopied(false);
   }, [value]);
   return (
     <CopyToClipboard text={value} onCopy={() => setCopied(true)}>
-      <Button size={size} type="text" style={style}>
+      <Button
+        size={size}
+        type="text"
+        style={style}
+        onClick={(e) => e.stopPropagation()}
+      >
         <Icon name={copied ? "check" : "copy"} />
-        {copied ? "Copied" : "Copy"}
+        {noText ? undefined : copied ? "Copied" : "Copy"}
       </Button>
     </CopyToClipboard>
   );

--- a/src/packages/frontend/components/help-icon.tsx
+++ b/src/packages/frontend/components/help-icon.tsx
@@ -8,11 +8,11 @@ Display a ? "help" icon, which -- when clicked -- shows a help tip
 */
 
 import { Button, Popover } from "antd";
-
 import { CSSProperties } from "react";
+
 import { React, useState } from "@cocalc/frontend/app-framework";
-import { Icon } from "./icon";
 import { COLORS } from "@cocalc/util/theme";
+import { Icon } from "./icon";
 
 interface Props {
   title: string;
@@ -31,18 +31,25 @@ export const HelpIcon: React.FC<Props> = ({
 
   return (
     <Popover
-      content={<div style={{ maxWidth }}>{children}</div>}
+      content={
+        <div onClick={(e) => e.stopPropagation()} style={{ maxWidth }}>
+          {children}
+        </div>
+      }
       title={
-        <>
+        <div onClick={(e) => e.stopPropagation()}>
           {title}
           <Button
             type="text"
             style={{ float: "right", fontWeight: "bold" }}
-            onClick={() => setOpen(false)}
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+            }}
           >
             <Icon name="times" />
           </Button>
-        </>
+        </div>
       }
       trigger="click"
       open={open}
@@ -51,6 +58,7 @@ export const HelpIcon: React.FC<Props> = ({
       <Icon
         style={{ color: COLORS.BS_BLUE_TEXT, cursor: "pointer", ...style }}
         name="question-circle"
+        onClick={(e) => e?.stopPropagation()}
       />
     </Popover>
   );

--- a/src/packages/frontend/components/path-link.tsx
+++ b/src/packages/frontend/components/path-link.tsx
@@ -3,16 +3,15 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { redux } from "@cocalc/frontend/app-framework";
 import {
   endswith,
   path_split,
   separate_file_extension,
-  should_open_in_foreground,
   trunc_middle,
 } from "@cocalc/util/misc";
-import { Tip } from "./tip";
 import { COLORS } from "@cocalc/util/theme";
+import { handle_log_click } from "../project/history/utils";
+import { Tip } from "./tip";
 
 interface Props {
   path: string;
@@ -90,13 +89,3 @@ export const PathLink: React.FC<Props> = ({
     return render_link(name);
   }
 };
-
-export function handle_log_click(e, path, project_id): void {
-  e.preventDefault();
-  const switch_to = should_open_in_foreground(e);
-  redux.getProjectActions(project_id).open_file({
-    path,
-    foreground: switch_to,
-    foreground_project: switch_to,
-  });
-}

--- a/src/packages/frontend/editors/task-editor/find.tsx
+++ b/src/packages/frontend/editors/task-editor/find.tsx
@@ -7,13 +7,14 @@
 Searching for tasks by full text search and done/deleted status.
 */
 
-import { useEffect, useRef } from "../../app-framework";
 import { Input } from "antd";
-import { ShowToggle } from "./show-toggle";
-import { EmptyTrash } from "./empty-trash";
-import { TaskActions } from "./actions";
-import { Counts, LocalViewStateMap } from "./types";
 import { CSSProperties } from "react";
+
+import { useEffect, useRef } from "@cocalc/frontend/app-framework";
+import { TaskActions } from "./actions";
+import { EmptyTrash } from "./empty-trash";
+import { ShowToggle } from "./show-toggle";
+import { Counts, LocalViewStateMap } from "./types";
 
 interface Props {
   actions: TaskActions;

--- a/src/packages/frontend/editors/task-editor/list.tsx
+++ b/src/packages/frontend/editors/task-editor/list.tsx
@@ -10,16 +10,17 @@ List of Tasks -- we use windowing via Virtuoso, so that even task lists with 500
 import { List, Set as immutableSet } from "immutable";
 import { useEffect, useMemo, useRef } from "react";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
-import useVirtuosoScrollHook from "@cocalc/frontend/components/virtuoso-scroll-hook";
-import Task from "./task";
-import { TaskActions } from "./actions";
-import { LocalTaskStateMap, SelectedHashtags, Tasks } from "./types";
 import { useDebouncedCallback } from "use-debounce";
+
 import useIsMountedRef from "@cocalc/frontend/app-framework/is-mounted-hook";
+import useVirtuosoScrollHook from "@cocalc/frontend/components/virtuoso-scroll-hook";
+import { TaskActions } from "./actions";
+import Task from "./task";
+import { LocalTaskStateMap, SelectedHashtags, Tasks } from "./types";
 
 import {
-  SortableList,
   SortableItem,
+  SortableList,
 } from "@cocalc/frontend/components/sortable-list";
 
 interface Props {
@@ -147,7 +148,8 @@ export default function TaskList({
   }
 
   function on_click(e) {
-    if (e.target === mainDivRef.current) {
+    // test, if e.target is a child of mainDivRef.current
+    if (mainDivRef.current.contains(e.target)) {
       actions?.enable_key_handler();
     }
   }

--- a/src/packages/frontend/frame-editors/task-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/task-editor/editor.ts
@@ -8,9 +8,10 @@ Top-level react component for editing markdown documents
 */
 
 import { createElement } from "react";
-import { createEditor } from "../frame-tree/editor";
+
 import { TaskEditor } from "@cocalc/frontend/editors/task-editor/editor";
 import { set } from "@cocalc/util/misc";
+import { createEditor } from "../frame-tree/editor";
 import { terminal } from "../terminal-editor/editor";
 import { time_travel } from "../time-travel-editor/editor";
 

--- a/src/packages/frontend/index.sass
+++ b/src/packages/frontend/index.sass
@@ -434,7 +434,4 @@ span.cc-project-fixedtab-drag:hover
   cusor: move
 
 div.cc-project-flyout-file-item:hover
-  background-color: $COL_GRAY_L0
-
-div.cc-project-flyout-file-item:hover
-  background-color: $COL_GRAY_L0
+  background-color: $COL_BLUE_LLL

--- a/src/packages/frontend/project/history/log-entry.tsx
+++ b/src/packages/frontend/project/history/log-entry.tsx
@@ -103,7 +103,8 @@ function areEqual(prev: Props, next: Props): boolean {
   return (
     prev.id == next.id &&
     prev.user_map == next.user_map &&
-    prev.cursor == next.cursor
+    prev.cursor == next.cursor &&
+    prev.backgroundStyle == next.backgroundStyle
   );
 }
 
@@ -672,7 +673,6 @@ export const LogEntry: React.FC<Props> = React.memo(
               display: "flex",
               flexDirection: "row",
               justifyContent: "space-between",
-
               ...backgroundStyle,
             }}
           >

--- a/src/packages/frontend/project/history/utils.ts
+++ b/src/packages/frontend/project/history/utils.ts
@@ -1,0 +1,22 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { redux } from "@cocalc/frontend/app-framework";
+import { should_open_in_foreground } from "@cocalc/util/misc";
+
+// used when clicking/opening a file open entry in the project activity log
+export function handle_log_click(
+  e: React.MouseEvent | React.KeyboardEvent,
+  path: string,
+  project_id: string
+): void {
+  e.preventDefault();
+  const switch_to = should_open_in_foreground(e);
+  redux.getProjectActions(project_id).open_file({
+    path,
+    foreground: switch_to,
+    foreground_project: switch_to,
+  });
+}

--- a/src/packages/frontend/project/page/common.tsx
+++ b/src/packages/frontend/project/page/common.tsx
@@ -1,0 +1,14 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { COLORS } from "@cocalc/util/theme";
+
+
+export const FIX_BORDER = `1px solid ${COLORS.GRAY_L0}`;
+
+export const FIX_BORDERS: React.CSSProperties = {
+  borderTop: FIX_BORDER,
+  borderRight: FIX_BORDER,
+} as const;

--- a/src/packages/frontend/project/page/common.tsx
+++ b/src/packages/frontend/project/page/common.tsx
@@ -5,7 +5,6 @@
 
 import { COLORS } from "@cocalc/util/theme";
 
-
 export const FIX_BORDER = `1px solid ${COLORS.GRAY_L0}`;
 
 export const FIX_BORDERS: React.CSSProperties = {

--- a/src/packages/frontend/project/page/file-tab.tsx
+++ b/src/packages/frontend/project/page/file-tab.tsx
@@ -52,7 +52,6 @@ type FixedTabs = {
   [name in FixedTab]: {
     label: string;
     icon: IconName;
-    tooltip?: string | ((props: { project_id: string }) => ReactNode);
     flyout: (props: { project_id: string; wrap: Function }) => JSX.Element;
     flyoutTitle?: string | ReactNode;
     noAnonymous?: boolean;
@@ -66,7 +65,6 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
   files: {
     label: "Explorer",
     icon: "folder-open",
-    tooltip: "Browse files",
     flyout: FilesFlyout,
     noAnonymous: false,
   },
@@ -74,14 +72,12 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
     label: "New",
     flyoutTitle: "New file",
     icon: "plus-circle",
-    tooltip: "Create new files",
     flyout: NewFlyout,
     noAnonymous: false,
   },
   log: {
     label: "Log",
     icon: "history",
-    tooltip: "Project activity log",
     flyout: LogFlyout,
     flyoutTitle: "Recent Files",
     noAnonymous: false,
@@ -89,7 +85,6 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
   search: {
     label: "Find",
     icon: "search",
-    tooltip: "Search files in the project",
     flyout: SearchFlyout,
     noAnonymous: false,
   },
@@ -102,14 +97,12 @@ export const FIXED_PROJECT_TABS: FixedTabs = {
   info: {
     label: PROJECT_INFO_TITLE,
     icon: "microchip",
-    tooltip: "Running processes, resource usage, …",
     flyout: ProjectInfoFlyout,
     noAnonymous: false,
   },
   settings: {
     label: "Settings",
     icon: "wrench",
-    tooltip: "Project settings and controls",
     flyout: SettingsFlyout,
     noAnonymous: false,
     flyoutTitle: "Status and controls",
@@ -322,7 +315,7 @@ export function FileTab(props: Readonly<Props>) {
   if (
     props.noPopover ||
     IS_MOBILE ||
-    (isFixedTab && other_settings.get("hide_action_popovers")) ||
+    isFixedTab ||
     (!isFixedTab && other_settings.get("hide_file_popovers"))
   ) {
     return body;

--- a/src/packages/frontend/project/page/flyouts/body.tsx
+++ b/src/packages/frontend/project/page/flyouts/body.tsx
@@ -49,7 +49,7 @@ export function FlyoutBody({
   );
 
   // use this *once* around a vertically scollable content div in the component, e.g. results in a search
-  function wrap(content, style: CSS = {}) {
+  function wrap(content: React.ReactNode, style: CSS = {}) {
     return (
       <div
         ref={setBodyDiv}

--- a/src/packages/frontend/project/page/flyouts/body.tsx
+++ b/src/packages/frontend/project/page/flyouts/body.tsx
@@ -9,9 +9,9 @@ import { CSS, useEffect, useState } from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
 import * as LS from "@cocalc/frontend/misc/local-storage-typed";
 import { FIXED_PROJECT_TABS, FixedTab } from "../file-tab";
-import { FIX_BORDER } from "../page";
 import { FIXED_TABS_BG_COLOR } from "../tabs";
 import { LSFlyout, lsKey, storeFlyoutState } from "./state";
+import { FIX_BORDER } from "../common";
 
 export function FlyoutBody({
   flyout,

--- a/src/packages/frontend/project/page/flyouts/body.tsx
+++ b/src/packages/frontend/project/page/flyouts/body.tsx
@@ -82,7 +82,9 @@ export function FlyoutBody({
       }}
     >
       {Body == null ? (
-        <Loading />
+        <div style={{ textAlign: "center", marginTop: "50px" }}>
+          <Loading />
+        </div>
       ) : (
         <Body project_id={project_id} wrap={wrap} />
       )}

--- a/src/packages/frontend/project/page/flyouts/body.tsx
+++ b/src/packages/frontend/project/page/flyouts/body.tsx
@@ -5,13 +5,18 @@
 
 import { debounce } from "lodash";
 
-import { CSS, useEffect, useState } from "@cocalc/frontend/app-framework";
+import {
+  CSS,
+  redux,
+  useEffect,
+  useState,
+} from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
 import * as LS from "@cocalc/frontend/misc/local-storage-typed";
+import { FIX_BORDER } from "../common";
 import { FIXED_PROJECT_TABS, FixedTab } from "../file-tab";
 import { FIXED_TABS_BG_COLOR } from "../tabs";
 import { LSFlyout, lsKey, storeFlyoutState } from "./state";
-import { FIX_BORDER } from "../common";
 
 export function FlyoutBody({
   flyout,
@@ -79,6 +84,11 @@ export function FlyoutBody({
         backgroundColor: FIXED_TABS_BG_COLOR,
         overflowY: "hidden",
         overflowX: "hidden",
+      }}
+      onFocus={() => {
+        // Remove any active key handler that is next to this side chat.
+        // E.g, this is critical for taks lists...
+        redux.getActions("page").erase_active_key_handler();
       }}
     >
       {Body == null ? (

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -8,21 +8,24 @@ import {
   orange as ANTD_ORANGE,
   yellow as ANTD_YELLOW,
 } from "@ant-design/colors";
+import { Tooltip } from "antd";
 
 import { CSS, useRef } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
 import { hexColorToRGBA } from "@cocalc/util/misc";
 import { server_time } from "@cocalc/util/relative-time";
 import { COLORS } from "@cocalc/util/theme";
-import { Tooltip } from "antd";
+
+// make sure two types of borders are of the same width
+const BORDER_WIDTH_PX = "4px";
 
 const FILE_ITEM_SELECTED_STYLE: CSS = {
-  backgroundColor: COLORS.GRAY_LL,
+  backgroundColor: COLORS.BLUE_LL, // bit darker than .cc-project-flyout-file-item:hover
 } as const;
 
 const FILE_ITEM_OPENED_STYLE: CSS = {
-  ...FILE_ITEM_SELECTED_STYLE,
   fontWeight: "bold",
+  backgroundColor: COLORS.GRAY_LL,
   color: COLORS.PROJECT.FIXED_LEFT_ACTIVE,
 } as const;
 
@@ -155,13 +158,13 @@ export function FileListItem({
       className="cc-project-flyout-file-item"
       style={{
         ...FILE_ITEM_LINE_STYLE,
-        ...(selected ? FILE_ITEM_SELECTED_STYLE : {}),
         ...(item.isopen
           ? item.isactive
             ? FILE_ITEM_ACTIVE_STYLE
             : FILE_ITEM_OPENED_STYLE
           : {}),
         ...itemStyle,
+        ...(selected ? FILE_ITEM_SELECTED_STYLE : {}),
       }}
     >
       {renderBody()}
@@ -184,7 +187,7 @@ export function fileItemStyle(time: number = 0, masked: boolean = false): CSS {
     col = hexColorToRGBA(ANTD_YELLOW[5], opacity);
   }
   return {
-    borderLeft: `4px solid ${col}`,
+    borderLeft: `${BORDER_WIDTH_PX} solid ${col}`,
     ...(masked ? { color: COLORS.GRAY_L } : {}),
   };
 }

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -20,7 +20,7 @@ import { COLORS } from "@cocalc/util/theme";
 const BORDER_WIDTH_PX = "4px";
 
 const FILE_ITEM_SELECTED_STYLE: CSS = {
-  backgroundColor: COLORS.BLUE_LL, // bit darker than .cc-project-flyout-file-item:hover
+  backgroundColor: COLORS.BLUE_LLL, // bit lighter than .cc-project-flyout-file-item:hover
 } as const;
 
 const FILE_ITEM_OPENED_STYLE: CSS = {

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -277,6 +277,11 @@ export function FilesFlyout({ project_id }): JSX.Element {
         setScrollIdx(null);
       }
     }
+
+    // if esc key is pressed, clear search and reset
+    else if (e.key === "Escape") {
+      setSearch("");
+    }
   }
 
   function renderItemIcon(

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -72,6 +72,7 @@ export function FilesFlyout({ project_id }): JSX.Element {
   const openFiles = useTypedRedux({ project_id }, "open_files_order");
   const [search, setSearch] = useState<string>("");
   const [scrollIdx, setScrollIdx] = useState<number | null>(null);
+  const [scollIdxHide, setScrollIdxHide] = useState<boolean>(false);
   const student_project_functionality =
     useStudentProjectFunctionality(project_id);
   const disableUploads = student_project_functionality.disableUploads ?? false;
@@ -333,7 +334,7 @@ export function FilesFlyout({ project_id }): JSX.Element {
           actions?.close_tab(path_to_file(current_path, name));
         }}
         tooltip={renderTooltip(age, item)}
-        selected={index === scrollIdx}
+        selected={!scollIdxHide && index === scrollIdx}
       />
     );
   }
@@ -458,6 +459,8 @@ export function FilesFlyout({ project_id }): JSX.Element {
             value={search}
             onKeyDown={filterKeyHandler}
             onChange={(e) => setSearch(e.target.value)}
+            onFocus={() => setScrollIdxHide(false)}
+            onBlur={() => setScrollIdxHide(true)}
             style={{ flex: "1", marginRight: "10px" }}
             allowClear
             prefix={<Icon name="search" />}

--- a/src/packages/frontend/project/page/flyouts/header.tsx
+++ b/src/packages/frontend/project/page/flyouts/header.tsx
@@ -9,8 +9,8 @@ import { useActions } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
 import { capitalize } from "@cocalc/util/misc";
 import { PathNavigator } from "../../explorer/path-navigator";
+import { FIX_BORDER } from "../common";
 import { FIXED_PROJECT_TABS, FixedTab } from "../file-tab";
-import { FIX_BORDER } from "../page";
 import { FIXED_TABS_BG_COLOR } from "../tabs";
 import { LogHeader } from "./log";
 

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Button, Input, Radio } from "antd";
+import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 
 import {
   CSS,
@@ -16,30 +17,28 @@ import {
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { Icon, IconName, Loading, TimeAgo } from "@cocalc/frontend/components";
-import { handle_log_click } from "@cocalc/frontend/components/path-link";
 import useVirtuosoScrollHook from "@cocalc/frontend/components/virtuoso-scroll-hook";
 import { file_options } from "@cocalc/frontend/editor-tmp";
 import { LogEntry } from "@cocalc/frontend/project/history/log-entry";
-import track from "@cocalc/frontend/user-tracking";
 import {
   EventRecordMap,
   to_search_string,
 } from "@cocalc/frontend/project/history/types";
+import track from "@cocalc/frontend/user-tracking";
 import { User } from "@cocalc/frontend/users";
 import {
-  path_to_file,
   search_match,
   search_split,
-  should_open_in_foreground,
   strictMod,
   tab_to_path,
   unreachable,
 } from "@cocalc/util/misc";
-import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
+import { COLORS } from "@cocalc/util/theme";
+import { handle_log_click } from "../../history/utils";
+import { FIX_BORDER } from "../common";
 import { FIXED_PROJECT_TABS } from "../file-tab";
 import { FileListItem, fileItemStyle } from "./components";
 import { FlyoutLogMode, getFlyoutLogMode, isFlyoutLogMode } from "./state";
-import { COLORS } from "@cocalc/util/theme";
 
 export const FLYOUT_LOG_DEFAULT_MODE = "files";
 
@@ -160,7 +159,6 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
   const openFiles = useTypedRedux({ project_id }, "open_files_order");
   const user_map = useTypedRedux("users", "user_map");
   const activeTab = useTypedRedux({ project_id }, "active_project_tab");
-  const current_path = useTypedRedux({ project_id }, "current_path");
   const virtuosoScroll = useVirtuosoScrollHook({
     cacheId: `${project_id}::flyout::log`,
   });
@@ -260,17 +258,12 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
   function open(e: React.MouseEvent | React.KeyboardEvent, index: number) {
     if (mode !== "files") return;
     const file: OpenedFile = log[index];
-    const fullPath = path_to_file(current_path, file.filename);
-    const foreground = should_open_in_foreground(e);
     track("open-file", {
       project_id,
-      path: fullPath,
+      path: file.filename,
       how: "click-on-log-file-flyout",
     });
-    actions?.open_file({
-      path: fullPath,
-      foreground,
-    });
+    handle_log_click(e, file.filename, project_id);
   }
 
   function onKeyUpHandler(e) {
@@ -322,7 +315,7 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
   function renderBottom() {
     if (project_log_all != null) return null;
     return (
-      <div style={{ flex: "1 1 auto", borderTop: `1px solid ${COLORS.GRAY}` }}>
+      <div style={{ flex: "1 1 auto", borderTop: FIX_BORDER }}>
         <Button
           block
           type="ghost"

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Input, Radio } from "antd";
+import { Button, Input, Radio } from "antd";
 
 import {
   CSS,
@@ -319,6 +319,23 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
     );
   }
 
+  function renderBottom() {
+    if (project_log_all != null) return null;
+    return (
+      <div style={{ flex: "1 1 auto", borderTop: `1px solid ${COLORS.GRAY}` }}>
+        <Button
+          block
+          type="ghost"
+          onClick={() => {
+            actions?.project_log_load_all();
+          }}
+        >
+          Load all log entries...
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <>
       <Input
@@ -334,6 +351,7 @@ export function LogFlyout({ max = 100, project_id, wrap }: Props): JSX.Element {
         prefix={<Icon name="search" />}
       />
       {wrap(list(), { marginTop: "10px" })}
+      {renderBottom()}
     </>
   );
 }

--- a/src/packages/frontend/project/page/flyouts/new.tsx
+++ b/src/packages/frontend/project/page/flyouts/new.tsx
@@ -197,7 +197,8 @@ export function NewFlyout({
     }
     return (
       <ErrorDisplay
-        style={{ marginBottom: "20px" }}
+        style={{ margin: 0, flex: "1 0 auto" }}
+        banner={true}
         error={message}
         onClose={(): void => {
           actions?.setState({ file_creation_error: "" });
@@ -223,9 +224,10 @@ export function NewFlyout({
   }
 
   function renderHead() {
+    const padding = { padding: "5px" };
     return (
-      <Space style={{ padding: "10px" }} direction="vertical">
-        <Space direction="horizontal">
+      <Space direction="vertical">
+        <Space direction="horizontal" style={padding}>
           Location:{" "}
           <PathNavigator
             mode={"flyout"}
@@ -239,7 +241,7 @@ export function NewFlyout({
           onChange={onChangeHandler}
           onKeyUp={onKeyUpHandler}
           onFocus={inputOnFocus}
-          style={{ width: "100%" }}
+          style={{ width: "100%", ...padding }}
           addonBefore={fileIcon()}
           addonAfter={renderExtAddon()}
         />
@@ -247,8 +249,8 @@ export function NewFlyout({
           style={{
             display: "flex",
             flexDirection: "column",
-            marginBottom: "10px",
             justifyContent: "space-between",
+            ...padding,
           }}
         >
           <Button
@@ -271,6 +273,7 @@ export function NewFlyout({
             </Text>
           )}
         </div>
+        {file_creation_error && renderError()}
       </Space>
     );
   }
@@ -281,7 +284,6 @@ export function NewFlyout({
         style={{ width: "100%", overflowX: "hidden", padding: "5px" }}
         direction="vertical"
       >
-        {file_creation_error && renderError()}
         <FileTypeSelector
           mode="flyout"
           selectedExt={ext}

--- a/src/packages/frontend/project/page/home-page/recent-files.tsx
+++ b/src/packages/frontend/project/page/home-page/recent-files.tsx
@@ -20,10 +20,10 @@ import {
   Text,
   TimeAgo,
 } from "@cocalc/frontend/components";
-import { handle_log_click } from "@cocalc/frontend/components/path-link";
 import { file_options } from "@cocalc/frontend/editor-tmp";
 import { EventRecordMap } from "@cocalc/frontend/project/history/types";
 import { User } from "@cocalc/frontend/users";
+import { handle_log_click } from "../../history/utils";
 
 interface OpenedFile {
   filename: string;

--- a/src/packages/frontend/project/page/page.tsx
+++ b/src/packages/frontend/project/page/page.tsx
@@ -45,6 +45,7 @@ import HomePageButton from "./home-page/button";
 import { useProjectStatus } from "./project-status-hook";
 import { SoftwareEnvUpgrade } from "./software-env-upgrade";
 import Tabs, { FIXED_TABS_BG_COLOR, VerticalFixedTabs } from "./tabs";
+import { FIX_BORDERS } from "./common";
 //import FirstSteps from "@cocalc/frontend/project/explorer/file-listing/first-steps";
 
 const PAGE_STYLE: React.CSSProperties = {
@@ -52,13 +53,6 @@ const PAGE_STYLE: React.CSSProperties = {
   flexDirection: "column",
   flex: 1,
   overflow: "hidden",
-} as const;
-
-export const FIX_BORDER = `1px solid ${COLORS.GRAY_L0}`;
-
-export const FIX_BORDERS: React.CSSProperties = {
-  borderTop: FIX_BORDER,
-  borderRight: FIX_BORDER,
 } as const;
 
 interface Props {

--- a/src/packages/frontend/project/page/tabs.tsx
+++ b/src/packages/frontend/project/page/tabs.tsx
@@ -163,7 +163,7 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
         : undefined;
 
     const style: CSS = {
-      margin: "5px 0px",
+      padding: "0",
       ...color,
       borderLeft: `4px solid ${
         activeTab == name ? COLORS.PROJECT.FIXED_LEFT_ACTIVE : "transparent"
@@ -181,7 +181,8 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
         isFixedTab={true}
         iconStyle={{
           fontSize: "24px",
-          margin: "0px 6px",
+          margin: "0",
+          padding: "5px 0px",
           ...color,
         }}
         flyout={name}

--- a/src/packages/frontend/project/search/body.tsx
+++ b/src/packages/frontend/project/search/body.tsx
@@ -22,6 +22,7 @@ import {
   SearchInput,
   Space,
 } from "@cocalc/frontend/components";
+import CopyButton from "@cocalc/frontend/components/copy-button";
 import infoToMode from "@cocalc/frontend/editors/slate/elements/code-block/info-to-mode";
 import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
 import { file_associations } from "@cocalc/frontend/file-associations";
@@ -539,6 +540,12 @@ function ProjectSearchResultLine(_: Readonly<ProjectSearchResultLineProps>) {
 
   async function click_filename(e: React.MouseEvent): Promise<void> {
     e.preventDefault();
+
+    // prevent a click if user is selecting text
+    if (window.getSelection()?.toString()) {
+      return;
+    }
+
     let chat;
     let path = path_to_file(most_recent_path, filename);
     const { tail } = path_split(path);
@@ -574,6 +581,14 @@ function ProjectSearchResultLine(_: Readonly<ProjectSearchResultLineProps>) {
         style={{ marginRight: "5px", marginLeft: "5px", overflow: "hidden" }}
         hoverable={true}
         onClick={click_filename}
+        extra={
+          <CopyButton
+            value={description}
+            noText
+            size="small"
+            style={{ padding: "0 5px" }}
+          />
+        }
       >
         <Snippet
           ext={ext}

--- a/src/packages/util/db-schema/accounts.ts
+++ b/src/packages/util/db-schema/accounts.ts
@@ -299,7 +299,6 @@ Table({
             dark_mode_sepia: 0,
             dark_mode_grayscale: 0,
             news_read_until: 0,
-            hide_action_popovers: false,
             hide_project_popovers: false,
             hide_file_popovers: false,
             hide_button_tooltips: false,


### PR DESCRIPTION
# Description

-  make the entire file item area clickable, but prevent the dropdown menu from triggering a click
- instead of caret sign, make background like hover. border's don't work well.
- load "full log" button
- keyboard scroll support for files in log entry + opening via return key
- get rid of popovers + remove associated account "other setting"
- fix opening file from log entries (re-using existing function)
- search: 
   - compact settings, use help icon for additional info
   - nested scrollbars if necessary
   - do not copy if text is selected, also add a small copy button
- flyout vs. tasks: remove key handler when focused
   - however, the focus never flipped back to tasks. how does chat do this? I had to change some code in `task-editor/list.tsx` **this is the only change outside flyouts, and it puzzles me, see comment**

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
