### PR TITLE
#6916: Added text editor support for `.cu` file extension (for CUDA C files)

### DIFF
--- a/src/packages/frontend/file-associations.ts
+++ b/src/packages/frontend/file-associations.ts
@@ -32,6 +32,7 @@ const codemirror_associations: { [ext: string]: string } = {
   asm: "text/x-gas",
   bash: "shell",
   c: "text/x-c",
+  cu: "text/x-c",
   zig: "text/x-c", // wrong, but much better than nothing
   "c++": "text/x-c++src",
   cob: "text/x-cobol",


### PR DESCRIPTION
Added support for `.cu` files via alias to `.c` syntax highlighting.


See below screenshot:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/0bb9e446-f458-4dd9-824c-5763eeacaa78)
