### PR TITLE
frontend/llm model selector: generalize how button/tooltip is rendered

### DIFF
--- a/src/packages/frontend/frame-editors/chatgpt/model-switch.tsx
+++ b/src/packages/frontend/frame-editors/chatgpt/model-switch.tsx
@@ -6,6 +6,7 @@ import {
   LLM_USERNAMES,
   LanguageModel,
   USER_SELECTABLE_LANGUAGE_MODELS,
+  isFreeModel,
   model2service,
 } from "@cocalc/util/db-schema/openai";
 
@@ -22,7 +23,6 @@ interface Props {
 
 // The tooltips below are adopted from chat.openai.com
 
-const GOOGLE_PALM: LanguageModel = "chat-bison-001";
 const GOOGLE_GEMINI: LanguageModel = "gemini-pro";
 
 export default function ModelSwitch({
@@ -46,43 +46,40 @@ export default function ModelSwitch({
     "google",
   );
 
+  function renderLLMButton(btnModel: LanguageModel, title: string) {
+    if (!USER_SELECTABLE_LANGUAGE_MODELS.includes(btnModel)) return;
+    const prefix = isFreeModel(btnModel) ? "FREE" : "NOT FREE";
+    return (
+      <Tooltip title={`${prefix}: ${title}`}>
+        <Radio.Button value={btnModel}>
+          {modelToName(btnModel)}
+          {btnModel === model
+            ? !isFreeModel(btnModel)
+              ? " (not free)"
+              : " (free)"
+            : undefined}
+        </Radio.Button>
+      </Tooltip>
+    );
+  }
+
   function renderOpenAI() {
     if (!showOpenAI) return null;
     return (
       <>
-        {USER_SELECTABLE_LANGUAGE_MODELS.includes("gpt-3.5-turbo") && (
-          <Tooltip
-            title={
-              "FREE: OpenAI's fastest model, great for most everyday tasks (4k token context)"
-            }
-          >
-            <Radio.Button value="gpt-3.5-turbo">
-              {modelToName("gpt-3.5-turbo")}
-            </Radio.Button>
-          </Tooltip>
+        {renderLLMButton(
+          "gpt-3.5-turbo",
+          "OpenAI's fastest model, great for most everyday tasks (4k token context)",
         )}
-        {USER_SELECTABLE_LANGUAGE_MODELS.includes("gpt-3.5-turbo-16k") && (
-          <Tooltip
-            title={`NOT FREE: Same as ${modelToName(
-              "gpt-3.5-turbo",
-            )} but with much larger context size (16k token context)`}
-          >
-            <Radio.Button value="gpt-3.5-turbo-16k">
-              {modelToName("gpt-3.5-turbo-16k")}
-            </Radio.Button>
-          </Tooltip>
+        {renderLLMButton(
+          "gpt-3.5-turbo-16k",
+          `Same as ${modelToName(
+            "gpt-3.5-turbo",
+          )} but with much larger context size (16k token context)`,
         )}
-        {USER_SELECTABLE_LANGUAGE_MODELS.includes("gpt-4") && (
-          <Tooltip
-            title={
-              "NOT FREE: OpenAI's most capable model, great for tasks that require creativity and advanced reasoning (8k token context)"
-            }
-          >
-            <Radio.Button value="gpt-4">
-              {modelToName("gpt-4")}
-              {model === "gpt-4" ? " (not free)" : ""}
-            </Radio.Button>
-          </Tooltip>
+        {renderLLMButton(
+          "gpt-4",
+          "OpenAI's most capable model, great for tasks that require creativity and advanced reasoning (8k token context)",
         )}
       </>
     );
@@ -93,23 +90,9 @@ export default function ModelSwitch({
 
     return (
       <>
-        {USER_SELECTABLE_LANGUAGE_MODELS.includes(GOOGLE_PALM) && (
-          <Tooltip
-            title={`Google's PaLM 2 Generative AI model ('${GOOGLE_PALM}', 8k token context)`}
-          >
-            <Radio.Button value={GOOGLE_PALM}>
-              {modelToName(GOOGLE_PALM)}
-            </Radio.Button>
-          </Tooltip>
-        )}
-        {USER_SELECTABLE_LANGUAGE_MODELS.includes(GOOGLE_GEMINI) && (
-          <Tooltip
-            title={`Google's Gemini Pro Generative AI model ('${GOOGLE_GEMINI}', 30k token context)`}
-          >
-            <Radio.Button value={GOOGLE_GEMINI}>
-              {modelToName(GOOGLE_GEMINI)}
-            </Radio.Button>
-          </Tooltip>
+        {renderLLMButton(
+          GOOGLE_GEMINI,
+          `Google's Gemini Pro Generative AI model ('${GOOGLE_GEMINI}', 30k token context)`,
         )}
       </>
     );

--- a/src/packages/frontend/frame-editors/chatgpt/title-bar-button.tsx
+++ b/src/packages/frontend/frame-editors/chatgpt/title-bar-button.tsx
@@ -13,7 +13,12 @@ import { Alert, Button, Input, Popover, Radio, Space, Tooltip } from "antd";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useLanguageModelSetting } from "@cocalc/frontend/account/useLanguageModelSetting";
-import { Icon, IconName, VisibleMDLG } from "@cocalc/frontend/components";
+import {
+  Icon,
+  IconName,
+  Title,
+  VisibleMDLG,
+} from "@cocalc/frontend/components";
 import AIAvatar from "@cocalc/frontend/components/ai-avatar";
 import { capitalize } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
@@ -240,14 +245,6 @@ export default function LanguageModelTitleBarButtonDialog({
     <Popover
       title={
         <div style={{ fontSize: "18px" }}>
-          <LanguageModelVendorAvatar model={model} />{" "}
-          <ModelSwitch
-            project_id={project_id}
-            size="small"
-            model={model}
-            setModel={setModel}
-          />{" "}
-          What would you like to do using {modelToName(model)}?
           <Button
             onClick={() => {
               setShowDialog(false);
@@ -268,6 +265,17 @@ export default function LanguageModelTitleBarButtonDialog({
               submitRef={submitRef}
             />
           </div>
+          <Title level={4}>
+            <LanguageModelVendorAvatar model={model} /> What would you like to
+            do using {modelToName(model)}?
+          </Title>
+          Switch model:{" "}
+          <ModelSwitch
+            project_id={project_id}
+            size="small"
+            model={model}
+            setModel={setModel}
+          />
         </div>
       }
       open={visible && showDialog}


### PR DESCRIPTION
# Description

- fixes #7143 by making the button text and tooltip generated by the same function
- also slightly adjusts how the title looks like, only for the title button bar modal:

![Screenshot from 2023-12-27 17-10-59](https://github.com/sagemathinc/cocalc/assets/207405/17b86146-9c34-42e5-98ea-f2c2c8e1a8a3)

- testing: this doesn't change anything substantial about how this component is used.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
