### PR TITLE
nbconvert: double timeout to 60s

### DIFF
--- a/src/packages/frontend/course/export/export-assignment.ts
+++ b/src/packages/frontend/course/export/export-assignment.ts
@@ -80,7 +80,7 @@ async function export_one_directory(
     }
   }
   let x: any;
-  const timeout = 30; // 30 seconds
+  const timeout = 60; // 60 seconds
   for (x of listing) {
     if (x.isdir) continue; // we ignore subdirectories...
     const { name } = x;

--- a/src/packages/frontend/jupyter/nbconvert.tsx
+++ b/src/packages/frontend/jupyter/nbconvert.tsx
@@ -183,9 +183,12 @@ export const NBConvert: React.FC<NBConvertProps> = React.memo(
       // --to script converts to probably a .py file
       if (to === "script" && backend_kernel_info != null) {
         // special case where extension may be different
-        ext = (backend_kernel_info
-          .getIn(["language_info", "file_extension"], "") as string)
-          .slice(1);
+        ext = (
+          backend_kernel_info.getIn(
+            ["language_info", "file_extension"],
+            ""
+          ) as string
+        ).slice(1);
         if (ext === "") {
           ext = "py";
         }
@@ -319,7 +322,7 @@ export const NBConvert: React.FC<NBConvertProps> = React.memo(
                 text="Exporting..."
               />{" "}
               <ProgressEstimate
-                seconds={NAMES[nbconvert_dialog.get("to")]?.estimate ?? 30}
+                seconds={NAMES[nbconvert_dialog.get("to")]?.estimate ?? 60}
               />
               {render_started()}
             </div>
@@ -379,7 +382,7 @@ export const NBConvert: React.FC<NBConvertProps> = React.memo(
       // workaround until #2569 is fixed.
       return (
         <Modal
-          visible={nbconvert_dialog != null}
+          open={nbconvert_dialog != null}
           onOk={close}
           onCancel={close}
           footer={null}
@@ -414,7 +417,7 @@ export const NBConvert: React.FC<NBConvertProps> = React.memo(
     }
     return (
       <Modal
-        visible={nbconvert_dialog != null}
+        open={nbconvert_dialog != null}
         onOk={close}
         onCancel={close}
         title={

--- a/src/packages/frontend/project/websocket/api.ts
+++ b/src/packages/frontend/project/websocket/api.ts
@@ -269,7 +269,7 @@ export class API {
   async jupyter_nbconvert(opts: NbconvertParams): Promise<any> {
     return await this.call(
       { cmd: "jupyter_nbconvert", opts },
-      (opts.timeout ?? 30) * 1000 + 5000
+      (opts.timeout ?? 60) * 1000 + 5000
     );
   }
 

--- a/src/packages/jupyter/kernel/kernel.ts
+++ b/src/packages/jupyter/kernel/kernel.ts
@@ -842,7 +842,7 @@ class JupyterKernel extends EventEmitter implements JupyterKernelInterface {
 
   async nbconvert(args: string[], timeout?: number): Promise<void> {
     if (timeout === undefined) {
-      timeout = 30; // seconds
+      timeout = 60; // seconds
     }
     if (!is_array(args)) {
       throw new Error("args must be an array");


### PR DESCRIPTION
# Description

- increase nbconvert timeout to 60s (saw a timeout for a user)
- fix 2x antd deprecation in nbconvert modal dialog

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
