### PR TITLE
#6928, #6919: Added current and running balance to `PurchasesTable` component

### DIFF
--- a/src/packages/frontend/purchases/purchases-page.tsx
+++ b/src/packages/frontend/purchases/purchases-page.tsx
@@ -63,6 +63,7 @@ export default function PurchasesPage() {
         limit={MAX_API_LIMIT}
         cutoff={dayjs().subtract(1, "day").toDate()}
         showRefresh
+        showBalance
       />
       <Divider style={{ marginTop: "30px" }}>
         All Transactions, Spending Limits, and Plots

--- a/src/packages/frontend/purchases/purchases.tsx
+++ b/src/packages/frontend/purchases/purchases.tsx
@@ -218,7 +218,7 @@ export function PurchasesTable({
       // Compute incremental balance
       //
       let b = balance;
-      x.forEach((row, i) => {
+      x.forEach((row) => {
         row["balance"] = b;
         b += row["sum"] ?? row["cost"] ?? 0;
       });


### PR DESCRIPTION
# Description

The running balance now shows as a new column in the `PurchasesTable` component, and a new field is shown at the bottom with the user's current balance:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/127bd3bb-f963-43e4-b7f9-15ef287c0c99)

Addresses #6928 and #6919.
