### PR TITLE
frontend/project-tab: if there is no internet, add an indicator icon to the project tab

### DIFF
--- a/src/packages/frontend/projects/projects-page.tsx
+++ b/src/packages/frontend/projects/projects-page.tsx
@@ -30,9 +30,10 @@ import { ProjectsSearch } from "./search";
 import { AddToProjectToken } from "./token";
 import ProjectsPageTour from "./tour";
 import { get_visible_hashtags, get_visible_projects } from "./util";
+import { COLORS } from "@cocalc/util/theme";
 
 const PROJECTS_TITLE_STYLE: React.CSSProperties = {
-  color: "#666",
+  color: COLORS.GRAY_D,
   fontSize: "24px",
   fontWeight: 500,
   marginBottom: "1ex",


### PR DESCRIPTION
# Description

- indicator icon for no internet (red globe, re-using the wifi icon in any way is too confusing, because it appears on the right of the tab when connecting)
- also a red warning text in hover box
- only shows up when running and the purchase aspect only in kucalc mode

![Screenshot from 2023-09-20 15-25-52](https://github.com/sagemathinc/cocalc/assets/207405/00c428ba-1a13-4f68-a6a5-a47a65bda67e)

---

![Screenshot from 2023-09-20 15-26-14](https://github.com/sagemathinc/cocalc/assets/207405/c448d4bb-2f6b-4c98-8faa-0fbd4f1f1798)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
