### PR TITLE
frontend/frame-tree/toolbar: store compute server dropdown state

### DIFF
--- a/src/packages/frontend/compute/select-server.tsx
+++ b/src/packages/frontend/compute/select-server.tsx
@@ -2,18 +2,19 @@
 Dropdown on frame title bar for running that Jupyter notebook or terminal on a compute server.
 */
 
+import { Modal, Select, Tooltip } from "antd";
+import { delay } from "awaiting";
+import { Map } from "immutable";
 import type { CSSProperties, ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Modal, Select, Tooltip } from "antd";
-import { useTypedRedux, redux } from "@cocalc/frontend/app-framework";
-import { webapp_client } from "@cocalc/frontend/webapp-client";
-import { cmp } from "@cocalc/util/misc";
-import { Icon } from "@cocalc/frontend/components";
-import { STATE_INFO } from "@cocalc/util/db-schema/compute-servers";
-import { capitalize } from "@cocalc/util/misc";
-import { DisplayImage } from "./select-image";
-import { delay } from "awaiting";
+
 import { avatar_fontcolor } from "@cocalc/frontend/account/avatar/font-color";
+import { redux, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { Icon } from "@cocalc/frontend/components";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import { STATE_INFO } from "@cocalc/util/db-schema/compute-servers";
+import { capitalize, cmp } from "@cocalc/util/misc";
+import { DisplayImage } from "./select-image";
 
 const PROJECT_COLOR = "#337ab7";
 
@@ -31,8 +32,9 @@ interface Props {
   path: string;
   frame_id: string;
   style?: CSSProperties;
-  actions?;
+  actions?; // comes from frame-editors/frame-tree/title-bar.tsx
   type: "terminal" | "jupyter_cell_notebook";
+  titlebar_state: Map<string, any>;
 }
 
 export default function SelectComputeServer({
@@ -42,6 +44,7 @@ export default function SelectComputeServer({
   actions,
   style,
   type,
+  titlebar_state,
 }: Props) {
   const account_id = useTypedRedux("account", "account_id");
   const getPath = (path) => {
@@ -53,13 +56,21 @@ export default function SelectComputeServer({
   const [confirmSwitch, setConfirmSwitch] = useState<boolean>(false);
   const [idNum, setIdNum] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(false);
-  const [open, setOpen] = useState<boolean>(false);
   const computeServers =
     useTypedRedux({ project_id }, "compute_servers")?.toJS() ?? [];
   const computeServerAssociations = useMemo(() => {
     return webapp_client.project_client.computeServers(project_id);
   }, [project_id]);
   const [value, setValue] = useState<string | null>(null);
+
+  const open: boolean = (titlebar_state?.getIn([
+    frame_id,
+    "compute_server_open",
+  ]) ?? false) as boolean;
+  // console.log("titlebar_state", open, " – ", titlebar_state?.toJS());
+  function setOpen(next: boolean) {
+    actions?.save_toolbar_state(frame_id, { compute_server_open: next });
+  }
 
   const okButtonRef = useRef();
   useEffect(() => {

--- a/src/packages/frontend/editors/slate/types.ts
+++ b/src/packages/frontend/editors/slate/types.ts
@@ -34,6 +34,7 @@ export interface Actions {
   registerSlateEditor?: (id: string, editor: SlateEditor) => void;
   ensure_syncstring_is_saved?: () => Promise<void>;
   save_editor_state?: (id: string, new_editor_state?: any) => void;
+  save_toolbar_state?: (id: string, new_toolbar_state?: any) => void;
   set_cursor_locs?: (locs: any[]) => void;
   set_value?: (value: string) => void;
   syncstring_commit?: () => void;

--- a/src/packages/frontend/frame-editors/code-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/code-editor/actions.ts
@@ -98,6 +98,9 @@ import { SHELLS } from "./editor";
 import { test_line } from "./simulate_typing";
 import { misspelled_words } from "./spell-check";
 
+// key in local_view_state, holding a map of toolbar states for each editor
+export const TITLEBAR_STATE_KEY = "titlebar";
+
 interface gutterMarkerParams {
   line: number;
   gutter_id: string;
@@ -1092,6 +1095,32 @@ export class Actions<
     }
     this.setState({
       local_view_state: local.set("editor_state", editor_state),
+    });
+    this._save_local_view_state();
+  }
+
+  // similar to the above, store the frame id specific toolbar state
+  // TODO: this is code duplication of the above, combine this in one function with wrappers
+  save_toolbar_state(id: string, new_toolbar_state?: any): void {
+    if (this._state === "closed") {
+      return;
+    }
+    const local = this.store.get("local_view_state");
+    if (local == null) {
+      return;
+    }
+    let toolbar_state = local.get(TITLEBAR_STATE_KEY) ?? Map();
+    if (new_toolbar_state == null) {
+      if (!toolbar_state.has(id)) {
+        return;
+      }
+      toolbar_state = toolbar_state.delete(id);
+    } else {
+      toolbar_state = toolbar_state.set(id, fromJS(new_toolbar_state));
+    }
+    console.log("next_toolbar_state", toolbar_state.toJS());
+    this.setState({
+      local_view_state: local.set(TITLEBAR_STATE_KEY, toolbar_state),
     });
     this._save_local_view_state();
   }

--- a/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
@@ -34,16 +34,18 @@ import { copy, hidden_meta_file, is_different } from "@cocalc/util/misc";
 import { delay } from "awaiting";
 import { Map, Set } from "immutable";
 import React from "react";
+
+import { AccountState } from "@cocalc/frontend/account/types";
 import {
   ReactDOM,
-  redux,
   Rendered,
-  useState,
+  redux,
   useEffect,
+  useState,
 } from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
 import { AvailableFeatures } from "@cocalc/frontend/project_configuration";
-import { Actions } from "../code-editor/actions";
+import { Actions, TITLEBAR_STATE_KEY } from "../code-editor/actions";
 import { cm as cm_spec } from "../code-editor/editor";
 import { is_safari } from "../generic/browser";
 import { TimeTravelActions } from "../time-travel-editor/actions";
@@ -54,7 +56,6 @@ import { get_file_editor } from "./register";
 import { FrameTitleBar } from "./title-bar";
 import * as tree_ops from "./tree-ops";
 import { EditorDescription, EditorSpec, EditorState, NodeDesc } from "./types";
-import { AccountState } from "@cocalc/frontend/account/types";
 
 interface FrameTreeProps {
   actions: Actions;
@@ -237,7 +238,7 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
     function render_titlebar(
       desc: NodeDesc,
       spec: EditorDescription,
-      editor_actions: Actions
+      editor_actions: Actions,
     ): Rendered {
       const id = desc.get("id");
       return (
@@ -263,6 +264,7 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
           pages={desc.get("pages")}
           is_visible={is_visible}
           tab_is_visible={tab_is_visible}
+          titlebar_state={local_view_state?.get(TITLEBAR_STATE_KEY)}
         />
       );
     }
@@ -271,7 +273,7 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
       desc: NodeDesc,
       component: any,
       spec: EditorDescription,
-      editor_actions: Actions
+      editor_actions: Actions,
     ) {
       const type = desc.get("type");
       const project_id_leaf = desc.get("project_id", project_id);
@@ -536,5 +538,5 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
       </div>
     );
   },
-  shouldMemoize
+  shouldMemoize,
 );

--- a/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/title-bar.tsx
@@ -15,9 +15,10 @@ import {
   Popover,
   Tooltip,
 } from "antd";
-import { List } from "immutable";
+import { List, Map } from "immutable";
 import { debounce } from "lodash";
 import { ReactNode, useEffect, useMemo, useRef } from "react";
+
 import {
   Button as AntdBootstrapButton,
   ButtonGroup,
@@ -26,38 +27,37 @@ import {
 import {
   CSS,
   React,
-  redux,
   Rendered,
+  redux,
   useForceUpdate,
   useRedux,
   useState,
 } from "@cocalc/frontend/app-framework";
 import {
   DropdownMenu,
+  Gap,
   Icon,
   IconName,
   MenuItems,
-  r_join,
-  Gap,
   VisibleMDLG,
+  r_join,
 } from "@cocalc/frontend/components";
+import { computeServersEnabled } from "@cocalc/frontend/compute/config";
+import SelectComputeServer from "@cocalc/frontend/compute/select-server";
 import { useStudentProjectFunctionality } from "@cocalc/frontend/course";
 import { EditorFileInfoDropdown } from "@cocalc/frontend/editors/file-info-dropdown";
-import { IS_MACOS } from "@cocalc/frontend/feature";
+import { IS_MACOS, IS_MOBILE } from "@cocalc/frontend/feature";
+import userTracking from "@cocalc/frontend/user-tracking";
 import { capitalize, copy, path_split, trunc_middle } from "@cocalc/util/misc";
+import ChatGPT from "../chatgpt/title-bar-button";
 import { Actions } from "../code-editor/actions";
 import { FORMAT_SOURCE_ICON } from "../frame-tree/config";
 import { is_safari } from "../generic/browser";
+import { redo as chatRedo, undo as chatUndo } from "../generic/chat";
 import { get_default_font_size } from "../generic/client";
 import { SaveButton } from "./save-button";
-import { ConnectionStatus, EditorDescription, EditorSpec } from "./types";
-import { undo as chatUndo, redo as chatRedo } from "../generic/chat";
-import ChatGPT from "../chatgpt/title-bar-button";
-import userTracking from "@cocalc/frontend/user-tracking";
 import TitleBarTour from "./title-bar-tour";
-import { IS_MOBILE } from "@cocalc/frontend/feature";
-import SelectComputeServer from "@cocalc/frontend/compute/select-server";
-import { computeServersEnabled } from "@cocalc/frontend/compute/config";
+import { ConnectionStatus, EditorDescription, EditorSpec } from "./types";
 
 // Certain special frame editors (e.g., for latex) have extra
 // actions that are not defined in the base code editor actions.
@@ -168,9 +168,10 @@ interface Props {
   pages?: number | List<string>;
   is_visible?: boolean;
   tab_is_visible?: boolean;
+  titlebar_state: Map<string, any>;
 }
 
-export const FrameTitleBar: React.FC<Props> = (props: Props) => {
+export const FrameTitleBar: React.FC<Props> = (props: Readonly<Props>) => {
   const is_active = props.active_id === props.id;
   const track = useMemo(() => {
     const { project_id, path } = props;
@@ -1940,6 +1941,7 @@ export const FrameTitleBar: React.FC<Props> = (props: Props) => {
         }}
         project_id={props.project_id}
         path={props.path}
+        titlebar_state={props.titlebar_state}
       />
     );
   }


### PR DESCRIPTION
# Description

this does not fix #7083 :-1: 

This patch introduces a `"titlebar"` entry in the `local_view_state`.  For this problem, my idea was to save the open state there, such that when it re-renders, it's not toggling back to the closed state. Unfortunately, it still resets the state to false (closed). I don't understand why.

Besides that, maybe the patch is still useful for future, for stateful toolbar settings specific to a frame.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
