### PR TITLE
7150: Added balance refresh to `PurchasesTable` refresh handler.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/sagemathinc/cocalc",
   "devDependencies": {
-    "express": "^4.18.2",
+    "express": "^4.17.1",
     "pnpm": "^8.10.2"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/sagemathinc/cocalc",
   "devDependencies": {
+    "express": "^4.18.2",
     "pnpm": "^8.10.2"
   }
 }

--- a/src/packages/frontend/purchases/purchases.tsx
+++ b/src/packages/frontend/purchases/purchases.tsx
@@ -240,6 +240,11 @@ export function PurchasesTable({
     }
   };
 
+  const refreshRecords = async () => {
+    await getPurchaseRecords();
+    await getBalance();
+  }
+
   useEffect(() => {
     getBalance();
   }, []);
@@ -296,7 +301,7 @@ export function PurchasesTable({
           />
           {showRefresh && (
             <Refresh
-              handleRefresh={getPurchaseRecords}
+              handleRefresh={refreshRecords}
               style={{ marginRight: "8px" }}
             />
           )}

--- a/src/packages/hub/package.json
+++ b/src/packages/hub/package.json
@@ -89,7 +89,7 @@
     "sinon": "^4.5.0"
   },
   "scripts": {
-    "preinstall": "only-allow pnpm",
+    "preinstall": "npx only-allow pnpm",
     "build": "tsc --build && coffee -m -c -o dist/ .",
     "hub-project-dev-nobuild": "unset DATA COCALC_ROOT BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} && PGUSER='smc'  NODE_ENV=${NODE_ENV:=development} NODE_OPTIONS='--max_old_space_size=10000 --trace-warnings --enable-source-maps --inspect' cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",
     "hub-personal": "unset DATA COCALC_ROOT BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} && PGUSER='smc'  NODE_ENV=${NODE_ENV:=development} NODE_OPTIONS='--max_old_space_size=10000 --trace-warnings --enable-source-maps --inspect' cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0 --personal",

--- a/src/packages/hub/package.json
+++ b/src/packages/hub/package.json
@@ -89,18 +89,18 @@
     "sinon": "^4.5.0"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
-    "build": "npx tsc  --build && coffee -m -c -o dist/ .",
-    "hub-project-dev-nobuild": "unset DATA COCALC_ROOT BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} && PGUSER='smc'  NODE_ENV=${NODE_ENV:=development} NODE_OPTIONS='--max_old_space_size=10000 --trace-warnings --enable-source-maps' pnpm cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",
-    "hub-personal": "unset DATA COCALC_ROOT BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} && PGUSER='smc'  NODE_ENV=${NODE_ENV:=development} NODE_OPTIONS='--max_old_space_size=10000 --trace-warnings --enable-source-maps' pnpm cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0 --personal",
-    "hub-project-dev": "pnpm build && pnpm hub-project-dev-nobuild",
-    "hub-project-prod": "pnpm build && unset DATA COCALC_ROOT  BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} &&   PGUSER='smc' NODE_ENV=production NODE_OPTIONS='--max_old_space_size=8000 --enable-source-maps' pnpm cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",
-    "hub-docker-dev": "export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && COCALC_DOCKER=true NODE_ENV=development PROJECTS=/projects/[project_id] PORT=443 NODE_OPTIONS='--max_old_space_size=8000 --trace-warnings --enable-source-maps' pnpm cocalc-hub-server --mode=multi-user --all --hostname=0.0.0.0 --https-key=/projects/conf/cert/key.pem --https-cert=/projects/conf/cert/cert.pem",
-    "hub-docker-prod": "export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && COCALC_DOCKER=true NODE_OPTIONS=--max_old_space_size=8000 NODE_ENV=production PROJECTS=/projects/[project_id] PORT=443 NODE_OPTIONS=--enable-source-maps pnpm cocalc-hub-server --mode=multi-user  --all --hostname=0.0.0.0 --https-key=/projects/conf/cert/key.pem --https-cert=/projects/conf/cert/cert.pem",
-    "hub-docker-prod-nossl": "export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && COCALC_DOCKER=true NODE_OPTIONS=--max_old_space_size=8000 NODE_ENV=production PROJECTS=/projects/[project_id] PORT=80 NODE_OPTIONS=--enable-source-maps pnpm cocalc-hub-server --mode=multi-user --all --hostname=0.0.0.0",
-    "tsc": "npx tsc  --watch  --pretty --preserveWatchOutput",
-    "test": "npx jest dist/",
-    "prepublishOnly": "pnpm test"
+    "preinstall": "only-allow pnpm",
+    "build": "tsc --build && coffee -m -c -o dist/ .",
+    "hub-project-dev-nobuild": "unset DATA COCALC_ROOT BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} && PGUSER='smc'  NODE_ENV=${NODE_ENV:=development} NODE_OPTIONS='--max_old_space_size=10000 --trace-warnings --enable-source-maps --inspect' cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",
+    "hub-personal": "unset DATA COCALC_ROOT BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} && PGUSER='smc'  NODE_ENV=${NODE_ENV:=development} NODE_OPTIONS='--max_old_space_size=10000 --trace-warnings --enable-source-maps --inspect' cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0 --personal",
+    "hub-project-dev": "build && NODE_OPTIONS='--inspect' hub-project-dev-nobuild",
+    "hub-project-prod": "build && unset DATA COCALC_ROOT BASE_PATH && export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && export PGHOST=${PGHOST:=`realpath $INIT_CWD/../../data/postgres/socket`} &&   PGUSER='smc' NODE_ENV=production NODE_OPTIONS='--max_old_space_size=8000 --enable-source-maps' cocalc-hub-server --mode=single-user --all --hostname=0.0.0.0",
+    "hub-docker-dev": "export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && COCALC_DOCKER=true NODE_ENV=development PROJECTS=/projects/[project_id] PORT=443 NODE_OPTIONS='--max_old_space_size=8000 --enable-source-maps --trace-warnings --inspect' cocalc-hub-server --mode=multi-user --all --hostname=0.0.0.0 --https-key=/projects/conf/cert/key.pem --https-cert=/projects/conf/cert/cert.pem",
+    "hub-docker-prod": "export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && COCALC_DOCKER=true NODE_ENV=production PROJECTS=/projects/[project_id] PORT=443 NODE_OPTIONS='--max_old_space_size=8000 --enable-source-maps' cocalc-hub-server --mode=multi-user --all --hostname=0.0.0.0 --https-key=/projects/conf/cert/key.pem --https-cert=/projects/conf/cert/cert.pem",
+    "hub-docker-prod-nossl": "export DEBUG=${DEBUG:='cocalc:*,-cocalc:silly:*'} && COCALC_DOCKER=true NODE_ENV=production PROJECTS=/projects/[project_id] PORT=80 NODE_OPTIONS='--max_old_space_size=8000 --enable-source-maps' cocalc-hub-server --mode=multi-user --all --hostname=0.0.0.0",
+    "tsc": "tsc --watch  --pretty --preserveWatchOutput",
+    "test": "jest dist/",
+    "prepublishOnly": "test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Also added `express` to `package.json` to allow `pnpm run c` out of the box, along with support for attaching v8 debugger to `hub` when running in development mode.

# Screenshot

![image](https://github.com/sagemathinc/cocalc/assets/17204901/0cfa0d75-f925-4f1f-ba5a-1937be19e902)


# Testing

Click the "Refresh" button in the `PurchasesTable` component at http://localhost:5000/settings/purchases. Verify that the balance is refreshed.
