### PR TITLE
frontend/datastore: break form apart to avoid re-rendering flicker

### DIFF
--- a/src/packages/frontend/project/settings/datastore.tsx
+++ b/src/packages/frontend/project/settings/datastore.tsx
@@ -315,12 +315,16 @@ export const Datastore: React.FC<Props> = React.memo((props: Props) => {
   }
 
   function render_action_buttons(_, record) {
+    const placement = isFlyout ? "right" : "bottom";
     return (
       <Space.Compact
         size={size}
         direction={isFlyout ? "vertical" : "horizontal"}
       >
-        <Tooltip title={`Modify ${record.name}'s configuration.`}>
+        <Tooltip
+          title={`Modify ${record.name}'s configuration.`}
+          placement={placement}
+        >
           <Button
             size={size}
             onClick={() => edit(record)}
@@ -328,7 +332,7 @@ export const Datastore: React.FC<Props> = React.memo((props: Props) => {
           ></Button>
         </Tooltip>
 
-        <Tooltip title={`Open ${record.name} in Files`}>
+        <Tooltip title={`Open ${record.name} in Files`} placement={placement}>
           <Button
             size={size}
             onClick={() => open(record)}
@@ -342,7 +346,7 @@ export const Datastore: React.FC<Props> = React.memo((props: Props) => {
           okText="Yes"
           cancelText="No"
         >
-          <Tooltip title={`Delete ${record.name}.`}>
+          <Tooltip title={`Delete ${record.name}.`} placement={placement}>
             <Button size={size} icon={<DeleteOutlined />}></Button>{" "}
           </Tooltip>
         </Popconfirm>


### PR DESCRIPTION
# Description

I think I understand the issue and this should fix #6946 – I wasn't able to reproduce this in testing, though.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
