### PR TITLE
frontend/flyout: make hover/active tabs more visible in pure flyout mode

### DIFF
--- a/src/packages/frontend/index.sass
+++ b/src/packages/frontend/index.sass
@@ -424,7 +424,7 @@ details summary
     display: block
 
 div.cc-project-fixedtab:hover
-  background-color: $COL_GRAY_LL
+  background-color: $COL_BLUE_LLLL
 
 span.cc-project-fixedtab-close
   flex: 0

--- a/src/packages/frontend/project/page/tabs.tsx
+++ b/src/packages/frontend/project/page/tabs.tsx
@@ -185,6 +185,10 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
       borderLeft: `4px solid ${
         isActive ? COLORS.PROJECT.FIXED_LEFT_ACTIVE : "transparent"
       }`,
+      // highlight active flyout in flyout-only mode more -- see https://github.com/sagemathinc/cocalc/issues/6855
+      ...(isActive && vbar === "flyout"
+        ? { backgroundColor: COLORS.BLUE_LLLL }
+        : undefined),
     };
 
     items.push(
@@ -216,7 +220,12 @@ export function VerticalFixedTabs(props: Readonly<FVTProps>) {
       key,
       onClick: () => {
         account_settings.set_other_settings(VBAR_KEY, key);
-        track("flyout", { aspect: "layout", value: key, how: "button", project_id });
+        track("flyout", {
+          aspect: "layout",
+          value: key,
+          how: "button",
+          project_id,
+        });
       },
       label: (
         <>


### PR DESCRIPTION
# Description

this addresses #6855

![Screenshot from 2023-09-08 11-14-51](https://github.com/sagemathinc/cocalc/assets/207405/a72e648f-e805-499f-87ea-cb6b6b88526c)




## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
