### PR TITLE
frontend/no internet hook: assume internet access for non-kubernetes deployments and show tooltip if project tab popover is disabled

### DIFF
--- a/src/packages/frontend/project/settings/has-internet-access-hook.ts
+++ b/src/packages/frontend/project/settings/has-internet-access-hook.ts
@@ -2,16 +2,29 @@
  *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
-import { useEffect, useState } from "@cocalc/frontend/app-framework";
+import {
+  useEffect,
+  useState,
+  useTypedRedux,
+} from "@cocalc/frontend/app-framework";
+import { KUCALC_DISABLED } from "@cocalc/util/db-schema/site-defaults";
 import { useRunQuota } from "./run-quota/hooks";
 
 // this reacts to changes of settings, user contributions, and licenses
 export function useProjectHasInternetAccess(project_id: string) {
   const [state, set_state] = useState<boolean>(false);
-
+  const customize_kucalc = useTypedRedux("customize", "kucalc");
+  const noKubernetes = customize_kucalc === KUCALC_DISABLED;
   const runQuota = useRunQuota(project_id, null);
 
   useEffect(() => {
+    // special case: we assume in any non-kubernetes environments, projects have internet access
+    if (noKubernetes) {
+      set_state(true);
+      return;
+    }
+    // otherwise, we use the run quota information, which is set server-side after processing
+    // the default quotas and any licenses/upgrades on top of it.
     const network = runQuota?.network;
     if (typeof network === "boolean") {
       set_state(network);

--- a/src/packages/frontend/projects/projects-nav.tsx
+++ b/src/packages/frontend/projects/projects-nav.tsx
@@ -4,7 +4,7 @@
  */
 
 import type { TabsProps } from "antd";
-import { Avatar, Popover, Tabs } from "antd";
+import { Avatar, Popover, Tabs, Tooltip } from "antd";
 
 import { Icon, Loading } from "@cocalc/frontend//components";
 import {
@@ -129,38 +129,41 @@ function ProjectTab({ project_id }: ProjectTabProps) {
     }
   }
 
-  function noInternetInfo() {
-    if (showNoInternet)
-      return (
-        <>
-          <div style={{ color: COLORS.ANTD_RED_WARN }}>
-            This project can't connect to the internet: {NO_INTERNET}.
-            {onKucalc && (
-              <>
-                {" "}
-                <BuyLicenseForProject
-                  buyText="Upgrade this project"
-                  asLink={true}
-                  size="small"
-                  style={{
-                    padding: 0,
-                    color: COLORS.ANTD_RED_WARN,
-                    fontWeight: "bold",
-                  }}
-                />{" "}
-                to unblock internet access.
-              </>
-            )}
-          </div>
-          <hr />
-        </>
-      );
+  function noInternetInfo(mode: "tooltip" | "popover") {
+    if (!showNoInternet) return;
+    const fontStyle = {
+      color: mode === "popover" ? COLORS.ANTD_RED_WARN : "white",
+    };
+    return (
+      <>
+        <div style={fontStyle}>
+          This project does not have access to the internet: {NO_INTERNET}.
+          {onKucalc && (
+            <>
+              {" "}
+              <BuyLicenseForProject
+                buyText="Upgrade this project"
+                asLink={true}
+                size="small"
+                style={{
+                  padding: 0,
+                  fontWeight: "bold",
+                  ...fontStyle,
+                }}
+              />{" "}
+              to unblock internet access.
+            </>
+          )}
+        </div>
+        {mode === "popover" ? <hr /> : null}
+      </>
+    );
   }
 
   function renderContent() {
     return (
       <div style={{ maxWidth: "400px", maxHeight: "50vh", overflow: "auto" }}>
-        {noInternetInfo()}
+        {noInternetInfo("popover")}
         <ProjectAvatarImage
           project_id={project_id}
           size={120}
@@ -179,8 +182,15 @@ function ProjectTab({ project_id }: ProjectTabProps) {
   }
 
   function renderNoInternet() {
-    if (showNoInternet)
-      return <Icon name="global" style={{ color: COLORS.ANTD_RED_WARN }} />;
+    if (!showNoInternet) return;
+    const noInternet = (
+      <Icon name="global" style={{ color: COLORS.ANTD_RED_WARN }} />
+    );
+    if (other_settings.get("hide_project_popovers")) {
+      return <Tooltip title={noInternetInfo("tooltip")}>{noInternet}</Tooltip>;
+    } else {
+      return noInternet;
+    }
   }
 
   function renderAvatar() {


### PR DESCRIPTION
# Description

This should fix the indicator icon. This actually fixes the more fundamental `useProjectHasInternetAccess` hook, which assumes there is always internet access in non-kubernetes deployments

this is the "yes" case for cocalc.com, showing the banner as well

![Screenshot from 2023-09-21 17-15-18](https://github.com/sagemathinc/cocalc/assets/207405/e4af6de4-09c0-410b-9cd9-df362336387c)


no indicator even though network is false, the docker "kucalc==no" case

![Screenshot from 2023-09-21 17-14-06](https://github.com/sagemathinc/cocalc/assets/207405/0a7be2c4-bf73-4e6e-ab0b-9c02350ed3ae)

and on-prem, similar to production but without the banner

![Screenshot from 2023-09-21 17-13-08](https://github.com/sagemathinc/cocalc/assets/207405/85be3029-30a4-4cb9-8126-4fc2ef5badf4)




## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
