### PR TITLE
frontend/flyout/files: duplicate controls at the top

### DIFF
--- a/src/packages/frontend/project/page/flyouts/consts.ts
+++ b/src/packages/frontend/project/page/flyouts/consts.ts
@@ -3,6 +3,8 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { CSS } from "@cocalc/frontend/app-framework";
+
 export const DEFAULT_EXT = "ipynb";
 
 export const FLYOUT_DEFAULT_WIDTH_PX: number = 350;
@@ -13,4 +15,21 @@ export const FLYOUT_EXTRA2_WIDTH_PX = Math.floor(FLYOUT_DEFAULT_WIDTH_PX * 1.4);
 export const FLYOUT_PADDING = "5px";
 
 // a non-standard filetype for a folder
-export const ACTIVE_FOLDER_TYPE = "_folder_"
+export const ACTIVE_FOLDER_TYPE = "_folder_";
+
+export const PANEL_STYLE_BOTTOM: CSS = {
+  width: "100%",
+  paddingLeft: "10px",
+  paddingRight: "10px",
+  paddingBottom: FLYOUT_PADDING,
+} as const;
+
+export const PANEL_STYLE_TOP: CSS = {
+  width: "100%",
+  paddingLeft: FLYOUT_PADDING,
+  paddingRight: FLYOUT_PADDING,
+  paddingBottom: FLYOUT_PADDING,
+};
+
+const PANEL_KEYS = ["selected", "terminal"];
+export type PanelKey = (typeof PANEL_KEYS)[number];

