### PR TITLE
frontend/files: shift+return to create file/folder

### DIFF
--- a/src/packages/frontend/components/search-input.tsx
+++ b/src/packages/frontend/components/search-input.tsx
@@ -10,7 +10,13 @@
 */
 
 import { Input, InputRef } from "antd";
-import { React, useEffect, useState, useRef } from "../app-framework";
+
+import {
+  React,
+  useEffect,
+  useRef,
+  useState,
+} from "@cocalc/frontend/app-framework";
 
 interface Props {
   size?;
@@ -35,12 +41,13 @@ interface Props {
 
 export const SearchInput: React.FC<Props> = React.memo((props) => {
   const [value, set_value] = useState<string>(
-    props.value ?? props.default_value ?? ""
+    props.value ?? props.default_value ?? "",
   );
   // if value changes, we update as well!
   useEffect(() => set_value(props.value ?? ""), [props.value]);
 
   const [ctrl_down, set_ctrl_down] = useState<boolean>(false);
+  const [shift_down, set_shift_down] = useState<boolean>(false);
 
   const input_ref = useRef<InputRef>(null);
 
@@ -57,8 +64,8 @@ export const SearchInput: React.FC<Props> = React.memo((props) => {
     input_ref.current?.focus();
   }, [focus]);
 
-  function get_opts(): { ctrl_down: boolean } {
-    return { ctrl_down };
+  function get_opts(): { ctrl_down: boolean; shift_down: boolean } {
+    return { ctrl_down, shift_down };
   }
 
   function clear_value(): void {
@@ -93,6 +100,9 @@ export const SearchInput: React.FC<Props> = React.memo((props) => {
         break;
       case 17:
         set_ctrl_down(true);
+        break;
+      case 16:
+        set_shift_down(true);
         break;
       case 13:
         submit();

--- a/src/packages/frontend/project/explorer/explorer.tsx
+++ b/src/packages/frontend/project/explorer/explorer.tsx
@@ -3,11 +3,11 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Alert } from "antd";
 import * as immutable from "immutable";
 import React from "react";
 import { Button, ButtonGroup, Col, Row } from "react-bootstrap";
 import * as underscore from "underscore";
-
 
 import { UsersViewing } from "@cocalc/frontend/account/avatar/users-viewing";
 import {
@@ -54,7 +54,6 @@ import { PathNavigator } from "./path-navigator";
 import { SearchBar } from "./search-bar";
 import ExplorerTour from "./tour/tour";
 import { ListingItem } from "./types";
-import { Alert } from "antd";
 
 function pager_range(page_size, page_number) {
   const start_index = page_size * page_number;
@@ -518,7 +517,7 @@ const Explorer0 = rclass(
             <Alert
               type="warning"
               icon={<Icon name="ban" />}
-              style={{textAlign: "center"}}
+              style={{ textAlign: "center" }}
               showIcon
               description={
                 <Paragraph>

--- a/src/packages/frontend/project/explorer/file-listing/no-files.tsx
+++ b/src/packages/frontend/project/explorer/file-listing/no-files.tsx
@@ -3,16 +3,18 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Button } from "antd";
 import { useMemo } from "react";
+
+import { Paragraph, Text } from "@cocalc/frontend/components";
 import { Icon } from "@cocalc/frontend/components/icon";
+import { FileTypeSelector } from "@cocalc/frontend/project/new";
 import { ProjectActions } from "@cocalc/frontend/project_actions";
+import { MainConfiguration } from "@cocalc/frontend/project_configuration";
+import { ChatGPTGenerateNotebookButton } from "../../page/home-page/chatgpt-generate-jupyter";
+import { useAvailableFeatures } from "../../use-available-features";
 import { HelpAlert } from "./help-alert";
 import { full_path_text } from "./utils";
-import { FileTypeSelector } from "@cocalc/frontend/project/new";
-import { Button } from "antd";
-import { MainConfiguration } from "@cocalc/frontend/project_configuration";
-import { useAvailableFeatures } from "../../use-available-features";
-import { ChatGPTGenerateNotebookButton } from "../../page/home-page/chatgpt-generate-jupyter";
 
 interface Props {
   name: string;
@@ -81,6 +83,12 @@ export default function NoFiles({
       >
         <Icon name="plus-circle" /> {buttonText}
       </Button>
+      <Paragraph
+        type="secondary"
+        style={{ textAlign: "center", marginTop: "10px" }}
+      >
+        (or <Text code>Shift+Return</Text> in the search box)
+      </Paragraph>
       <HelpAlert
         file_search={file_search}
         actual_new_filename={actualNewFilename}

--- a/src/packages/frontend/project/explorer/search-bar.tsx
+++ b/src/packages/frontend/project/explorer/search-bar.tsx
@@ -141,7 +141,7 @@ export const SearchBar = React.memo((props: Props) => {
       } else if (firstFolderPosition === file_search.length - 1) {
         text = `Showing folders matching ${file_search.slice(
           0,
-          file_search.length - 1
+          file_search.length - 1,
         )}`;
       } else {
         text = `Showing files matching ${file_search}`;
@@ -200,7 +200,10 @@ export const SearchBar = React.memo((props: Props) => {
     actions.setState({ file_creation_error: "" });
   }
 
-  function search_submit(value: string, opts: { ctrl_down: boolean }): void {
+  function search_submit(
+    value: string,
+    { ctrl_down, shift_down }: { ctrl_down: boolean; shift_down: boolean },
+  ): void {
     if (current_path == null) {
       return;
     }
@@ -216,18 +219,20 @@ export const SearchBar = React.memo((props: Props) => {
       } else {
         actions.open_file({
           path: new_path,
-          foreground: !opts.ctrl_down,
+          foreground: !ctrl_down,
         });
       }
-      if (opening_a_dir || !opts.ctrl_down) {
+      if (opening_a_dir || !ctrl_down) {
         actions.set_file_search("");
         actions.clear_selected_file_index();
       }
-    } else if (file_search.length > 0) {
+    } else if (file_search.length > 0 && shift_down) {
+      // only create a file, if shift is pressed as well to avoid creating
+      // jupyter notebooks (default file-type) by accident.
       if (file_search[file_search.length - 1] === "/") {
-        create_folder(!opts.ctrl_down);
+        create_folder(!ctrl_down);
       } else {
-        create_file(undefined, !opts.ctrl_down);
+        create_file(undefined, !ctrl_down);
       }
       actions.clear_selected_file_index();
     }


### PR DESCRIPTION
# Description

if a search in files (explorer or flyout) finds nothing, shift+return creates it. just return leads to accidentally created jupyter notebooks (default file type).

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
