### PR TITLE
User tracking expire

### DIFF
--- a/src/packages/database/postgres/user-tracking.ts
+++ b/src/packages/database/postgres/user-tracking.ts
@@ -3,11 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { PostgreSQL } from "./types";
-
-import { is_valid_uuid_string } from "@cocalc/util/misc";
-
 import { callback2 } from "@cocalc/util/async-utils";
+import { expire_time, is_valid_uuid_string } from "@cocalc/util/misc";
+import { PostgreSQL } from "./types";
 
 export async function record_user_tracking(
   db: PostgreSQL,
@@ -38,6 +36,7 @@ export async function record_user_tracking(
       "time       :: TIMESTAMP": "NOW()",
       "event      :: TEXT": event,
       "value      :: JSONB": value,
+      "expire     :: TIMESTAMP": expire_time(30 * 24 * 60 * 60),
     },
   });
 }

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -227,7 +227,14 @@ export function LogFlyout({
         itemStyle={fileItemStyle(time?.getTime())}
         multiline={true}
         selected={!scollIdxHide && index === scrollIdx}
-        onClick={(e) => handle_log_click(e, path, project_id)}
+        onClick={(e) => {
+          track("open-file", {
+            project_id,
+            path,
+            how: "click-on-log-file-flyout",
+          });
+          handle_log_click(e, path, project_id);
+        }}
         onClose={(e: React.MouseEvent, path: string) => {
           e.stopPropagation();
           actions?.close_tab(path);
@@ -293,7 +300,7 @@ export function LogFlyout({
     track("open-file", {
       project_id,
       path: file.filename,
-      how: "click-on-log-file-flyout",
+      how: "keypress-on-log-file-flyout",
     });
     handle_log_click(e, file.filename, project_id);
   }

--- a/src/packages/util/db-schema/tracking.ts
+++ b/src/packages/util/db-schema/tracking.ts
@@ -115,5 +115,9 @@ Table({
       type: "map",
       desc: "optional further info about the event (as a map)",
     },
+    expire: {
+      type: "timestamp",
+      desc: "future date, when the entry will be deleted",
+    },
   },
 });


### PR DESCRIPTION
# Description

- add col and set expire to 30 days on user_tracking entries
- add flyout/log open file tracking

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
