### PR TITLE
frontend/styling: add account settings to adjust aspects of the UI style

### DIFF
--- a/src/packages/frontend/account/other-settings.tsx
+++ b/src/packages/frontend/account/other-settings.tsx
@@ -309,9 +309,40 @@ export class OtherSettings extends Component<Props> {
     );
   }
 
+  private render_antd(): Rendered {
+    return (
+      <>
+        <Checkbox
+          checked={this.props.other_settings.get("antd_rounded", true)}
+          onChange={(e) => this.on_change("antd_rounded", e.target.checked)}
+        >
+          <b>Rounded Design</b>: use rounded corners for buttons, etc.
+        </Checkbox>
+        <Checkbox
+          checked={this.props.other_settings.get("antd_animate", true)}
+          onChange={(e) => this.on_change("antd_animate", e.target.checked)}
+        >
+          <b>Animations</b>: briefly animate some aspects, e.g. buttons
+        </Checkbox>
+        <Checkbox
+          checked={this.props.other_settings.get("antd_brandcolors", false)}
+          onChange={(e) => this.on_change("antd_brandcolors", e.target.checked)}
+        >
+          <b>Color Scheme</b>: use brand colors instead of default colors
+        </Checkbox>
+        <Checkbox
+          checked={this.props.other_settings.get("antd_compact", false)}
+          onChange={(e) => this.on_change("antd_compact", e.target.checked)}
+        >
+          <b>Compact Design</b>: use a more compact design
+        </Checkbox>
+      </>
+    );
+  }
+
   render_vertical_fixed_bar_options(): Rendered {
     const selected = getValidVBAROption(
-      this.props.other_settings.get(VBAR_KEY)
+      this.props.other_settings.get(VBAR_KEY),
     );
     return (
       <LabeledRow label="Vertical Project Bar">
@@ -341,53 +372,67 @@ export class OtherSettings extends Component<Props> {
       return <Loading />;
     }
     return (
-      <Panel
-        header={
-          <>
-            <Icon name="gear" /> Other
-          </>
-        }
-      >
-        {this.render_dark_mode()}
-        {this.render_confirm()}
-        {this.render_katex()}
-        {this.render_time_ago_absolute()}
-        {this.render_global_banner()}
-        {this.render_mask_files()}
-        {this.render_hide_project_popovers()}
-        {this.render_hide_file_popovers()}
-        {this.render_hide_button_tooltips()}
-        {this.render_no_free_warnings()}
-        {redux.getStore("customize").get("openai_enabled") && (
+      <>
+        <Panel
+          header={
+            <>
+              <Icon name="highlighter" /> Theme
+            </>
+          }
+        >
+          {this.render_dark_mode()}
+          {this.render_antd()}
+        </Panel>
+
+        <Panel
+          header={
+            <>
+              <Icon name="gear" /> Other
+            </>
+          }
+        >
+          {this.render_confirm()}
+          {this.render_katex()}
+          {this.render_time_ago_absolute()}
+          {this.render_global_banner()}
+          {this.render_mask_files()}
+          {this.render_hide_project_popovers()}
+          {this.render_hide_file_popovers()}
+          {this.render_hide_button_tooltips()}
+          {this.render_no_free_warnings()}
+          {redux.getStore("customize").get("openai_enabled") && (
+            <Checkbox
+              checked={!!this.props.other_settings.get("openai_disabled")}
+              onChange={(e) => {
+                this.on_change("openai_disabled", e.target.checked);
+                redux.getStore("projects").clearOpenAICache();
+              }}
+            >
+              <strong>Disable all OpenAI/ChatGPT integrations</strong>, e.g.,
+              extra buttons in Jupyter, @chatgpt mentions, etc.
+            </Checkbox>
+          )}
           <Checkbox
-            checked={!!this.props.other_settings.get("openai_disabled")}
+            checked={
+              !!this.props.other_settings.get("disable_markdown_codebar")
+            }
             onChange={(e) => {
-              this.on_change("openai_disabled", e.target.checked);
-              redux.getStore("projects").clearOpenAICache();
+              this.on_change("disable_markdown_codebar", e.target.checked);
             }}
           >
-            <strong>Disable all OpenAI/ChatGPT integrations</strong>, e.g.,
-            extra buttons in Jupyter, @chatgpt mentions, etc.
+            <strong>Disable the markdown code bar</strong> in all markdown
+            documents. Checking this hides the extra run, copy, and explain
+            buttons in fenced code blocks.
           </Checkbox>
-        )}
-        <Checkbox
-          checked={!!this.props.other_settings.get("disable_markdown_codebar")}
-          onChange={(e) => {
-            this.on_change("disable_markdown_codebar", e.target.checked);
-          }}
-        >
-          <strong>Disable the markdown code bar</strong> in all markdown
-          documents. Checking this hides the extra run, copy, and explain
-          buttons in fenced code blocks.
-        </Checkbox>
-        {this.render_vertical_fixed_bar_options()}
-        {this.render_new_filenames()}
-        {this.render_default_file_sort()}
-        {this.render_page_size()}
-        {this.render_standby_timeout()}
-        <div style={{ height: "10px" }} />
-        <Tours />
-      </Panel>
+          {this.render_vertical_fixed_bar_options()}
+          {this.render_new_filenames()}
+          {this.render_default_file_sort()}
+          {this.render_page_size()}
+          {this.render_standby_timeout()}
+          <div style={{ height: "10px" }} />
+          <Tours />
+        </Panel>
+      </>
     );
   }
 }

