### PR TITLE
frontend/flyout: file attributes in files list

### DIFF
--- a/src/packages/frontend/project/page/file-tab.tsx
+++ b/src/packages/frontend/project/page/file-tab.tsx
@@ -26,10 +26,10 @@ import { COLORS } from "@cocalc/util/theme";
 import { PROJECT_INFO_TITLE } from "../info";
 import { TITLE as SERVERS_TITLE } from "../servers";
 import {
-  ICON_USERS,
   ICON_UPGRADES,
-  TITLE_USERS,
+  ICON_USERS,
   TITLE_UPGRADES,
+  TITLE_USERS,
 } from "../servers/consts";
 import {
   CollabsFlyout,
@@ -64,7 +64,11 @@ type FixedTabs = {
   [name in FixedTab]: {
     label: string | ReactNode;
     icon: IconName;
-    flyout: (props: { project_id: string; wrap: Function }) => JSX.Element;
+    flyout: (props: {
+      project_id: string;
+      wrap: (content: JSX.Element, style?: CSS) => JSX.Element;
+      flyoutWidth: number;
+    }) => JSX.Element;
     flyoutTitle?: string | ReactNode;
     noAnonymous?: boolean;
   };

--- a/src/packages/frontend/project/page/flyouts/body.tsx
+++ b/src/packages/frontend/project/page/flyouts/body.tsx
@@ -20,13 +20,12 @@ import { FIXED_TABS_BG_COLOR } from "../tabs";
 import { FLYOUT_PADDING } from "./consts";
 import { LSFlyout, lsKey, storeFlyoutState } from "./state";
 
-export function FlyoutBody({
-  flyout,
-  flyoutWidth,
-}: {
+interface FlyoutBodyProps {
   flyout: FixedTab;
   flyoutWidth: number;
-}) {
+}
+
+export function FlyoutBody({ flyout, flyoutWidth }: FlyoutBodyProps) {
   const { project_id } = useProjectContext();
   // No "Ref", because otherwise we don't trigger the useEffect below
   const [bodyDiv, setBodyDiv] = useState<HTMLDivElement | null>(null);
@@ -98,7 +97,7 @@ export function FlyoutBody({
           <Loading />
         </div>
       ) : (
-        <Body project_id={project_id} wrap={wrap} />
+        <Body project_id={project_id} wrap={wrap} flyoutWidth={flyoutWidth} />
       )}
     </div>
   );

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ant-design/colors";
 import { Button, Tooltip } from "antd";
 
-import { CSS, React, useRef, useState } from "@cocalc/frontend/app-framework";
+import { CSS, React, useRef } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
 import { file_options } from "@cocalc/frontend/editor-tmp";
 import { hexColorToRGBA } from "@cocalc/util/misc";
@@ -89,10 +89,12 @@ interface FileListItemProps {
   onChecked?: (state: boolean) => void;
   itemStyle?: CSS;
   item: Item;
+  index?: number;
   tooltip?: JSX.Element | string;
   selected?: boolean;
   multiline?: boolean;
   showCheckbox?: boolean;
+  setShowCheckboxIndex?: (index: number | null) => void;
 }
 
 export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
@@ -102,16 +104,16 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     onPublic,
     onChecked,
     item,
+    index,
     itemStyle,
     tooltip,
     selected,
     onMouseDown,
     multiline = false,
     showCheckbox,
+    setShowCheckboxIndex,
   } = props;
   const selectable = onChecked != null;
-  const [hover, setHover] = useState(false);
-
   const itemRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -169,18 +171,18 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
   }
 
   function handleMouseEnter(): void {
-    if (!selectable) return;
-    setHover(true);
+    if (!selectable || index == null) return;
+    setShowCheckboxIndex?.(index);
   }
 
   function handleMouseLeave(): void {
     if (!selectable) return;
-    setHover(false);
+    setShowCheckboxIndex?.(null);
   }
 
   function renderBodyLeft(): JSX.Element {
     const iconName =
-      selectable && (showCheckbox || hover) && item.name !== ".."
+      selectable && showCheckbox && item.name !== ".."
         ? selected
           ? "check-square"
           : "square"

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -37,6 +37,7 @@ const FILE_ITEM_ACTIVE_STYLE: CSS = {
 };
 
 const FILE_ITEM_STYLE: CSS = {
+  flex: "1",
   whiteSpace: "nowrap",
   overflow: "hidden",
   textOverflow: "ellipsis",
@@ -196,9 +197,13 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
         style={ICON_STYLE}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={(e) => {
+        onClick={(e: React.MouseEvent) => {
           e?.stopPropagation();
-          onChecked?.(!selected);
+          if (onChecked != null) {
+            onChecked?.(!selected);
+          } else {
+            onClick?.(e);
+          }
         }}
       />
     );

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -109,6 +109,7 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     multiline = false,
     showCheckbox,
   } = props;
+  const selectable = onChecked != null;
   const [hover, setHover] = useState(false);
 
   const itemRef = useRef<HTMLDivElement>(null);
@@ -167,9 +168,19 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     }
   }
 
+  function handleMouseEnter(): void {
+    if (!selectable) return;
+    setHover(true);
+  }
+
+  function handleMouseLeave(): void {
+    if (!selectable) return;
+    setHover(false);
+  }
+
   function renderBodyLeft(): JSX.Element {
     const iconName =
-      (showCheckbox || hover) && item.name !== ".."
+      selectable && (showCheckbox || hover) && item.name !== ".."
         ? selected
           ? "check-square"
           : "square"
@@ -181,8 +192,8 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
       <Icon
         name={iconName}
         style={ICON_STYLE}
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         onClick={(e) => {
           e?.stopPropagation();
           onChecked?.(!selected);
@@ -201,7 +212,7 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
           onMouseDown?.(e, item.name);
         }}
         // additional mouseLeave to prevent stale hover state icon
-        onMouseLeave={() => setHover(false)}
+        onMouseLeave={handleMouseLeave}
       >
         {renderBodyLeft()} {renderItem()} {renderPublishedIcon()}
         {item.isopen ? renderCloseItem(item) : undefined}
@@ -225,7 +236,7 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     <div
       className="cc-project-flyout-file-item"
       // additional mouseLeave to prevent stale hover state icon
-      onMouseLeave={() => setHover(false)}
+      onMouseLeave={handleMouseLeave}
       style={{
         ...FILE_ITEM_LINE_STYLE,
         ...(item.isopen

--- a/src/packages/frontend/project/page/flyouts/consts.ts
+++ b/src/packages/frontend/project/page/flyouts/consts.ts
@@ -6,6 +6,8 @@
 export const DEFAULT_EXT = "ipynb";
 
 export const FLYOUT_DEFAULT_WIDTH_PX: number = 350;
+export const FLYOUT_EXTRA_WIDTH_PX = Math.floor(FLYOUT_DEFAULT_WIDTH_PX * 1.1);
+export const FLYOUT_EXTRA2_WIDTH_PX = Math.floor(FLYOUT_DEFAULT_WIDTH_PX * 1.4);
 
 // use this in styles for padding or margins
 export const FLYOUT_PADDING = "5px";

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -93,6 +93,9 @@ export function FilesFlyout(): JSX.Element {
   const isMountedRef = useIsMountedRef();
   const rootRef = useRef<HTMLDivElement>(null);
   const [rootHeightPx, setRootHeightPx] = useState<number>(0);
+  const [showCheckboxIndex, setShowCheckboxIndex] = useState<number | null>(
+    null
+  );
   const refInput = useRef<InputRef>(null);
   const current_path = useTypedRedux({ project_id }, "current_path");
   const strippedPublicPaths = useStrippedPublicPaths(project_id);
@@ -297,6 +300,10 @@ export function FilesFlyout(): JSX.Element {
     }
     setScrollIdx(null);
   }, [current_path]);
+
+  useEffect(() => {
+    setShowCheckboxIndex(null);
+  }, [directoryListings, current_path]);
 
   const triggerRootResize = debounce(
     () => setRootHeightPx(rootRef.current?.clientHeight ?? 0),
@@ -544,6 +551,7 @@ export function FilesFlyout(): JSX.Element {
     return (
       <FileListItem
         item={item}
+        index={index}
         onClick={(e) => handleFileClick(e, index)}
         onMouseDown={(e: React.MouseEvent, name: string) => {
           setSelectionOnMouseDown(window.getSelection()?.toString() ?? "");
@@ -558,7 +566,12 @@ export function FilesFlyout(): JSX.Element {
         }}
         onPublic={() => showFileSharingDialog(directoryFiles[index])}
         selected={isSelected}
-        showCheckbox={mode === "select" || checked_files?.size > 0}
+        showCheckbox={
+          mode === "select" ||
+          checked_files?.size > 0 ||
+          showCheckboxIndex === index
+        }
+        setShowCheckboxIndex={setShowCheckboxIndex}
         onChecked={(nextState: boolean) => {
           toggleSelected(index, item.name, nextState);
         }}
@@ -575,6 +588,7 @@ export function FilesFlyout(): JSX.Element {
         ref={virtuosoRef}
         style={{}}
         increaseViewportBy={10}
+        onMouseLeave={() => setShowCheckboxIndex(null)}
         totalCount={directoryFiles.length}
         itemContent={(index) => {
           const file = directoryFiles[index];

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -556,6 +556,7 @@ export function FilesFlyout(): JSX.Element {
         onMouseDown={(e: React.MouseEvent, name: string) => {
           setSelectionOnMouseDown(window.getSelection()?.toString() ?? "");
           if (e.button === 1) {
+            // middle mouse click
             actions?.close_tab(path_to_file(current_path, name));
           }
         }}

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -215,6 +215,12 @@ export function LogFlyout({
           e.stopPropagation();
           actions?.close_tab(path);
         }}
+        onMouseDown={(e: React.MouseEvent) => {
+          if (e.button === 1) {
+            // middle mouse click
+            actions?.close_tab(path);
+          }
+        }}
         tooltip={
           <>
             Last opened <TimeAgo date={time} /> by{" "}

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -37,6 +37,7 @@ import { handle_log_click } from "../../history/utils";
 import { FIX_BORDER } from "../common";
 import { FIXED_PROJECT_TABS } from "../file-tab";
 import { FileListItem, fileItemStyle } from "./components";
+import { FLYOUT_EXTRA_WIDTH_PX } from "./consts";
 import { FlyoutLogMode, getFlyoutLogMode, isFlyoutLogMode } from "./state";
 
 export const FLYOUT_LOG_DEFAULT_MODE = "files";
@@ -156,12 +157,14 @@ interface Props {
   project_id: string;
   max?: number;
   wrap: (list: JSX.Element, style?: CSS) => JSX.Element;
+  flyoutWidth: number;
 }
 
 export function LogFlyout({
   max = 1000,
   project_id,
   wrap,
+  flyoutWidth,
 }: Props): JSX.Element {
   const actions = useActions({ project_id });
   const mode: FlyoutLogMode = useTypedRedux({ project_id }, "flyout_log_mode");
@@ -197,6 +200,19 @@ export function LogFlyout({
     }
   }, [project_log, project_log_all, searchTerm, max, mode]);
 
+  const showExtra = useMemo(
+    () => flyoutWidth > FLYOUT_EXTRA_WIDTH_PX,
+    [flyoutWidth]
+  );
+
+  // end of hooks
+
+  function renderFileItemExtra(entry: OpenedFile) {
+    if (!showExtra) return null;
+    if (!entry.time) return;
+    return <TimeAgo date={entry.time} />;
+  }
+
   function renderFileItem(index: number, entry: OpenedFile) {
     const time = entry.time;
     const account_id = entry.account_id;
@@ -207,6 +223,7 @@ export function LogFlyout({
     return (
       <FileListItem
         item={{ name: path, isopen: isOpened, isactive: isActive }}
+        extra={renderFileItemExtra(entry)}
         itemStyle={fileItemStyle(time?.getTime())}
         multiline={true}
         selected={!scollIdxHide && index === scrollIdx}

--- a/src/packages/util/misc.ts
+++ b/src/packages/util/misc.ts
@@ -633,23 +633,26 @@ export function bind_methods<T extends object>(
   return obj;
 }
 
-export function human_readable_size(bytes: number | null | undefined): string {
+export function human_readable_size(
+  bytes: number | null | undefined,
+  short = false
+): string {
   if (bytes == null) {
     return "?";
   }
   if (bytes < 1000) {
-    return `${bytes} bytes`;
+    return `${bytes} ${short ? "b" : "bytes"}`;
   }
   if (bytes < 1000000) {
     const b = Math.floor(bytes / 100);
-    return `${b / 10} KB`;
+    return `${b / 10} ${short ? "K" : "KB"}`;
   }
   if (bytes < 1000000000) {
     const b = Math.floor(bytes / 100000);
-    return `${b / 10} MB`;
+    return `${b / 10} ${short ? "M" : "MB"}`;
   }
   const b = Math.floor(bytes / 100000000);
-  return `${b / 10} GB`;
+  return `${b / 10} ${short ? "G" : "GB"}`;
 }
 
 // Regexp used to test for URLs in a string.


### PR DESCRIPTION
# Description

- this depends on https://github.com/sagemathinc/cocalc/pull/6824 ... which must be merged first
- if flyout expands, show file attribute columns

upon expanding, show 2 or 3 columns:


![screenshot-localhost_5000-2023 07 11-14_51_32](https://github.com/sagemathinc/cocalc/assets/207405/faf84fbf-10a1-44d7-81bc-1cc7774f537e)

![screenshot-localhost_5000-2023 07 11-14_51_57](https://github.com/sagemathinc/cocalc/assets/207405/f1288e04-d358-4a8c-bcd4-edbd22f049c6)


![screenshot-localhost_5000-2023 07 11-14_52_27](https://github.com/sagemathinc/cocalc/assets/207405/576c757f-0e44-416c-8d7c-754b2018a308)

and columns depend a little bit on sort column, i.e. you can see the values the sort ordering is based on

![screenshot-localhost_5000-2023 07 11-14_53_07](https://github.com/sagemathinc/cocalc/assets/207405/f37ac6fa-c355-4148-bdd5-7d6065104044)

![screenshot-localhost_5000-2023 07 11-14_52_50](https://github.com/sagemathinc/cocalc/assets/207405/927309f3-58d7-4d51-93cd-3bdc6f4fad8f)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
