### PR TITLE
next/utils: adding tracking and stats for *.slides files

### DIFF
--- a/src/packages/database/postgres/stats.test.ts
+++ b/src/packages/database/postgres/stats.test.ts
@@ -1,0 +1,15 @@
+// to access the non-exported RESERVED object
+process.env["NODE_DEV"] = "TEST";
+
+import * as stats from "@cocalc/database/postgres/stats";
+
+test("query", () => {
+  const countQuery = (stats as any)._count_opened_files_query;
+  const q = countQuery(true);
+  expect(q.indexOf("'sage-chat'")).toBeGreaterThan(0);
+  expect(q.indexOf("SELECT DISTINCT")).toBeGreaterThan(0);
+
+  const q2 = countQuery(false);
+  expect(q2.indexOf("'slides'")).toBeGreaterThan(0);
+  expect(q2.indexOf("SELECT  event")).toBeGreaterThan(0);
+});

--- a/src/packages/next/components/statistics/opened-files.tsx
+++ b/src/packages/next/components/statistics/opened-files.tsx
@@ -43,7 +43,7 @@ const openedFilesColumns = [
     sorter: (a, b) =>
       cmp(
         extensionToInfo[a.ext]?.desc ?? a.ext,
-        extensionToInfo[b.ext]?.desc ?? b.ext
+        extensionToInfo[b.ext]?.desc ?? b.ext,
       ),
   },
   {
@@ -96,11 +96,12 @@ const extensionToInfo: { [ext: string]: { desc: string; link?: string } } = {
   },
   "sage-chat": { desc: "Chatroom" },
   board: { desc: "Whiteboard", link: "/features/whiteboard" },
+  slides: { desc: "Slides", link: "/features/slides" },
 } as const;
 
 function processFilesOpened(
   filesOpened,
-  distinct: boolean
+  distinct: boolean,
 ): {
   rows: {
     ext: string;
@@ -160,7 +161,7 @@ export default function OpenedFiles({
   const [distinct, setDistinct] = useState<boolean>(true);
   const { rows, lastHour } = useMemo(
     () => processFilesOpened(filesOpened, distinct),
-    [distinct, filesOpened]
+    [distinct, filesOpened],
   );
 
   return (

--- a/src/packages/util/db-schema/stats.ts
+++ b/src/packages/util/db-schema/stats.ts
@@ -62,30 +62,39 @@ export interface HistoricCounts {
   "30d"?: number;
 }
 
-interface CountsByExtension {
-  md?: string;
-  py?: string;
-  jpg?: string;
-  pdf?: string;
-  png?: string;
-  rmd?: string;
-  rnw?: string;
-  rst?: string;
-  svg?: string;
-  tex?: string;
-  txt?: string;
-  x11?: string;
-  jpeg?: string;
-  lean?: string;
-  rtex?: string;
-  sage?: string;
-  term?: string;
-  ipynb?: string;
-  tasks?: string;
-  course?: string;
-  sagews?: string;
-  "sage-chat"?: string;
-}
+export const EXTENSIONS = [
+  "board",
+  "chat",
+  "course",
+  "ipynb",
+  "jl",
+  "jpeg",
+  "jpg",
+  "lean",
+  "m",
+  "md",
+  "pdf",
+  "png",
+  "py",
+  "rmd",
+  "rnw",
+  "rst",
+  "rtex",
+  "sage-chat",
+  "sage",
+  "sagews",
+  "slides",
+  "svg",
+  "tasks",
+  "term",
+  "tex",
+  "txt",
+  "x11",
+] as const;
+
+type Extension = (typeof EXTENSIONS)[number];
+
+type CountsByExtension = Record<Extension, string>;
 
 export interface Stats {
   id: string;


### PR DESCRIPTION
# Description

- adding tracking for *.slides files
- showing them on the stats page
- also some type-related cleanup and testing the generated stats query

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
