### PR TITLE
frontend/flyout/new: support creating files without an extension

### DIFF
--- a/src/packages/frontend/project/new/file-type-selector.tsx
+++ b/src/packages/frontend/project/new/file-type-selector.tsx
@@ -25,7 +25,7 @@ interface Props {
   selectedExt?: string;
 }
 
-const delayShow = 1500;
+export const delayShow = 1500;
 
 // Use Rows and Cols to append more buttons to this class.
 // Could be changed to auto adjust to a list of pre-defined button names.

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -95,6 +95,9 @@ function useStrippedPublicPaths(project_id: string) {
 }
 
 function searchToFilename(search: string): string {
+  if (search.endsWith(" ")) {
+    return search.trim(); // base name, without extension
+  }
   search = search.trim();
   if (search === "") return "";
   // if last character is "/" return the search string

--- a/src/packages/frontend/project/utils.ts
+++ b/src/packages/frontend/project/utils.ts
@@ -112,7 +112,11 @@ export class NewFilenames {
       const new_name = this.new_filename(false);
       const rnd = uuid().split("-");
       const name = [new_name, ...rnd].join(this.filler());
-      return `${name}.${this.ext}`;
+      if (this.ext === "") {
+        return name;
+      } else {
+        return `${name}.${this.ext}`;
+      }
     }
   }
 
@@ -137,7 +141,7 @@ export class NewFilenames {
       default:
         // e.g. for python, join using "_"
         let fn = tokens.join(this.filler());
-        if (fullname && this.ext != null) {
+        if (fullname && this.ext != null && this.ext !== "") {
           fn += `.${this.ext}`;
         }
         return fn;


### PR DESCRIPTION
# Description
- this deals with #6886
- adds an explicit button
- as a shortcut, a space at the end of the filename
- also adds a button to the new-shortcuts in the flyout for creating a folder, and some edge-cases around that
- adjusts the filename generator, to deal with empty "" extensions


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
