### PR TITLE
#7161: Fixed subscription cancel/resume logic when computing cost to resume or cancel an existing subscription.

### DIFF
--- a/src/packages/next/pages/api/v2/purchases/cancel-subscription.ts
+++ b/src/packages/next/pages/api/v2/purchases/cancel-subscription.ts
@@ -23,6 +23,6 @@ async function get(req) {
     throw Error("must be signed in");
   }
   const { subscription_id, now } = getParams(req);
-  await cancelSubscription({ account_id, subscription_id, now });
+  await cancelSubscription({ account_id, subscription_id, cancelImmediately: now });
   return { status: "ok" };
 }

--- a/src/packages/server/purchases/cancel-subscription.ts
+++ b/src/packages/server/purchases/cancel-subscription.ts
@@ -1,39 +1,42 @@
 import getPool, { PoolClient } from "@cocalc/database/pool";
+import getLicense from "@cocalc/server/licenses/get-license";
+
 import editLicense from "./edit-license";
 import { getSubscription } from "./renew-subscription";
-import dayjs from "dayjs";
-import getLicense from "@cocalc/server/licenses/get-license";
 
 interface Options {
   account_id: string;
   subscription_id: number;
-  now?: boolean;
+  cancelImmediately?: boolean;
   client?: PoolClient;
 }
 
 export default async function cancelSubscription({
   account_id,
   subscription_id,
-  now,
+  cancelImmediately,
   client,
 }: Options) {
   const pool = client ?? getPool();
+  const now = new Date();
+
   await pool.query(
-    "UPDATE subscriptions SET status='canceled', canceled_at=NOW() WHERE id=$1",
-    [subscription_id]
+    "UPDATE subscriptions SET status='canceled', canceled_at=$1 WHERE id=$2",
+    [now, subscription_id]
   );
-  if (now) {
+  if (cancelImmediately) {
     const subscription = await getSubscription(subscription_id);
     const { metadata, current_period_end } = subscription;
     const license = await getLicense(metadata.license_id);
     let end;
-    if (license.activates != null && new Date(license.activates) > new Date()) {
+
+    if (license.activates != null && new Date(license.activates) > now) {
       // activation in the future
       end = new Date(license.activates);
     } else {
-      // 10 minutes in the future to avoid issues.
-      end = dayjs().add(10, "minutes").toDate();
+      end = now;
     }
+
     if (
       (license.expires != null && new Date(license.expires) <= end) ||
       current_period_end <= end
@@ -41,11 +44,19 @@ export default async function cancelSubscription({
       // license already ended
       return;
     }
+
     if (metadata?.type != "license" || metadata.license_id == null) {
       // only license subscriptions are currently implemented
       return;
     }
-    // edit the corresponding license so that it ends right now (and user gets credit).
+
+    // edit the corresponding license so that it ends either
+    //
+    // a) now, or
+    // b) at the same instant of activation
+    //
+    // (and user gets credit)
+    //
     await editLicense({
       isSubscriptionRenewal: true,
       account_id,

--- a/src/packages/server/purchases/edit-license.ts
+++ b/src/packages/server/purchases/edit-license.ts
@@ -31,12 +31,14 @@ import costToEditLicense, {
 } from "@cocalc/util/purchases/cost-to-edit-license";
 import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
 import { getQuota } from "@cocalc/server/licenses/purchase/create-license";
-import { assertPurchaseAllowed } from "./is-purchase-allowed";
-import createPurchase from "./create-purchase";
 import getName from "@cocalc/server/accounts/get-name";
 import { query_projects_using_site_license } from "@cocalc/database/postgres/site-license/analytics";
 import { restartProjectIfRunning } from "@cocalc/server/projects/control/util";
 import { currency } from "@cocalc/util/misc";
+import { ONE_HOUR_MS } from "@cocalc/util/consts/billing";
+
+import { assertPurchaseAllowed } from "./is-purchase-allowed";
+import createPurchase from "./create-purchase";
 
 const logger = getLogger("purchases:edit-license");
 
@@ -427,8 +429,7 @@ async function getSubscriptionCostPerHour(
   }
   // How many hours in the current period
   const hoursInPeriod =
-    (current_period_end.valueOf() - current_period_start.valueOf()) /
-    (1000 * 60 * 60);
+    (current_period_end.valueOf() - current_period_start.valueOf()) / ONE_HOUR_MS;
   // Divide cost of current period by hours in the period to get the cost per hour.
   return cost / hoursInPeriod;
 }

--- a/src/packages/server/purchases/maintain-subscriptions.ts
+++ b/src/packages/server/purchases/maintain-subscriptions.ts
@@ -188,7 +188,7 @@ async function cancelOnePendingSubscription({ account_id, purchase_id }) {
     await cancelSubscription({
       account_id,
       subscription_id,
-      now: true,
+      cancelImmediately: true,
       client,
     });
     await client.query("UPDATE purchases SET pending=false WHERE id=$1", [

--- a/src/packages/server/purchases/resume-subscription.test.ts
+++ b/src/packages/server/purchases/resume-subscription.test.ts
@@ -46,7 +46,7 @@ describe("create a subscription, cancel it, then resume it", () => {
     await cancelSubscription({
       account_id,
       subscription_id,
-      now: true,
+      cancelImmediately: true,
     });
     expect((await getSubscription(subscription_id)).status).toBe("canceled");
     const license = await getLicense(license_id);
@@ -69,7 +69,7 @@ describe("create a subscription, cancel it, then resume it", () => {
     await cancelSubscription({
       account_id,
       subscription_id,
-      now: true,
+      cancelImmediately: true,
     });
     const pool = getPool();
     await pool.query("DELETE FROM purchases WHERE account_id=$1", [

--- a/src/packages/util/consts/billing.ts
+++ b/src/packages/util/consts/billing.ts
@@ -3,7 +3,8 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-export const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+export const ONE_HOUR_MS = 60 * 60 * 1000;
+export const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 export const AVG_MONTH_DAYS = 30.5;
 export const AVG_YEAR_DAYS = 12 * AVG_MONTH_DAYS;
 export const ONE_MONTH_MS = AVG_MONTH_DAYS * ONE_DAY_MS;

--- a/src/packages/util/purchases/current-license-value.ts
+++ b/src/packages/util/purchases/current-license-value.ts
@@ -5,6 +5,7 @@ for refund or other purposes.
 
 import type { PurchaseInfo } from "@cocalc/util/licenses/purchase/types";
 import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
+import { ONE_HOUR_MS } from "@cocalc/util/consts/billing";
 
 interface Options {
   info: PurchaseInfo;
@@ -22,7 +23,7 @@ export default function currentLicenseValue({ info }: Options): number {
   if (info.cost_per_hour) {
     // if this is set, we use it to compute the value
     // The value is cost_per_hour times the number of hours left until info.end.
-    const hoursRemaining = (info.end.valueOf() - Date.now()) / (1000 * 60 * 60);
+    const hoursRemaining = (info.end.valueOf() - Date.now()) / ONE_HOUR_MS;
     // the hoursRemaining can easily be *negative* if info.end is in the past.
     // However the value of a license is never negative, so we max with 0.
     return Math.max(0, hoursRemaining * info.cost_per_hour);


### PR DESCRIPTION
# Description

This pull request reconciles the cost to cancel or resume an existing subscription. In particular, this pull request now computes the cost to resume a subscription based on the stored hourly rate of the subscription. There is still some follow-up work to do, so this is _not_ ready for merge, but these changes are ready for feedback. The items yet to be addressed are:

1) There is a discrepancy of precisely $0.02, which is introduced [here](https://github.com/schrodingersket/cocalc/blob/e78b23b3e07a5f0703d9c184266addbc1b7ab437/src/packages/util/purchases/cost-to-edit-license.ts#L177); the `modifiedPrice.discounted_cost` field is set to $0.02 when a refund is issued for an existing subscription license. It's not yet clear whether this should be removed when issuing a subscription.

2) Upon subscription cancellation, the cancelled subscription should be updated to current rates so that when resumed, the user is charged according to the latest subscription cost.

Note that this pull request only changes the backend code used to compute these costs, and is only a partial fix for #7141. This PR _should_ address #7171 and #7161, but will require further testing before closing those out.