### PR TITLE
Flyout enhancements #7

### DIFF
--- a/src/packages/frontend/account/other-settings.tsx
+++ b/src/packages/frontend/account/other-settings.tsx
@@ -61,7 +61,8 @@ export class OtherSettings extends Component<Props> {
         checked={!this.props.other_settings.get("show_global_info2")}
         onChange={(e) => this.toggle_global_banner(e.target.checked)}
       >
-        Show announcement banner (only shows up if there is a message)
+        <strong>Show announcement banner</strong>: only shows up if there is a
+        message
       </Checkbox>
     );
   }
@@ -72,8 +73,8 @@ export class OtherSettings extends Component<Props> {
         checked={!!this.props.other_settings.get("time_ago_absolute")}
         onChange={(e) => this.on_change("time_ago_absolute", e.target.checked)}
       >
-        Display timestamps as absolute points in time instead of relative to the
-        current time
+        Display <strong>timestamps as absolute points in time</strong> instead
+        of relative to the current time
       </Checkbox>
     );
   }
@@ -85,7 +86,8 @@ export class OtherSettings extends Component<Props> {
           checked={!!this.props.other_settings.get("confirm_close")}
           onChange={(e) => this.on_change("confirm_close", e.target.checked)}
         >
-          Confirm: always ask for confirmation before closing the browser window
+          <strong>Confirm Close:</strong> always ask for confirmation before
+          closing the browser window
         </Checkbox>
       );
     }
@@ -97,8 +99,9 @@ export class OtherSettings extends Component<Props> {
         checked={!!this.props.other_settings.get("katex")}
         onChange={(e) => this.on_change("katex", e.target.checked)}
       >
-        KaTeX: attempt to render formulas with KaTeX if possible (much faster,
-        but missing context menu options)
+        <strong>KaTeX:</strong> attempt to render formulas with{" "}
+        <A href={"https://katex.org/"}>KaTeX</A> (much faster, but missing
+        context menu options)
       </Checkbox>
     );
   }
@@ -126,8 +129,8 @@ export class OtherSettings extends Component<Props> {
         checked={!!this.props.other_settings.get("mask_files")}
         onChange={(e) => this.on_change("mask_files", e.target.checked)}
       >
-        Mask files: grey out files in the files viewer that you probably do not
-        want to open
+        <strong>Mask files:</strong> grey out files in the files viewer that you
+        probably do not want to open
       </Checkbox>
     );
   }
@@ -140,8 +143,8 @@ export class OtherSettings extends Component<Props> {
           this.on_change("hide_project_popovers", e.target.checked)
         }
       >
-        Hide Project Tab Popovers: do not show the popovers over the project
-        tabs
+        <strong>Hide Project Tab Popovers:</strong> do not show the popovers
+        over the project tabs
       </Checkbox>
     );
   }
@@ -152,7 +155,8 @@ export class OtherSettings extends Component<Props> {
         checked={!!this.props.other_settings.get("hide_file_popovers")}
         onChange={(e) => this.on_change("hide_file_popovers", e.target.checked)}
       >
-        Hide File Tab Popovers: do not show the popovers over file tabs
+        <strong>Hide File Tab Popovers:</strong> do not show the popovers over
+        file tabs
       </Checkbox>
     );
   }
@@ -165,7 +169,8 @@ export class OtherSettings extends Component<Props> {
           this.on_change("hide_button_tooltips", e.target.checked)
         }
       >
-        Hide Button Tooltips: hides some button tooltips (this is only partial)
+        <strong>Hide Button Tooltips:</strong> hides some button tooltips (this
+        is only partial)
       </Checkbox>
     );
   }
@@ -326,8 +331,8 @@ export class OtherSettings extends Component<Props> {
               redux.getStore("projects").clearOpenAICache();
             }}
           >
