### PR TITLE
expire more table data

### DIFF
--- a/src/packages/database/postgres-base.coffee
+++ b/src/packages/database/postgres-base.coffee
@@ -1006,6 +1006,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
 
     # Go through every table in the schema with a column called "expire", and
     # delete every entry where expire is <= right now.
+    # Note: this ignores those rows, where expire is NULL, because comparisons with NULL are NULL
     delete_expired: (opts) =>
         opts = defaults opts,
             count_only : false      # if true, only count the number of rows that would be deleted

--- a/src/packages/database/postgres-server-queries.coffee
+++ b/src/packages/database/postgres-server-queries.coffee
@@ -1367,6 +1367,10 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
         if @_throttle('log_file_access', 60, opts.project_id, opts.account_id, opts.filename)
             opts.cb?()
             return
+
+        # If expire no pii expiration is set, use 1 year as a fallback
+        expire = await pii_expire(@) ? expire_time(365*24*60*60)
+
         @_query
             query  : 'INSERT INTO file_access_log'
             values :
@@ -1375,6 +1379,7 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
                 'account_id :: UUID     ' : opts.account_id
                 'filename   :: TEXT     ' : opts.filename
                 'time       :: TIMESTAMP' : 'NOW()'
+                'expire     :: TIMESTAMP' : expire
             cb     : opts.cb
 
     ###

--- a/src/packages/database/postgres/pii.test.ts
+++ b/src/packages/database/postgres/pii.test.ts
@@ -1,0 +1,30 @@
+// basically check, that all valid fields for PII values work and give a suitable date in the future
+
+import {
+  EXTRAS,
+  pii_retention_parse,
+} from "@cocalc/util/db-schema/site-settings-extras";
+
+import { pii_retention_to_future } from "@cocalc/database/postgres/pii";
+
+function getValid(): string[] {
+  const vals = EXTRAS.pii_retention.valid;
+
+  // make TS happy
+  if (vals == null) return [];
+
+  return vals as string[];
+}
+
+test.each(getValid())("pii(%s)", async (pii: string) => {
+  const pii_val = pii_retention_parse(pii);
+  const v = await pii_retention_to_future(pii_val);
+  if (pii === "never") {
+    expect(v).toBeUndefined();
+  } else {
+    expect(v).toBeInstanceOf(Date);
+    const now = new Date();
+    const diff = v!.getTime() - now.getTime();
+    expect(diff).toBeGreaterThan(1000 * 60 * 60 * 24);
+  }
+});