--- a/src/packages/frontend/project/page/flyouts/files-controls.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-controls.tsx
@@ -1,0 +1,248 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Button, Descriptions, Space, Tooltip } from "antd";
+import immutable from "immutable";
+
+import { useActions, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { Icon, TimeAgo } from "@cocalc/frontend/components";
+import {
+  ACTION_BUTTONS_DIR,
+  ACTION_BUTTONS_FILE,
+  ACTION_BUTTONS_MULTI,
+  isDisabledSnapshots,
+} from "@cocalc/frontend/project/explorer/action-bar";
+import {
+  DirectoryListing,
+  DirectoryListingEntry,
+} from "@cocalc/frontend/project/explorer/types";
+import { FILE_ACTIONS } from "@cocalc/frontend/project_actions";
+import { human_readable_size, path_split, plural } from "@cocalc/util/misc";
+import { PANEL_STYLE_BOTTOM, PANEL_STYLE_TOP } from "./consts";
+import { useSingleFile } from "./utils";
+import { COLORS } from "@cocalc/util/theme";
+
+interface FilesSelectedControlsProps {
+  checked_files: immutable.Set<string>;
+  directoryFiles: DirectoryListing;
+  getFile: (path: string) => DirectoryListingEntry | undefined;
+  mode: "top" | "bottom";
+  project_id: string;
+  showFileSharingDialog(file): void;
+  open: (
+    e: React.MouseEvent | React.KeyboardEvent,
+    index: number,
+    skip?: boolean,
+  ) => void;
+  activeFile: DirectoryListingEntry | null;
+}
+
+export function FilesSelectedControls({
+  checked_files,
+  directoryFiles,
+  getFile,
+  mode,
+  open,
+  project_id,
+  showFileSharingDialog,
+  activeFile,
+}: FilesSelectedControlsProps) {
+  const current_path = useTypedRedux({ project_id }, "current_path");
+  const actions = useActions({ project_id });
+
+  const singleFile = useSingleFile({
+    checked_files,
+    activeFile,
+    getFile,
+    directoryFiles,
+  });
+
+  async function openAllSelectedFiles(e: React.MouseEvent) {
+    e.stopPropagation();
+    const skipDirs = checked_files.size > 1;
+    for (const file of checked_files) {
+      const basename = path_split(file).tail;
+      const index = directoryFiles.findIndex((f) => f.name === basename);
+      // skipping directories, because it makes no sense to flip through them rapidly
+      if (skipDirs && getFile(file)?.isdir) {
+        open(e, index, true);
+        continue;
+      }
+      open(e, index);
+      // wait 10ms to avoid opening all files at once
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  function renderFileInfoTop() {
+    if (checked_files.size === 0) {
+      let [nFiles, nDirs] = [0, 0];
+      for (const f of directoryFiles) {
+        if (f.isdir) {
+          nDirs++;
+        } else {
+          nFiles++;
+        }
+      }
+
+      return (
+        <div style={{ color: COLORS.GRAY_M }}>
+          <Icon name="files" /> {nFiles} {plural(nFiles, "file")}, {nDirs}{" "}
+          {plural(nDirs, "folder")}
+        </div>
+      );
+    }
+  }
+
+  function renderFileInfoBottom() {
+    if (singleFile != null) {
+      const { size, mtime, isdir } = singleFile;
+      const age = typeof mtime === "number" ? 1000 * mtime : null;
+      return (
+        <Descriptions size="small" layout="horizontal" column={1}>
+          {age ? (
+            <Descriptions.Item label="Modified" span={1}>
+              <TimeAgo date={new Date(age)} />
+            </Descriptions.Item>
+          ) : undefined}
+          {isdir ? (
+            <Descriptions.Item label="Contains">
+              {size} {plural(size, "item")}
+            </Descriptions.Item>
+          ) : (
+            <Descriptions.Item label="Size">
+              {human_readable_size(size)}
+            </Descriptions.Item>
+          )}
+          {singleFile.is_public ? (
+            <Descriptions.Item label="Published">
+              <Button
+                size="small"
+                icon={<Icon name="share-square" />}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  showFileSharingDialog(singleFile);
+                }}
+              >
+                configure
+              </Button>
+            </Descriptions.Item>
+          ) : undefined}
+        </Descriptions>
+      );
+    } else {
+      // summary of multiple selected files
+      if (checked_files.size > 1) {
+        let [totSize, startDT, endDT] = [0, new Date(0), new Date(0)];
+        for (const f of checked_files) {
+          const file = getFile(f);
+          if (file == null) continue;
+          const { size = 0, mtime, isdir } = file;
+          totSize += isdir ? 0 : size;
+          if (typeof mtime === "number") {
+            const dt = new Date(1000 * mtime);
+            if (startDT.getTime() === 0 || dt < startDT) startDT = dt;
+            if (endDT.getTime() === 0 || dt > endDT) endDT = dt;
+          }
+        }
+
+        return (
+          <Descriptions size="small" layout="horizontal" column={1}>
+            <Descriptions.Item label="Total size" span={1}>
+              {human_readable_size(totSize)}
+            </Descriptions.Item>
+            {startDT.getTime() > 0 ? (
+              <Descriptions.Item label="Modified" span={1}>
+                <div>
+                  <TimeAgo date={startDT} /> – <TimeAgo date={endDT} />
+                </div>
+              </Descriptions.Item>
+            ) : undefined}
+          </Descriptions>
+        );
+      }
+    }
+  }
+
+  function renderFileInfo() {
+    if (mode === "top") {
+      return renderFileInfoTop();
+    } else {
+      return renderFileInfoBottom();
+    }
+  }
+
+  function renderOpenFile() {
+    if (checked_files.size === 0) return;
+    return (
+      <Tooltip
+        title={
+          checked_files.size === 1
+            ? "Or double-click file in listing"
+            : "Open all selected files"
+        }
+      >
+        <Button type="primary" size="small" onClick={openAllSelectedFiles}>
+          <Icon name="edit-filled" /> Edit
+          {checked_files.size > 1 ? " all" : ""}
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  function renderButtons(names) {
+    return (
+      <Space direction="horizontal" wrap>
+        {checked_files.size > 0 ? renderOpenFile() : undefined}
+        <Space.Compact size="small">
+          {names.map((name) => {
+            const disabled =
+              isDisabledSnapshots(name) &&
+              (current_path?.startsWith(".snapshots") ?? false);
+
+            const { name: actionName, icon, hideFlyout } = FILE_ACTIONS[name];
+            if (hideFlyout) return;
+            return (
+              <Tooltip key={name} title={`${actionName}...`}>
+                <Button
+                  size="small"
+                  key={name}
+                  disabled={disabled}
+                  onClick={() => {
+                    // TODO re-using the existing controls is a stopgap. make this part of the flyouts.
+                    actions?.set_active_tab("files");
+                    actions?.set_file_action(
+                      name,
+                      () => path_split(checked_files.first()).tail,
+                    );
+                  }}
+                >
+                  <Icon name={icon} />
+                </Button>
+              </Tooltip>
+            );
+          })}
+        </Space.Compact>
+      </Space>
+    );
+  }
+
+  return (
+    <Space
+      direction="vertical"
+      size="small"
+      style={mode === "top" ? PANEL_STYLE_TOP : PANEL_STYLE_BOTTOM}
+    >
+      {singleFile
+        ? singleFile.isdir
+          ? renderButtons(ACTION_BUTTONS_DIR)
+          : renderButtons(ACTION_BUTTONS_FILE.filter((n) => n !== "download"))
+        : checked_files.size > 1
+        ? renderButtons(ACTION_BUTTONS_MULTI)
+        : undefined}
+      {renderFileInfo()}
+    </Space>
+  );
+}

--- a/src/packages/frontend/project/page/flyouts/files-select-extra.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-select-extra.tsx
@@ -1,0 +1,88 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2023 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Button, Tooltip, Space } from "antd";
+import immutable from "immutable";
+
+import { Button as BSButton } from "@cocalc/frontend/antd-bootstrap";
+import { Icon } from "@cocalc/frontend/components";
+
+interface FilesSelectButtonsProps {
+  checked_files: immutable.Set<string>;
+  mode: "open" | "select";
+  selectAllFiles(): void;
+  clearAllSelections(skip: boolean): void;
+  setMode: (mode: "open" | "select") => void;
+}
+
+export function FilesSelectButtons({
+  checked_files,
+  setMode,
+  mode,
+  selectAllFiles,
+  clearAllSelections,
+}: FilesSelectButtonsProps) {
+  function renderButtons() {
+    if (mode !== "select") return null;
+    if (checked_files.size === 0) {
+      return (
+        <Tooltip title="Select all files">
+          <Button
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              selectAllFiles();
+            }}
+          >
+            All
+          </Button>
+        </Tooltip>
+      );
+    } else {
+      return (
+        <Tooltip title="Deselect all selected files">
+          <Button
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              clearAllSelections(false);
+            }}
+          >
+            Clear
+          </Button>
+        </Tooltip>
+      );
+    }
+  }
+
+  return (
+    <Space.Compact size="small">
+      <BSButton
+        bsSize="xsmall"
+        active={mode === "select"}
+        title={
+          <>
+            Switch into file file selection mode.
+            <br />
+            Note: Like on a desktop, you can also use the Shift and Ctrl key for
+            selecting files – or hover over the file icon to reveal the
+            checkbox.
+          </>
+        }
+        onClick={(e) => {
+          e.stopPropagation();
+          const nextMode = mode === "select" ? "open" : "select";
+          if (nextMode === "open") {
+            clearAllSelections(true);
+          }
+          setMode(nextMode);
+        }}
+      >
+        <Icon name={mode === "select" ? "check-square" : "square"} /> Select
+      </BSButton>
+      {renderButtons()}
+    </Space.Compact>
+  );
+}

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -42,6 +42,7 @@ import {
   capitalize,
   copy_without,
   human_readable_size,
+  path_split,
   path_to_file,
   search_match,
   search_split,
@@ -338,6 +339,11 @@ export function FilesFlyout({
   }, [file_search]);
 
   // *** END HOOKS ***
+
+  function getFile(name: string): DirectoryListingEntry | undefined {
+    const basename = path_split(name).tail;
+    return fileMap[basename];
+  }
 
   if (directoryListings == null) {
     (async () => {
@@ -653,13 +659,30 @@ export function FilesFlyout({
     );
   }
 
+  function clearAllSelections(switchMode) {
+    if (switchMode) setMode("open");
+    setPrevSelected(null);
+    actions?.set_all_files_unchecked();
+  }
+
+  function selectAllFiles() {
+    actions?.set_file_list_checked(
+      directoryFiles
+        .filter((f) => f.name !== "..")
+        .map((f) => path_to_file(current_path, f.name)),
+    );
+  }
+
   return (
     <div
       ref={rootRef}
       style={{ flex: "1 0 auto", flexDirection: "column", display: "flex" }}
     >
       <FilesHeader
+        activeFile={activeFile}
+        getFile={getFile}
         activeFileSort={activeFileSort}
+        checked_files={checked_files}
         directoryFiles={directoryFiles}
         disableUploads={disableUploads}
         handleSearchChange={handleSearchChange}
@@ -670,7 +693,11 @@ export function FilesFlyout({
         setScrollIdx={setScrollIdx}
         setScrollIdxHide={setScrollIdxHide}
         setSearchState={setSearchState}
+        showFileSharingDialog={showFileSharingDialog}
         virtuosoRef={virtuosoRef}
+        modeState={[mode, setMode]}
+        clearAllSelections={clearAllSelections}
+        selectAllFiles={selectAllFiles}
       />
       {disableUploads ? (
         renderListing()
@@ -695,24 +722,15 @@ export function FilesFlyout({
         project_id={project_id}
         checked_files={checked_files}
         activeFile={activeFile}
-        directoryData={[directoryFiles, fileMap]}
+        directoryFiles={directoryFiles}
         modeState={[mode, setMode]}
         projectIsRunning={projectIsRunning}
         rootHeightPx={rootHeightPx}
-        clearAllSelections={(switchMode) => {
-          if (switchMode) setMode("open");
-          setPrevSelected(null);
-          actions?.set_all_files_unchecked();
-        }}
-        selectAllFiles={() => {
-          actions?.set_file_list_checked(
-            directoryFiles
-              .filter((f) => f.name !== "..")
-              .map((f) => path_to_file(current_path, f.name)),
-          );
-        }}
+        clearAllSelections={clearAllSelections}
+        selectAllFiles={selectAllFiles}
         open={open}
         showFileSharingDialog={showFileSharingDialog}
+        getFile={getFile}
       />
     </div>
   );

--- a/src/packages/frontend/project/page/flyouts/utils.ts
+++ b/src/packages/frontend/project/page/flyouts/utils.ts
@@ -3,9 +3,10 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { CSS } from "@cocalc/frontend/app-framework";
+import { CSS, useMemo } from "@cocalc/frontend/app-framework";
 import { getRandomColor } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
+import { DirectoryListingEntry } from "../../explorer/types";
 import { fileItemLeftBorder } from "./file-list-item";
 import { FlyoutActiveMode, FlyoutLogMode } from "./state";
 
@@ -27,4 +28,20 @@ export function deterministicColor(group: string) {
 export function randomLeftBorder(group: string): CSS {
   const col = deterministicColor(group);
   return fileItemLeftBorder(col);
+}
+
+export function useSingleFile({
+  checked_files,
+  activeFile,
+  getFile,
+  directoryFiles,
+}): DirectoryListingEntry | undefined {
+  return useMemo(() => {
+    if (checked_files.size === 0 && activeFile != null) {
+      return activeFile;
+    }
+    if (checked_files.size === 1) {
+      return getFile(checked_files.first() ?? "");
+    }
+  }, [checked_files, directoryFiles, activeFile]);
 }


### PR DESCRIPTION
# Description

for better or worse, this adds an "action bar" row at the top. other online file explorers alternate between the navigation/filter bar and the action buttons to safe space. We could try that in a follow up modification.

![Screenshot from 2024-01-18 14-04-19](https://github.com/sagemathinc/cocalc/assets/207405/ba226647-e55d-4dfd-bd5d-10003c967740)


![Screenshot from 2024-01-18 14-03-55](https://github.com/sagemathinc/cocalc/assets/207405/5765277c-a7ab-4e85-b57d-a6b32a7e6951)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