-            Disable all OpenAI/ChatGPT integrations, e.g., extra buttons in
-            Jupyter, @chatgpt mentions, etc.
+            <strong>Disable all OpenAI/ChatGPT integrations</strong>, e.g.,
+            extra buttons in Jupyter, @chatgpt mentions, etc.
           </Checkbox>
         )}
         <Checkbox
@@ -336,8 +341,9 @@ export class OtherSettings extends Component<Props> {
             this.on_change("disable_markdown_codebar", e.target.checked);
           }}
         >
-          Disable the markdown code bar in all markdown documents. Checking this
-          hides the extra run, copy, and explain buttons in fenced code blocks.
+          <strong>Disable the markdown code bar</strong> in all markdown
+          documents. Checking this hides the extra run, copy, and explain
+          buttons in fenced code blocks.
         </Checkbox>
         <Checkbox
           checked={!!this.props.other_settings.get("flyouts_default")}
@@ -346,7 +352,8 @@ export class OtherSettings extends Component<Props> {
           }}
         >
           <strong>Flyouts as default</strong>: Enabling this makes the vertical
-          bars for files, logs, settings, etc. the default.
+          bars for files, logs, settings, etc. the default. Use Shift-Click to
+          open full page.
         </Checkbox>
         {this.render_new_filenames()}
         {this.render_default_file_sort()}

--- a/src/packages/frontend/account/other-settings.tsx
+++ b/src/packages/frontend/account/other-settings.tsx
@@ -19,6 +19,7 @@ import {
 } from "@cocalc/frontend/components";
 import { IS_MOBILE, IS_TOUCH } from "@cocalc/frontend/feature";
 import { NewFilenameFamilies } from "@cocalc/frontend/project/utils";
