### PR TITLE
Flyout tweaks #4

### DIFF
--- a/src/packages/frontend/project/explorer/compute-file-masks.ts
+++ b/src/packages/frontend/project/explorer/compute-file-masks.ts
@@ -40,6 +40,7 @@ const MASKED_FILE_EXTENSIONS = {
     "synctex.gz",
     "synctex.gz(busy)",
     "toc",
+    "vrb", // https://github.com/sagemathinc/cocalc/issues/6977
     "xyc",
   ],
   rnw: ["tex", "NODOT-concordance.tex"],
@@ -56,7 +57,7 @@ const MASKED_FILE_EXTENSIONS = {
 export function compute_file_masks(listing: DirectoryListing): void {
   // map filename to file for easier lookup
   const filename_map: { [name: string]: DirectoryListingEntry } = dict(
-    listing.map((item) => [item.name, item])
+    listing.map((item) => [item.name, item]),
   );
   for (const file of listing) {
     // mask certain known directories

--- a/src/packages/frontend/project/history/utils.ts
+++ b/src/packages/frontend/project/history/utils.ts
@@ -8,11 +8,11 @@ import { should_open_in_foreground } from "@cocalc/util/misc";
 
 // used when clicking/opening a file open entry in the project activity log
 export function handle_log_click(
-  e: React.MouseEvent | React.KeyboardEvent,
+  e: React.MouseEvent | React.KeyboardEvent | undefined,
   path: string,
-  project_id: string
+  project_id: string,
 ): void {
-  e.preventDefault();
+  e?.preventDefault();
   const switch_to = should_open_in_foreground(e);
   redux.getProjectActions(project_id).open_file({
     path,

--- a/src/packages/frontend/project/page/flyouts/files-bottom.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-bottom.tsx
@@ -380,7 +380,7 @@ export function FilesBottom({
 
   function renderFileInfo() {
     if (singleFile != null) {
-      const { size, mtime, isdir } = singleFile;
+      const { size , mtime, isdir } = singleFile;
       const age = typeof mtime === "number" ? 1000 * mtime : null;
       return (
         <Descriptions size="small" layout="horizontal" column={1}>

--- a/src/packages/frontend/project/page/flyouts/files-terminal.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-terminal.tsx
@@ -159,7 +159,7 @@ export function TerminalFlyout({
       parent,
       undefined,
       undefined,
-      "" // cwd=home directory, we'll send cd commands later
+      "", // cwd=home directory, we'll send cd commands later
     );
     console.log("getTerminal", `$HOME/${currentPathRef.current}`);
     newTerminal.connect();
@@ -182,7 +182,6 @@ export function TerminalFlyout({
     terminalRef.current.is_visible = true;
     set_font_size();
     measure_size();
-    terminalRef.current.focus();
     // Get rid of browser context menu, which makes no sense on a canvas.
     // See https://stackoverflow.com/questions/10864249/disabling-right-click-context-menu-on-a-html-canvas
     // NOTE: this would probably make sense in DOM mode instead of canvas mode;
@@ -196,7 +195,6 @@ export function TerminalFlyout({
   }
 
   useEffect(() => {
-    terminalRef.current?.focus();
     return delete_terminal; // clean up on unmount
   }, []);
 
@@ -252,7 +250,7 @@ export function TerminalFlyout({
       }
     },
     200,
-    { leading: false, trailing: true }
+    { leading: false, trailing: true },
   );
 
   useEffect(set_font_size, [font_size]);

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -49,7 +49,7 @@ import {
   tab_to_path,
   unreachable,
 } from "@cocalc/util/misc";
-import { FileListItem, fileItemStyle } from "./components";
+import { FileListItem, fileItemStyle } from "./file-list-item";
 import {
   FLYOUT_EXTRA2_WIDTH_PX,
   FLYOUT_EXTRA_WIDTH_PX,
@@ -57,6 +57,11 @@ import {
 } from "./consts";
 import { FilesBottom } from "./files-bottom";
 import { FilesHeader } from "./files-header";
+
+type PartialClickEvent = Pick<
+  React.MouseEvent | React.KeyboardEvent,
+  "detail" | "shiftKey" | "ctrlKey" | "stopPropagation"
+>;
 
 const EMPTY_LISTING: [DirectoryListing, FileMap, null, boolean] = [
   [],
@@ -356,11 +361,11 @@ export function FilesFlyout({
   }
 
   function open(
-    e: React.MouseEvent | React.KeyboardEvent,
+    e: PartialClickEvent,
     index: number,
     skip = false, // to exclude directories
   ) {
-    e.stopPropagation();
+    e?.stopPropagation();
     const file = directoryFiles[index];
     if (file == null) return;
 
@@ -411,11 +416,17 @@ export function FilesFlyout({
     }
   }
 
-  function handleFileClick(e: React.MouseEvent, index: number) {
+  function handleFileClick(e: PartialClickEvent | undefined, index: number) {
+    e ??= {
+      detail: 1, // single click
+      shiftKey: false,
+      ctrlKey: false,
+      stopPropagation: () => {},
+    };
     // "hack" from explorer/file-listing/file-row.tsx to avoid a click,
     // if the user selects the filename -- ignore double clicks, though.
     if (
-      e.detail !== 2 &&
+      e?.detail !== 2 &&
       (window.getSelection()?.toString() ?? "") !== selectionOnMouseDown
     ) {
       return;
@@ -582,6 +593,7 @@ export function FilesFlyout({
         onChecked={(nextState: boolean) => {
           toggleSelected(index, item.name, nextState);
         }}
+        checked_files={checked_files}
       />
     );
   }

--- a/src/packages/frontend/project/page/flyouts/header.tsx
+++ b/src/packages/frontend/project/page/flyouts/header.tsx
@@ -78,6 +78,13 @@ export function FlyoutHeader(_: Readonly<Props>) {
     );
   }
 
+  function markFullpageTourDone() {
+    if (!highlightFullpage) return;
+    const actions = redux.getActions("account");
+    actions.setTourDone(FLYOUT_FULLPAGE_TOUR_NAME);
+    setHighlightFullpage(false);
+  }
+
   function renderFullpagePopupTitle() {
     return (
       <>
@@ -90,13 +97,7 @@ export function FlyoutHeader(_: Readonly<Props>) {
               vertical menu layout button selector at the bottom left.
             </div>
             <div style={{ textAlign: "center", marginTop: "10px" }}>
-              <Button
-                onClick={() => {
-                  const actions = redux.getActions("account");
-                  actions.setTourDone(FLYOUT_FULLPAGE_TOUR_NAME);
-                  setHighlightFullpage(false);
-                }}
-              >
+              <Button onClick={markFullpageTourDone}>
                 Don't show this again
               </Button>
             </div>
@@ -116,17 +117,9 @@ export function FlyoutHeader(_: Readonly<Props>) {
         : undefined),
     };
 
-    // force the tooltip to be open if we're highlighting the full page button
-    // using the tooltip or clicking on the "don't show this again" button,
-    // will disable its forced open state.
-    const extraProps = highlightFullpage ? { open: true } : {};
     return (
       <>
-        <Tooltip
-          title={renderFullpagePopupTitle()}
-          placement="bottom"
-          {...extraProps}
-        >
+        <Tooltip title={renderFullpagePopupTitle()} placement="bottom">
           <Icon
             name="expand"
             className="cc-project-fixedtab-fullpage"
@@ -139,11 +132,7 @@ export function FlyoutHeader(_: Readonly<Props>) {
                 flyout,
                 how: "click-on-flyout-expand-button",
               });
-              if (highlightFullpage) {
-                const actions = redux.getActions("account");
-                actions.setTourDone(FLYOUT_FULLPAGE_TOUR_NAME);
-                setHighlightFullpage(false);
-              }
+              markFullpageTourDone();
               // now, close the flyout panel, to finish the transition
               actions?.toggleFlyout(flyout);
             }}

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -38,7 +38,7 @@ import { debounce } from "lodash";
 import { handle_log_click } from "../../history/utils";
 import { FIX_BORDER } from "../common";
 import { FIXED_PROJECT_TABS } from "../file-tab";
-import { FileListItem, fileItemStyle } from "./components";
+import { FileListItem, fileItemStyle } from "./file-list-item";
 import { FLYOUT_EXTRA_WIDTH_PX } from "./consts";
 import { FlyoutLogMode, getFlyoutLogMode, isFlyoutLogMode } from "./state";
 
@@ -56,7 +56,7 @@ interface HeaderProps {
 
 export function LogHeader({ project_id }: HeaderProps): JSX.Element {
   const [mode, setModeState] = useState<FlyoutLogMode>(
-    getFlyoutLogMode(project_id)
+    getFlyoutLogMode(project_id),
   );
 
   function setMode(mode: FlyoutLogMode) {
@@ -108,7 +108,7 @@ function deriveFiles(project_log, searchTerm: string, max: number) {
     .filter(
       (entry: EventRecordMap) =>
         entry.getIn(["event", "filename"]) &&
-        entry.getIn(["event", "event"]) === "open"
+        entry.getIn(["event", "event"]) === "open",
     )
     .sort((a, b) => getTime(b) - getTime(a))
     .filter((entry: EventRecordMap) => {
@@ -143,7 +143,7 @@ function deriveHistory(project_log, searchTerm: string, max: number) {
         !(
           entry.getIn(["event", "filename"]) &&
           entry.getIn(["event", "event"]) === "open"
-        )
+        ),
     )
     .filter((entry: EventRecordMap) => {
       if (searchTerm === "") return true;
@@ -206,7 +206,7 @@ export function LogFlyout({
 
   const showExtra = useMemo(
     () => flyoutWidth > FLYOUT_EXTRA_WIDTH_PX,
-    [flyoutWidth]
+    [flyoutWidth],
   );
 
   // trigger a search state change, only once and with a debounce
@@ -215,7 +215,7 @@ export function LogFlyout({
       actions?.setState({ search: val });
     },
     20,
-    { leading: false, trailing: true }
+    { leading: false, trailing: true },
   );
 
   const handleOnChange = useCallback((val: string) => {
@@ -310,7 +310,7 @@ export function LogFlyout({
   function doScroll(dx: -1 | 1) {
     const nextIdx = strictMod(
       scrollIdx == null ? (dx === 1 ? 0 : -1) : scrollIdx + dx,
-      log.length
+      log.length,
     );
     setScrollIdx(nextIdx);
     virtuosoRef.current?.scrollToIndex({

--- a/src/packages/frontend/project/settings/run-quota/run-quota.tsx
+++ b/src/packages/frontend/project/settings/run-quota/run-quota.tsx
@@ -10,11 +10,10 @@ import { React, useMemo, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { A, NoWrap, QuestionMarkText, Tip } from "@cocalc/frontend/components";
 import { DOC_CLOUD_STORAGE_URL } from "@cocalc/util/consts/project";
 import { KUCALC_COCALC_COM } from "@cocalc/util/db-schema/site-defaults";
-import { plural } from "@cocalc/util/misc";
 import { PROJECT_UPGRADES } from "@cocalc/util/schema";
 import { COLORS } from "@cocalc/util/theme";
 import { DedicatedResources } from "@cocalc/util/types/dedicated";
-import { upgrade2quota_key, Upgrades } from "@cocalc/util/upgrades/quota";
+import { Upgrades, upgrade2quota_key } from "@cocalc/util/upgrades/quota";
 import { Project } from "../types";
 import { renderBoolean } from "./components";
 import {
@@ -24,13 +23,13 @@ import {
   useRunQuota,
 } from "./hooks";
 import {
-  booleanValueStr,
-  QuotaData,
   QUOTAS_BOOLEAN,
+  QuotaData,
   RunQuotaType,
   SHOW_MAX,
   Usage,
   Value,
+  booleanValueStr,
 } from "./misc";
 
 const { Text } = Typography;
@@ -169,11 +168,7 @@ export const RunQuota: React.FC<Props> = React.memo(
         return `This quota is ${booleanValueStr(quota)}.`;
       } else if (key === "patch") {
         return usage != null
-          ? `There are ${usage.display} ${plural(
-              usage.display,
-              "patch",
-              "patches"
-            )} in total.`
+          ? `There are ${usage.display} patch(es) in total.`
           : ``;
       } else {
         const curStr =
@@ -330,5 +325,5 @@ export const RunQuota: React.FC<Props> = React.memo(
     }
 
     return <div>{renderQuotas()}</div>;
-  }
+  },
 );

--- a/src/packages/frontend/site-licenses/site-license-public-info-component.tsx
+++ b/src/packages/frontend/site-licenses/site-license-public-info-component.tsx
@@ -59,7 +59,7 @@ interface Props {
 }
 
 export const SiteLicensePublicInfo: React.FC<Props> = (
-  props: Readonly<Props>
+  props: Readonly<Props>,
 ) => {
   const {
     license_id,
@@ -859,8 +859,8 @@ export const SiteLicensePublicInfo: React.FC<Props> = (
     }
   }
 
-  function render_manager(account_id: string): JSX.Element | void {
-    if (account_id == redux.getStore("account").get("account_id")) return;
+  function render_manager(account_id: string): JSX.Element | null {
+    if (account_id == redux.getStore("account").get("account_id")) return null;
     return (
       <span key={account_id}>
         ,{" "}

--- a/src/packages/next/components/landing/executables-table.tsx
+++ b/src/packages/next/components/landing/executables-table.tsx
@@ -52,11 +52,16 @@ const COLUMNS = [
     key: "output",
     dataIndex: "output",
     width: "40%",
-    render: (output) => (
-      <div style={INFO_STYLE}>
-        <pre style={PRE_STYLE}>{output}</pre>
-      </div>
-    ),
+    render: (output) => {
+      return {
+        props: { style: { padding: "0 0 1em 0" } },
+        children: (
+          <div style={INFO_STYLE}>
+            <pre style={PRE_STYLE}>{output}</pre>
+          </div>
+        ),
+      };
+    },
   },
 ];
 
@@ -74,7 +79,7 @@ export default function ExecutablesTable({
       debounce((e) => {
         setSearch(e.target.value);
       }, 300),
-    []
+    [],
   );
 
   let data: Item[];

--- a/src/packages/util/misc.ts
+++ b/src/packages/util/misc.ts
@@ -139,7 +139,7 @@ export function separate_file_extension(name: string): {
 // if there is no extension, add it.
 export function change_filename_extension(
   path: string,
-  new_ext: string
+  new_ext: string,
 ): string {
   const { name } = separate_file_extension(path);
   return `${name}.${new_ext}`;
@@ -276,7 +276,7 @@ import { v4 as v4uuid } from "uuid";
 export const uuid: () => string = v4uuid;
 
 const uuid_regexp = new RegExp(
-  /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/i
+  /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/i,
 );
 export function is_valid_uuid_string(uuid?: any): boolean {
   return (
@@ -420,7 +420,11 @@ export function assert_valid_email_address(email: string): void {
 export const to_json = JSON.stringify;
 
 // gives the plural form of the word if the number should be plural
-export function plural(number, singular, plural = `${singular}s`) {
+export function plural(
+  number: number = 0,
+  singular: string,
+  plural: string = `${singular}s`,
+) {
   if (["GB", "G", "MB"].includes(singular)) {
     return singular;
   }
@@ -513,7 +517,7 @@ export function getIn(x: any, path: string[], default_value?: any): any {
 export function replace_all(
   s: string,
   search: string,
-  replace: string
+  replace: string,
 ): string {
   return s.split(search).join(replace);
 }
@@ -523,7 +527,7 @@ export function replace_all(
 export function replace_all_function(
   s: string,
   search: string,
-  replace_f: (i: number) => string
+  replace_f: (i: number) => string,
 ): string {
   const v = s.split(search);
   const w: string[] = [];
@@ -607,7 +611,7 @@ function get_methods(obj: object): string[] {
     Object.getOwnPropertyNames(current_obj).map((item) => properties.add(item));
   } while ((current_obj = Object.getPrototypeOf(current_obj)));
   return [...properties.keys()].filter(
-    (item) => typeof obj[item] === "function"
+    (item) => typeof obj[item] === "function",
   );
 }
 
@@ -621,7 +625,7 @@ function get_methods(obj: object): string[] {
 // loop and for which you want 'safer' semantics.
 export function bind_methods<T extends object>(
   obj: T,
-  method_names: undefined | string[] = undefined
+  method_names: undefined | string[] = undefined,
 ): T {
   if (method_names === undefined) {
     method_names = get_methods(obj);
@@ -635,7 +639,7 @@ export function bind_methods<T extends object>(
 
 export function human_readable_size(
   bytes: number | null | undefined,
-  short = false
+  short = false,
 ): string {
   if (bytes == null) {
     return "?";
@@ -726,7 +730,7 @@ https://security.stackexchange.com/questions/1952/how-long-should-a-random-nonce
 const BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 export function secure_random_token(
   length: number = 16,
-  alphabet: string = BASE58 // default is this crypto base58 less ambiguous numbers/letters
+  alphabet: string = BASE58, // default is this crypto base58 less ambiguous numbers/letters
 ): string {
   let s = "";
   if (length == 0) return s;
@@ -797,7 +801,7 @@ export function round2up(num: number): number {
 export function parse_number_input(
   input: any,
   round_number: boolean = true,
-  allow_negative: boolean = false
+  allow_negative: boolean = false,
 ): number | undefined {
   if (typeof input == "boolean") {
     return input ? 1 : 0;
@@ -875,7 +879,7 @@ export function coerce_codomain_to_numbers(map: { [k: string]: any }): {
 // pass in properly typed inputs.
 export function map_sum(
   a?: { [k: string]: number },
-  b?: { [k: string]: number }
+  b?: { [k: string]: number },
 ): { [k: string]: number } {
   if (a == null) {
     return coerce_codomain_to_numbers(b ?? {});
@@ -902,7 +906,7 @@ export function map_sum(
 
 export function map_diff(
   a?: { [k: string]: number },
-  b?: { [k: string]: number }
+  b?: { [k: string]: number },
 ): { [k: string]: number } {
   if (b == null) {
     return coerce_codomain_to_numbers(a ?? {});
@@ -936,7 +940,7 @@ export function map_diff(
 export function search_split(
   search: string,
   allowRegexp: boolean = true,
-  regexpOptions: string = "i"
+  regexpOptions: string = "i",
 ): (string | RegExp)[] {
   search = search.trim();
   if (
@@ -974,7 +978,7 @@ export function search_split(
       }
     } else {
       terms.push(
-        allowRegexp ? stringOrRegExp(element, regexpOptions) : element
+        allowRegexp ? stringOrRegExp(element, regexpOptions) : element,
       );
     }
   }
@@ -1272,7 +1276,7 @@ export function original_path(path: string): string {
   const ext = filename_extension(s.tail);
   let x = s.tail.slice(
     s.tail[0] === "." ? 1 : 0,
-    s.tail.length - (ext.length + 1)
+    s.tail.length - (ext.length + 1),
   );
   if (s.head !== "") {
     x = s.head + "/" + x;
@@ -1390,14 +1394,14 @@ export function retry_until_success(opts: {
     if (opts.log != null) {
       if (opts.max_tries != null) {
         opts.log(
-          `retry_until_success(${opts.name}) -- try ${tries}/${opts.max_tries}`
+          `retry_until_success(${opts.name}) -- try ${tries}/${opts.max_tries}`,
         );
       }
       if (opts.max_time != null) {
         opts.log(
           `retry_until_success(${opts.name}) -- try ${tries} (started ${
             Date.now() - start_time
-          }ms ago; will stop before ${opts.max_time}ms max time)`
+          }ms ago; will stop before ${opts.max_time}ms max time)`,
         );
       }
       if (opts.max_tries == null && opts.max_time == null) {
@@ -1412,12 +1416,12 @@ export function retry_until_success(opts: {
         }
         if (err && opts.warn != null) {
           opts.warn(
-            `retry_until_success(${opts.name}) -- err=${JSON.stringify(err)}`
+            `retry_until_success(${opts.name}) -- err=${JSON.stringify(err)}`,
           );
         }
         if (opts.log != null) {
           opts.log(
-            `retry_until_success(${opts.name}) -- err=${JSON.stringify(err)}`
+            `retry_until_success(${opts.name}) -- err=${JSON.stringify(err)}`,
           );
         }
         if (opts.max_tries != null && opts.max_tries <= tries) {
@@ -1425,13 +1429,13 @@ export function retry_until_success(opts: {
             `maximum tries (=${
               opts.max_tries
             }) exceeded - last error ${JSON.stringify(err)}`,
-            err
+            err,
           );
           return;
         }
         delta = Math.min(
           opts.max_delay as number,
-          (opts.factor as number) * delta
+          (opts.factor as number) * delta,
         );
         if (
           opts.max_time != null &&
@@ -1441,7 +1445,7 @@ export function retry_until_success(opts: {
             `maximum time (=${
               opts.max_time
             }ms) exceeded - last error ${JSON.stringify(err)}`,
-            err
+            err,
           );
           return;
         }
@@ -1618,7 +1622,7 @@ export function parse_hashtags(t: string): [number, number][] {
 // that might be dangerous, right)?
 export function path_is_in_public_paths(
   path: string,
-  paths: string[] | Set<string> | object | undefined
+  paths: string[] | Set<string> | object | undefined,
 ): boolean {
   return containing_public_path(path, paths) != null;
 }
@@ -1629,7 +1633,7 @@ export function path_is_in_public_paths(
 // paths can be an array or object (with keys the paths) or a Set
 export function containing_public_path(
   path: string,
-  paths: string[] | Set<string> | object | undefined
+  paths: string[] | Set<string> | object | undefined,
 ): undefined | string {
   if (paths == null || path == null) {
     // just in case of non-typescript clients
@@ -1693,7 +1697,7 @@ export function lstrip(s: string): string {
 }
 
 export function date_to_snapshot_format(
-  d: Date | undefined | null | number
+  d: Date | undefined | null | number,
 ): string {
   if (d == null) {
     d = 0;
@@ -1736,13 +1740,13 @@ export function currency(n: number, d?: number) {
 export function stripeAmount(
   unitPrice: number,
   currency: string,
-  units = 1
+  units = 1,
 ): string {
   // input is in pennies
   if (currency !== "usd") {
     // TODO: need to make this look nice with symbols for other currencies...
     return `${currency == "eur" ? "€" : ""}${to_money(
-      (units * unitPrice) / 100
+      (units * unitPrice) / 100,
     )} ${currency.toUpperCase()}`;
   }
   return `$${to_money((units * unitPrice) / 100)} USD`;
@@ -1750,7 +1754,7 @@ export function stripeAmount(
 
 export function planInterval(
   interval: string,
-  interval_count: number = 1
+  interval_count: number = 1,
 ): string {
   return `${interval_count} ${plural(interval_count, interval)}`;
 }
@@ -1770,7 +1774,7 @@ function seconds2hms_days(
   d: number,
   h: number,
   m: number,
-  longform: boolean
+  longform: boolean,
 ): string {
   h = h % 24;
   const s = h * 60 * 60 + m * 60;
@@ -1791,7 +1795,7 @@ export function seconds2hm(secs: number, longform: boolean = false): string {
 export function seconds2hms(
   secs: number,
   longform: boolean = false,
-  show_seconds: boolean = true
+  show_seconds: boolean = true,
 ): string {
   let s;
   if (!longform && secs < 10) {
@@ -1920,7 +1924,7 @@ export function has_null_leaf(obj: object): boolean {
 // It returns an object, mapping each student to a list of N peers.
 export function peer_grading(
   students: string[],
-  N: number = 2
+  N: number = 2,
 ): { [student_id: string]: string[] } {
   if (N <= 0) {
     throw Error("Number of peer assigments must be at least 1");
@@ -2032,7 +2036,7 @@ export function suggest_duplicate_filename(name: string): string {
 // Kahn, Arthur B. (1962), "Topological sorting of large networks", Communications of the ACM
 export function top_sort(
   DAG: { [node: string]: string[] },
-  opts: { omit_sources?: boolean } = { omit_sources: false }
+  opts: { omit_sources?: boolean } = { omit_sources: false },
 ): string[] {
   const { omit_sources } = opts;
   const source_names: string[] = [];
@@ -2218,7 +2222,7 @@ export function jupyter_language_to_name(lang: string): string {
 // Find the kernel whose name is closest to the given name.
 export function closest_kernel_match(
   name: string,
-  kernel_list: immutable.List<immutable.Map<string, string>>
+  kernel_list: immutable.List<immutable.Map<string, string>>,
 ): immutable.Map<string, string> {
   name = name.toLowerCase().replace("matlab", "octave");
   name = name === "python" ? "python3" : name;
@@ -2250,7 +2254,7 @@ export function closest_kernel_match(
         bestMatch &&
         compareVersionStrings(
           k.get("name") ?? "",
-          bestMatch.get("name") ?? ""
+          bestMatch.get("name") ?? "",
         ) === 1)
     ) {
       bestValue = v;
@@ -2412,7 +2416,7 @@ export function firstLetterUppercase(str: string | undefined) {
  */
 export function getRandomColor(
   s: string,
-  opts?: { min: number; max: number }
+  opts?: { min: number; max: number },
 ): string {
   const { min = 120, max = 220 } = opts ?? {};
   const mod = max - min;


### PR DESCRIPTION
# Description

- don't popup fullpage tooltip by default, only highlight
- not flyout: remove some padding in the next/software/execs table to make it more compact
- context menu PoC: selects file (if none are selected) for single file operations and download/view – or opens multi-file operations. see below.
- fix too much focusing in files mini terminal
- fix #6977


## context menu (a first step)

![Screenshot from 2023-10-13 18-24-34](https://github.com/sagemathinc/cocalc/assets/207405/5f5d4ef8-11a6-49af-8966-376557df5b5e)

![Screenshot from 2023-10-13 18-25-05](https://github.com/sagemathinc/cocalc/assets/207405/0e4d8cba-5289-4815-8d5f-d9249fa9010d)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
