### PR TITLE
frontend/log: mark EventRecord.time as optional

### DIFF
--- a/src/packages/frontend/project/history/log-entry.tsx
+++ b/src/packages/frontend/project/history/log-entry.tsx
@@ -3,6 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Tooltip } from "antd";
+import React from "react";
+
 import { Avatar } from "@cocalc/frontend/account/avatar/avatar";
 import { CSS, redux, Rendered } from "@cocalc/frontend/app-framework";
 import {
@@ -22,8 +25,6 @@ import track from "@cocalc/frontend/user-tracking";
 import { describe_quota } from "@cocalc/util/licenses/describe-quota";
 import * as misc from "@cocalc/util/misc";
 import { round1 } from "@cocalc/util/misc";
-import { Tooltip } from "antd";
-import React from "react";
 import { Col, Grid, Row } from "react-bootstrap";
 import { SystemProcess } from "./system-process";
 import {
@@ -69,7 +70,7 @@ const file_action_icons: {
 
 interface Props {
   id: string;
-  time: Date;
+  time?: Date;
   event: ProjectEvent | string;
   account_id: string;
   user_map?: UserMap;

--- a/src/packages/frontend/project/history/types.ts
+++ b/src/packages/frontend/project/history/types.ts
@@ -3,16 +3,17 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { SiteLicenseQuota } from "@cocalc/util/types/site-licenses";
 import { Map } from "immutable";
-import { TypedMap } from "../../app-framework";
+
+import { TypedMap } from "@cocalc/frontend/app-framework";
+import { SiteLicenseQuota } from "@cocalc/util/types/site-licenses";
 
 export type EventRecord = {
   id: string;
   event: TypedMap<ProjectEvent>;
   account_id: string;
   project_id?: string;
-  time: Date;
+  time?: Date;
 };
 
 export type EventRecordMap = TypedMap<EventRecord>;


### PR DESCRIPTION
# Description

Just a small detail after yesterday. Marking the "time" as optional in the type. It doesn't help when packed into the TypedMap, but at least the situation in general is written down somewhere.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
