### PR TITLE
#6974: Added `/v2/api/purchases/get-balance-admin` API endpoint 

### DIFF
--- a/src/packages/frontend/purchases/api.ts
+++ b/src/packages/frontend/purchases/api.ts
@@ -24,6 +24,12 @@ export async function getBalance(): Promise<number> {
   return await api("purchases/get-balance");
 }
 
+// Admins can get balance for any specified user -- error if called by non-admin.
+// account_id is required.
+export async function getBalanceAdmin(account_id: string) {
+  return await api("purchases/get-balance-admin", { account_id });
+}
+
 export async function getPendingBalance(): Promise<number> {
   return await api("purchases/get-pending-balance");
 }

--- a/src/packages/next/pages/api/v2/purchases/get-balance-admin.ts
+++ b/src/packages/next/pages/api/v2/purchases/get-balance-admin.ts
@@ -1,0 +1,35 @@
+/*
+Allows admins to get balance for a specific user.
+*/
+
+
+import getBalance from "@cocalc/server/purchases/get-balance";
+import getAccountId from "lib/account/get-account";
+import getParams from "lib/api/get-params";
+import userIsInGroup from "@cocalc/server/accounts/is-in-group";
+
+export default async function handle(req, res) {
+  try {
+    res.json(await get(req));
+  } catch (err) {
+    res.json({ error: `${err.message}` });
+    return;
+  }
+}
+
+async function get(req) {
+  const admin_account_id = await getAccountId(req);
+  if (admin_account_id == null) {
+    throw Error("must be signed in");
+  }
+  // This user MUST be an admin:
+  if (!(await userIsInGroup(admin_account_id, "admin"))) {
+    throw Error("only admins can use the get-balance-admin endpoint");
+  }
+
+  const {
+    account_id,
+  } = getParams(req, { allowGet: true });
+
+  return await getBalance(account_id);
+}


### PR DESCRIPTION
...to support querying user balance as admin. Updated `getBalance` function in frontend to fetch account-specific balance when `account_id` is provided. Decoupled purchases query and balance/total computation.

Fixes #6974 .

See below screenshot:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/b59417b8-666b-43c1-87d3-6fc85e75624e)
