### PR TITLE
frontend/flyout: 5th round of fixes

### DIFF
--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ant-design/colors";
 import { Button, Tooltip } from "antd";
 
-import { CSS, React, useRef, useState } from "@cocalc/frontend/app-framework";
+import { CSS, React, useRef } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
 import { file_options } from "@cocalc/frontend/editor-tmp";
 import { hexColorToRGBA } from "@cocalc/util/misc";
@@ -89,10 +89,12 @@ interface FileListItemProps {
   onChecked?: (state: boolean) => void;
   itemStyle?: CSS;
   item: Item;
+  index?: number;
   tooltip?: JSX.Element | string;
   selected?: boolean;
   multiline?: boolean;
   showCheckbox?: boolean;
+  setShowCheckboxIndex?: (index: number | null) => void;
 }
 
 export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
@@ -102,16 +104,16 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     onPublic,
     onChecked,
     item,
+    index,
     itemStyle,
     tooltip,
     selected,
     onMouseDown,
     multiline = false,
     showCheckbox,
+    setShowCheckboxIndex,
   } = props;
   const selectable = onChecked != null;
-  const [hover, setHover] = useState(false);
-
   const itemRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -169,18 +171,18 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
   }
 
   function handleMouseEnter(): void {
-    if (!selectable) return;
-    setHover(true);
+    if (!selectable || index == null) return;
+    setShowCheckboxIndex?.(index);
   }
 
   function handleMouseLeave(): void {
     if (!selectable) return;
-    setHover(false);
+    setShowCheckboxIndex?.(null);
   }
 
   function renderBodyLeft(): JSX.Element {
     const iconName =
-      selectable && (showCheckbox || hover) && item.name !== ".."
+      selectable && showCheckbox && item.name !== ".."
         ? selected
           ? "check-square"
           : "square"

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -37,6 +37,7 @@ const FILE_ITEM_ACTIVE_STYLE: CSS = {
 };
 
 const FILE_ITEM_STYLE: CSS = {
+  flex: "1",
   whiteSpace: "nowrap",
   overflow: "hidden",
   textOverflow: "ellipsis",
@@ -196,9 +197,13 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
         style={ICON_STYLE}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={(e) => {
+        onClick={(e: React.MouseEvent) => {
           e?.stopPropagation();
-          onChecked?.(!selected);
+          if (onChecked != null) {
+            onChecked?.(!selected);
+          } else {
+            onClick?.(e);
+          }
         }}
       />
     );

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -109,6 +109,7 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     multiline = false,
     showCheckbox,
   } = props;
+  const selectable = onChecked != null;
   const [hover, setHover] = useState(false);
 
   const itemRef = useRef<HTMLDivElement>(null);
@@ -167,9 +168,19 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     }
   }
 
+  function handleMouseEnter(): void {
+    if (!selectable) return;
+    setHover(true);
+  }
+
+  function handleMouseLeave(): void {
+    if (!selectable) return;
+    setHover(false);
+  }
+
   function renderBodyLeft(): JSX.Element {
     const iconName =
-      (showCheckbox || hover) && item.name !== ".."
+      selectable && (showCheckbox || hover) && item.name !== ".."
         ? selected
           ? "check-square"
           : "square"
@@ -181,8 +192,8 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
       <Icon
         name={iconName}
         style={ICON_STYLE}
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         onClick={(e) => {
           e?.stopPropagation();
           onChecked?.(!selected);
@@ -201,7 +212,7 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
           onMouseDown?.(e, item.name);
         }}
         // additional mouseLeave to prevent stale hover state icon
-        onMouseLeave={() => setHover(false)}
+        onMouseLeave={handleMouseLeave}
       >
         {renderBodyLeft()} {renderItem()} {renderPublishedIcon()}
         {item.isopen ? renderCloseItem(item) : undefined}
@@ -225,7 +236,7 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     <div
       className="cc-project-flyout-file-item"
       // additional mouseLeave to prevent stale hover state icon
-      onMouseLeave={() => setHover(false)}
+      onMouseLeave={handleMouseLeave}
       style={{
         ...FILE_ITEM_LINE_STYLE,
         ...(item.isopen

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -93,6 +93,9 @@ export function FilesFlyout(): JSX.Element {
   const isMountedRef = useIsMountedRef();
   const rootRef = useRef<HTMLDivElement>(null);
   const [rootHeightPx, setRootHeightPx] = useState<number>(0);
+  const [showCheckboxIndex, setShowCheckboxIndex] = useState<number | null>(
+    null
+  );
   const refInput = useRef<InputRef>(null);
   const current_path = useTypedRedux({ project_id }, "current_path");
   const strippedPublicPaths = useStrippedPublicPaths(project_id);
@@ -297,6 +300,10 @@ export function FilesFlyout(): JSX.Element {
     }
     setScrollIdx(null);
   }, [current_path]);
+
+  useEffect(() => {
+    setShowCheckboxIndex(null);
+  }, [directoryListings, current_path]);
 
   const triggerRootResize = debounce(
     () => setRootHeightPx(rootRef.current?.clientHeight ?? 0),
@@ -544,6 +551,7 @@ export function FilesFlyout(): JSX.Element {
     return (
       <FileListItem
         item={item}
+        index={index}
         onClick={(e) => handleFileClick(e, index)}
         onMouseDown={(e: React.MouseEvent, name: string) => {
           setSelectionOnMouseDown(window.getSelection()?.toString() ?? "");
@@ -558,7 +566,12 @@ export function FilesFlyout(): JSX.Element {
         }}
         onPublic={() => showFileSharingDialog(directoryFiles[index])}
         selected={isSelected}
-        showCheckbox={mode === "select" || checked_files?.size > 0}
+        showCheckbox={
+          mode === "select" ||
+          checked_files?.size > 0 ||
+          showCheckboxIndex === index
+        }
+        setShowCheckboxIndex={setShowCheckboxIndex}
         onChecked={(nextState: boolean) => {
           toggleSelected(index, item.name, nextState);
         }}
@@ -575,6 +588,7 @@ export function FilesFlyout(): JSX.Element {
         ref={virtuosoRef}
         style={{}}
         increaseViewportBy={10}
+        onMouseLeave={() => setShowCheckboxIndex(null)}
         totalCount={directoryFiles.length}
         itemContent={(index) => {
           const file = directoryFiles[index];

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -556,6 +556,7 @@ export function FilesFlyout(): JSX.Element {
         onMouseDown={(e: React.MouseEvent, name: string) => {
           setSelectionOnMouseDown(window.getSelection()?.toString() ?? "");
           if (e.button === 1) {
+            // middle mouse click
             actions?.close_tab(path_to_file(current_path, name));
           }
         }}

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -215,6 +215,12 @@ export function LogFlyout({
           e.stopPropagation();
           actions?.close_tab(path);
         }}
+        onMouseDown={(e: React.MouseEvent) => {
+          if (e.button === 1) {
+            // middle mouse click
+            actions?.close_tab(path);
+          }
+        }}
         tooltip={
           <>
             Last opened <TimeAgo date={time} /> by{" "}


### PR DESCRIPTION
# Description

- log entries can't be selected: fixes #6821
- mitigate stuck hover checkboxes by only showing one at a time
- log: trigger click on file icon, since it can't be selected
- flex-expand file item label, such that close and published icons are on the right hand side
- log/file entry: middle mouse click closes, just like with a files/file entry

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
