### PR TITLE
fixing a couple  antd deprecations

### DIFF
--- a/src/packages/frontend/collaborators/add-collaborators.tsx
+++ b/src/packages/frontend/collaborators/add-collaborators.tsx
@@ -522,7 +522,6 @@ export const AddCollaborators: React.FC<Props> = ({
           ref={select_ref}
           mode="multiple"
           allowClear
-          showArrow
           autoFocus={autoFocus}
           open={autoFocus ? true : undefined}
           filterOption={(s, opt) => {

--- a/src/packages/frontend/project/page/flyouts/files-bottom.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-bottom.tsx
@@ -4,7 +4,14 @@
  */
 
 import { CaretRightOutlined } from "@ant-design/icons";
-import { Button, Collapse, Descriptions, Space, Tooltip } from "antd";
+import {
+  Button,
+  Collapse,
+  CollapseProps,
+  Descriptions,
+  Space,
+  Tooltip,
+} from "antd";
 import immutable from "immutable";
 import { debounce } from "lodash";
 
@@ -632,6 +639,25 @@ export function FilesBottom({
     border: "none",
   } as const;
 
+  const items: CollapseProps["items"] = [
+    {
+      key: "selected",
+      label: renderSelectedHeader(),
+      extra: renderSelectExtra(),
+      style,
+      className: "cc-project-flyout-files-panel",
+      children: renderSelected(),
+    },
+    {
+      key: "terminal",
+      label: terminalHeader(),
+      extra: renderTerminalExtra(),
+      style: { ...style, borderTop: FIX_BORDER },
+      className: "cc-project-flyout-files-panel",
+      children: renderTerminal(),
+    },
+  ];
+
   return (
     <Collapse
       ref={collapseRef}
@@ -648,25 +674,7 @@ export function FilesBottom({
         flex: "0 0 auto",
         borderTop: FIX_BORDER,
       }}
-    >
-      <Collapse.Panel
-        className="cc-project-flyout-files-panel"
-        header={renderSelectedHeader()}
-        key="selected"
-        style={style}
-        extra={renderSelectExtra()}
-      >
-        {renderSelected()}
-      </Collapse.Panel>
-      <Collapse.Panel
-        className="cc-project-flyout-files-panel"
-        header={terminalHeader()}
-        extra={renderTerminalExtra()}
-        key="terminal"
-        style={{ ...style, borderTop: FIX_BORDER }}
-      >
-        {renderTerminal()}
-      </Collapse.Panel>
-    </Collapse>
+      items={items}
+    />
   );
 }

--- a/src/packages/frontend/project/trial-banner.tsx
+++ b/src/packages/frontend/project/trial-banner.tsx
@@ -233,7 +233,7 @@ export const TrialBanner: React.FC<BannerProps> = React.memo(
       <Alert
         type="warning"
         closable={closable}
-        closeText={
+        closeIcon={
           closable ? (
             <Tag
               style={{ marginTop: "10px", fontSize: style.fontSize }}


### PR DESCRIPTION
# Description

- Select's "showArrow" is default and will be removed
- a `Collapse.Panel` → `items`
- Alert's closeText is closeIcon now

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