+import track from "@cocalc/frontend/user-tracking";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { DEFAULT_NEW_FILENAMES, NEW_FILENAMES } from "@cocalc/util/db-schema";
 import {
@@ -319,7 +320,10 @@ export class OtherSettings extends Component<Props> {
             style={{ marginBottom: "10px" }}
             selected={selected}
             options={VBAR_OPTIONS}
-            on_change={(value) => this.on_change(VBAR_KEY, value)}
+            on_change={(value) => {
+              this.on_change(VBAR_KEY, value);
+              track("flyout", { aspect: "layout", how: "account", value });
+            }}
           />
           <Paragraph
             type="secondary"

--- a/src/packages/frontend/account/other-settings.tsx
+++ b/src/packages/frontend/account/other-settings.tsx
@@ -14,12 +14,19 @@ import {
   LabeledRow,
   Loading,
   NumberInput,
+  Paragraph,
   SelectorInput,
 } from "@cocalc/frontend/components";
 import { IS_MOBILE, IS_TOUCH } from "@cocalc/frontend/feature";
 import { NewFilenameFamilies } from "@cocalc/frontend/project/utils";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { DEFAULT_NEW_FILENAMES, NEW_FILENAMES } from "@cocalc/util/db-schema";
+import {
+  VBAR_EXPLANATION,
+  VBAR_KEY,
+  VBAR_OPTIONS,
+  getValidVBAROption,
+} from "../project/page/vbar";
 import { dark_mode_mins, get_dark_mode_config } from "./dark-mode";
 import Tours from "./tours";
 
@@ -301,6 +308,30 @@ export class OtherSettings extends Component<Props> {
     );
   }
 
+  render_vertical_fixed_bar_options(): Rendered {
+    const selected = getValidVBAROption(
+      this.props.other_settings.get(VBAR_KEY)
+    );
+    return (
+      <LabeledRow label="Vertical Project Bar">
+        <div>
+          <SelectorInput
+            style={{ marginBottom: "10px" }}
+            selected={selected}
+            options={VBAR_OPTIONS}
+            on_change={(value) => this.on_change(VBAR_KEY, value)}
+          />
+          <Paragraph
+            type="secondary"
+            ellipsis={{ expandable: true, symbol: "more" }}
+          >
+            {VBAR_EXPLANATION}
+          </Paragraph>
+        </div>
+      </LabeledRow>
+    );
+  }
+
   render() {
     if (this.props.other_settings == null) {
       return <Loading />;
@@ -345,16 +376,7 @@ export class OtherSettings extends Component<Props> {
           documents. Checking this hides the extra run, copy, and explain
           buttons in fenced code blocks.
         </Checkbox>
-        <Checkbox
-          checked={!!this.props.other_settings.get("flyouts_default")}
-          onChange={(e) => {
-            this.on_change("flyouts_default", e.target.checked);
-          }}
-        >
-          <strong>Flyouts as default</strong>: Enabling this makes the vertical
-          bars for files, logs, settings, etc. the default. Use Shift-Click to
-          open full page.
-        </Checkbox>
+        {this.render_vertical_fixed_bar_options()}
         {this.render_new_filenames()}
         {this.render_default_file_sort()}
         {this.render_page_size()}

--- a/src/packages/frontend/index.sass
+++ b/src/packages/frontend/index.sass
@@ -426,8 +426,13 @@ details summary
 div.cc-project-fixedtab:hover
   background-color: $COL_GRAY_LL
 
-span.cc-project-fixedtab-close:hover
-  background-color: $COL_GRAY_L0
+span.cc-project-fixedtab-close
+  flex: 0
+  float: right
+  font-size: 12px  // same as Antd closable tabs
+  color: $COL_GRAY
+  &:hover
+    background-color: $COL_GRAY_L0
 
 span.cc-project-fixedtab-drag:hover
   background-color: $COL_GRAY_L0

--- a/src/packages/frontend/project/explorer/explorer.tsx
+++ b/src/packages/frontend/project/explorer/explorer.tsx
@@ -3,6 +3,11 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import * as immutable from "immutable";
+import React from "react";
+import { Alert, Button, ButtonGroup, Col, Row } from "react-bootstrap";
+import * as underscore from "underscore";
+
 import { UsersViewing } from "@cocalc/frontend/account/avatar/users-viewing";
 import {
   TypedMap,
@@ -36,10 +41,6 @@ import {
 import { ProjectActions } from "@cocalc/frontend/project_store";
 import { ProjectMap, ProjectStatus } from "@cocalc/frontend/todo-types";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
-import * as immutable from "immutable";
-import React from "react";
-import { Alert, Button, ButtonGroup, Col, Row } from "react-bootstrap";
-import * as underscore from "underscore";
 import AskNewFilename from "../ask-filename";
 import { useProjectContext } from "../context";
 import { CourseProjectExtraHelp } from "../warnings/course-project";

--- a/src/packages/frontend/project/explorer/path-navigator.tsx
+++ b/src/packages/frontend/project/explorer/path-navigator.tsx
@@ -71,7 +71,7 @@ export const PathNavigator: React.FC<Props> = React.memo(
           // yes, must be called as a normal function.
           createPathSegmentLink({
             path: history_segments.slice(0, i + 1 || undefined).join("/"),
-            display: hide ? <>&middot;</> : trunc_middle(segment, 15),
+            display: hide ? <>&bull;</> : trunc_middle(segment, 15),
             full_name: segment,
             key: i + 1,
             on_click: (path) => actions?.open_directory(path, true, false),

--- a/src/packages/frontend/project/explorer/path-segment-link.tsx
+++ b/src/packages/frontend/project/explorer/path-segment-link.tsx
@@ -3,7 +3,8 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Tip } from "@cocalc/frontend/components";
+import { Tooltip } from "antd";
+
 import { CSS } from "@cocalc/frontend/app-framework";
 
 interface Props {
@@ -41,9 +42,9 @@ export function createPathSegmentLink(props: Readonly<Props>): PathSegmentItem {
   function render_content(): JSX.Element | string | undefined {
     if (full_name && full_name !== display) {
       return (
-        <Tip tip={full_name} placement="bottom" title="Full name">
+        <Tooltip title={full_name} placement="bottom">
           {display}
-        </Tip>
+        </Tooltip>
       );
     } else {
       return display;

--- a/src/packages/frontend/project/page/file-tab.tsx
+++ b/src/packages/frontend/project/page/file-tab.tsx
@@ -42,6 +42,7 @@ import {
   ServersFlyout,
   SettingsFlyout,
 } from "./flyouts";
+import { VBAR_KEY, getValidVBAROption } from "./vbar";
 
 const { file_options } = require("@cocalc/frontend/editor");
 
@@ -175,7 +176,7 @@ export function FileTab(props: Readonly<Props>) {
     name === "info" && project_status?.get("alerts")?.size > 0;
   const other_settings = useTypedRedux("account", "other_settings");
   const active_flyout = useTypedRedux({ project_id }, "flyout");
-  const flyoutsDefault = other_settings.get("flyouts_default", false);
+  const vbar = getValidVBAROption(other_settings.get(VBAR_KEY));
 
   // True if there is activity (e.g., active output) in this tab
   const has_activity = useRedux(
@@ -222,8 +223,8 @@ export function FileTab(props: Readonly<Props>) {
         });
       }
     } else if (name != null) {
-      if (flyout != null && flyoutsDefault) {
-        if (anyModifierKey) {
+      if (flyout != null && vbar !== "both") {
+        if (anyModifierKey !== (vbar === "full")) {
           setActiveTab(name);
         } else {
           actions?.toggleFlyout(flyout);
@@ -244,7 +245,7 @@ export function FileTab(props: Readonly<Props>) {
   }
 
   function renderFlyoutCaret() {
-    if (IS_MOBILE || flyout == null || flyoutsDefault) return;
+    if (IS_MOBILE || flyout == null || vbar !== "both") return;
 
     const color =
       flyout === active_flyout

--- a/src/packages/frontend/project/page/file-tab.tsx
+++ b/src/packages/frontend/project/page/file-tab.tsx
@@ -188,11 +188,21 @@ export function FileTab(props: Readonly<Props>) {
     actions.close_tab(path);
   }
 
+  function setActiveTab(name: string) {
+    actions?.set_active_tab(name);
+    track("switch-to-fixed-tab", {
+      project_id,
+      name,
+      how: "click-on-tab",
+    });
+  }
+
   function click(e: React.MouseEvent) {
     e.stopPropagation();
     if (actions == null) return;
+    const anyModifierKey = e.ctrlKey || e.shiftKey || e.metaKey;
     if (path != null) {
-      if (e.ctrlKey || e.shiftKey || e.metaKey) {
+      if (anyModifierKey) {
         // shift/ctrl/option clicking on *file* tab opens in a new popout window.
         actions.open_file({
           path,
@@ -213,14 +223,13 @@ export function FileTab(props: Readonly<Props>) {
       }
     } else if (name != null) {
       if (flyout != null && flyoutsDefault) {
-        actions?.toggleFlyout(flyout);
+        if (anyModifierKey) {
+          setActiveTab(name);
+        } else {
+          actions?.toggleFlyout(flyout);
+        }
       } else {
-        actions.set_active_tab(name);
-        track("switch-to-fixed-tab", {
-          project_id,
-          name,
-          how: "click-on-tab",
-        });
+        setActiveTab(name);
       }
     }
   }

--- a/src/packages/frontend/project/page/flyouts/header.tsx
+++ b/src/packages/frontend/project/page/flyouts/header.tsx
@@ -7,13 +7,13 @@ import { Tooltip } from "antd";
 
 import { Icon } from "@cocalc/frontend/components";
 import { capitalize } from "@cocalc/util/misc";
+import { useProjectContext } from "../../context";
 import { PathNavigator } from "../../explorer/path-navigator";
 import { FIX_BORDER } from "../common";
 import { FIXED_PROJECT_TABS, FixedTab } from "../file-tab";
 import { FIXED_TABS_BG_COLOR } from "../tabs";
 import { FLYOUT_PADDING } from "./consts";
 import { LogHeader } from "./log";
-import { useProjectContext } from "../../context";
 
 interface Props {
   flyoutWidth: number;
@@ -45,16 +45,13 @@ export function FlyoutHeader(_: Readonly<Props>) {
 
   function closeBtn() {
     return (
-      <Tooltip title="Hide this action panel" placement="bottom">
+      <Tooltip title="Hide this panel" placement="bottom">
         <Icon
-          name="vertical-right-outlined"
+          name="times"
           className="cc-project-fixedtab-close"
           style={{
-            flex: "0",
-            float: "right",
+            marginRight: FLYOUT_PADDING,
             padding: FLYOUT_PADDING,
-            borderRadius: "2px",
-            margin: "0",
           }}
           onClick={() => actions?.toggleFlyout(flyout)}
         />
@@ -113,6 +110,7 @@ export function FlyoutHeader(_: Readonly<Props>) {
       style={{
         display: "flex",
         flexDirection: "row",
+        alignItems: "start",
         borderRight: FIX_BORDER,
         borderTop: FIX_BORDER,
         borderLeft: FIX_BORDER,

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -10,6 +10,7 @@ import {
   CSS,
   redux,
   useActions,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -33,6 +34,7 @@ import {
   unreachable,
 } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
+import { debounce } from "lodash";
 import { handle_log_click } from "../../history/utils";
 import { FIX_BORDER } from "../common";
 import { FIXED_PROJECT_TABS } from "../file-tab";
@@ -178,7 +180,9 @@ export function LogFlyout({
   });
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
+  const search = useTypedRedux({ project_id }, "search") ?? "";
   const [searchTerm, setSearchTerm] = useState<string>("");
+
   const [scrollIdx, setScrollIdx] = useState<number | null>(null);
   const [scollIdxHide, setScrollIdxHide] = useState<boolean>(false);
 
@@ -192,18 +196,40 @@ export function LogFlyout({
 
     switch (mode) {
       case "files":
-        return deriveFiles(log, searchTerm, max);
+        return deriveFiles(log, search, max);
       case "history":
-        return deriveHistory(log, searchTerm, max);
+        return deriveHistory(log, search, max);
       default:
         unreachable(mode);
     }
-  }, [project_log, project_log_all, searchTerm, max, mode]);
+  }, [project_log, project_log_all, search, max, mode]);
 
   const showExtra = useMemo(
     () => flyoutWidth > FLYOUT_EXTRA_WIDTH_PX,
     [flyoutWidth]
   );
+
+  // trigger a search state change, only once and with a debounce
+  const setSearchState = debounce(
+    (val: string): void => {
+      actions?.setState({ search: val });
+    },
+    20,
+    { leading: false, trailing: true }
+  );
+
+  const handleOnChange = useCallback((val: string) => {
+    setScrollIdx(null);
+    setSearchTerm(val);
+    setSearchState(val);
+  }, []);
+
+  // incoming change, change the search term
+  useEffect(() => {
+    if (search === searchTerm) return;
+    setScrollIdx(null);
+    setSearchTerm(search);
+  }, [search]);
 
   // end of hooks
 
@@ -317,8 +343,7 @@ export function LogFlyout({
 
     // if esc key is pressed, empty the search term and reset scroll index
     if (e.key === "Escape") {
-      setSearchTerm("");
-      setScrollIdx(null);
+      handleOnChange("");
     }
   }
 
@@ -371,7 +396,9 @@ export function LogFlyout({
         style={{ flex: "1", marginRight: "10px" }}
         size="small"
         value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          handleOnChange(e.target.value);
+        }}
         onKeyDown={onKeyDownHandler}
         onFocus={() => setScrollIdxHide(false)}
         onBlur={() => setScrollIdxHide(true)}

--- a/src/packages/frontend/project/page/tabs.tsx
+++ b/src/packages/frontend/project/page/tabs.tsx
@@ -7,12 +7,14 @@
 Tabs in a particular project.
 */
 
-import { Switch, Tooltip } from "antd";
+import type { MenuProps } from "antd";
+import { Button, Dropdown, Modal, Switch, Tooltip } from "antd";
 import { debounce, throttle } from "lodash";
 import { ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
 
-import { CSS, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { CSS, useActions, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { ChatIndicator } from "@cocalc/frontend/chat/chat-indicator";
+import { Icon } from "@cocalc/frontend/components";
 import track from "@cocalc/frontend/user-tracking";
 import { tab_to_path } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
@@ -20,6 +22,12 @@ import { useProjectContext } from "../context";
 import { FIXED_PROJECT_TABS, FileTab, FixedTab } from "./file-tab";
 import FileTabs from "./file-tabs";
 import { ShareIndicator } from "./share-indicator";
+import {
+  VBAR_EXPLANATION,
+  VBAR_KEY,
+  VBAR_OPTIONS,
+  getValidVBAROption,
+} from "./vbar";
 
 const INDICATOR_STYLE: React.CSSProperties = {
   overflow: "hidden",
@@ -88,9 +96,10 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
     project_id,
     active_project_tab: activeTab,
   } = useProjectContext();
+  const account_settings = useActions("account");
   const active_flyout = useTypedRedux({ project_id }, "flyout");
   const other_settings = useTypedRedux("account", "other_settings");
-  const flyoutsDefault = other_settings.get("flyouts_default", false);
+  const vbar = getValidVBAROption(other_settings.get(VBAR_KEY));
   const isAnonymous = useTypedRedux("account", "is_anonymous");
   const parent = useRef<HTMLDivElement>(null);
   const tabs = useRef<HTMLDivElement>(null);
@@ -168,7 +177,7 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
         ? { color: COLORS.PROJECT.FIXED_LEFT_ACTIVE }
         : undefined;
 
-    const isActive = (flyoutsDefault ? active_flyout : activeTab) === name;
+    const isActive = (vbar === "flyout" ? active_flyout : activeTab) === name;
 
     const style: CSS = {
       padding: "0",
@@ -198,6 +207,62 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
     );
   }
 
+  function renderLayoutSelector() {
+    const title = "Vertical bar layout";
+
+    const items: NonNullable<MenuProps["items"]> = Object.entries(
+      VBAR_OPTIONS
+    ).map(([key, label]) => ({
+      key,
+      onClick: () => {
+        account_settings.set_other_settings(VBAR_KEY, key);
+      },
+      label: (
+        <>
+          <Icon
+            name="check"
+            style={key === vbar ? undefined : { visibility: "hidden" }}
+          />{" "}
+          {label}
+        </>
+      ),
+    }));
+
+    items.unshift({ key: "delim-top", type: "divider" });
+    items.unshift({
+      key: "title",
+      label: (
+        <>
+          <Icon name="layout" /> {title}{" "}
+        </>
+      ),
+    });
+
+    items.push({ key: "delimiter", type: "divider" });
+    items.push({
+      key: "info",
+      label: (
+        <>
+          <Icon name="question-circle" /> More info
+        </>
+      ),
+      onClick: () => {
+        Modal.info({
+          title: title,
+          content: VBAR_EXPLANATION,
+        });
+      },
+    });
+
+    return (
+      <div style={{ textAlign: "center" }}>
+        <Dropdown menu={{ items }} trigger={["click"]} placement="topLeft">
+          <Button icon={<Icon name="layout" />} style={{ margin: "5px" }} />
+        </Dropdown>
+      </div>
+    );
+  }
+
   return (
     <div
       ref={parent}
@@ -217,6 +282,7 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
       >
         {items}
         <div style={{ flex: 1 }}></div> {/* moves hide switch to the bottom */}
+        {renderLayoutSelector()}
         <Tooltip title="Hide the action bar" placement="right">
           <Switch
             style={{ margin: "10px" }}

--- a/src/packages/frontend/project/page/tabs.tsx
+++ b/src/packages/frontend/project/page/tabs.tsx
@@ -216,6 +216,7 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
       key,
       onClick: () => {
         account_settings.set_other_settings(VBAR_KEY, key);
+        track("flyout", { aspect: "layout", value: key, how: "button", project_id });
       },
       label: (
         <>

--- a/src/packages/frontend/project/page/vbar.tsx
+++ b/src/packages/frontend/project/page/vbar.tsx
@@ -1,0 +1,35 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// in the other_settings map
+export const VBAR_KEY = "vertical_fixed_bar";
+
+export const VBAR_EXPLANATION = (
+  <>
+    This feature modifies the functionality of the project's left-side button
+    bar. By default, it displays buttons for full pages and small caret signs
+    for flyout panels. When selecting the "full pages" option, only buttons are
+    shown, and they open full pages upon clicking. Conversely, when opting for
+    the "flyout panels" mode, only flyout panels expand upon clicking. In both
+    of the latter cases, the alternative panel type can be displayed by
+    shift-clicking on the corresponding button.
+  </>
+);
+
+export const VBAR_OPTIONS = {
+  both: "Full pages and flyout panels",
+  flyout: "Buttons expand/collapse compact flyouts",
+  full: "Buttons show full pages",
+} as const;
+
+export const VBAR_OPTIONS_DEFAULT = "both";
+
+export function getValidVBAROption(
+  vbar_setting: any
+): keyof typeof VBAR_OPTIONS {
+  if (typeof vbar_setting !== "string") return VBAR_OPTIONS_DEFAULT;
+  if (VBAR_OPTIONS[vbar_setting] == null) return VBAR_OPTIONS_DEFAULT;
+  return vbar_setting as keyof typeof VBAR_OPTIONS;
+}

--- a/src/packages/frontend/project_actions.ts
+++ b/src/packages/frontend/project_actions.ts
@@ -1224,8 +1224,12 @@ export class ProjectActions extends Actions<ProjectStoreState> {
         if (show_files) {
           this.set_active_tab("files", {
             update_file_listing: false,
-            change_history: change_history,
+            change_history: false, // see "if" below
           });
+        }
+        if (change_history) {
+          // i.e. regardless of show_files is true or false, we might want to record this in the history
+          this.set_url_to_path(store.get("current_path") ?? "", "");
         }
         this.set_all_files_unchecked();
       }

--- a/src/packages/frontend/project_actions.ts
+++ b/src/packages/frontend/project_actions.ts
@@ -59,6 +59,7 @@ import {
 } from "./project_configuration";
 import { ModalInfo, ProjectStore, ProjectStoreState } from "./project_store";
 import { webapp_client } from "./webapp-client";
+import { VBAR_KEY, getValidVBAROption } from "./project/page/vbar";
 const { defaults, required } = misc;
 
 const BAD_FILENAME_CHARACTERS = "\\";
@@ -376,10 +377,8 @@ export class ProjectActions extends Actions<ProjectStoreState> {
       let next_active_tab: string | undefined = undefined;
       if (size === 1) {
         const account_store = this.redux.getStore("account") as any;
-        const flyoutsDefault = account_store?.getIn(
-          ["other_settings", "flyouts_default"],
-          false
-        );
+        const vbar = account_store?.getIn(["other_settings", VBAR_KEY]);
+        const flyoutsDefault = getValidVBAROption(vbar) === "flyout";
         next_active_tab = flyoutsDefault ? "home" : "files";
       } else {
         let path: string | undefined;


### PR DESCRIPTION
# Description

-  fix not recording browser history when switching directories, this also fixes this for clicking on the breadcrumb path selector
- larger mini breadcrumb dot
- sync file-filter and log-filter search state + debouncing
- close icon is the same as for tabs
- account level option to change vertical bar layout: both, flyout or pages ... and adding a select menu to the bar to surface this

   
   ![Screenshot from 2023-07-13 11-36-08](https://github.com/sagemathinc/cocalc/assets/207405/51b4d319-98f9-4903-8b1d-d4f008dd6015)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
