### PR TITLE
flyout fixes: fullpage and maybe the file listing click

### DIFF
--- a/src/packages/frontend/components/time-ago.tsx
+++ b/src/packages/frontend/components/time-ago.tsx
@@ -31,7 +31,7 @@ function timeago_formatter(value, unit, suffix, _date) {
 // is a *chance* they are different
 export function is_different_date(
   date0: string | Date | number | undefined | null,
-  date1: string | Date | number | undefined | null
+  date1: string | Date | number | undefined | null,
 ): boolean {
   const t0 = typeof date0;
   const t1 = typeof date1;
@@ -57,6 +57,7 @@ interface TimeAgoElementProps {
   time_ago_absolute?: boolean;
   style?: CSS;
   minPeriod?: number;
+  click_to_toggle?: boolean;
 }
 
 export const TimeAgoElement: React.FC<TimeAgoElementProps> = ({
@@ -67,6 +68,7 @@ export const TimeAgoElement: React.FC<TimeAgoElementProps> = ({
   date,
   style,
   minPeriod,
+  click_to_toggle,
 }) => {
   if (live == null) live = true;
 
@@ -104,13 +106,15 @@ export const TimeAgoElement: React.FC<TimeAgoElementProps> = ({
     } catch (err) {
       s = `${err}`;
     }
+    const el = render_timeago_element(d);
+    if (!click_to_toggle) return el;
     return (
       <Popover
         trigger="click"
         title={s}
         content={() => (
           <>
-            <div>{render_timeago_element(d)}</div>
+            <div>{el}</div>
             {iso(d)}
             <ToggleRelativeAndAbsolute />
             {tip}
@@ -118,7 +122,7 @@ export const TimeAgoElement: React.FC<TimeAgoElementProps> = ({
         )}
         placement={placement}
       >
-        {render_timeago_element(d)}
+        {el}
       </Popover>
     );
   }
@@ -130,6 +134,8 @@ export const TimeAgoElement: React.FC<TimeAgoElementProps> = ({
     } catch (err) {
       s = `${err}`;
     }
+    const el = <span style={{ cursor: "pointer", ...style }}>{s}</span>;
+    if (!click_to_toggle) return el;
     return (
       <Popover
         trigger="click"
@@ -143,7 +149,7 @@ export const TimeAgoElement: React.FC<TimeAgoElementProps> = ({
         )}
         placement={placement}
       >
-        <span style={{ cursor: "pointer", ...style }}>{s}</span>
+        {el}
       </Popover>
     );
   }
@@ -172,12 +178,21 @@ interface TimeAgoProps {
   date?;
   minPeriod?: number;
   time_ago_absolute?: boolean;
+  click_to_toggle?: boolean; // default true
 }
 
 export const TimeAgo: React.FC<TimeAgoProps> = React.memo(
   (props: TimeAgoElementProps) => {
-    const { placement, tip, live, style, date, minPeriod, time_ago_absolute } =
-      props;
+    const {
+      placement,
+      tip,
+      live,
+      style,
+      date,
+      minPeriod,
+      time_ago_absolute,
+      click_to_toggle = true,
+    } = props;
 
     const other_settings = useTypedRedux("account", "other_settings");
     if (date == null) return <></>;
@@ -193,6 +208,7 @@ export const TimeAgo: React.FC<TimeAgoProps> = React.memo(
         }
         style={style}
         minPeriod={minPeriod}
+        click_to_toggle={click_to_toggle}
       />
     );
   },
@@ -200,9 +216,14 @@ export const TimeAgo: React.FC<TimeAgoProps> = React.memo(
     // areEqual
     return !(
       is_different_date(props.date, next.date) ||
-      misc_is_different(props, next, ["placement", "tip", "live"])
+      misc_is_different(props, next, [
+        "placement",
+        "tip",
+        "live",
+        "click_to_toggle",
+      ])
     );
-  }
+  },
 );
 
 function ToggleRelativeAndAbsolute({}) {

--- a/src/packages/frontend/project/page/flyouts/body.tsx
+++ b/src/packages/frontend/project/page/flyouts/body.tsx
@@ -10,6 +10,7 @@ import {
   redux,
   useEffect,
   useState,
+  useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
 import * as LS from "@cocalc/frontend/misc/local-storage-typed";
@@ -27,6 +28,8 @@ interface FlyoutBodyProps {
 
 export function FlyoutBody({ flyout, flyoutWidth }: FlyoutBodyProps) {
   const { project_id } = useProjectContext();
+  const hideActionButtons = useTypedRedux({ project_id }, "hideActionButtons");
+
   // No "Ref", because otherwise we don't trigger the useEffect below
   const [bodyDiv, setBodyDiv] = useState<HTMLDivElement | null>(null);
   const Body = FIXED_PROJECT_TABS[flyout].flyout;
@@ -50,7 +53,7 @@ export function FlyoutBody({ flyout, flyoutWidth }: FlyoutBodyProps) {
       }
     },
     1000,
-    { leading: false, trailing: true }
+    { leading: false, trailing: true },
   );
 
   // use this *once* around a vertically scollable content div in the component, e.g. results in a search.
@@ -71,21 +74,27 @@ export function FlyoutBody({ flyout, flyoutWidth }: FlyoutBodyProps) {
     );
   }
 
+  const padding = hideActionButtons
+    ? `${FLYOUT_PADDING} 0 0 0`
+    : `${FLYOUT_PADDING} 0 0 ${FLYOUT_PADDING}`;
+
+  const style: CSS = {
+    display: "flex",
+    flexDirection: "column",
+    padding,
+    margin: 0,
+    marginRight: "0",
+    borderRight: FIX_BORDER,
+    width: flyoutWidth,
+    height: "100%",
+    backgroundColor: FIXED_TABS_BG_COLOR,
+    overflowY: "hidden",
+    overflowX: "hidden",
+  };
+
   return (
     <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        padding: `${FLYOUT_PADDING} 0 0 ${FLYOUT_PADDING}`,
-        margin: 0,
-        marginRight: "0",
-        borderRight: FIX_BORDER,
-        width: flyoutWidth,
-        height: "100%",
-        backgroundColor: FIXED_TABS_BG_COLOR,
-        overflowY: "hidden",
-        overflowX: "hidden",
-      }}
+      style={style}
       onFocus={() => {
         // Remove any active key handler that is next to this side chat.
         // E.g, this is critical for taks lists...

--- a/src/packages/frontend/project/page/flyouts/components.tsx
+++ b/src/packages/frontend/project/page/flyouts/components.tsx
@@ -180,10 +180,8 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
   }
 
   function handleClick(e: React.MouseEvent): void {
-    if (e.target === itemRef.current || e.target === bodyRef.current) {
-      e.stopPropagation();
-      onClick?.(e);
-    }
+    e.stopPropagation();
+    onClick?.(e);
   }
 
   function handleMouseEnter(): void {

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -496,16 +496,25 @@ export function FilesFlyout({
     actions?.set_file_action("share");
   }
 
+  function renderTimeAgo(item: DirectoryListingEntry) {
+    const { mtime, isopen = false } = item;
+    if (typeof mtime === "number") {
+      return (
+        <TimeAgo
+          date={1000 * mtime}
+          // don't popup the toggle if you just clicked to open the file
+          click_to_toggle={isopen}
+        />
+      );
+    }
+  }
+
   function renderListItemExtra(item: DirectoryListingEntry) {
     if (!showExtra) return null;
     const col = activeFileSort.get("column_name");
     switch (col) {
       case "time":
-        const { mtime } = item;
-        if (typeof mtime === "number") {
-          return <TimeAgo date={1000 * mtime} />;
-        }
-        break;
+        return renderTimeAgo(item);
       case "type":
         if (item.isdir) return "Folder";
         const { ext } = separate_file_extension(item.name);
@@ -527,10 +536,7 @@ export function FilesFlyout({
         return human_readable_size(item.size, true);
       case "size":
       case "name":
-        const { mtime } = item;
-        if (typeof mtime === "number") {
-          return <TimeAgo date={1000 * mtime} />;
-        }
+        return renderTimeAgo(item);
       default:
         return null;
     }


### PR DESCRIPTION
# Description

- don't show flyout in fullpage
- tweak some margins/padding
- possibly fix #6918
- when clicking on the timestamp of a file to open it, do not show the timestamp toggle. maybe that should never show up if someone clicks there.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
