### PR TITLE
#6920: Added time zone label to license start/stop times.

### DIFF
--- a/src/packages/next/components/misc/date-range.tsx
+++ b/src/packages/next/components/misc/date-range.tsx
@@ -15,6 +15,7 @@ interface Props {
   maxDaysInFuture?: number; // don't allow dates this far in the future from now
   disabled?: boolean;
   initialValues?: DateRangeType;
+  suffix?: string;
 }
 
 export default function DateRange(props: Props) {
@@ -25,6 +26,7 @@ export default function DateRange(props: Props) {
     maxDaysInFuture,
     disabled = false,
     initialValues = [undefined, undefined],
+    suffix
   } = props;
 
   const [dateRange, setDateRange] = useState<DateRangeType>(initialValues);
@@ -114,6 +116,9 @@ export default function DateRange(props: Props) {
             : undefined
         }
       />
+      {suffix && (
+        <span style={{marginLeft: '5px'}}>{suffix}</span>
+      )}
     </div>
   );
 }

--- a/src/packages/next/components/store/usage-and-duration.tsx
+++ b/src/packages/next/components/store/usage-and-duration.tsx
@@ -21,6 +21,15 @@ interface Props {
   extraDuration?: ReactNode;
 }
 
+function getTimezoneFromDate(date: Date, format: 'long'|'short'='long'): string {
+  return Intl.DateTimeFormat(undefined, {
+    timeZoneName: format,
+  }).formatToParts(date)
+    .find(x => x.type === 'timeZoneName')
+    ?.value || '';
+}
+
+
 export function UsageAndDuration(props: Props) {
   const {
     showExplanations = false,
@@ -70,25 +79,28 @@ export function UsageAndDuration(props: Props) {
     const period = getFieldValue("period");
     if (period !== "range") return;
     const range = getFieldValue("range");
+    const invalidRange = range?.[0] == null || range?.[1] == null;
     return (
-      <>
-        {(range?.[0] == null || range?.[1] == null) && (
-          <div style={{ textAlign: "center", color: "#ff4d4f" }}>
-            Please enter a range of dates.
-          </div>
-        )}
+      <Form.Item label="License Term"
+                 name="range"
+                 rules={[{ required: true }]}
+                 help={invalidRange ? "Please enter a valid license range." : ""}
+                 validateStatus={invalidRange ? "error" : "success"}
+                 style={{ paddingBottom: "30px" }}
+      >
         <DateRange
           disabled={disabled}
           noPast
           maxDaysInFuture={365 * 4}
-          style={{ margin: "5px 0 30px", textAlign: "center" }}
+          style={{ marginTop: "5px" }}
           initialValues={getFieldValue("range")}
           onChange={(range) => {
             form.setFieldsValue({ range });
             onChange();
           }}
+          suffix={(range && range[0]) && `(${getTimezoneFromDate(range[0] as Date, 'long')})`}
         />
-      </>
+      </Form.Item>
     );
   }
 


### PR DESCRIPTION
This pull request only partially addresses #6920; I'm quite sure how to spoof invoices to test changes, but I did get the timezone name sorted out for license start/end dates:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/725706c8-7100-42fc-9e5d-1ed4fdea6de7)

