### PR TITLE
next/store: tweak overview page

### DIFF
--- a/src/cocalc.code-workspace
+++ b/src/cocalc.code-workspace
@@ -56,6 +56,15 @@
     },
     {
       "path": "packages/compute"
+    },
+    {
+      "path": "packages/terminal"
+    },
+    {
+      "path": "packages/comm"
+    },
+    {
+      "path": "packages/api-client"
     }
   ],
   "settings": {

--- a/src/packages/frontend/components/icon.tsx
+++ b/src/packages/frontend/components/icon.tsx
@@ -705,3 +705,6 @@ export const Icon: React.FC<Props> = (props: Props) => {
     return <BorderOutlined {...props} alt={name} />;
   }
 };
+
+// TOOD move this to a shared lib, which can import the IconName type
+export const PAYASYOUGO_ICON: IconName = "compass";

--- a/src/packages/frontend/components/icon.tsx
+++ b/src/packages/frontend/components/icon.tsx
@@ -43,9 +43,9 @@ import {
   CheckOutlined,
   CheckSquareOutlined,
   ClockCircleOutlined,
+  CloseCircleFilled,
   CloseCircleOutlined,
   CloseCircleTwoTone,
-  CloseCircleFilled,
   CloseOutlined,
   CloudDownloadOutlined,
   CloudFilled,
@@ -62,6 +62,7 @@ import {
   CopyOutlined,
   CreditCardOutlined,
   DashboardOutlined,
+  DatabaseFilled,
   DatabaseOutlined,
   DeleteOutlined,
   DeploymentUnitOutlined,
@@ -299,7 +300,9 @@ const IconSpec: { [name: string]: any } = {
   cut: ScissorOutlined,
   dashboard: DashboardOutlined,
   database: DatabaseOutlined,
-  dedicated: DeploymentUnitOutlined, // icon for "dedicated resources"
+  "database-filled": DatabaseFilled,
+  "deployment-unit": DeploymentUnitOutlined,
+  dedicated: DatabaseOutlined, // icon for "dedicated resources", looks like a server rack
   desktop: DesktopOutlined,
   discord: { IconFont: "discord" },
   docker: { IconFont: "docker" },
@@ -586,7 +589,7 @@ try {
             const id = `icon-${x}`;
             if (document.getElementById(id) == null) {
               console.error(
-                `ERROR -- the IconFont ${x} is not in components/iconfont.cn!  Fix this or the icon ${name} will be broken.`,
+                `ERROR -- the IconFont ${x} is not in components/iconfont.cn!  Fix this or the icon ${name} will be broken.`
               );
             }
           }
@@ -681,7 +684,7 @@ export const Icon: React.FC<Props> = (props: Props) => {
     if (missing[props.name ?? ""] == null) {
       missing[props.name ?? ""] = true;
       console.warn(
-        `Icon "${props.name}" is not defined -- fix this in components/icon.tsx.`,
+        `Icon "${props.name}" is not defined -- fix this in components/icon.tsx.`
       );
     }
     // make it hopefully clear to devs that this icon is broken

--- a/src/packages/frontend/project/settings/quota-editor/pay-as-you-go.tsx
+++ b/src/packages/frontend/project/settings/quota-editor/pay-as-you-go.tsx
@@ -3,23 +3,24 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { CSSProperties, useEffect, useMemo, useState } from "react";
-import { Alert, Button, Card, Popconfirm, Tag } from "antd";
-import { Icon, Loading } from "@cocalc/frontend/components";
-import { webapp_client } from "@cocalc/frontend/webapp-client";
-import { PROJECT_UPGRADES } from "@cocalc/util/schema";
-import QuotaRow from "./quota-row";
-import Information from "./information";
-import type { ProjectQuota } from "@cocalc/util/db-schema/purchase-quotas";
 import { useRedux, useTypedRedux } from "@cocalc/frontend/app-framework";
-import CostPerHour from "./cost-per-hour";
-import { copy_without } from "@cocalc/util/misc";
+import { Icon, Loading } from "@cocalc/frontend/components";
+import { PAYASYOUGO_ICON } from "@cocalc/frontend/components/icon";
 import { load_target } from "@cocalc/frontend/history";
 import DynamicallyUpdatingCost from "@cocalc/frontend/purchases/pay-as-you-go/dynamically-updating-cost";
 import startProject from "@cocalc/frontend/purchases/pay-as-you-go/start-project";
 import stopProject from "@cocalc/frontend/purchases/pay-as-you-go/stop-project";
 import track0 from "@cocalc/frontend/user-tracking";
 import { User } from "@cocalc/frontend/users";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import type { ProjectQuota } from "@cocalc/util/db-schema/purchase-quotas";
+import { copy_without } from "@cocalc/util/misc";
+import { PROJECT_UPGRADES } from "@cocalc/util/schema";
+import { Alert, Button, Card, Popconfirm, Tag } from "antd";
+import { CSSProperties, useEffect, useMemo, useState } from "react";
+import CostPerHour from "./cost-per-hour";
+import Information from "./information";
+import QuotaRow from "./quota-row";
 
 function track(obj) {
   track0("pay-as-you-go-project-upgrade", obj);
@@ -49,7 +50,7 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
   const [editing, setEditing] = useState<boolean>(false);
   // one we are editing:
   const [quotaState, setQuotaState] = useState<ProjectQuota | null>(
-    savedQuotaState,
+    savedQuotaState
   );
 
   const runningWithUpgrade = useMemo(() => {
@@ -69,7 +70,7 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
       try {
         setStatus("Loading quotas...");
         setMaxQuotas(
-          await webapp_client.purchases_client.getPayAsYouGoMaxProjectQuotas(),
+          await webapp_client.purchases_client.getPayAsYouGoMaxProjectQuotas()
         );
       } catch (err) {
         setError(`${err}`);
@@ -94,7 +95,7 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
       setError("");
       await webapp_client.purchases_client.setPayAsYouGoProjectQuotas(
         project_id,
-        quotaState,
+        quotaState
       );
     } catch (err) {
       setError(`${err}`);
@@ -199,7 +200,7 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
       style={style}
       title={
         <h4>
-          <Icon name="compass" /> Pay As You Go
+          <Icon name={PAYASYOUGO_ICON} /> Pay As You Go
           <RunningStatus project={project} />
           {runningWithUpgrade && (
             <>
@@ -310,7 +311,7 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
                 setQuotaState(null);
                 await webapp_client.purchases_client.setPayAsYouGoProjectQuotas(
                   project_id,
-                  {},
+                  {}
                 );
               }}
             >

--- a/src/packages/next/components/store/index.tsx
+++ b/src/packages/next/components/store/index.tsx
@@ -5,6 +5,7 @@
 import { Alert, Layout } from "antd";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+
 import { COLORS } from "@cocalc/util/theme";
 import Anonymous from "components/misc/anonymous";
 import Loading from "components/share/loading";
@@ -15,13 +16,13 @@ import useCustomize from "lib/use-customize";
 import Boost from "./boost";
 import Cart from "./cart";
 import Checkout from "./checkout";
-import Vouchers from "./vouchers";
 import Congrats from "./congrats";
 import DedicatedResource from "./dedicated";
 import Menu from "./menu";
 import Overview from "./overview";
 import SiteLicense from "./site-license";
 import { StoreInplaceSignInOrUp } from "./store-inplace-signup";
+import Vouchers from "./vouchers";
 
 const { Content } = Layout;
 

--- a/src/packages/next/components/store/overview.tsx
+++ b/src/packages/next/components/store/overview.tsx
@@ -3,18 +3,19 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Icon } from "@cocalc/frontend/components/icon";
-import { Paragraph, Text } from "components/misc";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import { Icon, PAYASYOUGO_ICON } from "@cocalc/frontend/components/icon";
+import { Paragraph } from "components/misc";
 import A from "components/misc/A";
 import SiteName from "components/share/site-name";
 import {
-  OverviewRow,
   OVERVIEW_LARGE_ICON,
   OVERVIEW_STYLE,
+  OverviewRow,
   Product,
 } from "lib/styles/layouts";
-import { useRouter } from "next/router";
-import { useEffect } from "react";
 
 export default function Overview() {
   const router = useRouter();
@@ -31,9 +32,8 @@ export default function Overview() {
         Welcome to the <SiteName /> Store!
       </h2>
       <div style={{ fontSize: "13pt" }}>
-        Shop below, explore an{" "}
-        <A href="/pricing">overview of products and pricing</A>, or{" "}
-        <A href="/vouchers">explore vouchers</A>.
+        Shop below or explore an{" "}
+        <A href="/pricing">available products and pricing</A>.
       </div>
       <OverviewRow>
         <Product icon="key" title="License" href="/store/site-license">
@@ -57,6 +57,18 @@ export default function Overview() {
         <Product href={"/pricing/onprem"} icon="server" title="On-Premises">
           Run CoCalc on your own machine or cluster in order to keep your data
           on-site and use compute resources that you already have.
+        </Product>
+        <Product href={"/store/vouchers"} icon="gift" title="Vouchers">
+          Purchase a <A href={"/vouchers"}>voucher code</A> and gift it to
+          someone else.
+        </Product>
+        <Product
+          href={"https://doc.cocalc.com/paygo.html"}
+          icon={PAYASYOUGO_ICON}
+          title="Pay As You Go"
+        >
+          Define resources for a project or service and pay only for what you
+          actually use.
         </Product>
       </OverviewRow>
       <Paragraph style={{ marginTop: "4em" }}>

--- a/src/packages/next/components/store/overview.tsx
+++ b/src/packages/next/components/store/overview.tsx
@@ -41,34 +41,28 @@ export default function Overview() {
           internet access, more CPU and memory, etc.
         </Product>
         <Product icon="rocket" title="License Booster" href="/store/boost">
-          Add additional upgrades to an existing upgrade license.
+          Add additional upgrades to an existing and <em>compatible</em>{" "}
+          license.
         </Product>
         <Product
-          href={"/store/dedicated?type=disk"}
+          href={"/store/dedicated"}
           icon="save"
-          title="Dedicated Disk"
+          icon2="dedicated"
+          title="Dedicated Disk/VM"
         >
-          Add local storage to your project.
+          Attach a large dedicated disk for more storage to your project or run
+          your project on a dedicated Virtual Machine to harness much more CPU
+          and memory.
         </Product>
-        <Product
-          href={"/store/dedicated?type=vm"}
-          icon="dedicated"
-          title="Dedicated Virtual Machine"
-        >
-          Move your project to a much more powerful Virtual Machine.
+        <Product href={"/pricing/onprem"} icon="server" title="On-Premises">
+          Run CoCalc on your own machine or cluster in order to keep your data
+          on-site and use compute resources that you already have.
         </Product>
       </OverviewRow>
       <Paragraph style={{ marginTop: "4em" }}>
         If you already selected one or more items, view your{" "}
         <A href="/store/cart">shopping cart</A> or go straight to{" "}
         <A href="/store/checkout">checkout</A>.
-      </Paragraph>
-      <Paragraph>
-        It is also possible to run <SiteName /> on your own infrastructure:{" "}
-        <Text strong>
-          <A href={"/pricing/onprem"}>on-premises offerings</A>
-        </Text>
-        .
       </Paragraph>
       <Paragraph>
         You can also browse your <A href="/billing">billing records</A> or{" "}

--- a/src/packages/next/lib/styles/layouts.tsx
+++ b/src/packages/next/lib/styles/layouts.tsx
@@ -7,7 +7,7 @@ import { Col, Row } from "antd";
 
 import { Icon } from "@cocalc/frontend/components/icon";
 import { COLORS } from "@cocalc/util/theme";
-import { Paragraph, Title } from "components/misc";
+import { CSS, Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
 
 const gridProps = { sm: 24, md: 12 } as const;
@@ -37,26 +37,57 @@ export const OVERVIEW_LARGE_ICON_MARGIN: React.CSSProperties = {
   fontSize: "80px",
 } as const;
 
+const ICON_SIZE = "50px";
+const ICON_STYLE: CSS = { fontSize: ICON_SIZE, fontWeight: "bold" } as const;
+
 export function Product({
   icon,
+  icon2,
   title,
   href,
   children,
   external,
 }: {
   icon;
+  icon2?;
   title;
   href;
   children;
   external?;
 }) {
+  function renderIcon2() {
+    if (!icon2) return null;
+    return (
+      <>
+        <span
+          style={{
+            fontSize: "30px",
+            paddingLeft: "10px",
+            paddingRight: "10px",
+          }}
+        >
+          /
+        </span>
+        <Icon style={ICON_STYLE} name={icon2} />
+      </>
+    );
+  }
+
   return (
     <Col {...gridProps}>
-      <A href={href} external={external}>
-        <Icon
-          style={{ fontSize: "50px", fontWeight: "bold", display: "block" }}
-          name={icon}
-        />
+      {/* display: flex to avoid line breaks if there are 2 icons */}
+      <A
+        href={href}
+        external={external}
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          marginBottom: "10px",
+        }}
+      >
+        <Icon style={ICON_STYLE} name={icon} />
+        {renderIcon2()}
       </A>
       <Title
         level={2}

--- a/src/packages/next/pages/pricing/onprem.tsx
+++ b/src/packages/next/pages/pricing/onprem.tsx
@@ -187,16 +187,17 @@ function Body() {
               database.
             </li>
             <li>
-              Regarding storage, a network file-system like{" "}
-              <Text strong>NFS</Text>, supporting{" "}
+              Regarding storage, a shared network file-system like{" "}
+              <Text strong>NFS</Text> will hold the data of all projects. The
+              only pre-requisite is it needs to support the Kubernetes{" "}
               <A
                 href={
                   "https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes"
                 }
               >
                 ReadWriteMany
-              </A>
-              , will hold the data of all projects.
+              </A>{" "}
+              file-system access mode.
             </li>
           </ul>
         </Paragraph>
@@ -256,6 +257,12 @@ function Body() {
         <Icon name="server" style={{ marginRight: "30px" }} /> CoCalc - On
         Premises Offerings
       </Title>
+
+      <Paragraph>
+        CoCalc's on-premises offerings allow you to run CoCalc on your own
+        machine or cluster in order to keep your data on-site and use compute
+        resources that you already have.
+      </Paragraph>
       <div>
         <Alert
           type="info"


### PR DESCRIPTION
# Description

This adds on-prem, vouchers and pay as you go more prominently on the store page ... with links and a short explanation text.

![Screenshot from 2023-09-22 14-45-42](https://github.com/sagemathinc/cocalc/assets/207405/c604b785-2e7a-47a8-8d2f-35ee50652ce8)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
