### PR TITLE
Fix student pay and banner

### DIFF
--- a/src/packages/frontend/project/explorer/explorer.tsx
+++ b/src/packages/frontend/project/explorer/explorer.tsx
@@ -460,7 +460,7 @@ const Explorer0 = rclass(
             <Icon name="exclamation-triangle" /> Your instructor requires that
             you pay the one-time ${STUDENT_COURSE_PRICE} course fee for this
             project.
-            {cards && <CourseProjectExtraHelp />}
+            {cards ? <CourseProjectExtraHelp /> : undefined}
           </h4>
           {this.render_upgrade_in_place()}
         </Alert>

--- a/src/packages/frontend/project/trial-banner.tsx
+++ b/src/packages/frontend/project/trial-banner.tsx
@@ -39,10 +39,10 @@ const A_STYLE_ELEVATED: CSS = {
 } as const;
 
 export const ALERT_STYLE: CSS = {
-  paddingTop: "0px",
+  paddingTop: "5px",
   paddingLeft: "10px",
   paddingRight: "5px",
-  paddingBottom: "5px",
+  paddingBottom: "0px",
   marginBottom: 0,
   fontSize: "9pt",
   borderRadius: 0,
@@ -128,13 +128,13 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
       <strong>No upgrades</strong>
     );
 
-    function renderMessage(): JSX.Element | undefined {
-      const buy_and_upgrade = (
+    function renderBuyAndUpgrade(text: string = "with a license"): JSX.Element {
+      return (
         <>
           <BuyLicenseForProject
             project_id={project_id}
-            buyText={"with a license"}
-            voucherText={"a voucher"}
+            buyText={text}
+            voucherText={"redeem a voucher"}
             asLink={true}
             style={{ padding: 0, fontSize: style.fontSize, ...a_style }}
           />
@@ -144,13 +144,15 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
           </a>
         </>
       );
+    }
 
+    function renderMessage(): JSX.Element | undefined {
       if (allow_run === false) {
         return (
           <span>
             There are too many free trial projects running right now.
             <br />
-            Try again later or {buy_and_upgrade}.
+            Try again later or {renderBuyAndUpgrade()}.
           </span>
         );
       }
@@ -159,7 +161,7 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
         return (
           <span>
             {trial_project} You can improve hosting quality and get internet
-            access {buy_and_upgrade}.
+            access {renderBuyAndUpgrade()}.
             <br />
             Otherwise, {humanizeList([...NO_HOST, NO_INTERNET])}
             {"."}
@@ -174,6 +176,8 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
             </A>{" "}
             or {humanizeList(NO_HOST)}
             {"."}
+            <br />
+            {renderBuyAndUpgrade("Buy a license")}
           </span>
         );
       } else if (internet) {
@@ -185,6 +189,8 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
             </A>{" "}
             or {NO_INTERNET}
             {"."}
+            <br />
+            {renderBuyAndUpgrade("Buy a license")}
           </span>
         );
       }

--- a/src/packages/frontend/project/warnings/course-project.tsx
+++ b/src/packages/frontend/project/warnings/course-project.tsx
@@ -3,8 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-
-
 export const CourseProjectExtraHelp: React.FC = () => {
   return (
     <div style={{ marginTop: "10px" }}>
@@ -16,5 +14,3 @@ export const CourseProjectExtraHelp: React.FC = () => {
     </div>
   );
 };
-
-

--- a/src/packages/frontend/projects/actions.ts
+++ b/src/packages/frontend/projects/actions.ts
@@ -29,6 +29,7 @@ import { Set } from "immutable";
 import json_stable from "json-stable-stringify";
 import { ProjectsState, store } from "./store";
 import { load_all_projects, switch_to_project } from "./table";
+import { isEqual } from "lodash";
 
 export type Datastore = boolean | string[] | undefined;
 
@@ -314,13 +315,17 @@ export class ProjectsActions extends Actions<ProjectsState> {
     if (typeof envvars?.inherit === "boolean") {
       course.envvars = envvars;
     }
-    // null for shared/nbgrader project, otherwise student project
-    if (account_id != null && email_address != null) {
+    // account_id and email is null for shared/nbgrader project, otherwise student project
+    // the corresponding check of the two fields below is the
+    // is_student = ... or-test in ProjectsStore::date_when_course_payment_required
+    if (account_id != null) {
       course.account_id = account_id;
+    }
+    if (email_address != null) {
       course.email_address = email_address;
     }
-    // json_stable -- I'm tired and this needs to just work for comparing.
-    if (json_stable(course_info) === json_stable(course)) {
+    // lodash.isEqual: deep comparison of two objects
+    if (isEqual(course_info, course)) {
       // already set as required; do nothing
       return;
     }

--- a/src/packages/frontend/projects/actions.ts
+++ b/src/packages/frontend/projects/actions.ts
@@ -26,10 +26,9 @@ import { DEFAULT_QUOTAS } from "@cocalc/util/schema";
 import { SiteLicenseQuota } from "@cocalc/util/types/site-licenses";
 import { Upgrades } from "@cocalc/util/upgrades/types";
 import { Set } from "immutable";
-import json_stable from "json-stable-stringify";
+import { isEqual } from "lodash";
 import { ProjectsState, store } from "./store";
 import { load_all_projects, switch_to_project } from "./table";
-import { isEqual } from "lodash";
 
 export type Datastore = boolean | string[] | undefined;
 


### PR DESCRIPTION
# Description

- tried testing upgrades, but ended up debugging student pay. there is a test, only setting account_id and email only if both are known. [the corresponding test is an or](https://github.com/sagemathinc/cocalc/blob/08e186f36aeddee8a8476bd5b1ac62f17acb40c2/src/packages/frontend/projects/store.ts#L162).
- also saw odd margins with the trial banner, something must have changed slightly. in any case, now there is a link to buy upgrades.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
