### PR TITLE
frontend: rename our "Space" to "Gap", to avoid the name clash with antd

### DIFF
--- a/src/packages/frontend/account/avatar/avatar.tsx
+++ b/src/packages/frontend/account/avatar/avatar.tsx
@@ -11,7 +11,7 @@ import {
   useAsyncEffect,
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
-import { Space } from "@cocalc/frontend/components";
+import { Gap } from "@cocalc/frontend/components";
 import { ProjectTitle } from "@cocalc/frontend/projects/project-title";
 import { DEFAULT_COLOR } from "@cocalc/frontend/users/store";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
@@ -165,7 +165,7 @@ const Avatar0: React.FC<Props> = (props) => {
     if (line != null) {
       return (
         <span>
-          <Space /> (Line {line})
+          <Gap /> (Line {line})
         </span>
       );
     }

--- a/src/packages/frontend/account/licenses/managed-licenses.tsx
+++ b/src/packages/frontend/account/licenses/managed-licenses.tsx
@@ -22,7 +22,7 @@ import {
   ErrorDisplay,
   Icon,
   Loading,
-  Space,
+  Gap,
   Title,
 } from "@cocalc/frontend/components";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
@@ -132,7 +132,7 @@ export const ManagedLicenses: React.FC = () => {
           {render_show_all()}
           <Button onClick={reload} disabled={loading}>
             <Icon name="redo" />
-            <Space /> <Space /> {loading ? "Loading..." : "Refresh all"}
+            <Gap /> <Gap /> {loading ? "Loading..." : "Refresh all"}
           </Button>
         </div>
       </Title>

--- a/src/packages/frontend/account/profile-settings.tsx
+++ b/src/packages/frontend/account/profile-settings.tsx
@@ -6,7 +6,7 @@
 import { Map } from "immutable";
 import { rclass, rtypes, Component, Rendered } from "../app-framework";
 import { Panel } from "../antd-bootstrap";
-import { LabeledRow, Loading, Space } from "../components";
+import { LabeledRow, Loading, Gap } from "../components";
 import { ColorPicker } from "../colorpicker";
 import { ProfileImageSelector } from "./profile-image";
 import { set_account_table } from "./util";
@@ -49,8 +49,8 @@ class ProfileSettings extends Component<Props, State> {
     return (
       <>
         <Avatar account_id={this.props.account_id} size={48} />
-        <Space />
-        <Space />
+        <Gap />
+        <Gap />
         Avatar
       </>
     );

--- a/src/packages/frontend/account/public-paths/public-paths.tsx
+++ b/src/packages/frontend/account/public-paths/public-paths.tsx
@@ -21,7 +21,7 @@ import {
   ErrorDisplay,
   Icon,
   Loading,
-  Space,
+  Gap,
   TimeAgo,
   A,
 } from "@cocalc/frontend/components";
@@ -247,7 +247,7 @@ export const PublicPaths: React.FC = () => {
       />
       <Button onClick={fetch} disabled={loading} style={{ float: "right" }}>
         <Icon name="redo" />
-        <Space /> <Space /> {loading ? "Loading..." : "Refresh"}
+        <Gap /> <Gap /> {loading ? "Loading..." : "Refresh"}
       </Button>
       <h2>Public files ({paths?.length ?? "?"})</h2>
       Files that have been published in any project that you have actively used.

--- a/src/packages/frontend/account/settings/account-settings.tsx
+++ b/src/packages/frontend/account/settings/account-settings.tsx
@@ -25,7 +25,7 @@ import {
   A,
   ErrorDisplay,
   Icon,
-  Space,
+  Gap,
   TimeAgo,
 } from "@cocalc/frontend/components";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
@@ -297,7 +297,7 @@ export class AccountSettings extends Component<Props, State> {
         <Col xs={12}>
           <div className="pull-right">
             <SignOut everywhere={false} highlight={true} />
-            {!this.props.is_anonymous ? <Space /> : undefined}
+            {!this.props.is_anonymous ? <Gap /> : undefined}
             {!this.props.is_anonymous ? (
               <SignOut everywhere={true} />
             ) : undefined}

--- a/src/packages/frontend/account/settings/account-settings.tsx
+++ b/src/packages/frontend/account/settings/account-settings.tsx
@@ -3,6 +3,10 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Alert as AntdAlert, Space } from "antd";
+import { List, Map } from "immutable";
+import { join } from "path";
+
 import {
   Alert,
   Button,
@@ -17,15 +21,15 @@ import {
 import {
   Component,
   React,
-  redux,
   Rendered,
   TypedMap,
+  redux,
 } from "@cocalc/frontend/app-framework";
 import {
   A,
   ErrorDisplay,
-  Icon,
   Gap,
+  Icon,
   TimeAgo,
 } from "@cocalc/frontend/components";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
@@ -37,9 +41,6 @@ import { log } from "@cocalc/frontend/user-tracking";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { keys, startswith } from "@cocalc/util/misc";
 import { PassportStrategyFrontend } from "@cocalc/util/types/passport-types";
-import { Alert as AntdAlert, Space as AntdSpace } from "antd";
-import { List, Map } from "immutable";
-import { join } from "path";
 import { SiteName, TermsOfService } from "../../customize";
 import { open_new_tab } from "../../misc/open-browser-tab";
 import { DeleteAccount } from "../delete-account";
@@ -394,9 +395,9 @@ export class AccountSettings extends Component<Props, State> {
       <div>
         <hr key="hr0" />
         <h5 style={{ color: "#666" }}>{heading}</h5>
-        <AntdSpace size={[10, 10]} wrap style={{ marginBottom: "10px" }}>
+        <Space size={[10, 10]} wrap style={{ marginBottom: "10px" }}>
           {btns}
-        </AntdSpace>
+        </Space>
         {this.render_add_strategy_link()}
       </div>
     );

--- a/src/packages/frontend/account/ssh-keys/ssh-key-list.tsx
+++ b/src/packages/frontend/account/ssh-keys/ssh-key-list.tsx
@@ -12,7 +12,7 @@ import {
   HelpIcon,
   Icon,
   SettingBox,
-  Space,
+  Gap,
   TimeAgo,
 } from "@cocalc/frontend/components";
 import { cmp } from "@cocalc/util/misc";
@@ -34,7 +34,7 @@ export const SSHKeyList: React.FC<SSHKeyListProps> = (
   function render_header() {
     return (
       <>
-        SSH keys <Space />
+        SSH keys <Gap />
         {help && <HelpIcon title="Using SSH Keys">{help}</HelpIcon>}
       </>
     );

--- a/src/packages/frontend/account/upgrades/upgrades-page.tsx
+++ b/src/packages/frontend/account/upgrades/upgrades-page.tsx
@@ -10,7 +10,7 @@ import {
   redux,
   rtypes,
 } from "@cocalc/frontend/app-framework";
-import { A, Icon, Loading, Space } from "@cocalc/frontend/components";
+import { A, Icon, Loading, Gap } from "@cocalc/frontend/components";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 import { plural, round1 } from "@cocalc/util/misc";
 import { PROJECT_UPGRADES } from "@cocalc/util/schema";
@@ -72,7 +72,7 @@ class UpgradesPage extends Component<reduxProps> {
             <A href={join(appBasePath, "store")}>Store</A>.
           </p>
         </div>
-        <Space />
+        <Gap />
       </div>
     );
   }

--- a/src/packages/frontend/admin/site-settings/index.tsx
+++ b/src/packages/frontend/admin/site-settings/index.tsx
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Alert, Button, Input, InputRef, Modal, Tag, Row, Col } from "antd";
+import { Alert, Button, Col, Input, InputRef, Modal, Row, Tag } from "antd";
 import { delay } from "awaiting";
 import { isEqual } from "lodash";
 import { useMemo, useRef, useState } from "react";
@@ -13,10 +13,10 @@ import { Well } from "@cocalc/frontend/antd-bootstrap";
 import { redux } from "@cocalc/frontend/app-framework";
 import useCounter from "@cocalc/frontend/app-framework/counter-hook";
 import {
+  Gap,
   Icon,
   Loading,
   Paragraph,
-  Space,
   Title,
 } from "@cocalc/frontend/components";
 import { query } from "@cocalc/frontend/frame-editors/generic/client";
@@ -251,7 +251,7 @@ export default function SiteSettings({}) {
     return (
       <div>
         <SaveButton />
-        <Space />
+        <Gap />
         <CancelButton />
       </div>
     );
@@ -314,9 +314,9 @@ export default function SiteSettings({}) {
     return (
       <div style={{ marginBottom: "1rem" }}>
         <strong>Tests:</strong>
-        <Space />
+        <Gap />
         Email:
-        <Space />
+        <Gap />
         <Input
           style={{ width: "auto" }}
           defaultValue={redux.getStore("account").get("email_address")}
@@ -509,7 +509,7 @@ export default function SiteSettings({}) {
           </Col>
         </Row>
         {editRows}
-        <Space />
+        <Gap />
         {!filter.trim() && <Tests />}
         {!filter.trim() && <Buttons />}
         {filter.trim() && (

--- a/src/packages/frontend/admin/users/user.tsx
+++ b/src/packages/frontend/admin/users/user.tsx
@@ -7,7 +7,7 @@
 Display of basic information about a user, with link to get more information about that user.
 */
 
-import { Icon, Space, TimeAgo } from "@cocalc/frontend/components";
+import { Icon, Gap, TimeAgo } from "@cocalc/frontend/components";
 import { Component, Rendered } from "@cocalc/frontend/app-framework";
 import { capitalize } from "@cocalc/util/misc";
 import { Row, Col } from "@cocalc/frontend/antd-bootstrap";
@@ -157,17 +157,17 @@ export class UserResult extends Component<Props, State> {
     return (
       <div>
         {this.render_more_link("projects")}
-        <Space />
-        <Space />
+        <Gap />
+        <Gap />
         {this.render_more_link("subscriptions")}
-        <Space />
-        <Space />
+        <Gap />
+        <Gap />
         {this.render_more_link("impersonate")}
-        <Space />
-        <Space />
+        <Gap />
+        <Gap />
         {this.render_more_link("password")}
-        <Space />
-        <Space />
+        <Gap />
+        <Gap />
         {this.render_more_link("ban")}
       </div>
     );

--- a/src/packages/frontend/antd-bootstrap.tsx
+++ b/src/packages/frontend/antd-bootstrap.tsx
@@ -37,7 +37,7 @@ import {
 import { MouseEventHandler } from "react";
 
 import { r_join } from "@cocalc/frontend/components/r_join";
-import { Gap } from "@cocalc/frontend/components/space";
+import { Gap } from "@cocalc/frontend/components/gap";
 
 // Note regarding buttons -- there are 6 semantics meanings in bootstrap, but
 // only four in antd, and it we can't automatically collapse them down in a meaningful

--- a/src/packages/frontend/antd-bootstrap.tsx
+++ b/src/packages/frontend/antd-bootstrap.tsx
@@ -37,7 +37,7 @@ import {
 import { MouseEventHandler } from "react";
 
 import { r_join } from "@cocalc/frontend/components/r_join";
-import { Space } from "@cocalc/frontend/components/space";
+import { Gap } from "@cocalc/frontend/components/space";
 
 // Note regarding buttons -- there are 6 semantics meanings in bootstrap, but
 // only four in antd, and it we can't automatically collapse them down in a meaningful
@@ -210,7 +210,7 @@ export function ButtonToolbar(props: {
 }) {
   return (
     <div className={props.className} style={props.style}>
-      {r_join(props.children, <Space />)}
+      {r_join(props.children, <Gap />)}
     </div>
   );
 }

--- a/src/packages/frontend/app/warnings.tsx
+++ b/src/packages/frontend/app/warnings.tsx
@@ -1,6 +1,6 @@
 import { redux, React, TypedMap } from "../app-framework";
 import { webapp_client } from "../webapp-client";
-import { Icon, Space } from "../components";
+import { Icon, Gap } from "../components";
 import { SiteName } from "../customize";
 import { get_browser } from "../feature";
 
@@ -32,7 +32,7 @@ export const VersionWarning: React.FC<VersionWarningProps> = React.memo(
       return (
         <div>
           <br />
-          THIS IS A CRITICAL UPDATE. YOU MUST <Space />
+          THIS IS A CRITICAL UPDATE. YOU MUST <Gap />
           <a
             onClick={() => window.location.reload()}
             style={{
@@ -44,7 +44,7 @@ export const VersionWarning: React.FC<VersionWarningProps> = React.memo(
           >
             RELOAD THIS PAGE
           </a>
-          <Space /> IMMEDIATELY OR YOU WILL BE DISCONNECTED. Sorry for the
+          <Gap /> IMMEDIATELY OR YOU WILL BE DISCONNECTED. Sorry for the
           inconvenience.
         </div>
       );
@@ -70,7 +70,7 @@ export const VersionWarning: React.FC<VersionWarningProps> = React.memo(
 
     return (
       <div style={style}>
-        <Icon name={"refresh"} /> New Version Available: upgrade by <Space />
+        <Icon name={"refresh"} /> New Version Available: upgrade by <Gap />
         <a
           onClick={() => window.location.reload()}
           style={{

--- a/src/packages/frontend/billing/confirm-payment-method.tsx
+++ b/src/packages/frontend/billing/confirm-payment-method.tsx
@@ -5,7 +5,7 @@
 
 import { Alert, Well } from "react-bootstrap";
 import { Component, Rendered } from "../app-framework";
-import { Space } from "../components/space";
+import { Gap } from "../components/gap";
 import { Icon } from "../components/icon";
 
 import { Customer, Source } from "./types";
@@ -36,7 +36,7 @@ export class ConfirmPaymentMethod extends Component<Props> {
         <p>
           The initial payment will be processed with the card below. Future
           payments will be made with whichever card you have set as your default
-          <Space />
+          <Gap />
           <b>at the time of renewal</b>.
         </p>
       </span>

--- a/src/packages/frontend/billing/license-examples.tsx
+++ b/src/packages/frontend/billing/license-examples.tsx
@@ -12,7 +12,7 @@ import { Cost, User } from "@cocalc/util/licenses/purchase/types";
 import { COLORS } from "@cocalc/util/theme";
 import { Col, Row, Table } from "react-bootstrap";
 import { React } from "../app-framework";
-import { Icon, IconName, Space } from "../components";
+import { Icon, IconName, Gap } from "../components";
 const { Panel } = require("react-bootstrap");
 
 // This component renders 3 price examples for licensed upgrades in a row
@@ -48,7 +48,7 @@ export const LicenseExamples: React.FC<Props> = ({
         <span style={{ fontWeight: "bold", color: "#444" }}>
           {value_str} {unit}
         </span>
-        <Space />
+        <Gap />
         <span style={{ color: COLORS.GRAY }}>{resource}</span>
       </div>
     );
@@ -74,7 +74,7 @@ export const LicenseExamples: React.FC<Props> = ({
       return (
         <span style={style}>
           <span style={{ fontSize: smallpx, verticalAlign: "super" }}>$</span>
-          <Space />
+          <Gap />
           <span style={{ fontSize: largepx }}>{usd.toFixed(2)}</span>
           {descr && <span style={{ fontSize: smallpx }}> / {descr}</span>}
         </span>
@@ -185,9 +185,9 @@ export const LicenseExamples: React.FC<Props> = ({
     return (
       <Col sm={4} key={title}>
         <Panel header={header} bsStyle={"info"}>
-          <Space />
+          <Gap />
           {lines.map((line) => render_example_line(line))}
-          <Space />
+          <Gap />
 
           {render_single_price(example)}
           {render_monthyear_price(example)}
@@ -216,9 +216,9 @@ export const LicenseExamples: React.FC<Props> = ({
           </>
         )}
       </p>
-      <Space />
+      <Gap />
       {render()}
-      <Space />
+      <Gap />
     </>
   );
 };

--- a/src/packages/frontend/billing/payment-method.tsx
+++ b/src/packages/frontend/billing/payment-method.tsx
@@ -6,7 +6,7 @@
 import { Rendered, useState } from "../app-framework";
 import { Alert, Button, ButtonToolbar, Row, Col } from "react-bootstrap";
 import { Icon, IconName} from "../components/icon";
-import { Space } from "../components/space";
+import { Gap } from "../components/gap";
 import { brand_to_icon_name } from "./data";
 
 import { Source } from "./types";
@@ -39,7 +39,7 @@ export const PaymentMethod: React.FC<Props> = (props) => {
             <p>
               All future payments will be made with the card that is the default{" "}
               <b>at the time of renewal</b>. Changing your default card right
-              before a subscription renewal will cause the <Space />
+              before a subscription renewal will cause the <Gap />
               new default to be charged instead of the previous one.
             </p>
           </Col>
@@ -105,8 +105,8 @@ export const PaymentMethod: React.FC<Props> = (props) => {
         <Col md={1}>{props.source.address_country}</Col>
         <Col md={2}>
           {props.source.address_state}
-          <Space />
-          <Space />
+          <Gap />
+          <Gap />
           {props.source.address_zip}
         </Col>
         {props.set_as_default != null || props.delete_method != null

--- a/src/packages/frontend/billing/plan-info.tsx
+++ b/src/packages/frontend/billing/plan-info.tsx
@@ -9,7 +9,7 @@ import { plural, capitalize } from "@cocalc/util/misc";
 import { Component, Rendered } from "../app-framework";
 import { Tip } from "../components/tip";
 import { Icon } from "../components/icon";
-import { Space } from "../components/space";
+import { Gap } from "../components/gap";
 import { r_join } from "../components/r_join";
 import { Button } from "react-bootstrap";
 const { Panel } = require("react-bootstrap"); // since the typescript declarations are our of sync with our crappy old version.
@@ -32,7 +32,7 @@ export class PlanInfo extends Component<Props> {
             {value * data.pricing_factor}{" "}
             {plural(value * data.pricing_factor, data.pricing_unit)}
           </span>
-          <Space />
+          <Gap />
           <span style={{ color: "#666" }}>{data.display}</span>
         </Tip>
       </div>
@@ -47,7 +47,7 @@ export class PlanInfo extends Component<Props> {
     return (
       <span key={period} style={{ whiteSpace: "nowrap" }}>
         <span style={{ fontSize: "16px", verticalAlign: "super" }}>$</span>
-        <Space />
+        <Gap />
         <span style={{ fontSize: "30px" }}>{price}</span>
         <span style={{ fontSize: "14px" }}> / {period}</span>
       </span>
@@ -127,7 +127,7 @@ export class PlanInfo extends Component<Props> {
           this.props.on_click != null ? this.props.on_click() : undefined
         }
       >
-        <Space />
+        <Gap />
         {PROJECT_UPGRADES.field_order
           .filter((name) => benefits[name])
           .map((name) =>
@@ -137,7 +137,7 @@ export class PlanInfo extends Component<Props> {
               params[name]
             )
           )}
-        <Space />
+        <Gap />
 
         <div style={{ textAlign: "center", marginTop: "10px" }}>
           {this.render_price(prices)}

--- a/src/packages/frontend/billing/project-quota-free-table.tsx
+++ b/src/packages/frontend/billing/project-quota-free-table.tsx
@@ -12,7 +12,7 @@ import { Component, Rendered } from "../app-framework";
 import { DEFAULT_QUOTAS, PROJECT_UPGRADES } from "@cocalc/util/schema";
 import { Tip } from "../components/tip";
 import { Icon } from "../components/icon";
-import { Space } from "../components/space";
+import { Gap } from "../components/gap";
 const { Panel } = require("react-bootstrap"); // since the typescript declarations are our of sync with our crappy old version.
 
 import { render_project_quota } from "./util";
@@ -30,14 +30,14 @@ export class ProjectQuotaFreeTable extends Component {
   public render(): Rendered {
     return (
       <Panel header={this.render_header()} bsStyle="info">
-        <Space />
+        <Gap />
         <div style={{ marginBottom: "5px", marginLeft: "10px" }}>
           <Tip
             title="Free servers"
             tip="Many free projects are crammed together inside weaker compute machines, competing for CPU, RAM and I/O."
           >
             <span style={{ fontWeight: "bold", color: "#666" }}>low-grade</span>
-            <Space />
+            <Gap />
             <span style={{ color: "#999" }}>Server hosting</span>
           </Tip>
         </div>
@@ -47,18 +47,18 @@ export class ProjectQuotaFreeTable extends Component {
             tip="Despite working inside a web-browser, free projects are not allowed to directly access the internet due to security/abuse reasons."
           >
             <span style={{ fontWeight: "bold", color: "#666" }}>no</span>
-            <Space />
+            <Gap />
             <span style={{ color: "#999" }}>Internet access</span>
           </Tip>
         </div>
         {PROJECT_UPGRADES.field_order
           .filter((name) => DEFAULT_QUOTAS[name])
           .map((name) => render_project_quota(name, DEFAULT_QUOTAS[name]))}
-        <Space />
+        <Gap />
         <div style={{ textAlign: "center", marginTop: "10px" }}>
           <h3 style={{ textAlign: "left" }}>
             <span style={{ fontSize: "16px", verticalAlign: "super" }}>$</span>
-            <Space />
+            <Gap />
             <span style={{ fontSize: "30px" }}>0</span>
           </h3>
         </div>

--- a/src/packages/frontend/billing/util.tsx
+++ b/src/packages/frontend/billing/util.tsx
@@ -7,7 +7,7 @@ import { Rendered } from "../app-framework";
 import { Icon } from "../components/icon";
 import { PROJECT_UPGRADES } from "@cocalc/util/schema";
 import { Tip } from "../components/tip";
-import { Space } from "../components/space";
+import { Gap } from "../components/gap";
 import { round1, plural } from "@cocalc/util/misc";
 import { stripeAmount } from "@cocalc/util/misc";
 
@@ -44,7 +44,7 @@ export function render_project_quota(name: string, value: number): Rendered {
         <span style={{ fontWeight: "bold", color: "#666" }}>
           {round1(amount)} {plural(amount, unit)}
         </span>
-        <Space />
+        <Gap />
         <span style={{ color: "#999" }}>{data.display}</span>
       </Tip>
     </div>

--- a/src/packages/frontend/chat/message.tsx
+++ b/src/packages/frontend/chat/message.tsx
@@ -20,7 +20,7 @@ import {
   useRef,
   useState,
 } from "@cocalc/frontend/app-framework";
-import { Icon, Space, TimeAgo, Tip } from "@cocalc/frontend/components";
+import { Icon, Gap, TimeAgo, Tip } from "@cocalc/frontend/components";
 import { Button, Tooltip, Row, Col } from "antd";
 import { getUserName } from "./chat-log";
 import { HistoryTitle, HistoryFooter, History } from "./history";
@@ -202,7 +202,7 @@ export default function Message(props: Props) {
         {is_editing ? (
           <span style={{ margin: "10px 10px 0 10px", display: "inline-block" }}>
             <Button onClick={on_cancel}>Cancel</Button>
-            <Space />
+            <Gap />
             <Button onClick={saveEditedMessage} type="primary">
               Save (shift+enter)
             </Button>

--- a/src/packages/frontend/chat/message.tsx
+++ b/src/packages/frontend/chat/message.tsx
@@ -3,31 +3,32 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { CSSProperties } from "react";
+import { Button, Col, Row, Tooltip } from "antd";
 import { Map } from "immutable";
-import { IS_TOUCH } from "@cocalc/frontend/feature";
+import { CSSProperties } from "react";
+
 import { Avatar } from "@cocalc/frontend/account/avatar/avatar";
-import {
-  is_editing,
-  message_colors,
-  newest_content,
-  sender_is_viewer,
-} from "./utils";
-import MostlyStaticMarkdown from "@cocalc/frontend/editors/slate/mostly-static-markdown";
 import {
   redux,
   useMemo,
   useRef,
   useState,
 } from "@cocalc/frontend/app-framework";
-import { Icon, Gap, TimeAgo, Tip } from "@cocalc/frontend/components";
-import { Button, Tooltip, Row, Col } from "antd";
-import { getUserName } from "./chat-log";
-import { HistoryTitle, HistoryFooter, History } from "./history";
-import ChatInput from "./input";
+import { Gap, Icon, TimeAgo, Tip } from "@cocalc/frontend/components";
+import MostlyStaticMarkdown from "@cocalc/frontend/editors/slate/mostly-static-markdown";
+import { IS_TOUCH } from "@cocalc/frontend/feature";
 import { ChatActions } from "./actions";
-import { Time } from "./time";
+import { getUserName } from "./chat-log";
+import { History, HistoryFooter, HistoryTitle } from "./history";
+import ChatInput from "./input";
 import { Name } from "./name";
+import { Time } from "./time";
+import {
+  is_editing,
+  message_colors,
+  newest_content,
+  sender_is_viewer,
+} from "./utils";
 
 const regenerateCutoff = 1000 * 60 * 3; // how long to show the "regenerate button" for chatgpt.
 

--- a/src/packages/frontend/collaborators/add-collaborators.tsx
+++ b/src/packages/frontend/collaborators/add-collaborators.tsx
@@ -19,7 +19,7 @@ import {
   useState,
 } from "../app-framework";
 import { Button, ButtonToolbar, Well } from "../antd-bootstrap";
-import { Icon, Loading, ErrorDisplay, Space } from "../components";
+import { Icon, Loading, ErrorDisplay, Gap } from "../components";
 import { webapp_client } from "../webapp-client";
 import { SITE_NAME } from "@cocalc/util/theme";
 import {
@@ -633,7 +633,7 @@ export const AddCollaborators: React.FC<Props> = ({
     return (
       <div>
         <Button onClick={reset}>Cancel</Button>
-        <Space />
+        <Gap />
         <Button disabled={disabled} onClick={add_selected} bsStyle="primary">
           <Icon name="user-plus" /> {label}
         </Button>

--- a/src/packages/frontend/collaborators/current-collabs.tsx
+++ b/src/packages/frontend/collaborators/current-collabs.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import { redux, useRedux, CSS } from "../app-framework";
 import { Well, Row, Col } from "react-bootstrap";
-import { Space, Icon, SettingBox } from "../components";
+import { Gap, Icon, SettingBox } from "../components";
 import { Project } from "@cocalc/frontend/project/settings/types";
 import { User } from "../users";
 import { Popconfirm, Button } from "antd";
@@ -67,7 +67,7 @@ export const CurrentCollaboratorsPanel: React.FC<Props> = (props: Props) => {
           style={{ marginBottom: "0", float: "right" }}
         >
           <Icon name="user-times" />
-          <Space /> Remove...
+          <Gap /> Remove...
         </Button>
       </Popconfirm>
     );
@@ -88,7 +88,7 @@ export const CurrentCollaboratorsPanel: React.FC<Props> = (props: Props) => {
               show_avatar={true}
             />
             <span>
-              <Space />({user.group})
+              <Gap />({user.group})
             </span>
           </Col>
           <Col sm={4}>{user_remove_button(user.account_id, user.group)}</Col>

--- a/src/packages/frontend/collaborators/project-invite-tokens.tsx
+++ b/src/packages/frontend/collaborators/project-invite-tokens.tsx
@@ -20,7 +20,7 @@ import { PROJECT_INVITE_QUERY_PARAM } from "./handle-project-invite";
 
 import { Button, Card, Popconfirm, Table } from "antd";
 import { React, useState, useIsMountedRef } from "../app-framework";
-import { CopyToClipBoard, Icon, Loading, Space, TimeAgo } from "../components";
+import { CopyToClipBoard, Icon, Loading, Gap, TimeAgo } from "../components";
 import { ProjectInviteToken } from "@cocalc/util/db-schema/project-invite-tokens";
 import { webapp_client } from "../webapp-client";
 import { alert_message } from "../alerts";
@@ -153,7 +153,7 @@ export const ProjectInviteTokens: React.FC<Props> = React.memo(
         >
           <Button disabled={fetching}>
             <Icon name="plus" />
-            <Space /> Create token...
+            <Gap /> Create token...
           </Button>
         </Popconfirm>
       );
@@ -163,7 +163,7 @@ export const ProjectInviteTokens: React.FC<Props> = React.memo(
       return (
         <Button onClick={fetch_tokens} disabled={fetching}>
           <Icon name="refresh" spin={fetching} />
-          <Space /> Refresh
+          <Gap /> Refresh
         </Button>
       );
     }
@@ -253,7 +253,7 @@ export const ProjectInviteTokens: React.FC<Props> = React.memo(
           created: created ? <TimeAgo date={created} /> : undefined,
           expires: expires ? (
             <span>
-              <TimeAgo date={expires} /> <Space />
+              <TimeAgo date={expires} /> <Gap />
               {render_expire_button(token, expires)}
             </span>
           ) : undefined,
@@ -281,7 +281,7 @@ export const ProjectInviteTokens: React.FC<Props> = React.memo(
         <br />
         <br />
         {render_create_token()}
-        <Space />
+        <Gap />
         {render_refresh()}
         <br />
         <br />

--- a/src/packages/frontend/components/gap.tsx
+++ b/src/packages/frontend/components/gap.tsx
@@ -3,6 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-export function Space() {
+export function Gap() {
   return <span>&nbsp;</span>;
 }

--- a/src/packages/frontend/components/index.tsx
+++ b/src/packages/frontend/components/index.tsx
@@ -41,7 +41,7 @@ export { SelectorInput } from "./selector-input";
 export { SettingBox } from "./setting-box";
 export { SimpleX } from "./simple-x";
 export { SkinnyError } from "./skinny-error";
-export { Space } from "./space";
+export { Gap } from "./gap";
 export * from "./table-of-contents";
 export { TextInput } from "./text-input";
 export { is_different_date, TimeAgo, TimeAgoElement } from "./time-ago";

--- a/src/packages/frontend/components/link-retry.tsx
+++ b/src/packages/frontend/components/link-retry.tsx
@@ -10,7 +10,7 @@ import {
   useIsMountedRef,
   useState,
 } from "@cocalc/frontend/app-framework";
-import { Icon, Loading, Space } from "@cocalc/frontend/components";
+import { Icon, Loading, Gap } from "@cocalc/frontend/components";
 import { open_new_tab } from "@cocalc/frontend/misc";
 import { retry_until_success } from "@cocalc/util/async-utils";
 import { COLORS } from "@cocalc/util/theme";
@@ -97,13 +97,13 @@ const LinkRetry: React.FC<Props> = (props: Props) => {
           </a>
           {mode === "link" && loading && (
             <span>
-              <Space /> <Loading text={props.loadingText} />
+              <Gap /> <Loading text={props.loadingText} />
             </span>
           )}
           {error && (
             <>
               <span style={{ color: COLORS.ANTD_RED_WARN }}>
-                <Space /> (failed to load)
+                <Gap /> (failed to load)
               </span>
             </>
           )}

--- a/src/packages/frontend/components/login-link.tsx
+++ b/src/packages/frontend/components/login-link.tsx
@@ -6,14 +6,14 @@
 import { redux } from "../app-framework";
 import { Alert } from "../antd-bootstrap";
 import { Icon } from "./icon";
-import { Space } from "./space";
+import { Gap } from "./gap";
 
 export const LoginLink: React.FC = () => {
   return (
     <Alert bsStyle="info" style={{ margin: "15px" }}>
       <Icon name="sign-in" style={{ fontSize: "13pt", marginRight: "10px" }} />{" "}
       Please
-      <Space />
+      <Gap />
       <a
         style={{ cursor: "pointer" }}
         onClick={() => redux.getActions("page").set_active_tab("account")}

--- a/src/packages/frontend/components/project-state.tsx
+++ b/src/packages/frontend/components/project-state.tsx
@@ -6,7 +6,7 @@
 import { React, useTypedRedux } from "../app-framework";
 import { COMPUTE_STATES } from "@cocalc/util/schema";
 import { ProjectStatus } from "../todo-types";
-import { Space } from "./space";
+import { Gap } from "./gap";
 import { Icon } from "./icon";
 import { KUCALC_COCALC_COM } from "@cocalc/util/db-schema/site-defaults";
 
@@ -50,7 +50,7 @@ export const ProjectState: React.FC<Props> = (props: Props) => {
   return (
     <span>
       <Icon name={icon} /> {display}
-      <Space />
+      <Gap />
       {!stable && renderSpinner()}
       {renderDescription(s)}
     </span>

--- a/src/packages/frontend/course/assignments/assignments-panel.tsx
+++ b/src/packages/frontend/course/assignments/assignments-panel.tsx
@@ -13,7 +13,7 @@ import {
   useRedux,
   useState,
 } from "@cocalc/frontend/app-framework";
-import { Icon, Space, Tip } from "@cocalc/frontend/components";
+import { Icon, Gap, Tip } from "@cocalc/frontend/components";
 import ScrollableList from "@cocalc/frontend/components/scrollable-list";
 import { cmp_array } from "@cocalc/util/misc";
 import { Alert, Col, Row } from "antd";
@@ -145,7 +145,7 @@ export const AssignmentsPanel: React.FC<Props> = React.memo((props: Props) => {
         }}
       >
         {display_name}
-        <Space />
+        <Gap />
         {active_assignment_sort.get("column_name") === column_name ? (
           <Icon
             style={{ marginRight: "10px" }}

--- a/src/packages/frontend/course/assignments/skip.tsx
+++ b/src/packages/frontend/course/assignments/skip.tsx
@@ -10,7 +10,7 @@ Skip assigning or collecting an assignment, so next step can be attempted.
 import { React, Rendered } from "@cocalc/frontend/app-framework";
 import { CourseActions } from "../actions";
 import { AssignmentRecord } from "../store";
-import { Icon, Space, Tip } from "../../components";
+import { Icon, Gap, Tip } from "../../components";
 import { Button } from "antd";
 
 interface SkipCopyProps {
@@ -39,7 +39,7 @@ export const SkipCopy: React.FC<SkipCopyProps> = (props: SkipCopyProps) => {
         // don't bother even trying to implement skip and peer grading at once.
         extra = (
           <span>
-            <Space /> (Please disable this or peer grading.)
+            <Gap /> (Please disable this or peer grading.)
           </span>
         );
       }

--- a/src/packages/frontend/course/common/progress.tsx
+++ b/src/packages/frontend/course/common/progress.tsx
@@ -8,7 +8,7 @@ Progress indicator for assigning/collecting/etc. a particular assignment or hand
 */
 
 import { React, CSS } from "@cocalc/frontend/app-framework";
-import { Icon, Space } from "@cocalc/frontend/components";
+import { Icon, Gap } from "@cocalc/frontend/components";
 import { COLORS } from "@cocalc/util/theme";
 
 const progress_info: CSS = {
@@ -38,7 +38,7 @@ export const Progress: React.FC<ProgressProps> = React.memo(
         return (
           <span style={{ fontSize: "12pt" }}>
             <Icon name="check-circle" />
-            <Space />
+            <Gap />
           </span>
         );
       }

--- a/src/packages/frontend/course/common/student-assignment-info.tsx
+++ b/src/packages/frontend/course/common/student-assignment-info.tsx
@@ -18,7 +18,7 @@ import {
   ErrorDisplay,
   Icon,
   Markdown,
-  Space,
+  Gap,
   Tip
 } from "@cocalc/frontend/components";
 import { MarkdownInput } from "@cocalc/frontend/editors/markdown-input";
@@ -436,7 +436,7 @@ export const StudentAssignmentInfo: React.FC<StudentAssignmentInfoProps> =
       return (
         <div key="open_recopy">
           {render_open_recopy_confirm(name, copy, copy_tip, placement)}
-          <Space />
+          <Gap />
           <Button key="open" bsSize={bsSize} onClick={open}>
             <Tip title="Open assignment" placement={placement} tip={open_tip}>
               <Icon name="folder-open" /> Open

--- a/src/packages/frontend/course/configuration/configuration-panel.tsx
+++ b/src/packages/frontend/course/configuration/configuration-panel.tsx
@@ -28,7 +28,7 @@ import {
   LabeledRow,
   Loading,
   MarkdownInput,
-  Space,
+  Gap,
   TextInput,
   TimeAgo,
   ErrorDisplay,
@@ -529,7 +529,7 @@ export const ConfigurationPanel: React.FC<Props> = React.memo(
             <span style={{ fontSize: "18pt" }}>
               <Icon name="check" />
             </span>{" "}
-            <Space />
+            <Gap />
             {render_require_students_pay_desc()}
           </span>
         );

--- a/src/packages/frontend/course/configuration/terminal-command.tsx
+++ b/src/packages/frontend/course/configuration/terminal-command.tsx
@@ -21,7 +21,7 @@ import {
   useActions,
   useRedux,
 } from "@cocalc/frontend/app-framework";
-import { Icon, Space } from "@cocalc/frontend/components";
+import { Icon, Gap } from "@cocalc/frontend/components";
 import { COLORS } from "@cocalc/util/theme";
 import { CourseActions } from "../actions";
 import { CourseStore, TerminalCommand, TerminalCommandOutput } from "../store";
@@ -48,7 +48,7 @@ export const TerminalCommandPanel: React.FC<Props> = React.memo(
           disabled={running}
         >
           <Icon name={running ? "cocalc-ring" : "play"} spin={running} />{" "}
-          <Space /> Run
+          <Gap /> Run
         </Button>
       );
     }

--- a/src/packages/frontend/course/configuration/terminal-command.tsx
+++ b/src/packages/frontend/course/configuration/terminal-command.tsx
@@ -3,14 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import {
-  List as AntdList,
-  Button,
-  Card,
-  Form,
-  Input,
-  Space as AntdSpace,
-} from "antd";
+import { List as AntdList, Button, Card, Form, Input, Space } from "antd";
 import { List, Map, fromJS } from "immutable";
 
 import {
@@ -21,7 +14,7 @@ import {
   useActions,
   useRedux,
 } from "@cocalc/frontend/app-framework";
-import { Icon, Gap } from "@cocalc/frontend/components";
+import { Gap, Icon } from "@cocalc/frontend/components";
 import { COLORS } from "@cocalc/util/theme";
 import { CourseActions } from "../actions";
 import { CourseStore, TerminalCommand, TerminalCommandOutput } from "../store";
@@ -66,7 +59,7 @@ export const TerminalCommandPanel: React.FC<Props> = React.memo(
             run_terminal_command();
           }}
         >
-          <AntdSpace.Compact style={{ display: "flex", whiteSpace: "nowrap" }}>
+          <Space.Compact style={{ display: "flex", whiteSpace: "nowrap" }}>
             <Input
               style={{ fontFamily: "monospace" }}
               placeholder="Terminal command..."
@@ -75,7 +68,7 @@ export const TerminalCommandPanel: React.FC<Props> = React.memo(
               }}
             />
             {render_button(running)}
-          </AntdSpace.Compact>
+          </Space.Compact>
         </Form>
       );
     }

--- a/src/packages/frontend/course/nbgrader/nbgrader-button.tsx
+++ b/src/packages/frontend/course/nbgrader/nbgrader-button.tsx
@@ -16,7 +16,7 @@ import {
   useRedux,
   useState,
 } from "../../app-framework";
-import { Icon, Space, Tip } from "../../components";
+import { Icon, Gap, Tip } from "../../components";
 import { CourseStore, NBgraderRunInfo, PARALLEL_DEFAULT } from "../store";
 import { CourseActions } from "../actions";
 import { nbgrader_status } from "./util";
@@ -156,7 +156,7 @@ export const NbgraderButton: React.FC<Props> = React.memo(
       <span>
         {" "}
         <Icon name="cocalc-ring" spin />
-        <Space /> Nbgrader is running
+        <Gap /> Nbgrader is running
       </span>
     ) : (
       <span>Nbgrader...</span>
@@ -168,7 +168,7 @@ export const NbgraderButton: React.FC<Props> = React.memo(
             style={{ width: "20px" }}
             name={show_more_info ? "caret-down" : "caret-right"}
           />
-          <Space /> {label}
+          <Gap /> {label}
         </Button>
         {show_more_info && render_more_info()}
       </div>

--- a/src/packages/frontend/course/pay-banner.tsx
+++ b/src/packages/frontend/course/pay-banner.tsx
@@ -14,7 +14,7 @@ import { CSS, React, useTypedRedux } from "../app-framework";
 
 import { Alert } from "antd";
 import { CourseSettingsRecord } from "./store";
-import { Icon, Space } from "../components";
+import { Icon, Gap } from "../components";
 
 interface PayBannerProps {
   settings: CourseSettingsRecord;
@@ -93,7 +93,7 @@ export const PayBanner: React.FC<PayBannerProps> = React.memo(
               style={{ float: "right", marginTop: "3px" }}
             />
             <Icon name="exclamation-triangle" />
-            <Space />
+            <Gap />
             {mesg}
           </div>
         }

--- a/src/packages/frontend/course/students/students-panel-student.tsx
+++ b/src/packages/frontend/course/students/students-panel-student.tsx
@@ -14,7 +14,7 @@ import { Rendered } from "@cocalc/frontend/app-framework";
 import {
   Icon,
   MarkdownInput,
-  Space,
+  Gap,
   TimeAgo,
   Tip,
 } from "@cocalc/frontend/components";
@@ -398,7 +398,7 @@ export const Student: React.FC<StudentProps> = React.memo(
         return (
           <div>
             Are you sure you want to delete this student?
-            <Space />
+            <Gap />
             <ButtonGroup>
               <Button onClick={delete_student} bsStyle="danger" bsSize={bsSize}>
                 <Icon name="trash" /> YES, Delete

--- a/src/packages/frontend/course/students/students-panel.tsx
+++ b/src/packages/frontend/course/students/students-panel.tsx
@@ -18,7 +18,7 @@ import {
   ErrorDisplay,
   Icon,
   SearchInput,
-  Space,
+  Gap,
   Tip,
 } from "@cocalc/frontend/components";
 import ScrollableList from "@cocalc/frontend/components/scrollable-list";
@@ -437,9 +437,9 @@ export const StudentsPanel: React.FC<StudentsPanelReactProps> = React.memo(
           </Form.Item>
           <Form.Item>
             {render_cancel()}
-            <Space />
+            <Gap />
             {render_add_selector_button(options)}
-            <Space />
+            <Gap />
             {render_add_all_students_button(options)}
           </Form.Item>
         </>
@@ -654,7 +654,7 @@ export const StudentsPanel: React.FC<StudentsPanelReactProps> = React.memo(
           }}
         >
           {display_name}
-          <Space />
+          <Gap />
           {render_sort_icon(column_name)}
         </a>
       );

--- a/src/packages/frontend/custom-software/selector.tsx
+++ b/src/packages/frontend/custom-software/selector.tsx
@@ -14,7 +14,7 @@ import {
   Icon,
   Markdown,
   SearchInput,
-  Space,
+  Gap,
 } from "@cocalc/frontend/components";
 import {
   CompanyName,
@@ -412,7 +412,7 @@ export const SoftwareEnvironment: React.FC<Props> = (props: Props) => {
             set_state(img, display, "standard");
           }}
         />
-        <Space />
+        <Gap />
       </Col>
     );
   }

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -26,7 +26,7 @@ import {
   r_join,
   smc_git_rev,
   smc_version,
-  Space,
+  Gap,
   UNIT,
 } from "@cocalc/frontend/components";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
@@ -482,7 +482,7 @@ export const Footer: React.FC = React.memo(() => {
   return (
     <footer style={style}>
       <hr />
-      <Space />
+      <Gap />
       {contents()}
     </footer>
   );

--- a/src/packages/frontend/editors/file-info-dropdown.tsx
+++ b/src/packages/frontend/editors/file-info-dropdown.tsx
@@ -13,7 +13,7 @@ import {
   HiddenXS,
   Icon,
   IconName,
-  Space,
+  Gap,
 } from "@cocalc/frontend/components";
 import { MenuItems } from "@cocalc/frontend/components/dropdown-menu";
 import { useStudentProjectFunctionality } from "@cocalc/frontend/course";
@@ -129,7 +129,7 @@ export const EditorFileInfoDropdown: React.FC<Props> = React.memo(
           <Icon name={"file"} />
           {label && (
             <HiddenXS>
-              <Space />
+              <Gap />
               {label}
             </HiddenXS>
           )}

--- a/src/packages/frontend/editors/stopwatch/button-bar.tsx
+++ b/src/packages/frontend/editors/stopwatch/button-bar.tsx
@@ -11,13 +11,13 @@ import { Rendered } from "@cocalc/frontend/app-framework";
 import { TimeActions } from "./actions";
 import { HistoryOutlined, RedoOutlined, UndoOutlined } from "@ant-design/icons";
 import { Button } from "antd";
-import { Space } from "@cocalc/frontend/components/space";
+import { Gap } from "@cocalc/frontend/components/space";
 
 export function ButtonBar({ actions }: { actions: TimeActions }): JSX.Element {
   return (
     <div style={{ margin: "1px" }}>
       {timeTravelButton(actions)}
-      <Space />
+      <Gap />
       {undoRedoGroup(actions)}
     </div>
   );

--- a/src/packages/frontend/editors/stopwatch/button-bar.tsx
+++ b/src/packages/frontend/editors/stopwatch/button-bar.tsx
@@ -6,12 +6,12 @@
 /*
 Some buttons
 */
-
-import { Rendered } from "@cocalc/frontend/app-framework";
-import { TimeActions } from "./actions";
 import { HistoryOutlined, RedoOutlined, UndoOutlined } from "@ant-design/icons";
 import { Button } from "antd";
-import { Gap } from "@cocalc/frontend/components/space";
+
+import { Rendered } from "@cocalc/frontend/app-framework";
+import { Gap } from "@cocalc/frontend/components/gap";
+import { TimeActions } from "./actions";
 
 export function ButtonBar({ actions }: { actions: TimeActions }): JSX.Element {
   return (

--- a/src/packages/frontend/editors/task-editor/due.tsx
+++ b/src/packages/frontend/editors/task-editor/due.tsx
@@ -10,7 +10,7 @@ Task due date
 */
 
 import { React, CSS } from "../../app-framework";
-import { DateTimePicker, Icon, Space, TimeAgo } from "../../components";
+import { DateTimePicker, Icon, Gap, TimeAgo } from "../../components";
 import { TaskActions } from "./actions";
 
 const STYLE: CSS = {
@@ -80,7 +80,7 @@ export const DueDate: React.FC<Props> = React.memo(
       }
       return (
         <span style={{ color: "#888" }}>
-          <Space />
+          <Gap />
           <Icon
             name="times"
             onClick={() => {

--- a/src/packages/frontend/editors/task-editor/headings.tsx
+++ b/src/packages/frontend/editors/task-editor/headings.tsx
@@ -13,7 +13,7 @@ Headings of the task list:
 
 import { Row, Col } from "../../antd-bootstrap";
 import { React } from "../../app-framework";
-import { Icon, Space } from "../../components";
+import { Icon, Gap } from "../../components";
 
 import { HEADINGS, HEADINGS_DIR } from "./headings-info";
 import { TaskActions } from "./actions";
@@ -41,7 +41,7 @@ const Heading: React.FC<HeadingProps> = React.memo(
         {heading}
         {dir != null && (
           <span>
-            <Space />
+            <Gap />
             {dir == "asc" ? (
               <Icon name="caret-down" />
             ) : (

--- a/src/packages/frontend/frame-editors/frame-tree/format-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/format-bar.tsx
@@ -9,7 +9,7 @@ The format bar.
 
 import { Button, ButtonGroup } from "@cocalc/frontend/antd-bootstrap";
 import { React, Rendered } from "@cocalc/frontend/app-framework";
-import { Icon, isIconName, Space } from "@cocalc/frontend/components";
+import { Icon, isIconName, Gap } from "@cocalc/frontend/components";
 import { ColorButton } from "@cocalc/frontend/components/color-picker";
 import FontFamilyMenu from "@cocalc/frontend/components/font-family";
 import FontSizeMenu from "@cocalc/frontend/components/font-size";
@@ -130,7 +130,7 @@ export const FormatBar: React.FC<Props> = React.memo((props: Props) => {
     }
     return (
       <>
-        <Space />
+        <Gap />
         <ButtonGroup key={"format"}>
           {render_button("format_code", "Format selected text as code", "code")}
           {render_button(
@@ -154,7 +154,7 @@ export const FormatBar: React.FC<Props> = React.memo((props: Props) => {
             "align-justify"
           )}
         </ButtonGroup>
-        <Space />
+        <Gap />
         <ButtonGroup key={"format2"}>
           {render_button(
             "unformat",
@@ -220,12 +220,12 @@ export const FormatBar: React.FC<Props> = React.memo((props: Props) => {
       {render_font_dropdowns()}
       <div className={"cc-frame-tree-format-bar"}>
         {render_text_style_buttons()}
-        <Space />
+        <Gap />
         {render_insert_buttons()}
-        <Space />
+        <Gap />
         {render_insert_dialog_buttons()}
         {render_format_buttons()}
-        <Space />
+        <Gap />
       </div>
     </div>
   );

--- a/src/packages/frontend/frame-editors/frame-tree/status-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/status-bar.tsx
@@ -13,7 +13,7 @@ This is basically used now as "ephemeral messages".
 */
 
 import { CSSProperties } from "react";
-import { Icon, Space } from "@cocalc/frontend/components";
+import { Icon, Gap } from "@cocalc/frontend/components";
 
 const STYLE = {
   opacity: 0.85,
@@ -45,7 +45,7 @@ export default function StatusBar({ status, onClear }: Props) {
         style={{ float: "right", marginTop: "2.5px" }}
       />
       {status}
-      <Space />
+      <Gap />
     </div>
   );
 }

--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -38,7 +38,7 @@ import {
   IconName,
   MenuItems,
   r_join,
-  Space,
+  Gap,
   VisibleMDLG,
 } from "@cocalc/frontend/components";
 import { useStudentProjectFunctionality } from "@cocalc/frontend/course";
@@ -1796,7 +1796,7 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
           key={"buttons"}
           className={"cc-frame-tree-title-bar-buttons"}
         >
-          {r_join(w, <Space />)}
+          {r_join(w, <Gap />)}
         </div>
       );
     } finally {

--- a/src/packages/frontend/frame-editors/lean-editor/lean-messages.tsx
+++ b/src/packages/frontend/frame-editors/lean-editor/lean-messages.tsx
@@ -4,7 +4,7 @@
  */
 
 import { List, Map } from "immutable";
-import { Icon, IconName, Space, TimeAgo } from "@cocalc/frontend/components";
+import { Icon, IconName, Gap, TimeAgo } from "@cocalc/frontend/components";
 import { server_time } from "../generic/client";
 import { Message } from "./types";
 import { capitalize, is_different } from "@cocalc/util/misc";
@@ -98,15 +98,15 @@ export class RenderedMessage extends Component<MessageProps, {}> {
           }}
         >
           <Icon name={message_icon(message.severity)} />
-          <Space />
+          <Gap />
           {message.pos_line !== undefined && message.pos_col !== undefined
             ? render_pos(message.pos_line, message.pos_col)
             : undefined}
-          <Space />
+          <Gap />
           {message.severity !== undefined
             ? render_severity(message.severity)
             : undefined}
-          <Space />
+          <Gap />
           {message.caption !== undefined
             ? render_caption(message.caption)
             : undefined}
@@ -181,9 +181,9 @@ class LeanMessages extends Component<Props, {}> {
         }}
       >
         <Icon name="cocalc-ring" spin />
-        <Space />
+        <Gap />
         {capitalize(task.desc)}
-        <Space /> (Processing lines {task.pos_line}-{task.end_pos_line})
+        <Gap /> (Processing lines {task.pos_line}-{task.end_pos_line})
       </div>
     );
   }

--- a/src/packages/frontend/landing-page/reset-password.tsx
+++ b/src/packages/frontend/landing-page/reset-password.tsx
@@ -10,7 +10,7 @@ Password reset modal dialog
 import { React, ReactDOM, redux, Rendered } from "../app-framework";
 import { HelpEmailLink } from "../customize";
 import { Modal, FormGroup, FormControl, Row, Button } from "../antd-bootstrap";
-import { Space, Loading } from "../components";
+import { Gap, Loading } from "../components";
 import { unreachable } from "@cocalc/util/misc";
 
 interface Props {
@@ -105,7 +105,7 @@ export const ResetPassword: React.FC<Props> = (props: Props) => {
           <Row>
             <div style={{ textAlign: "right", paddingRight: 15 }}>
               <Button onClick={(e) => hide_reset_password(e)}>Cancel</Button>
-              <Space />
+              <Gap />
               <Button
                 bsStyle="primary"
                 disabled={mode === "resetting"}

--- a/src/packages/frontend/project/anonymous-name.tsx
+++ b/src/packages/frontend/project/anonymous-name.tsx
@@ -16,7 +16,7 @@ import {
   useRedux,
   useTypedRedux,
 } from "../app-framework";
-import { Icon, Space } from "../components";
+import { Icon, Gap } from "../components";
 const { SiteName } = require("../customize");
 
 interface Props {
@@ -84,7 +84,7 @@ const AnonymousNameInput: React.FC<Props> = React.memo(({ project_id }) => {
           Sign Up
         </a>
         Thank you {anonName ? "" : ` ${first_name} ${last_name} `} for using{" "}
-        <SiteName />!<Space />
+        <SiteName />!<Gap />
         {anonName && (
           <>
             Set your name:{" "}

--- a/src/packages/frontend/project/explorer/action-bar.tsx
+++ b/src/packages/frontend/project/explorer/action-bar.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import * as immutable from "immutable";
-import { HiddenSM, Icon, Space } from "../../components";
+import { HiddenSM, Icon, Gap } from "../../components";
 import { COLORS } from "@cocalc/util/theme";
 import { ComputeImages } from "@cocalc/frontend/custom-software/init";
 import { ProjectActions } from "@cocalc/frontend/project_store";
@@ -177,7 +177,7 @@ export const ActionBar: React.FC<Props> = (props) => {
             total,
             "item"
           )} selected`}</span>
-          <Space />
+          <Gap />
           {render_select_entire_directory()}
         </div>
       );

--- a/src/packages/frontend/project/explorer/file-listing/listing-header.tsx
+++ b/src/packages/frontend/project/explorer/file-listing/listing-header.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { TypedMap } from "@cocalc/frontend/app-framework";
-import { Icon, Space } from "@cocalc/frontend/components";
+import { Icon, Gap } from "@cocalc/frontend/components";
 const { Row, Col } = require("react-bootstrap");
 
 // TODO: Flatten active_file_sort for easy PureComponent use
@@ -40,7 +40,7 @@ export const ListingHeader: React.FC<Props> = (props: Props) => {
         style={{ color: "#428bca", fontWeight: "bold" }}
       >
         {display_name}
-        <Space />
+        <Gap />
         {active_file_sort.get("column_name") === column_name ? (
           <Icon
             style={inner_icon_style}

--- a/src/packages/frontend/project/history/log-entry.tsx
+++ b/src/packages/frontend/project/history/log-entry.tsx
@@ -13,7 +13,7 @@ import {
   IconName,
   PathLink,
   r_join,
-  Space,
+  Gap,
   TimeAgo,
   Tip,
 } from "@cocalc/frontend/components";
@@ -125,7 +125,7 @@ export const LogEntry: React.FC<Props> = React.memo(
       return (
         <span>
           opened
-          <Space />
+          <Gap />
           <PathLink
             path={event.filename}
             full={true}
@@ -150,7 +150,7 @@ export const LogEntry: React.FC<Props> = React.memo(
       return (
         <span>
           set the public path
-          <Space />
+          <Gap />
           <PathLink
             path={event.path}
             full={true}
@@ -656,10 +656,10 @@ export const LogEntry: React.FC<Props> = React.memo(
               </Col>
               <Col sm={11}>
                 {render_user()}
-                <Space />
+                <Gap />
                 {render_desc()}
                 {renderDuration()}
-                <Space />
+                <Gap />
                 <TimeAgo style={style} date={props.time} />
               </Col>
             </Row>

--- a/src/packages/frontend/project/search/body.tsx
+++ b/src/packages/frontend/project/search/body.tsx
@@ -20,7 +20,7 @@ import {
   Icon,
   Loading,
   SearchInput,
-  Space,
+  Gap,
 } from "@cocalc/frontend/components";
 import CopyButton from "@cocalc/frontend/components/copy-button";
 import infoToMode from "@cocalc/frontend/editors/slate/elements/code-block/info-to-mode";
@@ -486,7 +486,7 @@ function ProjectSearchOutputHeader({ project_id }: { project_id: string }) {
 
       <h4>
         Results of searching in {output_path()} for "{most_recent_search}"
-        <Space />
+        <Gap />
         <Button
           onClick={() =>
             actions?.setState({

--- a/src/packages/frontend/project/search/body.tsx
+++ b/src/packages/frontend/project/search/body.tsx
@@ -10,17 +10,17 @@ of course, a disaster waiting to happen.  They all need to
 be in a single namespace somehow...!
 */
 
-import { Space as AntdSpace, Button, Card, Col, Row, Switch, Tag } from "antd";
+import { Button, Card, Col, Row, Space, Switch, Tag } from "antd";
 
 import { Alert, Checkbox, Well } from "@cocalc/frontend/antd-bootstrap";
 import { useActions, useTypedRedux } from "@cocalc/frontend/app-framework";
 import {
   A,
+  Gap,
   HelpIcon,
   Icon,
   Loading,
   SearchInput,
-  Gap,
 } from "@cocalc/frontend/components";
 import CopyButton from "@cocalc/frontend/components/copy-button";
 import infoToMode from "@cocalc/frontend/editors/slate/elements/code-block/info-to-mode";
@@ -149,7 +149,7 @@ export const ProjectSearchBody: React.FC<{
   function renderHeaderFlyout() {
     const divStyle = { cursor: "pointer", padding: "2px 5px" };
     return (
-      <AntdSpace style={{ padding: "5px" }} direction="vertical">
+      <Space style={{ padding: "5px" }} direction="vertical">
         <ProjectSearchInput
           project_id={project_id}
           neural={neural_search}
@@ -221,7 +221,7 @@ export const ProjectSearchBody: React.FC<{
             </HelpIcon>
           </div>
         )}
-      </AntdSpace>
+      </Space>
     );
   }
 
@@ -408,7 +408,7 @@ function ProjectSearchOutput({
   function renderResultList() {
     if (isFlyout) {
       return wrap?.(
-        <AntdSpace
+        <Space
           direction="vertical"
           size="small"
           style={{
@@ -417,7 +417,7 @@ function ProjectSearchOutput({
           }}
         >
           {render_get_results()}
-        </AntdSpace>,
+        </Space>,
         { borderTop: `1px solid ${COLORS.GRAY_L}` }
       );
     } else {

--- a/src/packages/frontend/project/settings/compute-image-selector.tsx
+++ b/src/packages/frontend/project/settings/compute-image-selector.tsx
@@ -11,7 +11,7 @@ import { fromJS } from "immutable";
 
 import { Col, Row } from "@cocalc/frontend/antd-bootstrap";
 import { useTypedRedux } from "@cocalc/frontend/app-framework";
-import { Icon, Loading, Space, Text } from "@cocalc/frontend/components";
+import { Icon, Loading, Gap, Text } from "@cocalc/frontend/components";
 import { SoftwareEnvironments } from "@cocalc/frontend/customize";
 import { unreachable } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
@@ -167,11 +167,11 @@ export const ComputeImageSelector: React.FC<ComputeImageSelectorProps> = (
         <Col xs={12}>
           <Row style={{ fontSize: "12pt" }}>
             <Icon name={"hdd"} style={{ marginTop: "5px" }} />
-            <Space />
+            <Gap />
             Selected image
-            <Space />
+            <Gap />
             {render_selector()}
-            <Space />
+            <Gap />
             {render_doubt()}
           </Row>
           <Row>{render_info(true)}</Row>
@@ -182,7 +182,7 @@ export const ComputeImageSelector: React.FC<ComputeImageSelectorProps> = (
       return (
         <Col xs={12}>
           <Icon name={"hdd"} />
-          <Space />
+          <Gap />
           <span style={{ fontSize: "12pt", fontWeight: "bold" }}>
             {render_selector()}
           </span>

--- a/src/packages/frontend/project/settings/environment.tsx
+++ b/src/packages/frontend/project/settings/environment.tsx
@@ -23,7 +23,7 @@ import {
   useRedux,
   useState,
 } from "@cocalc/frontend/app-framework";
-import { ErrorDisplay, SettingBox, Space } from "@cocalc/frontend/components";
+import { ErrorDisplay, SettingBox, Gap } from "@cocalc/frontend/components";
 
 export const ENV_VARS_ICON = "bars";
 interface Props {
@@ -100,7 +100,7 @@ export const Environment: React.FC<Props> = ({ project_id }) => {
       >
         Cancel
       </Button>
-      <Space />
+      <Gap />
       <Button disabled={disabled} onClick={save}>
         {saving ? "Saving..." : disabled ? "Saved" : "Save..."}
       </Button>

--- a/src/packages/frontend/project/settings/quota-console.tsx
+++ b/src/packages/frontend/project/settings/quota-console.tsx
@@ -21,7 +21,7 @@ import {
   Icon,
   LabeledRow,
   Loading,
-  Space,
+  Gap,
   Tip,
 } from "@cocalc/frontend/components";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
@@ -375,7 +375,7 @@ export const QuotaConsole: React.FC<Props> = (props: Props) => {
     }
     return (
       <span>
-        <Space /> (<b>{disk} MB</b> used)
+        <Gap /> (<b>{disk} MB</b> used)
       </span>
     );
   }
@@ -386,7 +386,7 @@ export const QuotaConsole: React.FC<Props> = (props: Props) => {
     }
     return (
       <span>
-        <Space /> (<b>{memory} MB</b> used)
+        <Gap /> (<b>{memory} MB</b> used)
       </span>
     );
   }
@@ -440,7 +440,7 @@ export const QuotaConsole: React.FC<Props> = (props: Props) => {
       ),
       edit: (
         <span>
-          <b>{render_input("disk_quota")} MB</b> disk space limit <Space />{" "}
+          <b>{render_input("disk_quota")} MB</b> disk space limit <Gap />{" "}
           {render_disk_used(disk)}
         </span>
       ),

--- a/src/packages/frontend/project/start-button.tsx
+++ b/src/packages/frontend/project/start-button.tsx
@@ -26,7 +26,7 @@ import {
   Delay,
   Icon,
   ProjectState,
-  Space,
+  Gap,
   VisibleMDLG,
 } from "@cocalc/frontend/components";
 import { server_seconds_ago } from "@cocalc/util/misc";
@@ -175,7 +175,7 @@ export const StartButton: React.FC<Props> = (props: Props) => {
           }}
         >
           {starting ? <Icon name="cocalc-ring" spin /> : <Icon name="play" />}
-          <Space /> <Space /> Start{starting ? "ing" : ""} project
+          <Gap /> <Gap /> Start{starting ? "ing" : ""} project
         </Button>
       </div>
     );

--- a/src/packages/frontend/project/warnings/no-network.tsx
+++ b/src/packages/frontend/project/warnings/no-network.tsx
@@ -5,7 +5,7 @@
 
 import { Alert } from "../../antd-bootstrap";
 import { plural } from "@cocalc/util/misc";
-import { A, Icon, Space } from "../../components";
+import { A, Icon, Gap } from "../../components";
 import { Options, project_warning_opts } from "./util";
 import { PolicyPricingPageUrl } from "../../customize";
 import { LICENSE_MIN_PRICE } from "@cocalc/util/consts/billing";
@@ -41,7 +41,7 @@ export const NoNetworkProjectWarning: React.FC<Options> = (props) => {
     } else {
       suggestion = (
         <span>
-          <Space />
+          <Gap />
           <A href={url}>Licenses start at {LICENSE_MIN_PRICE}...</A>
         </span>
       );

--- a/src/packages/frontend/project/warnings/non-member.tsx
+++ b/src/packages/frontend/project/warnings/non-member.tsx
@@ -6,7 +6,7 @@
 
 import { Alert } from "../../antd-bootstrap";
 import { plural } from "@cocalc/util/misc";
-import { A, Icon, Space } from "../../components";
+import { A, Icon, Gap } from "../../components";
 import { Options, project_warning_opts } from "./util";
 import { PolicyPricingPageUrl } from "../../customize";
 
@@ -46,7 +46,7 @@ export const NonMemberProjectWarning: React.FC<Options> = (opts) => {
     } else {
       suggestion = (
         <span>
-          <Space />
+          <Gap />
           <A href={url}>
             Licenses start at about $3/month...
           </A>
@@ -62,7 +62,7 @@ export const NonMemberProjectWarning: React.FC<Options> = (opts) => {
         <strong>running on a free server</strong>
       </h4>
       <p>
-        <Space />
+        <Gap />
         Projects running on free servers compete for resources with a large
         number of other free projects. The free servers are{" "}
         <b>

--- a/src/packages/frontend/projects/create-project.tsx
+++ b/src/packages/frontend/projects/create-project.tsx
@@ -22,7 +22,7 @@ import {
   useState,
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
-import { A, ErrorDisplay, Icon, Space } from "@cocalc/frontend/components";
+import { A, ErrorDisplay, Icon, Gap } from "@cocalc/frontend/components";
 import {
   derive_project_img_name,
   SoftwareEnvironment,
@@ -172,7 +172,7 @@ export const NewProjectCreator: React.FC<Props> = (props: Props) => {
         <div style={{ marginTop: "30px" }}>
           <Alert bsStyle="info">
             <Icon name="cocalc-ring" spin />
-            <Space /> Creating project...
+            <Gap /> Creating project...
           </Alert>
         </div>
       );
@@ -428,7 +428,7 @@ export const NewProjectCreator: React.FC<Props> = (props: Props) => {
     return (
       <Row style={{ width: "100%", paddingBottom: "20px" }}>
         <Col sm={24}>
-          <Space />
+          <Gap />
           {render_input_section()}
         </Col>
       </Row>

--- a/src/packages/frontend/projects/project-list-desc.tsx
+++ b/src/packages/frontend/projects/project-list-desc.tsx
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Icon, Space } from "../components";
+import { Icon, Gap } from "../components";
 import { plural } from "@cocalc/util/misc";
 import { Button } from "antd";
 import { Alert, ButtonGroup, ButtonToolbar } from "../antd-bootstrap";
@@ -74,8 +74,8 @@ export const ProjectsListingDescription: React.FC<Props> = ({
         whose title, description, state or users match{" "}
         <strong>{query.trim() ? `'${query}'` : "anything"}</strong>
         {query.trim() && <> (use a space to select everything)</>}.
-        <Space />
-        <Space />
+        <Gap />
+        <Gap />
         <Button
           onClick={() => {
             set_show_alert("none");
@@ -144,12 +144,12 @@ export const ProjectsListingDescription: React.FC<Props> = ({
       return (
         <Alert bsStyle="warning" style={{ fontSize: "1.3em" }}>
           Only showing the {visible_projects.length}
-          <Space />
+          <Gap />
           <strong>{`${deleted ? "deleted " : ""}${
             hidden ? "hidden " : ""
           }`}</strong>
           {plural(visible_projects.length, "project")}
-          <Space />
+          <Gap />
           {query !== "" ? render_span(query) : undefined}
           {render_projects_actions_toolbar()}
           {render_projects_actions_alert()}

--- a/src/packages/frontend/projects/project-row.tsx
+++ b/src/packages/frontend/projects/project-row.tsx
@@ -23,7 +23,7 @@ import {
   Markdown,
   Paragraph,
   ProjectState,
-  Space,
+  Gap,
   TimeAgo,
 } from "@cocalc/frontend/components";
 import {
@@ -90,7 +90,7 @@ export const ProjectRow: React.FC<Props> = ({ project_id, index }: Props) => {
             <span style={{ fontSize: "15pt" }}>
               <Icon name={add_collab ? "caret-down" : "caret-right"} />
             </span>
-            <Space />
+            <Gap />
             <Icon
               name="user"
               style={{ fontSize: "16pt", marginRight: "10px" }}

--- a/src/packages/frontend/site-licenses/admin/component.tsx
+++ b/src/packages/frontend/site-licenses/admin/component.tsx
@@ -22,7 +22,7 @@ import {
   Icon,
   Loading,
   r_join,
-  Space,
+  Gap,
   Title,
 } from "@cocalc/frontend/components";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
@@ -158,7 +158,7 @@ export const SiteLicenses: React.FC<{}> = () => {
           style={{ margin: "15px 0", float: "right" }}
         >
           <Icon name="plus" spin={creating} />
-          <Space /> Create license...
+          <Gap /> Create license...
         </Button>
       </Popconfirm>
     );
@@ -264,14 +264,14 @@ export const SiteLicenses: React.FC<{}> = () => {
         {render_error()}
         <div>
           {render_search()}
-          <Space />
-          <Space />
+          <Gap />
+          <Gap />
           {render_search_button()}
-          <Space />
-          <Space />
+          <Gap />
+          <Gap />
           {render_create_new_license()}
-          <Space />
-          <Space />
+          <Gap />
+          <Gap />
           {render_search_restriction_note()}
           {render_export()}
           {render_loading()}

--- a/src/packages/frontend/site-licenses/admin/license.tsx
+++ b/src/packages/frontend/site-licenses/admin/license.tsx
@@ -14,7 +14,7 @@ import {
   CopyToClipBoard,
   DateTimePicker,
   Icon,
-  Space,
+  Gap,
   TimeAgo,
 } from "@cocalc/frontend/components";
 import {
@@ -523,7 +523,7 @@ export const License: React.FC<Props> = (props: Props) => {
         <Button onClick={() => actions.cancel_editing(id)} disabled={saving}>
           Cancel
         </Button>
-        <Space />
+        <Gap />
         <Button
           disabled={edits == null || edits.size <= 1 || saving}
           bsStyle="success"

--- a/src/packages/frontend/site-licenses/admin/managers.tsx
+++ b/src/packages/frontend/site-licenses/admin/managers.tsx
@@ -7,7 +7,7 @@ import { List } from "immutable";
 import { redux, useState, useTypedRedux } from "../../app-framework";
 import { ManagerInfo } from "./types";
 import { User } from "../../users";
-import { r_join, Space } from "../../components";
+import { r_join, Gap } from "../../components";
 import { Button } from "../../antd-bootstrap";
 import { Popconfirm } from "antd";
 import { alert_message } from "../../alerts";
@@ -55,7 +55,7 @@ export const Managers: React.FC<Props> = ({
         >
           <Button>Remove this manager...</Button>
         </Popconfirm>
-        <Space />
+        <Gap />
         <Button onClick={() => show_manager_info()}>Close</Button>
       </div>
     );
@@ -120,7 +120,7 @@ export const Managers: React.FC<Props> = ({
             }
           }}
         />
-        <Space />
+        <Gap />
         <Button disabled={!add_value.trim()} onClick={() => add_manager()}>
           Add manager
         </Button>

--- a/src/packages/frontend/site-licenses/purchase/link.tsx
+++ b/src/packages/frontend/site-licenses/purchase/link.tsx
@@ -6,7 +6,7 @@
 /* Link to purchasing a license */
 
 import { redux, useTypedRedux } from "@cocalc/frontend/app-framework";
-import { Icon, Space } from "@cocalc/frontend/components";
+import { Icon, Gap } from "@cocalc/frontend/components";
 import { Button } from "antd";
 import { PurchaseOneLicense } from "./purchase";
 
@@ -21,7 +21,7 @@ export const PurchaseOneLicenseLink: React.FC = () => {
     <div>
       <Button disabled={expand} type="primary" onClick={() => set_expand(true)}>
         <Icon name={"shopping-cart"} />
-        <Space /> Buy a license...
+        <Gap /> Buy a license...
       </Button>
       {expand && (
         <>

--- a/src/packages/frontend/site-licenses/purchase/purchase-method.tsx
+++ b/src/packages/frontend/site-licenses/purchase/purchase-method.tsx
@@ -19,7 +19,7 @@ import {
   useTypedRedux,
   useState,
 } from "@cocalc/frontend/app-framework";
-import { Icon, Loading, Space } from "@cocalc/frontend/components";
+import { Icon, Loading, Gap } from "@cocalc/frontend/components";
 import { alert_message } from "@cocalc/frontend/alerts";
 import { PaymentMethods } from "@cocalc/frontend/billing/payment-methods";
 
@@ -69,7 +69,7 @@ export const PurchaseMethod: React.FC<Props> = React.memo(
             size="large"
             onClick={() => set_buy_confirm(true)}
           >
-            <Icon name="check" /> <Space /> <Space /> Checkout...
+            <Icon name="check" /> <Gap /> <Gap /> Checkout...
           </Button>
         )}
         {source && buy_confirm && (
@@ -80,7 +80,7 @@ export const PurchaseMethod: React.FC<Props> = React.memo(
             </div>
             <br />
             <Button type="primary" size="large" onClick={() => onClose(source)}>
-              <Icon name="credit-card" /> <Space /> Complete Purchase
+              <Icon name="credit-card" /> <Gap /> Complete Purchase
             </Button>
           </div>
         )}

--- a/src/packages/frontend/site-licenses/purchase/purchase.tsx
+++ b/src/packages/frontend/site-licenses/purchase/purchase.tsx
@@ -20,7 +20,7 @@ import {
   ErrorDisplay,
   Icon,
   Loading,
-  Space,
+  Gap,
 } from "@cocalc/frontend/components";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 import { supportURL } from "@cocalc/frontend/support/url";
@@ -438,9 +438,9 @@ export const PurchaseOneLicense: React.FC<Props> = React.memo(({ onClose }) => {
             set_end(value[1].toDate());
           }}
         />
-        <Space />
-        <Space />
-        <Space />
+        <Gap />
+        <Gap />
+        <Gap />
         <Dropdown overlay={menu}>
           <a className="ant-dropdown-link" onClick={(e) => e.preventDefault()}>
             End after... <DownOutlined />
@@ -680,8 +680,8 @@ export const PurchaseOneLicense: React.FC<Props> = React.memo(({ onClose }) => {
           type="primary"
         >
           <Icon name="envelope" />
-          <Space />
-          <Space /> Copy information to support ticket...
+          <Gap />
+          <Gap /> Copy information to support ticket...
         </Button>
       </div>
     );

--- a/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
+++ b/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
@@ -29,7 +29,7 @@ import {
   useState,
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
-import { A, Space } from "@cocalc/frontend/components";
+import { A, Gap } from "@cocalc/frontend/components";
 import {
   LicenseIdleTimeouts,
   requiresMemberhosting,
@@ -67,7 +67,7 @@ const UNIT_STYLE: CSS = {
 function render_explanation(s): JSX.Element {
   return (
     <span style={{ color: "#888" }}>
-      <Space /> - {s}
+      <Gap /> - {s}
     </span>
   );
 }
@@ -167,7 +167,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
               onChange({ cpu: Math.round(x) });
             }}
           />
-          <Space />
+          <Gap />
           <span style={UNIT_STYLE}>shared CPU {plural(quota.cpu, "core")}</span>
         </Col>
         <Col md={col.max}>
@@ -212,7 +212,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
               onChange({ ram: Math.round(x) });
             }}
           />
-          <Space />
+          <Gap />
           <span style={UNIT_STYLE}>shared G RAM</span>
         </Col>
         <Col md={col.max}>
@@ -259,7 +259,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
               }
             }}
           />
-          <Space />
+          <Gap />
           <span style={UNIT_STYLE}>
             dedicated CPU {plural(quota.dedicated_cpu, "core")}
           </span>
@@ -312,7 +312,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
               }
             }}
           />
-          <Space />
+          <Gap />
           <span style={UNIT_STYLE}>dedicated G RAM</span>
         </Col>
         <Col md={col.max}>
@@ -358,7 +358,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
               onChange({ disk: Math.round(x) });
             }}
           />
-          <Space />
+          <Gap />
           <span style={UNIT_STYLE}>G disk space</span>
         </Col>
         <Col md={col.max}>

--- a/src/packages/frontend/site-licenses/site-license-public-info-component.tsx
+++ b/src/packages/frontend/site-licenses/site-license-public-info-component.tsx
@@ -30,7 +30,7 @@ import {
   LicenseStatus,
   licenseStatusProvidesUpgrades,
 } from "@cocalc/util/upgrades/quota";
-import { CopyToClipBoard, Icon, Loading, Space, TimeAgo } from "../components";
+import { CopyToClipBoard, Icon, Loading, Gap, TimeAgo } from "../components";
 import { DisplayUpgrades, scale_by_display_factors } from "./admin/upgrades";
 import { LicensePurchaseInfo } from "./purchase-info-about-license";
 import { LICENSE_ACTIVATION_RULES } from "./rules";
@@ -539,7 +539,7 @@ export const SiteLicensePublicInfo: React.FC<Props> = (props: Props) => {
     return (
       <Button onClick={() => fetch_info(true)}>
         <Icon name="redo" />
-        <Space /> Refresh
+        <Gap /> Refresh
       </Button>
     );
   }
@@ -580,7 +580,7 @@ export const SiteLicensePublicInfo: React.FC<Props> = (props: Props) => {
       >
         <Button>
           <Icon name="times" />
-          <Space /> Remove...
+          <Gap /> Remove...
         </Button>
       </Popconfirm>
     );

--- a/src/packages/frontend/users/user.tsx
+++ b/src/packages/frontend/users/user.tsx
@@ -6,7 +6,7 @@
 //TODO: Make useable without passing in user_map
 
 import { Component } from "../app-framework";
-import { Space, TimeAgo, Tip } from "../components";
+import { Gap, TimeAgo, Tip } from "../components";
 import { is_valid_uuid_string, trunc_middle } from "@cocalc/util/misc";
 import { UserMap } from "./types";
 import { actions } from "./actions";
@@ -126,7 +126,7 @@ export class User extends Component<Props> {
           {this.props.show_avatar && (
             <>
               <Avatar account_id={this.props.account_id} first_name={n} />
-              <Space />
+              <Gap />
             </>
           )}
           {n}


### PR DESCRIPTION
# Description

ok, this should do it. the only previous use of `"Gap"` in frontend is for the software, not any component name. Hence no chance to cause unintended usage of something that already exists. Also, renaming `AntdSpace` aliases to `Space`.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
 