--- a/src/packages/frontend/app/context.tsx
+++ b/src/packages/frontend/app/context.tsx
@@ -5,12 +5,15 @@
 
 import { debounce } from "lodash";
 import { createContext, useContext } from "react";
+import type { SizeType } from "antd/es/config-provider/SizeContext";
+import { ThemeConfig, theme } from "antd";
 
 import {
   CSS,
   useEffect,
   useMemo,
   useState,
+  useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { COLORS } from "@cocalc/util/theme";
 import {
@@ -25,6 +28,8 @@ import {
 export interface AppState {
   pageWidthPx: number;
   pageStyle: PageStyle;
+  antdComponentSize?: SizeType;
+  antdTheme?: ThemeConfig;
 }
 
 export const AppContext = createContext<AppState>({
@@ -66,6 +71,52 @@ export function useAppStateProvider() {
   return {
     pageWidthPx,
     pageStyle,
+  };
+}
+
+export function useAntdStyleProvider() {
+  const other_settings = useTypedRedux("account", "other_settings");
+  const rounded = other_settings?.get("antd_rounded", true);
+  const animate = other_settings?.get("antd_animate", true);
+  const branded = other_settings?.get("antd_brandcolors", false);
+  const compact = other_settings?.get("antd_compact", false);
+
+  const borderStyle = rounded
+    ? undefined
+    : { borderRadius: 0, borderRadiusLG: 0, borderRadiusSM: 0 };
+
+  const animationStyle = animate
+    ? undefined
+    : {
+        motionDurationMid: "0s",
+        motionDurationSlow: "0s",
+        motionEaseInOut: "none",
+        motionEaseInQuint: "none",
+        motionEaseOutQuint: "none",
+      };
+
+  const brandedColors = branded
+    ? { colorPrimary: COLORS.COCALC_BLUE }
+    : undefined;
+
+  const algorithm = compact ? { algorithm: theme.compactAlgorithm } : undefined;
+
+  const antdTheme: ThemeConfig = {
+    ...algorithm,
+    token: {
+      ...brandedColors,
+      ...borderStyle,
+      ...animationStyle,
+    },
+    components: {
+      Button: {
+        ...brandedColors,
+      },
+    },
+  };
+
+  return {
+    antdTheme,
   };
 }
 

--- a/src/packages/frontend/app/render.tsx
+++ b/src/packages/frontend/app/render.tsx
@@ -4,17 +4,25 @@
  */
 
 import { createRoot } from "react-dom/client";
+import { ConfigProvider as AntdConfigProvider } from "antd";
 
 import { Redux } from "@cocalc/frontend/app-framework";
-import { AppContext, useAppStateProvider } from "./context";
+import {
+  AppContext,
+  useAppStateProvider,
+  useAntdStyleProvider,
+} from "./context";
 
 function Root({ Page }) {
   const appState = useAppStateProvider();
+  const { antdTheme } = useAntdStyleProvider();
 
   return (
     <Redux>
       <AppContext.Provider value={appState}>
-        <Page />
+        <AntdConfigProvider theme={antdTheme}>
+          <Page />
+        </AntdConfigProvider>
       </AppContext.Provider>
     </Redux>
   );
@@ -34,7 +42,7 @@ export async function xxx_render(): Promise<void> {
   const { Page } = await import("./page");
   ReactDOM.render(
     <Root Page={Page} />,
-    document.getElementById("cocalc-webapp-container")
+    document.getElementById("cocalc-webapp-container"),
   );
 }
 


### PR DESCRIPTION
# Description

This is very much an experiment to see if and how this works and to open up some possibilities. Merging this PR doesn't change anything with the UI, but it adds a separate section for theming in the account settings:

![Screenshot from 2023-10-17 15-32-32](https://github.com/sagemathinc/cocalc/assets/207405/fcb94288-de3c-4bcc-94f4-4f0efe1b3fe7)

In particular, I wanted to see how an edged UI without animations looks and feels – and I like it.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
