### PR TITLE
Flyout active tweaks #3

### DIFF
--- a/src/packages/frontend/project/page/flyouts/active-tabs.tsx
+++ b/src/packages/frontend/project/page/flyouts/active-tabs.tsx
@@ -29,12 +29,14 @@ interface Props {
   openTabs: string[];
   dndDragEnd: (event: any) => void;
   renderFileItem: (path: string, how: "file" | "undo") => JSX.Element;
+  disabled: boolean;
 }
 
 export function OpenFileTabs({
   openTabs,
   dndDragEnd,
   renderFileItem,
+  disabled,
 }: Props): JSX.Element {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -54,7 +56,12 @@ export function OpenFileTabs({
       <SortableContext items={openTabs} strategy={verticalListSortingStrategy}>
         <DragOverlay modifiers={[restrictToWindowEdges]} />
         {openTabs.map((path: string) => (
-          <SortableTab key={path} path={path} renderFileItem={renderFileItem} />
+          <SortableTab
+            key={path}
+            path={path}
+            renderFileItem={renderFileItem}
+            disabled={disabled}
+          />
         ))}
       </SortableContext>
     </DndContext>
@@ -64,9 +71,11 @@ export function OpenFileTabs({
 function SortableTab({
   path,
   renderFileItem,
+  disabled,
 }: {
   path: string;
   renderFileItem: Props["renderFileItem"];
+  disabled: boolean;
 }) {
   const {
     attributes,
@@ -75,7 +84,7 @@ function SortableTab({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: path });
+  } = useSortable({ id: path, disabled });
 
   const style = {
     transform: DNDCSS.Transform.toString(transform),

--- a/src/packages/frontend/project/page/flyouts/active-top.tsx
+++ b/src/packages/frontend/project/page/flyouts/active-top.tsx
@@ -8,12 +8,12 @@
 
 import { Button, Input, InputRef, Radio, Space, Tooltip } from "antd";
 
-import { useMemo, useRef } from "@cocalc/frontend/app-framework";
+import { CSS, useMemo, useRef } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
 import { useProjectContext } from "@cocalc/frontend/project/context";
 import { COLORS } from "@cocalc/util/theme";
+import { FLYOUT_DEFAULT_WIDTH_PX, FLYOUT_PADDING } from "./consts";
 import { FlyoutActiveMode, storeFlyoutState } from "./state";
-import { FLYOUT_DEFAULT_WIDTH_PX } from "./consts";
 
 interface ActiveTopProps {
   mode: FlyoutActiveMode;
@@ -123,43 +123,64 @@ export function ActiveTop(props: Readonly<ActiveTopProps>) {
     }
   }
 
-  function renderInput() {
+  function renderFilterSortRow() {
+    const style: CSS = {
+      ...(flyoutWidth > FLYOUT_DEFAULT_WIDTH_PX * 0.5
+        ? { width: "12em" }
+        : { width: "6em" }),
+      flex: "1 0 auto",
+    };
+
     return (
-      <Tooltip
-        title={
-          <>
-            Filter opened and starred files. [Return] openes the first match,
-            [ESC] clears the filter.
-          </>
-        }
-        placement="top"
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+        }}
       >
-        <Input
-          ref={filterRef}
-          placeholder="Filter..."
-          style={
-            (!showText || flyoutWidth >= FLYOUT_DEFAULT_WIDTH_PX - 2)
-              ? { width: "6em" }
-              : undefined
+        <Tooltip
+          title={
+            <>
+              Filter opened and starred files. [Return] openes the first match,
+              [ESC] clears the filter.
+            </>
           }
+          placement="top"
+        >
+          <Input
+            ref={filterRef}
+            placeholder="Filter..."
+            style={style}
+            size="small"
+            value={filterTerm}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setFilterTerm(e.target.value);
+            }}
+            onKeyDown={onKeyDownHandler}
+            allowClear
+            prefix={<Icon name="search" />}
+          />
+        </Tooltip>
+        <Space
+          direction="horizontal"
           size="small"
-          value={filterTerm}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setFilterTerm(e.target.value);
-          }}
-          onKeyDown={onKeyDownHandler}
-          allowClear
-          prefix={<Icon name="search" />}
-        />
-      </Tooltip>
+          style={{ flex: "1 0 auto", justifyContent: "flex-end" }}
+        >
+          <Button size="small" icon={<Icon name="sort-amount-up" />} />
+          <Button size="small" icon={<Icon name="times" />} />
+        </Space>
+      </div>
     );
   }
 
   return (
-    <Space wrap={true}>
-      {renderToggleShowStarred()}
-      {renderConfiguration()}
-      {renderInput()}
-    </Space>
+    <>
+      <Space wrap={true} style={{ paddingBottom: FLYOUT_PADDING }}>
+        {renderToggleShowStarred()}
+        {renderConfiguration()}
+      </Space>
+      {renderFilterSortRow()}
+    </>
   );
 }

--- a/src/packages/frontend/project/page/flyouts/active.tsx
+++ b/src/packages/frontend/project/page/flyouts/active.tsx
@@ -46,6 +46,7 @@ import {
   FLYOUT_PADDING,
 } from "./consts";
 import { FileListItem } from "./file-list-item";
+import { FlyoutFilterWarning } from "./filter-warning";
 import {
   FlyoutActiveMode,
   FlyoutActiveStarred,
@@ -593,6 +594,12 @@ export function ActiveFlyout(props: Readonly<Props>): JSX.Element {
     }
   }
 
+  function renderWarnings() {
+    return (
+      <FlyoutFilterWarning filter={filterTerm} setFilter={setFilterTerm} />
+    );
+  }
+
   return (
     <>
       <ActiveTop
@@ -606,6 +613,7 @@ export function ActiveFlyout(props: Readonly<Props>): JSX.Element {
         openFirstMatchingFile={openFirstMatchingFile}
         flyoutWidth={flyoutWidth}
       />
+      {renderWarnings()}
       {renderGroups()}
       {renderUndo()}
     </>

--- a/src/packages/frontend/project/page/flyouts/files-header.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-header.tsx
@@ -27,6 +27,7 @@ import { COLORS } from "@cocalc/util/theme";
 import { FIX_BORDER } from "../common";
 import { DEFAULT_EXT, FLYOUT_PADDING } from "./consts";
 import { ActiveFileSort } from "./files";
+import { FlyoutClearFilter, FlyoutFilterWarning } from "./filter-warning";
 
 function searchToFilename(search: string): string {
   if (search.endsWith(" ")) {
@@ -212,20 +213,6 @@ export function FilesHeader(props: Readonly<Props>): JSX.Element {
     );
   }
 
-  function renderClearSearchSmall() {
-    return (
-      <Tooltip title="Clear search" placement="bottom">
-        <Button
-          size="small"
-          type="text"
-          style={{ float: "right", color: COLORS.GRAY_M }}
-          onClick={() => setSearchState("")}
-          icon={<Icon name="close-circle-filled" />}
-        />
-      </Tooltip>
-    );
-  }
-
   function renderFileCreationError() {
     if (!file_creation_error) return;
     return (
@@ -247,18 +234,7 @@ export function FilesHeader(props: Readonly<Props>): JSX.Element {
     if (file_search === "") return;
     if (!isEmpty) {
       return (
-        <Alert
-          type="info"
-          banner
-          showIcon={false}
-          style={{ padding: FLYOUT_PADDING, margin: 0 }}
-          description={
-            <>
-              {renderClearSearchSmall()}
-              Only showing files matching "<Text code>{file_search}</Text>".
-            </>
-          }
-        />
+        <FlyoutFilterWarning filter={file_search} setFilter={setSearchState} />
       );
     }
   }
@@ -281,7 +257,7 @@ export function FilesHeader(props: Readonly<Props>): JSX.Element {
         description={
           <>
             <div>
-              {renderClearSearchSmall()}
+              <FlyoutClearFilter setFilter={setSearchState} />
               No files match the current filter.
             </div>
             <div>

--- a/src/packages/frontend/project/page/flyouts/filter-warning.tsx
+++ b/src/packages/frontend/project/page/flyouts/filter-warning.tsx
@@ -1,0 +1,53 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Alert, Button, Tooltip } from "antd";
+
+import { Icon, Text } from "@cocalc/frontend/components";
+import { COLORS } from "@cocalc/util/theme";
+import { FLYOUT_PADDING } from "./consts";
+
+export function FlyoutFilterWarning({
+  filter,
+  setFilter,
+}: {
+  filter: string;
+  setFilter: (string) => void;
+}) {
+  if (!filter) return null;
+
+  return (
+    <Alert
+      type="info"
+      banner
+      showIcon={false}
+      style={{ padding: FLYOUT_PADDING, margin: 0 }}
+      description={
+        <>
+          <FlyoutClearFilter setFilter={setFilter} />
+          Only showing files matching "<Text code>{filter}</Text>".
+        </>
+      }
+    />
+  );
+}
+
+export function FlyoutClearFilter({
+  setFilter,
+}: {
+  setFilter: (string) => void;
+}) {
+  return (
+    <Tooltip title="Clear search" placement="bottom">
+      <Button
+        size="small"
+        type="text"
+        style={{ float: "right", color: COLORS.GRAY_M }}
+        onClick={() => setFilter("")}
+        icon={<Icon name="close-circle-filled" />}
+      />
+    </Tooltip>
+  );
+}

--- a/src/packages/frontend/project/page/flyouts/state.ts
+++ b/src/packages/frontend/project/page/flyouts/state.ts
@@ -20,6 +20,14 @@ export function isFlyoutActiveMode(val?: string): val is FlyoutActiveMode {
   return ActiveModes.includes(val as any);
 }
 
+const ActiveTabSorts = ["custom", "alphanum-up", "alphanum-down"] as const;
+export type FlyoutActiveTabSort = (typeof ActiveTabSorts)[number];
+export function isFlyoutActiveTabSort(
+  val?: string,
+): val is FlyoutActiveTabSort {
+  return ActiveTabSorts.includes(val as any);
+}
+
 export type FlyoutActiveStarred = string[];
 export function isFlyoutActiveStarred(val?: any): val is FlyoutActiveStarred {
   return Array.isArray(val) && val.every((x) => typeof x === "string");
@@ -40,6 +48,7 @@ export type LSFlyout = {
   settings?: string[]; // expanded panels
   starred?: FlyoutActiveStarred;
   showStarred?: boolean;
+  activeTabSort?: FlyoutActiveTabSort;
 };
 
 function isPositiveNumber(val: any): val is number {
@@ -61,6 +70,7 @@ export function storeFlyoutState(
     starred?: FlyoutActiveStarred;
     showStarred?: boolean;
     width?: number | null;
+    activeTabSort?: FlyoutActiveTabSort;
   },
 ): void {
   const { scroll, expanded, width, mode, files } = state;
@@ -116,6 +126,10 @@ export function storeFlyoutState(
     if (typeof state.showStarred === "boolean") {
       current.showStarred = state.showStarred;
     }
+
+    if (isFlyoutActiveTabSort(state.activeTabSort)) {
+      current.activeTabSort = state.activeTabSort;
+    }
   }
 
   LS.set(key, current);
@@ -157,4 +171,11 @@ export function getFlyoutActiveStarred(
 
 export function getFlyoutActiveShowStarred(project_id: string): boolean {
   return LS.get<LSFlyout>(lsKey(project_id))?.showStarred ?? true;
+}
+
+export function getFlyoutActiveTabSort(
+  project_id: string,
+): FlyoutActiveTabSort {
+  const activeTabSort = LS.get<LSFlyout>(lsKey(project_id))?.activeTabSort;
+  return isFlyoutActiveTabSort(activeTabSort) ? activeTabSort : "custom";
 }


### PR DESCRIPTION
# Description

- make two rows at the tops for the controls
- refactor filter warning, just like with the explorer flyout
- sort open tabs by custom or alphabetical order (I know about #7080 and recent usage, but that's for later)
- close all with popconfirm

![Screenshot from 2023-11-29 14-23-46](https://github.com/sagemathinc/cocalc/assets/207405/74547534-d6bc-4124-9255-e63a1d13749a)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
