### PR TITLE
Mix dedicated disk with paygo

### DIFF
--- a/src/packages/database/postgres/site-license/hook.test.ts
+++ b/src/packages/database/postgres/site-license/hook.test.ts
@@ -14,9 +14,25 @@
  * The quota function uses a deep copy operation on all its arguments to avoid this.
  */
 
+// see packages/database/pool/pool.ts for where this name is also hard coded:
+process.env.PGDATABASE = "smc_ephemeral_testing_database";
+
 import { isEqual } from "lodash";
 
-import { quota_with_reasons } from "@cocalc/util/upgrades/quota";
+import getPool, { initEphemeralDatabase } from "@cocalc/database/pool";
+// import { db } from "@cocalc/database";
+// import { site_license_hook } from "@cocalc/database/postgres/site-license/hook";
+// import createProject from "@cocalc/server/projects/create";
+// import { uuid } from "@cocalc/util/misc";
+import { quota_with_reasons, SiteLicenses } from "@cocalc/util/upgrades/quota";
+
+beforeAll(async () => {
+  await initEphemeralDatabase({});
+}, 15000);
+
+afterAll(async () => {
+  await getPool().end();
+});
 
 test("allow for much larger max_upgrades", () => {
   const site_settings = {
@@ -45,7 +61,7 @@ test("allow for much larger max_upgrades", () => {
     datastore: true,
   };
 
-  const site_licenses = {
+  const site_licenses: SiteLicenses = {
     a: {
       quota: { cpu: 2, ram: 13 },
     },
@@ -208,3 +224,100 @@ test("two licenses", () => {
   // in particular, this implies that the second license indeed HAS an effect and hence will be used.
   expect(isEqual(q1, q2)).toBe(false);
 });
+
+// TODO the test below would be very important to get to work, but the call to the site_license_hook has no effect at all
+
+// describe("site_license_hook", () => {
+//   const pool = getPool();
+//   const account_id = uuid();
+//   const license_id_1 = uuid();
+//   const license_id_2 = uuid();
+
+//   let project_id;
+//   test("creates a project", async () => {
+//     project_id = await createProject({
+//       account_id,
+//       title: "Test Project",
+//     });
+//   });
+
+//   test("setup project license", async () => {
+//     const site_licenses_data: SiteLicenses = {
+//       [license_id_1]: {
+//         quota: {
+//           dedicated_disk: { speed: "standard", size_gb: 128, name: "bar" },
+//         },
+//       },
+//       [license_id_2]: {
+//         quota: {
+//           ram: 2,
+//           cpu: 1,
+//           disk: 3,
+//           always_running: true,
+//           member: true,
+//           user: "academic",
+//         },
+//       },
+//     };
+
+//     await pool.query(
+//       "UPDATE projects SET site_license=$1 WHERE project_id=$2",
+//       [site_licenses_data, project_id]
+//     );
+//   });
+
+//   test("PAYGO mixes with dedicated disk", async () => {
+//     // run the hook -- "true" means there are PAYGO upgrades, different mode of how the license hook operates
+//     await site_license_hook(db(), project_id, true);
+
+//     const { rows } = await pool.query(
+//       "SELECT * FROM projects WHERE project_id=$1",
+//       [project_id]
+//     );
+//     expect(rows.length).toBe(1);
+//     const site_licenses = rows[0].site_license;
+//     expect(rows[0].site_license).toEqual({
+//       [license_id_1]: {
+//         quota: {
+//           dedicated_disk: { name: "bar", size_gb: 128, speed: "standard" },
+//         },
+//       },
+//       [license_id_2]: {
+//         quota: {
+//           always_running: true,
+//           cpu: 1,
+//           disk: 3,
+//           member: true,
+//           ram: 2,
+//           user: "academic",
+//         },
+//       },
+//     });
+
+//     const q = quota_with_reasons({}, { [account_id]: {} }, site_licenses);
+//     // projects on dedicated VMs get this quota
+//     expect(q).toEqual({
+//       quota: {
+//         always_running: false,
+//         cpu_limit: 1,
+//         cpu_request: 0.02,
+//         dedicated_disks: [
+//           {
+//             name: "bar",
+//             size_gb: 128,
+//             speed: "standard",
+//           },
+//         ],
+//         dedicated_vm: false,
+//         disk_quota: 3000,
+//         idle_timeout: 1800,
+//         member_host: false,
+//         memory_limit: 1000,
+//         memory_request: 200,
+//         network: false,
+//         privileged: false,
+//       },
+//       reasons: {},
+//     });
+//   });
+// });

--- a/src/packages/database/postgres/site-license/hook.ts
+++ b/src/packages/database/postgres/site-license/hook.ts
@@ -389,7 +389,7 @@ class SiteLicenseHook {
         );
         return "exhausted";
       } else {
-        if (this.paygoActive) {
+        if (this.paygoActive && this.isNotDedicatedDisk(license)) {
           this.dbg.info(`due to PAYGO, license ${license_id} is ineffective`);
           return "ineffective";
         } else {
@@ -398,6 +398,15 @@ class SiteLicenseHook {
         }
       }
     }
+  }
+
+  // Return true, if the license is not a dedicated disk license.
+  private isNotDedicatedDisk(license: LicenseMap): boolean {
+    const quota = license.get("quota");
+    if (quota == null) return true;
+    const disk = quota.get("dedicated_disk");
+    if (disk == null) return true;
+    return false;
   }
 
   /**

--- a/src/packages/frontend/site-licenses/rules.tsx
+++ b/src/packages/frontend/site-licenses/rules.tsx
@@ -24,10 +24,15 @@ const RULES = (
       regular license.
     </li>
     <li>
-      A <b>Dedicated Disk</b> can only be attached to one project.
+      A <b>Dedicated Disk</b> can only be active with one project, since there
+      is only one physical disk.
     </li>
     <li>
       A <b>Dedicated VM</b> renders regular and boost licenses ineffective.
+    </li>
+    <li>
+      Active <b>"Pay as you go"</b> upgrades render regular and boost licenses
+      ineffective.
     </li>
   </ul>
 );


### PR DESCRIPTION
# Description

Under PayGo, a dedicated disk, and other special licenses like ext_rw and patches should stay active. Any other license should be disabled. The logic is in `disallowUnderPAYGO`. I also tried to add a test, but it didn't work – I'll leave the code as a comment to complete this later.  Hence this fixes https://github.com/sagemathinc/cocalc/issues/6881

Additionally, I added an explanation that regular/boost are ineffective under PayGo and clarified dedicated disks a little bit.

## screenshots

paygo active:

![Screenshot from 2023-09-13 13-53-45](https://github.com/sagemathinc/cocalc/assets/207405/5ea85af9-c2d6-4c2a-898d-62899cd31fde)

paygo inactive:

![Screenshot from 2023-09-13 13-54-15](https://github.com/sagemathinc/cocalc/assets/207405/fe90ef67-4cf3-4dac-a7b0-50c9ef5e22f2)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
