### PR TITLE
frontend/flyout/files: show top buttons when file is selected

### DIFF
--- a/src/packages/frontend/project/page/flyouts/files-controls.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-controls.tsx
@@ -77,23 +77,23 @@ export function FilesSelectedControls({
   }
 
   function renderFileInfoTop() {
-    if (checked_files.size === 0) {
-      let [nFiles, nDirs] = [0, 0];
-      for (const f of directoryFiles) {
-        if (f.isdir) {
-          nDirs++;
-        } else {
-          nFiles++;
-        }
-      }
+    if (checked_files.size !== 0) return;
 
-      return (
-        <div style={{ color: COLORS.GRAY_M }}>
-          <Icon name="files" /> {nFiles} {plural(nFiles, "file")}, {nDirs}{" "}
-          {plural(nDirs, "folder")}
-        </div>
-      );
+    let [nFiles, nDirs] = [0, 0];
+    for (const f of directoryFiles) {
+      if (f.isdir) {
+        nDirs++;
+      } else {
+        nFiles++;
+      }
     }
+
+    return (
+      <div style={{ color: COLORS.GRAY_M }}>
+        <Icon name="files" /> {nFiles} {plural(nFiles, "file")}, {nDirs}{" "}
+        {plural(nDirs, "folder")}
+      </div>
+    );
   }
 
   function renderFileInfoBottom() {
@@ -193,6 +193,8 @@ export function FilesSelectedControls({
   }
 
   function renderButtons(names) {
+    if (mode === "top" && checked_files.size === 0) return;
+
     return (
       <Space direction="horizontal" wrap>
         {checked_files.size > 0 ? renderOpenFile() : undefined}

--- a/src/packages/frontend/project/page/flyouts/files-select-extra.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-select-extra.tsx
@@ -26,6 +26,7 @@ export function FilesSelectButtons({
 }: FilesSelectButtonsProps) {
   function renderButtons() {
     if (mode !== "select") return null;
+
     if (checked_files.size === 0) {
       return (
         <Tooltip title="Select all files">


### PR DESCRIPTION
# Description

This is a silly bugfix: only show the action buttons if at least one file is selected. otherwise those clicks end up in a confusing void...



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
