### PR TITLE
tweaks around paygo and missing quota warnings

### DIFF
--- a/src/packages/frontend/antd-bootstrap.tsx
+++ b/src/packages/frontend/antd-bootstrap.tsx
@@ -38,6 +38,7 @@ import { MouseEventHandler } from "react";
 import { inDarkMode } from "@cocalc/frontend/account/dark-mode";
 import { r_join } from "@cocalc/frontend/components/r_join";
 import { Gap } from "@cocalc/frontend/components/gap";
+import { COLORS } from "@cocalc/util/theme";
 
 // Note regarding buttons -- there are 6 semantics meanings in bootstrap, but
 // only four in antd, and it we can't automatically collapse them down in a meaningful
@@ -92,7 +93,7 @@ function parse_bsStyle(props: {
       // it should be so for
       // now just copy the style.
       style = {
-        backgroundColor: "#f0ad4e",
+        backgroundColor: COLORS.BG_WARNING,
         borderColor: "#eea236",
         color: "#ffffff",
       };

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -244,11 +244,11 @@ function process_software(software, is_cocalc_com) {
     actions.setState({ software });
   } else {
     if (is_cocalc_com) {
-      actions.setState({ software: fromJS(FALLBACK_SOFTWARE_ENV) as any});
+      actions.setState({ software: fromJS(FALLBACK_SOFTWARE_ENV) as any });
     } else {
       software = sanitizeSoftwareEnv(
         { software: FALLBACK_ONPREM_ENV, purpose: "webapp" },
-        dbg
+        dbg,
       );
       actions.setState({ software });
     }
@@ -291,7 +291,7 @@ export const HelpEmailLink: React.FC<HelpEmailLink> = React.memo(
     } else {
       return <Loading style={{ display: "inline" }} />;
     }
-  }
+  },
 );
 
 export const SiteName: React.FC = React.memo(() => {
@@ -330,7 +330,7 @@ const SiteDescription0 = rclass<{ style?: React.CSSProperties }>(
         return <Loading style={{ display: "inline" }} />;
       }
     }
-  }
+  },
 );
 
 // TODO: not used?
@@ -396,7 +396,7 @@ const CustomizeStringElement = rclass<CustomizeStringProps>(
     render() {
       return <span>{this.props[this.props.name]}</span>;
     }
-  }
+  },
 );
 
 // TODO: not used?
@@ -434,7 +434,7 @@ const AccountCreationEmailInstructions0 = rclass<{}>(
         </h3>
       );
     }
-  }
+  },
 );
 
 // TODO is this used?
@@ -498,6 +498,7 @@ export const PolicyPrivacyPageUrl = join(appBasePath, "policies/privacy");
 export const PolicyCopyrightPageUrl = join(appBasePath, "policies/copyright");
 export const PolicyTOSPageUrl = join(appBasePath, "policies/terms");
 export const SystemStatusUrl = join(appBasePath, "info/status");