--- a/src/packages/server/projects/control/kucalc.test.ts
+++ b/src/packages/server/projects/control/kucalc.test.ts
@@ -1,0 +1,110 @@
+import getPool, { initEphemeralDatabase } from "@cocalc/database/pool";
+import init, { getProject } from "@cocalc/server/projects/control";
+import { uuid } from "@cocalc/util/misc";
+
+beforeAll(async () => {
+  await initEphemeralDatabase();
+}, 15000);
+
+afterAll(async () => {
+  await getPool().end();
+});
+
+// hardcoded in projects/control/kucalc.ts
+const EXPECTED_EXPIRATION_MS = 30 * 24 * 60 * 60 * 1000;
+
+describe("kucalc", () => {
+  init("kucalc");
+
+  const id = uuid();
+  const project = getProject(id);
+
+  test("scheduled copy/date", async () => {
+    const in1minute = new Date(Date.now() + 60 * 1000);
+    const id2 = uuid();
+    const copyID = await project.copyPath({
+      path: "file.md",
+      target_path: "file2.md",
+      target_project_id: id2,
+      scheduled: in1minute,
+    });
+
+    const pool = getPool();
+    const data = (
+      await pool.query("SELECT * from copy_paths WHERE id=$1", [copyID])
+    ).rows[0];
+
+    expect(data.id).toEqual(copyID);
+    expect(data.expire.getTime() / 1000).toBeCloseTo(
+      (in1minute.getTime() + EXPECTED_EXPIRATION_MS) / 1000,
+    );
+    expect(data.scheduled.getTime() / 1000).toBeCloseTo(
+      in1minute.getTime() / 1000,
+    );
+    expect(data.source_path).toEqual("file.md");
+    expect(data.target_path).toEqual("file2.md");
+    expect(data.target_project_id).toEqual(id2);
+    expect(data.time.getTime()).toBeLessThan(data.scheduled.getTime());
+  });
+
+  // in this test, we also don't specify a sepearte project
+  test("scheduled copy/string", async () => {
+    const in1minute: string = new Date(Date.now() + 60 * 1000).toISOString();
+    const copyID = await project.copyPath({
+      path: "file.md",
+      scheduled: in1minute,
+    });
+
+    // this mimics database::copy_path.status(...)
+    const pool = getPool();
+    const data = (
+      await pool.query("SELECT * from copy_paths WHERE id=$1", [copyID])
+    ).rows[0];
+
+    const in1minuteDate = new Date(in1minute);
+    expect(data.id).toEqual(copyID);
+    expect(data.expire.getTime() / 1000).toBeCloseTo(
+      (in1minuteDate.getTime() + EXPECTED_EXPIRATION_MS) / 1000,
+    );
+    expect(data.scheduled.getTime() / 1000).toBeCloseTo(
+      in1minuteDate.getTime() / 1000,
+    );
+    expect(data.source_path).toEqual("file.md");
+    expect(data.target_path).toEqual("file.md");
+    expect(data.target_project_id).toEqual(id);
+    expect(data.time.getTime()).toBeLessThan(data.scheduled.getTime());
+  });
+
+  test("immediate copy_path", async () => {
+    const id2 = uuid();
+    const copyID = await project.copyPath({
+      path: "file.md",
+      target_path: "file2.md",
+      target_project_id: id2,
+      overwrite_newer: true,
+      delete_missing: true,
+      backup: true,
+      wait_until_done: false,
+    });
+
+    // this mimics database::copy_path.status(...)
+    const pool = getPool();
+    const data = (
+      await pool.query("SELECT * from copy_paths WHERE id=$1", [copyID])
+    ).rows[0];
+
+    expect(data.id).toEqual(copyID);
+    expect(data.expire.getTime() / 1000).toBeCloseTo(
+      (Date.now() + EXPECTED_EXPIRATION_MS) / 1000,
+    );
+    expect(data.scheduled).toBeNull();
+    expect(data.source_path).toEqual("file.md");
+    expect(data.target_path).toEqual("file2.md");
+    expect(data.target_project_id).toEqual(id2);
+    expect(data.time.getTime()).toBeLessThan(Date.now());
+    expect(data.backup).toBe(true);
+    expect(data.delete_missing).toBe(true);
+    expect(data.overwrite_newer).toBe(true);
+    expect(data.public).toBeNull();
+  });
+});

--- a/src/packages/util/db-schema/copy-paths.ts
+++ b/src/packages/util/db-schema/copy-paths.ts
@@ -86,6 +86,10 @@ Table({
       type: "string",
       desc: "if the copy failed or output any errors, they are put here.",
     },
+    expire: {
+      type: "timestamp",
+      desc: "expire after 1 month",
+    },
   },
   rules: {
     primary_key: "id",

--- a/src/packages/util/db-schema/file-access-log.ts
+++ b/src/packages/util/db-schema/file-access-log.ts
@@ -42,5 +42,9 @@ Table({
     time: {
       type: "timestamp",
     },
+    expire: {
+      type: "timestamp",
+      desc: "Either expire after the given PII retention period, or after 1 year, whichever is sooner.",
+    },
   },
 });

--- a/src/packages/util/db-schema/jupyter.ts
+++ b/src/packages/util/db-schema/jupyter.ts
@@ -58,6 +58,10 @@ Table({
         type: "code",
       },
     },
+    expire: {
+      type: "timestamp",
+      desc: "expire a log entry after 1 month",
+    },
   },
   rules: {
     desc: "Jupyter Kernel Execution Log",
@@ -116,6 +120,10 @@ Table({
       render: {
         type: "json",
       },
+    },
+    expire: {
+      type: "timestamp",
+      desc: "this is last_active + 1 month",
     },
   },
   rules: {


### PR DESCRIPTION
# Description

## :warning: do not merge

* db/file_access_log: introduce "expire" column, with either the PII retention or 1 year as fallback
* add test for all possible pii expiration values, since we parse them
* db/central_log: expire after 1 year, unless it's a special case
* db/copy_paths: add an expiration for that kucalc related table
   * with the additional detail, that scheduled copy events are postponed 1 month after the scheduled time, at least
   * also added a new test for `control/kucalc.ts`
* db/jupyter_api_cache and jupyter_api_log: expire after 1 month (log is used for abuse, and only looks at 1 hour ago … 1 month is enough data to still have enough insight)

---

Test: I went through the tables in our kucalc test environment, including checking the copy event and the API call for scheduled copies


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
