### PR TITLE
#6919: Added user balance to store navbar when user is logged in.

### DIFF
--- a/src/packages/next/components/store/checkout.tsx
+++ b/src/packages/next/components/store/checkout.tsx
@@ -17,7 +17,7 @@ import {
   Spin,
   Table,
 } from "antd";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Icon } from "@cocalc/frontend/components/icon";
 import { money } from "@cocalc/util/licenses/purchase/utils";
 import { copy_without as copyWithout, isValidUUID } from "@cocalc/util/misc";
@@ -35,6 +35,7 @@ import { currency, round2up, round2down } from "@cocalc/util/misc";
 import type { CheckoutParams } from "@cocalc/server/purchases/shopping-cart-checkout";
 import { ProductColumn } from "./cart";
 import ShowError from "@cocalc/frontend/components/error";
+import { StoreBalanceContext } from "../../lib/balance";
 
 enum PaymentIntent {
   PAY_TOTAL,
@@ -53,6 +54,7 @@ export default function Checkout() {
   const { profile, reload: reloadProfile } = useProfileWithReload({
     noCache: true,
   });
+  const { refreshBalance } = useContext(StoreBalanceContext);
   const [session, setSession] = useState<{ id: string; url: string } | null>(
     null,
   );
@@ -161,6 +163,7 @@ export default function Checkout() {
       // The purchase failed.
       setError(err.message);
     } finally {
+      refreshBalance();
       if (!isMounted.current) return;
       setCompletingPurchase(false);
     }

--- a/src/packages/next/components/store/index.tsx
+++ b/src/packages/next/components/store/index.tsx
@@ -4,12 +4,14 @@
  */
 import { Alert, Layout } from "antd";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
+import * as purchasesApi from "@cocalc/frontend/purchases/api";
 import { COLORS } from "@cocalc/util/theme";
 import Anonymous from "components/misc/anonymous";
 import Loading from "components/share/loading";
 import SiteName from "components/share/site-name";
+import { StoreBalanceContext } from "lib/balance";
 import { MAX_WIDTH } from "lib/config";
 import useProfile from "lib/hooks/profile";
 import useCustomize from "lib/use-customize";
@@ -44,9 +46,26 @@ export default function StoreLayout({ page }: Props) {
   const router = useRouter();
   const profile = useProfile({ noCache: true });
 
+  const [balance, setBalance] = useState<number>();
+
+  const refreshBalance = async () => {
+    if (!profile || !profile.account_id) {
+      setBalance(undefined);
+      return;
+    }
+
+    // Set balance if user is logged in
+    //
+    setBalance(await purchasesApi.getBalance());
+  };
+
   useEffect(() => {
     router.prefetch("/store/site-license");
   }, []);
+
+  useEffect(() => {
+    refreshBalance();
+  }, [profile]);
 
   function renderNotCommercial(): JSX.Element {
     return (
@@ -139,10 +158,10 @@ export default function StoreLayout({ page }: Props) {
           }}
         >
           <div style={{ maxWidth: MAX_WIDTH, margin: "auto" }}>
-            <>
+            <StoreBalanceContext.Provider value={{ balance, refreshBalance }}>
               <Menu main={main} />
               {body()}
-            </>
+            </StoreBalanceContext.Provider>
           </div>
         </Content>
       </Layout>

--- a/src/packages/next/components/store/menu.tsx
+++ b/src/packages/next/components/store/menu.tsx
@@ -3,41 +3,68 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Icon } from "@cocalc/frontend/components/icon";
-import { Menu, MenuProps, Typography } from "antd";
+import React, { useContext } from 'react';
+import { Menu, MenuProps, Flex, Typography } from "antd";
 import { useRouter } from "next/router";
+
+import { currency } from "@cocalc/util/misc";
+import { Icon } from "@cocalc/frontend/components/icon";
+import { StoreBalanceContext } from "../../lib/balance";
+
 const { Text } = Typography;
 
 type MenuItem = Required<MenuProps>["items"][number];
 
-export default function ConfigMenu({ main }) {
-  const router = useRouter();
+const styles: { [k: string]: React.CSSProperties } = {
+  menuBookend: {
+    height: "100%",
+    whiteSpace: "nowrap",
+  },
+  menu: {
+    width: "100%",
+    height: "100%",
+    border: 0
+  },
+  menuContainer: {
+    marginBottom: "24px",
+    whiteSpace: "nowrap",
+    alignItems: "center",
+    border: 0,
+    borderBottom: "1px solid rgba(5, 5, 5, 0.06)",
+    boxShadow: "none",
+  }
+};
 
-  function select(e) {
-    router.push(`/store/${e.keyPath[0]}`, undefined, {
+export interface ConfigMenuProps {
+  main?: string;
+}
+
+export default function ConfigMenu({ main }: ConfigMenuProps) {
+  const router = useRouter();
+  const { balance } = useContext(StoreBalanceContext);
+
+  const handleMenuItemSelect: MenuProps['onSelect'] = ({ keyPath }) => {
+    router.push(`/store/${keyPath[0]}`, undefined, {
       scroll: false,
     });
   }
 
   const items: MenuItem[] = [
-    { label: <Text strong>Store</Text>, key: "" },
     {
       label: "Licenses",
       key: "site-license",
       icon: <Icon name="key" />,
     },
-    //     {
-    //       label: "Booster",
-    //       key: "boost",
-    //       icon: <Icon name="rocket" />,
-    //     },
-    //     {
-    //       label: "Dedicated VM or Disk",
-    //       key: "dedicated",
-    //       icon: <Icon name="dedicated" />,
-    //     },
-    { label: "Cart", key: "cart", icon: <Icon name="shopping-cart" /> },
-    { label: "Checkout", key: "checkout", icon: <Icon name="list" /> },
+    {
+      label: "Cart",
+      key: "cart",
+      icon: <Icon name="shopping-cart" />,
+    },
+    {
+      label: "Checkout",
+      key: "checkout",
+      icon: <Icon name="list" />,
+    },
     {
       label: "Congrats",
       key: "congrats",
@@ -51,12 +78,18 @@ export default function ConfigMenu({ main }) {
   ];
 
   return (
-    <Menu
-      mode="horizontal"
-      selectedKeys={[main]}
-      style={{ height: "100%", marginBottom: "24px" }}
-      onSelect={select}
-      items={items}
-    />
+    <Flex gap="middle" justify="space-between" style={styles.menuContainer}>
+      <Text strong style={styles.menuBookend}>Store</Text>
+      <Menu
+        mode="horizontal"
+        selectedKeys={main ? [main] : undefined}
+        style={styles.menu}
+        onSelect={handleMenuItemSelect}
+        items={items}
+      />
+      <Text strong style={styles.menuBookend}>
+        {balance !== undefined ? `Balance: ${currency(balance)}` : null}
+      </Text>
+    </Flex>
   );
 }

--- a/src/packages/next/components/store/vouchers.tsx
+++ b/src/packages/next/components/store/vouchers.tsx
@@ -22,7 +22,7 @@ import {
   Space,
 } from "antd";
 import dayjs from "dayjs";
-import { useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { Icon } from "@cocalc/frontend/components/icon";
 import { money } from "@cocalc/util/licenses/purchase/utils";
 import { plural } from "@cocalc/util/misc";
@@ -58,6 +58,7 @@ import {
 import type { CheckoutParams } from "@cocalc/server/purchases/shopping-cart-checkout";
 import { ExplainPaymentSituation } from "./checkout";
 import AddCashVoucher from "./add-cash-voucher";
+import { StoreBalanceContext } from "../../lib/balance";
 
 interface Config {
   whenPay: WhenPay;
@@ -76,6 +77,7 @@ export default function CreateVouchers() {
   const { profile, reload: reloadProfile } = useProfileWithReload({
     noCache: true,
   });
+  const { refreshBalance } = useContext(StoreBalanceContext);
   const [orderError, setOrderError] = useState<string>("");
   const [subTotal, setSubTotal] = useState<number>(0);
 
@@ -225,6 +227,7 @@ export default function CreateVouchers() {
       // The purchase failed.
       setOrderError(err.message);
     } finally {
+      refreshBalance();
       if (!isMounted.current) return;
       setCompletingPurchase(false);
     }

--- a/src/packages/next/lib/balance.ts
+++ b/src/packages/next/lib/balance.ts
@@ -1,0 +1,15 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { createContext } from "react";
+
+export interface StoreBalance  {
+  balance?: number;
+  refreshBalance: () => Promise<void>;
+}
+
+export const StoreBalanceContext = createContext<StoreBalance>({
+  refreshBalance: async () => {},
+});


### PR DESCRIPTION
# Description

This pull request adds the user's balance to the top-right of the navbar in the Store. When not logged in, no balance is shown. The balance is refreshed when either a voucher or shopping cart purchase is completed or fails (the refresh is triggered in the corresponding `finally` blocks).

Screenshot (see top-right):

![image](https://github.com/sagemathinc/cocalc/assets/17204901/031b8a31-ba9b-42ed-b0b3-1cd311b12bd3)

This PR is in draft until a couple UX questions are answered, namely:

1) Given that a) there are only two operations in the store that can change the balance, and b) we don't have any sort of event triggers that fire on the frontend when the balance is changed anyway, does it make sense to add a button to refresh the balance manually?

2) Is the `Account Balance: $20.00` text in the above screenshot still necessary, given that the account balance is displayed? Or is it still useful to have around?