+export const PAYGODocsUrl = "https://doc.cocalc.com/paygo.html";
 
 // 1. Google analytics
 async function setup_google_analytics(w) {

--- a/src/packages/frontend/project/settings/body.tsx
+++ b/src/packages/frontend/project/settings/body.tsx
@@ -74,7 +74,7 @@ export const Body: React.FC<ReactProps> = React.memo((props: ReactProps) => {
     (kucalc === KUCALC_ON_PREMISES && datastore);
 
   const showNonMemberWarning =
-    commercial && runQuota != null && !runQuota?.member_host;
+    commercial && runQuota != null && !runQuota.member_host;
   const showNoInternetWarning =
     commercial && runQuota != null && !runQuota.network;
 

--- a/src/packages/frontend/project/settings/body.tsx
+++ b/src/packages/frontend/project/settings/body.tsx
@@ -5,6 +5,7 @@
 
 import React from "react";
 import { Col, Row } from "react-bootstrap";
+
 import {
   redux,
   useActions,
@@ -12,9 +13,7 @@ import {
 } from "@cocalc/frontend/app-framework";
 import { Icon, Paragraph, SettingBox } from "@cocalc/frontend/components";
 import { getStudentProjectFunctionality } from "@cocalc/frontend/course";
-import { commercial } from "@cocalc/frontend/customize";
 import { Customer, ProjectMap } from "@cocalc/frontend/todo-types";
-import { webapp_client } from "@cocalc/frontend/webapp-client";
 import {
   KUCALC_COCALC_COM,
   KUCALC_ON_PREMISES,
@@ -22,10 +21,10 @@ import {
 import { is_different } from "@cocalc/util/misc";
 import { NewFileButton } from "../new/new-file-button";
 import {
-  ICON_USERS,
   ICON_UPGRADES,
-  TITLE_USERS,
+  ICON_USERS,
   TITLE_UPGRADES,
+  TITLE_USERS,
 } from "../servers/consts";
 import { NoNetworkProjectWarning } from "../warnings/no-network";
 import { NonMemberProjectWarning } from "../warnings/non-member";
@@ -36,6 +35,7 @@ import { Environment } from "./environment";
 import { HideDeleteBox } from "./hide-delete-box";
 import { ProjectCapabilities } from "./project-capabilites";
 import { ProjectControl } from "./project-control";
+import { useRunQuota } from "./run-quota/hooks";
 import SavingProjectSettingsError from "./saving-project-settings-error";
 import { SSHPanel } from "./ssh";
 import { Project } from "./types";
@@ -57,62 +57,31 @@ const is_same = (prev: ReactProps, next: ReactProps) => {
 };
 
 export const Body: React.FC<ReactProps> = React.memo((props: ReactProps) => {
-  const { project_id, account_id, project, email_address } = props;
+  const { project_id, account_id, project } = props;
   const project_actions = useActions({ project_id });
-  const get_total_upgrades = redux.getStore("account").get_total_upgrades;
   const kucalc = useTypedRedux("customize", "kucalc");
+  const runQuota = useRunQuota(project_id, null);
   const ssh_gateway = useTypedRedux("customize", "ssh_gateway");
   const datastore = useTypedRedux("customize", "datastore");
-
-  const projects_store = redux.getStore("projects");
-  const {
-    get_course_info,
-    get_total_upgrades_you_have_applied,
-    get_total_project_quotas,
-  } = projects_store;
+  const commercial = useTypedRedux("customize", "commercial");
 
   // get the description of the share, in case the project is being shared
   const id = project_id;
-
-  const upgrades_you_can_use = get_total_upgrades();
-
-  const course_info = get_course_info(project_id);
-  const upgrades_you_applied_to_all_projects =
-    get_total_upgrades_you_have_applied();
-  const total_project_quotas = get_total_project_quotas(id); // only available for non-admin for now.
 
   const student = getStudentProjectFunctionality(project_id);
   const showDatastore =
     kucalc === KUCALC_COCALC_COM ||
     (kucalc === KUCALC_ON_PREMISES && datastore);
 
+  const showNonMemberWarning =
+    commercial && runQuota != null && !runQuota?.member_host;
+  const showNoInternetWarning =
+    commercial && runQuota != null && !runQuota.network;
+
   return (
     <div>
-      {commercial &&
-      total_project_quotas != undefined &&
-      !total_project_quotas.member_host ? (
-        <NonMemberProjectWarning
-          upgrade_type="member_host"
-          upgrades_you_can_use={upgrades_you_can_use}
-          upgrades_you_applied_to_all_projects={
-            upgrades_you_applied_to_all_projects
-          }
-          course_info={course_info}
-          account_id={webapp_client.account_id}
-          email_address={email_address}
-        />
-      ) : undefined}
-      {commercial &&
-      total_project_quotas != undefined &&
-      !total_project_quotas.network ? (
-        <NoNetworkProjectWarning
-          upgrade_type="network"
-          upgrades_you_can_use={upgrades_you_can_use}
-          upgrades_you_applied_to_all_projects={
-            upgrades_you_applied_to_all_projects
-          }
-        />
-      ) : undefined}
+      {showNonMemberWarning ? <NonMemberProjectWarning /> : undefined}
+      {showNoInternetWarning ? <NoNetworkProjectWarning /> : undefined}
       <h1 style={{ marginTop: "0px" }}>
         <Icon name="wrench" /> Project Settings and Controls
       </h1>

--- a/src/packages/frontend/project/settings/quota-editor/pay-as-you-go.tsx
+++ b/src/packages/frontend/project/settings/quota-editor/pay-as-you-go.tsx
@@ -3,6 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Alert, Button, Card, Popconfirm, Tag } from "antd";
+import { CSSProperties, useEffect, useMemo, useState } from "react";
+
 import { useRedux, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { Icon, Loading } from "@cocalc/frontend/components";
 import { PAYASYOUGO_ICON } from "@cocalc/frontend/components/icon";
@@ -14,13 +17,12 @@ import track0 from "@cocalc/frontend/user-tracking";
 import { User } from "@cocalc/frontend/users";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import type { ProjectQuota } from "@cocalc/util/db-schema/purchase-quotas";
-import { copy_without } from "@cocalc/util/misc";
+import { copy_without, unreachable } from "@cocalc/util/misc";
 import { PROJECT_UPGRADES } from "@cocalc/util/schema";
-import { Alert, Button, Card, Popconfirm, Tag } from "antd";
-import { CSSProperties, useEffect, useMemo, useState } from "react";
 import CostPerHour from "./cost-per-hour";
 import Information from "./information";
 import QuotaRow from "./quota-row";
+import { isEmpty } from "lodash";
 
 function track(obj) {
   track0("pay-as-you-go-project-upgrade", obj);
@@ -30,6 +32,8 @@ function track(obj) {
 // found them too difficult to cost out, so exclude them (only
 // admins can set them).
 const EXCLUDE = new Set(["memory_request", "cpu_shares"]);
+
+type Preset = "budget" | "small" | "medium" | "large" | "max";
 
 interface Props {
   project_id: string;
@@ -46,11 +50,11 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
       ? null
       : project
           .getIn(["pay_as_you_go_quotas", webapp_client.account_id])
-          ?.toJS() ?? {};
+          ?.toJS() ?? getPresetValue("small");
   const [editing, setEditing] = useState<boolean>(false);
   // one we are editing:
   const [quotaState, setQuotaState] = useState<ProjectQuota | null>(
-    savedQuotaState
+    savedQuotaState,
   );
 
   const runningWithUpgrade = useMemo(() => {
@@ -70,7 +74,7 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
       try {
         setStatus("Loading quotas...");
         setMaxQuotas(
-          await webapp_client.purchases_client.getPayAsYouGoMaxProjectQuotas()
+          await webapp_client.purchases_client.getPayAsYouGoMaxProjectQuotas(),
         );
       } catch (err) {
         setError(`${err}`);
@@ -82,7 +86,11 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
 
   useEffect(() => {
     if (editing) {
-      setQuotaState(savedQuotaState);
+      if (isEmpty(savedQuotaState)) {
+        setQuotaState(getPresetValue("small") ?? {});
+      } else {
+        setQuotaState(savedQuotaState);
+      }
     }
   }, [editing]);
 
@@ -95,7 +103,7 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
       setError("");
       await webapp_client.purchases_client.setPayAsYouGoProjectQuotas(
         project_id,
-        quotaState
+        quotaState,
       );
     } catch (err) {
       setError(`${err}`);
@@ -122,41 +130,58 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
     }
   }
 
-  function handlePreset(preset) {
+  function getPresetValue(preset: Preset) {
+    switch (preset) {
+      case "max":
+        return maxQuotas;
+      case "budget":
+        return {
+          member_host: 0,
+          network: 1,
+          cores: 1,
+          memory: 1000,
+          disk_quota: 3000,
+          mintime: 0.5,
+        };
+      case "small":
+        return {
+          member_host: 1,
+          network: 1,
+          cores: 1,
+          memory: 2000,
+          disk_quota: 3000,
+          mintime: 0.5,
+        };
+      case "medium":
+        return {
+          member_host: 1,
+          network: 1,
+          cores: 2,
+          memory: 6000,
+          disk_quota: 4000,
+          mintime: 2,
+        };
+      case "large":
+        return {
+          member_host: 1,
+          network: 1,
+          always_running: 1,
+          cores: 3,
+          memory: 10000,
+          disk_quota: 6000,
+        };
+
+      default:
+        unreachable(preset);
+    }
+  }
+
+  function handlePreset(preset: Preset) {
     track({ action: "preset", preset, project_id });
     if (maxQuotas == null) return;
-    let x;
-    if (preset == "max") {
-      x = maxQuotas;
-    } else if (preset == "min") {
-      x = {
-        member_host: 0,
-        network: 1,
-        cores: 1,
-        memory: 1000,
-        disk_quota: 3000,
-        mintime: 0.5,
-      };
-    } else if (preset == "medium") {
-      x = {
-        member_host: 1,
-        network: 1,
-        cores: 2,
-        memory: 8000,
-        disk_quota: 4000,
-        mintime: 2,
-      };
-    } else if (preset == "large") {
-      x = {
-        member_host: 1,
-        network: 1,
-        always_running: 1,
-        cores: 3,
-        memory: 10000,
-        disk_quota: 6000,
-      };
-    }
-    x = copy_without(x, Array.from(EXCLUDE));
+    const val = getPresetValue(preset);
+    if (val == null) return;
+    const x = copy_without(val, Array.from(EXCLUDE));
     for (const key in x) {
       if (maxQuotas[key] != null && maxQuotas[key] < x[key]) {
         x[key] = maxQuotas[key];
@@ -195,44 +220,240 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
     return <Loading />;
   }
 
-  return (
-    <Card
-      style={style}
-      title={
-        <h4>
-          <Icon name={PAYASYOUGO_ICON} /> Pay As You Go
-          <RunningStatus project={project} />
-          {runningWithUpgrade && (
-            <>
-              {" "}
-              (Amount:{" "}
-              <DynamicallyUpdatingCost
-                alwaysNonnegative
-                costPerHour={
-                  project?.getIn([
-                    "run_quota",
-                    "pay_as_you_go",
-                    "quota",
-                    "cost",
-                  ]) ?? 0
-                }
-                start={project?.getIn([
+  function renderRunningWithUpgrade() {
+    if (!runningWithUpgrade) return;
+
+    return (
+      <div>
+        This project is running with the pay as you go quota upgrades that{" "}
+        <a
+          onClick={() => {
+            load_target("settings/purchases");
+          }}
+        >
+          you purchased
+        </a>
+        . You will be charged <b>by the second</b> until the project is stopped.
+        <div>
+          <Popconfirm
+            title={"Stop project?"}
+            description={
+              <div style={{ maxWidth: "400px" }}>
+                When you next start the project, it will be upgraded unless you
+                explicitly disable upgrades. (If a collaborator starts the
+                project you will not be charged.)
+              </div>
+            }
+            onConfirm={() => handleStop(false)}
+          >
+            <Button style={{ marginRight: "8px", marginTop: "15px" }}>
+              <Icon name="stop" /> Stop Project
+            </Button>
+          </Popconfirm>
+          <Popconfirm
+            title={"Stop project and disable upgrades?"}
+            description={
+              <div style={{ maxWidth: "400px" }}>
+                Project will stop and will not automatically be upgraded until
+                you explicitly enable upgrades again here.
+              </div>
+            }
+            onConfirm={() => handleStop(true)}
+          >
+            <Button style={{ marginRight: "8px", marginTop: "15px" }}>
+              <Icon name="stop" /> Disable Upgrades...
+            </Button>
+          </Popconfirm>
+          <Button onClick={() => setEditing(!editing)}>
+            {editing ? "Hide" : "Show"} Quotas
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  function renderUpgradeOrClear() {
+    if (editing || runningWithUpgrade) return;
+
+    return (
+      <div>
+        <Button
+          onClick={() => {
+            if (!editing) {
+              track({ action: "open", project_id });
+            }
+            setEditing(!editing);
+          }}
+        >
+          <Icon name="credit-card" /> Upgrade...
+        </Button>
+        {project?.getIn(["state", "state"]) != "running" && (
+          <Button
+            disabled={quotaState == null || Object.keys(quotaState).length == 0}
+            style={{ marginLeft: "8px" }}
+            onClick={async () => {
+              setQuotaState(null);
+              await webapp_client.purchases_client.setPayAsYouGoProjectQuotas(
+                project_id,
+                {},
+              );
+            }}
+          >
+            <Icon name="credit-card" /> Clear Upgrades
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  function renderStartWithUpgrades() {
+    if (!editing || runningWithUpgrade) return;
+
+    return (
+      <div style={{ marginTop: "15px" }}>
+        <Button onClick={handleClose}>Close</Button>
+        <Popconfirm
+          title="Run project with exactly these quotas?"
+          description={
+            <div style={{ width: "400px" }}>
+              The project will restart with your quotas applied.{" "}
+              <b>
+                You will be charged by the second for usage during this session.
+              </b>
+              <br /> <br />
+              NOTES: No licenses will be applied. Only one person can upgrade a
+              project at once, though all collaborators get to use the upgraded
+              version of the project.
+            </div>
+          }
+          onConfirm={handleRun}
+          okText="Upgrade"
+          cancelText="No"
+        >
+          <Button style={{ marginLeft: "8px" }} type="primary">
+            <Icon name="save" /> Start With Upgrades...
+          </Button>
+        </Popconfirm>
+      </div>
+    );
+  }
+
+  function renderEditing() {
+    if (!editing) return;
+
+    return (
+      <>
+        {error && (
+          <Alert
+            style={{ margin: "15px" }}
+            type="error"
+            showIcon
+            description={error}
+            closable
+            onClose={() => setError("")}
+          />
+        )}
+        <div style={{ margin: "15px 0" }}>
+          <Tag
+            icon={<Icon name="battery-empty" />}
+            style={{ cursor: "pointer" }}
+            color="blue"
+            onClick={() => handlePreset("budget")}
+          >
+            Budget
+          </Tag>
+          <Tag
+            icon={<Icon name="battery-quarter" />}
+            style={{ cursor: "pointer" }}
+            color="blue"
+            onClick={() => handlePreset("small")}
+          >
+            Small
+          </Tag>
+          <Tag
+            icon={<Icon name="battery-half" />}
+            style={{ cursor: "pointer" }}
+            color="blue"
+            onClick={() => handlePreset("medium")}
+          >
+            Medium
+          </Tag>
+          <Tag
+            icon={<Icon name="battery-three-quarters" />}
+            style={{ cursor: "pointer" }}
+            color="blue"
+            onClick={() => handlePreset("large")}
+          >
+            Large
+          </Tag>
+          <Tag
+            icon={<Icon name="battery-full" />}
+            style={{ cursor: "pointer" }}
+            color="blue"
+            onClick={() => handlePreset("max")}
+          >
+            Max
+          </Tag>
+          <hr />
+        </div>
+        {PROJECT_UPGRADES.field_order
+          .filter((name) => !EXCLUDE.has(name))
+          .map((name) => (
+            <QuotaRow
+              key={name}
+              name={name as any}
+              quotaState={quotaState}
+              setQuotaState={setQuotaState}
+              maxQuotas={maxQuotas}
+              disabled={runningWithUpgrade}
+            />
+          ))}
+      </>
+    );
+  }
+
+  function renderTitle() {
+    return (
+      <h4>
+        <Icon name={PAYASYOUGO_ICON} /> Pay As You Go
+        <RunningStatus project={project} />
+        {runningWithUpgrade && (
+          <>
+            {" "}
+            (Amount:{" "}
+            <DynamicallyUpdatingCost
+              alwaysNonnegative
+              costPerHour={
+                project?.getIn([
                   "run_quota",
                   "pay_as_you_go",
                   "quota",
-                  "start",
-                ])}
-              />
-              )
-            </>
-          )}
-          {status ? (
-            <Tag color="success" style={{ marginLeft: "30px" }}>
-              {status}
-            </Tag>
-          ) : undefined}
-        </h4>
-      }
+                  "cost",
+                ]) ?? 0
+              }
+              start={project?.getIn([
+                "run_quota",
+                "pay_as_you_go",
+                "quota",
+                "start",
+              ])}
+            />
+            )
+          </>
+        )}
+        {status ? (
+          <Tag color="success" style={{ marginLeft: "30px" }}>
+            {status}
+          </Tag>
+        ) : undefined}
+      </h4>
+    );
+  }
+
+  return (
+    <Card
+      style={style}
+      title={renderTitle()}
       type="inner"
       extra={<Information />}
     >
@@ -241,174 +462,10 @@ export default function PayAsYouGoQuotaEditor({ project_id, style }: Props) {
           <CostPerHour quota={quotaState} />
         </div>
       )}
-      {runningWithUpgrade && (
-        <div>
-          This project is running with the pay as you go quota upgrades that{" "}
-          <a
-            onClick={() => {
-              load_target("settings/purchases");
-            }}
-          >
-            you purchased
-          </a>
-          . You will be charged <b>by the second</b> until the project is
-          stopped.
-          <div>
-            <Popconfirm
-              title={"Stop project?"}
-              description={
-                <div style={{ maxWidth: "400px" }}>
-                  When you next start the project, it will be upgraded unless
-                  you explicitly disable upgrades. (If a collaborator starts the
-                  project you will not be charged.)
-                </div>
-              }
-              onConfirm={() => handleStop(false)}
-            >
-              <Button style={{ marginRight: "8px", marginTop: "15px" }}>
-                <Icon name="stop" /> Stop Project
-              </Button>
-            </Popconfirm>
-            <Popconfirm
-              title={"Stop project and disable upgrades?"}
-              description={
-                <div style={{ maxWidth: "400px" }}>
-                  Project will stop and will not automatically be upgraded until
-                  you explicitly enable upgrades again here.
-                </div>
-              }
-              onConfirm={() => handleStop(true)}
-            >
-              <Button style={{ marginRight: "8px", marginTop: "15px" }}>
-                <Icon name="stop" /> Disable Upgrades...
-              </Button>
-            </Popconfirm>
-            <Button onClick={() => setEditing(!editing)}>
-              {editing ? "Hide" : "Show"} Quotas
-            </Button>
-          </div>
-        </div>
-      )}
-      {!editing && !runningWithUpgrade && (
-        <div>
-          <Button
-            onClick={() => {
-              if (!editing) {
-                track({ action: "open", project_id });
-              }
-              setEditing(!editing);
-            }}
-          >
-            <Icon name="credit-card" /> Upgrade...
-          </Button>
-          {project?.getIn(["state", "state"]) != "running" && (
-            <Button
-              disabled={
-                quotaState == null || Object.keys(quotaState).length == 0
-              }
-              style={{ marginLeft: "8px" }}
-              onClick={async () => {
-                setQuotaState(null);
-                await webapp_client.purchases_client.setPayAsYouGoProjectQuotas(
-                  project_id,
-                  {}
-                );
-              }}
-            >
-              <Icon name="credit-card" /> Clear Upgrades
-            </Button>
-          )}
-        </div>
-      )}
-      {editing && !runningWithUpgrade && (
-        <div style={{ marginTop: "15px" }}>
-          <Button onClick={handleClose}>Close</Button>
-          <Popconfirm
-            title="Run project with exactly these quotas?"
-            description={
-              <div style={{ width: "400px" }}>
-                The project will restart with your quotas applied.{" "}
-                <b>
-                  You will be charged by the second for usage during this
-                  session.
-                </b>
-                <br /> <br />
-                NOTES: No licenses will be applied. Only one person can upgrade
-                a project at once, though all collaborators get to use the
-                upgraded version of the project.
-              </div>
-            }
-            onConfirm={handleRun}
-            okText="Upgrade"
-            cancelText="No"
-          >
-            <Button style={{ marginLeft: "8px" }} type="primary">
-              <Icon name="save" /> Start With Upgrades...
-            </Button>
-          </Popconfirm>
-        </div>
-      )}
-      {editing && (
-        <>
-          {error && (
-            <Alert
-              style={{ margin: "15px" }}
-              type="error"
-              showIcon
-              description={error}
-              closable
-              onClose={() => setError("")}
-            />
-          )}
-          <div style={{ margin: "15px 0" }}>
-            <Tag
-              icon={<Icon name="battery-quarter" />}
-              style={{ cursor: "pointer" }}
-              color="blue"
-              onClick={() => handlePreset("min")}
-            >
-              Min
-            </Tag>
-            <Tag
-              icon={<Icon name="battery-half" />}
-              style={{ cursor: "pointer" }}
-              color="blue"
-              onClick={() => handlePreset("medium")}
-            >
-              Medium
-            </Tag>
-            <Tag
-              icon={<Icon name="battery-three-quarters" />}
-              style={{ cursor: "pointer" }}
-              color="blue"
-              onClick={() => handlePreset("large")}
-            >
-              Large
-            </Tag>
-            <Tag
-              icon={<Icon name="battery-full" />}
-              style={{ cursor: "pointer" }}
-              color="blue"
-              onClick={() => handlePreset("max")}
-            >
-              Max
-            </Tag>
-            <hr />
-          </div>
-          {PROJECT_UPGRADES.field_order
-            .filter((name) => !EXCLUDE.has(name))
-            .map((name) => (
-              <QuotaRow
-                key={name}
-                name={name as any}
-                quotaState={quotaState}
-                setQuotaState={setQuotaState}
-                maxQuotas={maxQuotas}
-                disabled={runningWithUpgrade}
-              />
-            ))}
-        </>
-      )}
+      {renderRunningWithUpgrade()}
+      {renderUpgradeOrClear()}
+      {renderStartWithUpgrades()}
+      {renderEditing()}
     </Card>
   );
 }

--- a/src/packages/frontend/project/warnings/no-network.tsx
+++ b/src/packages/frontend/project/warnings/no-network.tsx
@@ -3,51 +3,11 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Alert } from "../../antd-bootstrap";
-import { plural } from "@cocalc/util/misc";
-import { A, Icon, Gap } from "../../components";
-import { Options, project_warning_opts } from "./util";
-import { PolicyPricingPageUrl } from "../../customize";
-import { LICENSE_MIN_PRICE } from "@cocalc/util/consts/billing";
+import { Alert } from "@cocalc/frontend/antd-bootstrap";
+import { Icon } from "@cocalc/frontend/components";
+import { UPGRADE_HINT } from "./non-member";
 
-export const NoNetworkProjectWarning: React.FC<Options> = (props) => {
-  let suggestion;
-  const { total, avail } = project_warning_opts(props);
-  if (avail > 0) {
-    // have upgrade available
-    suggestion = (
-      <span>
-        <b>
-          <i>
-            You have {avail} unused internet access {plural(avail, "upgrade")}
-          </i>
-        </b>
-        . Click 'Adjust your upgrade contributions...' below.
-      </span>
-    );
-  } else if (avail <= 0) {
-    const url = PolicyPricingPageUrl;
-    if (total > 0) {
-      suggestion = (
-        <span>
-          Your {total} internet access {plural(total, "upgrade")} are already in
-          use on other projects. You can{" "}
-          <A href={url}>purchase further upgrades </A> by adding a subscription
-          (you can add the same subscription multiple times), or disable an
-          internet access upgrade for another project to free a spot up for this
-          one.
-        </span>
-      );
-    } else {
-      suggestion = (
-        <span>
-          <Gap />
-          <A href={url}>Licenses start at {LICENSE_MIN_PRICE}...</A>
-        </span>
-      );
-    }
-  }
-
+export function NoNetworkProjectWarning() {
   return (
     <Alert bsStyle="warning" style={{ margin: "15px" }}>
       <h4>
@@ -57,9 +17,8 @@ export const NoNetworkProjectWarning: React.FC<Options> = (props) => {
       <p>
         Projects without internet access enabled cannot connect to external
         websites, download software packages, or invite and notify collaborators
-        via email.
-        {suggestion}
+        via email. {UPGRADE_HINT}
       </p>
     </Alert>
   );
-};
+}

--- a/src/packages/frontend/project/warnings/non-member.tsx
+++ b/src/packages/frontend/project/warnings/non-member.tsx
@@ -3,77 +3,30 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Alert } from "@cocalc/frontend/antd-bootstrap";
+import { A, Icon, Paragraph } from "@cocalc/frontend/components";
+import { PAYGODocsUrl, PolicyPricingPageUrl } from "@cocalc/frontend/customize";
+import { LICENSE_MIN_PRICE } from "@cocalc/util/consts/billing";
 
-import { Alert } from "../../antd-bootstrap";
-import { plural } from "@cocalc/util/misc";
-import { A, Icon, Gap } from "../../components";
-import { Options, project_warning_opts } from "./util";
-import { PolicyPricingPageUrl } from "../../customize";
+export const UPGRADE_HINT = (
+  <>
+    <A href={PolicyPricingPageUrl}>Licenses start at ${LICENSE_MIN_PRICE}</A> or
+    upgrade via <A href={PAYGODocsUrl}>Pay-as-you-go</A>.
+  </>
+);
 
-export const NonMemberProjectWarning: React.FC<Options> = (opts) => {
-  const { total, avail } = project_warning_opts(opts);
-
-  let suggestion;
-
-  if (avail > 0) {
-    // have upgrade available
-    suggestion = (
-      <span>
-        <b>
-          <i>
-            You have {avail} unused members-only hosting{" "}
-            {plural(avail, "upgrade")}
-          </i>
-        </b>
-        . Click 'Adjust your upgrade contributions...' below.
-      </span>
-    );
-  } else if (avail <= 0) {
-    const url = PolicyPricingPageUrl;
-    if (total > 0) {
-      suggestion = (
-        <span>
-          Your {total} members-only hosting {plural(total, "upgrade")} are
-          already in use on other projects. You can{" "}
-          <A href={url}>
-            purchase further upgrades{" "}
-          </A>{" "}
-          by adding a subscription (you can add the same subscription multiple
-          times), or disable member-only hosting for another project to free a
-          spot up for this one.
-        </span>
-      );
-    } else {
-      suggestion = (
-        <span>
-          <Gap />
-          <A href={url}>
-            Licenses start at about $3/month...
-          </A>
-        </span>
-      );
-    }
-  }
-
+export function NonMemberProjectWarning() {
   return (
     <Alert bsStyle="warning" style={{ margin: "15px" }}>
       <h4>
         <Icon name="exclamation-triangle" /> Warning: this project is{" "}
         <strong>running on a free server</strong>
       </h4>
-      <p>
-        <Gap />
-        Projects running on free servers compete for resources with a large
-        number of other free projects. The free servers are{" "}
-        <b>
-          <i>randomly rebooted frequently</i>
-        </b>
-        , and are often{" "}
-        <b>
-          <i>much more heavily loaded</i>
-        </b>{" "}
-        than member-only servers. {suggestion}
-      </p>
+      <Paragraph>
+        This project does not have a <b>member-hosting upgrade</b>. This means
+        it runs on much more heavily loaded machines, where projects compete for
+        resources with many other free projects. {UPGRADE_HINT}
+      </Paragraph>
     </Alert>
   );
-};
+}

--- a/src/packages/frontend/project/warnings/util.ts
+++ b/src/packages/frontend/project/warnings/util.ts
@@ -3,8 +3,8 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { months_before } from "@cocalc/util/misc";
-import { webapp_client } from "../../webapp-client";
 
 export function course_warning(pay?: Date): boolean {
   if (!pay) {
@@ -13,35 +13,4 @@ export function course_warning(pay?: Date): boolean {
   // require subscription until 3 months after start (an estimate for when
   // class ended, and less than when what student did pay for will have expired).
   return webapp_client.server_time() <= months_before(-3, pay);
-}
-
-export interface Options {
-  upgrades_you_can_use?: any;
-  upgrades_you_applied_to_all_projects?: any;
-  course_info?: any;
-  account_id?: any;
-  email_address?: any;
-  upgrade_type?: any;
-}
-
-export function project_warning_opts({
-  upgrades_you_can_use,
-  upgrades_you_applied_to_all_projects,
-  course_info,
-  account_id,
-  email_address,
-  upgrade_type,
-}: Options) {
-  const total = upgrades_you_can_use?.[upgrade_type] ?? 0;
-  const used = upgrades_you_applied_to_all_projects?.[upgrade_type] ?? 0;
-  return {
-    total,
-    used,
-    avail: total - used,
-    // no *guarantee* that course_info is immutable.js since just comes from database
-    course_warning: course_warning(course_info?.get?.("pay")),
-    course_info,
-    account_id,
-    email_address,
-  };
 }

--- a/src/packages/util/theme.ts
+++ b/src/packages/util/theme.ts
@@ -106,6 +106,7 @@ const MAIN_COLORS = {
   BG_RED: "#d9534f", // the red bootstrap color of the button background
   FG_RED: "#c9302c", // red used for text
   FG_BLUE: "#428bca", // blue used for text
+  BG_WARNING: "#f0ad4e", // e.g. used for the orange warning when a button is active
 
   ANTD_LINK_BLUE: "#1677ff", // blue used for links
   ANTD_LINK_BLUE_DARK: "#003eb3", // dark blue used for links


### PR DESCRIPTION
# Description

- only show quota warnings in project settings, if those are really not set – based on run quota
- refactor some parts of the paygo upgrade panel
- emphasize more clearly when an upgrade schema is configured – I got confused and well, a  highlighted button and an explanation text would have helped me
- also, I tweaked the default schema to be a small one, but with internet and member hosting. there is now a new "budget" variant, which removes member hosting and which isn't the default (and it also does not show up, when the paygo quotas are cleared)

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
