### PR TITLE
npm: getting rid of async-await-utils

### DIFF
--- a/src/compute/compute/lib/jupyter.ts
+++ b/src/compute/compute/lib/jupyter.ts
@@ -12,7 +12,7 @@ import debug from "debug";
 import { once } from "@cocalc/util/async-utils";
 import { COMPUTER_SERVER_CURSOR_TYPE } from "@cocalc/util/compute/manager";
 import { SYNCDB_OPTIONS } from "@cocalc/jupyter/redux/sync";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 const log = debug("cocalc:compute:jupyter");
 

--- a/src/compute/compute/package.json
+++ b/src/compute/compute/package.json
@@ -38,7 +38,6 @@
     "@cocalc/terminal": "workspace:*",
     "@cocalc/util": "workspace:*",
     "@types/ws": "^8.5.9",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "cookie": "^0.5.0",
     "debug": "^4.3.2",

--- a/src/packages/backend/get-listing.ts
+++ b/src/packages/backend/get-listing.ts
@@ -17,7 +17,7 @@ Use ?random= or ?time= if you're worried about cacheing.
 Browser client code only uses this through the websocket anyways.
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import type { Dirent, Stats } from "node:fs";
 import { lstat, readdir, readlink, stat } from "node:fs/promises";
 import { getLogger } from "./logger";
@@ -29,7 +29,7 @@ const logger = getLogger("directory-listing");
 const HOME = process.env.SMC_LOCAL_HUB_HOME ?? process.env.HOME ?? "";
 
 const getListing = reuseInFlight(
-  async (
+  async(
     path: string, // assumed in home directory!
     hidden: boolean = false,
   ): Promise<DirectoryListingEntry[]> => {

--- a/src/packages/backend/package.json
+++ b/src/packages/backend/package.json
@@ -33,7 +33,6 @@
     "@cocalc/backend": "workspace:*",
     "@cocalc/util": "workspace:*",
     "@types/debug": "^4.1.7",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "chokidar": "^3.5.3",
     "debug": "^4.3.2",

--- a/src/packages/database/package.json
+++ b/src/packages/database/package.json
@@ -26,7 +26,6 @@
     "@types/pg": "^8.6.1",
     "@types/uuid": "^8.3.1",
     "async": "^1.5.2",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "better-sqlite3": "^8.3.0",
     "debug": "^4.3.2",

--- a/src/packages/database/pool/cached.ts
+++ b/src/packages/database/pool/cached.ts
@@ -22,7 +22,7 @@ fine, since this would only be a problem when they change the name
 of multiple projects.
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import LRU from "lru-cache";
 import { Pool } from "pg";
 

--- a/src/packages/database/postgres/news.ts
+++ b/src/packages/database/postgres/news.ts
@@ -28,7 +28,7 @@ ORDER BY date DESC
 LIMIT 100`;
 
 export async function getFeedData(): Promise<NewsItem[]> {
-  return await C.query<NewsItem>(Q_FEED);
+  return await C.query(Q_FEED);
 }
 
 // ::timestamptz because if your server is not in UTC, it will be converted to UTC
@@ -43,7 +43,7 @@ WHERE id = $1`;
 // This is used for editing a news item
 export async function getNewsItem(
   id: number,
-  cached = true
+  cached = true,
 ): Promise<NewsItem | null> {
   return await C.queryOne<NewsItem>(Q_BY_ID, [id], cached);
 }
@@ -106,9 +106,9 @@ OFFSET $2`;
 
 export async function getIndex(
   limit: number,
-  offset: number
+  offset: number,
 ): Promise<NewsItem[]> {
-  return await C.query<NewsItem>(Q_INDEX, [limit, offset]);
+  return await C.query(Q_INDEX, [limit, offset]);
 }
 
 // get the most recent news item
@@ -138,9 +138,9 @@ LIMIT $1`;
 
 // of the last n picked by Q_RECENT, select one deterministically different every 10 minutes
 export async function getRecentHeadlines(
-  n: number
+  n: number,
 ): Promise<RecentHeadline[] | null> {
-  const headlines = await C.query<RecentHeadline>(Q_RECENT, [n]);
+  const headlines = await C.query(Q_RECENT, [n]);
   if (headlines.length === 0) return null;
   return headlines;
 }

--- a/src/packages/database/postgres/personal.ts
+++ b/src/packages/database/postgres/personal.ts
@@ -8,7 +8,7 @@ Functionality related to running cocalc in personal mode.
 */
 
 import { PostgreSQL } from "./types";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { uuid } from "@cocalc/util/misc";
 
 async function _get_personal_user(database: PostgreSQL): Promise<string> {

--- a/src/packages/database/postgres/remember-me.ts
+++ b/src/packages/database/postgres/remember-me.ts
@@ -12,7 +12,7 @@ OF course, not everything is rewritten yet...
 import { PostgreSQL } from "./types";
 const { one_result } = require("../postgres-base");
 import { callback } from "awaiting";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 async function _get_remember_me(
   db: PostgreSQL,

--- a/src/packages/database/postgres/util.ts
+++ b/src/packages/database/postgres/util.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import LRU from "lru-cache";
 import { Pool } from "pg";
 import { sha1 } from "@cocalc/backend/misc_node";
@@ -61,11 +61,11 @@ export class LRUQueryCache {
   }
 
   public query = reuseInFlight(
-    async <T,>(
+    async (
       query: string,
       args: (string | number | Date)[] = [],
       cached = true,
-    ): Promise<T[]> => {
+    ) => {
       const key = sha1(JSON.stringify([query, ...args]));
 
       if (cached) {

--- a/src/packages/frontend/account/licenses/util.ts
+++ b/src/packages/frontend/account/licenses/util.ts
@@ -4,7 +4,8 @@
  */
 
 import { Map } from "immutable";
-import { reuseInFlight } from "async-await-utils/hof";
+
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { field_cmp, cmp_Date } from "@cocalc/util/misc";
 import { SiteLicense } from "@cocalc/util/types/site-licenses";

--- a/src/packages/frontend/app/monitor-connection.ts
+++ b/src/packages/frontend/app/monitor-connection.ts
@@ -7,13 +7,14 @@
 // state in the page store.
 
 import { delay } from "awaiting";
-import { reuseInFlight } from "async-await-utils/hof";
-import { redux } from "../app-framework";
-import { SITE_NAME } from "@cocalc/util/theme";
+
+import { alert_message } from "@cocalc/frontend/alerts";
+import { redux } from "@cocalc/frontend/app-framework";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { minutes_ago } from "@cocalc/util/misc";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
+import { SITE_NAME } from "@cocalc/util/theme";
 import { ConnectionStatus } from "./store";
-import { alert_message } from "../alerts";
-import { webapp_client } from "../webapp-client";
 
 const DISCONNECTED_STATE_DELAY_MS = 5000;
 const CONNECTING_STATE_DELAY_MS = 3000;
@@ -110,7 +111,7 @@ export function init_connection(): void {
       recent_disconnects.length = 0; // see https://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript
       reconnection_warning = +new Date();
       console.log(
-        `ALERT: connection unstable, notification + attempting to fix it -- ${attempt} attempts and ${num_recent_disconnects()} disconnects`
+        `ALERT: connection unstable, notification + attempting to fix it -- ${attempt} attempts and ${num_recent_disconnects()} disconnects`,
       );
       if (!recent_wakeup_from_standby()) {
         alert_message(msg);
@@ -122,7 +123,7 @@ export function init_connection(): void {
     }
 
     console.log(
-      `attempt: ${attempt} and num_recent_disconnects: ${num_recent_disconnects()}`
+      `attempt: ${attempt} and num_recent_disconnects: ${num_recent_disconnects()}`,
     );
     // NOTE: On mobile devices the websocket is disconnected every time one backgrounds
     // the application.  This normal and expected behavior, which does not indicate anything

--- a/src/packages/frontend/client/project.ts
+++ b/src/packages/frontend/client/project.ts
@@ -15,7 +15,7 @@ import {
   defaults,
   coerce_codomain_to_numbers,
 } from "@cocalc/util/misc";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import * as message from "@cocalc/util/message";
 import { DirectoryListingEntry } from "@cocalc/util/types";
 import { connection_to_project } from "../project/websocket/connect";

--- a/src/packages/frontend/components/run-button/index.tsx
+++ b/src/packages/frontend/components/run-button/index.tsx
@@ -13,8 +13,8 @@ import {
   useState,
 } from "react";
 import TimeAgo from "react-timeago";
-import { reuseInFlight } from "async-await-utils/hof";
 
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 //import { file_associations } from "@cocalc/frontend/file-associations";
 //import OpenAIAvatar from "@cocalc/frontend/components/openai-avatar";
 import { Icon } from "@cocalc/frontend/components/icon";
@@ -118,7 +118,7 @@ export default function RunButton({
       setOutput0(
         outputMessagesRef.current == null ? null : (
           <Output output={outputMessagesRef.current} old />
-        )
+        ),
       );
     } else {
       outputMessagesRef.current = messages;
@@ -374,7 +374,7 @@ export default function RunButton({
                   setKernelName(name);
                   setShowPopover(false);
                   setInfo?.(
-                    `${kernelLanguage(name, project_id)} {kernel="${name}"}`
+                    `${kernelLanguage(name, project_id)} {kernel="${name}"}`,
                   );
                 }}
                 kernel={kernelName}
@@ -496,5 +496,5 @@ type GetFromCache = (hash: string) => Promise<{
 }>;
 
 const getFromDatabaseCache: GetFromCache = reuseInFlight(
-  async (hash) => await api("execute", { hash })
+  async (hash) => await api("execute", { hash }),
 );

--- a/src/packages/frontend/compute/api.ts
+++ b/src/packages/frontend/compute/api.ts
@@ -5,7 +5,7 @@ import type {
   Cloud,
 } from "@cocalc/util/db-schema/compute-servers";
 import type { GoogleCloudData } from "@cocalc/util/compute/cloud/google-cloud/compute-cost";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 export async function createServer(opts: {
   project_id: string;

--- a/src/packages/frontend/compute/sync-all.ts
+++ b/src/packages/frontend/compute/sync-all.ts
@@ -1,5 +1,5 @@
 import { webapp_client } from "@cocalc/frontend/webapp-client";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { throttle } from "lodash";
 import { redux } from "@cocalc/frontend/app-framework";
 

--- a/src/packages/frontend/course/configuration/actions.ts
+++ b/src/packages/frontend/course/configuration/actions.ts
@@ -15,7 +15,7 @@ import {
 import { Datastore, EnvVars } from "@cocalc/frontend/projects/actions";
 import { store as projects_store } from "@cocalc/frontend/projects/store";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { CourseActions, primary_key } from "../actions";
 import { DEFAULT_LICENSE_UPGRADE_HOST_PROJECT } from "../store";
 import { SiteLicenseStrategy, SyncDBRecord, UpgradeGoal } from "../types";

--- a/src/packages/frontend/course/students/actions.ts
+++ b/src/packages/frontend/course/students/actions.ts
@@ -15,7 +15,7 @@ import { map } from "awaiting";
 import { redux } from "../../app-framework";
 import { webapp_client } from "../../webapp-client";
 import { defaults, required, uuid } from "@cocalc/util/misc";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 export class StudentsActions {
   private course_actions: CourseActions;

--- a/src/packages/frontend/frame-editors/code-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/code-editor/actions.ts
@@ -21,7 +21,7 @@ const SAVE_WORKAROUND =
   "Ensure your network connection is solid. If this problem persists, you might need to close and open this file, restart this project in project settings, or contact support (help@cocalc.com)";
 
 import type { TourProps } from "antd";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { delay } from "awaiting";
 import * as CodeMirror from "codemirror";
 import { List, Map, fromJS, Set as iSet } from "immutable";

--- a/src/packages/frontend/frame-editors/code-editor/code-editor-manager.ts
+++ b/src/packages/frontend/frame-editors/code-editor/code-editor-manager.ts
@@ -7,7 +7,7 @@
 Manage a collection of code editors of various files in frame trees...
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 import { close, filename_extension } from "@cocalc/util/misc";
 import { Actions, CodeEditorState } from "../code-editor/actions";

--- a/src/packages/frontend/frame-editors/frame-tree/register.ts
+++ b/src/packages/frontend/frame-editors/frame-tree/register.ts
@@ -9,7 +9,7 @@ Generic register function -- used by each frame tree editor to register itself w
 Basically, this is like register_file_editor, but much more specialized.
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { register_file_editor as general_register_file_editor } from "@cocalc/frontend/file-editors";
 import { redux_name } from "@cocalc/frontend/app-framework";
 import { IconName } from "@cocalc/frontend/components/icon";

--- a/src/packages/frontend/frame-editors/jupyter-editor/snippets/utils.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/snippets/utils.ts
@@ -6,7 +6,7 @@
 import { pick, merge } from "lodash";
 import { basename } from "path";
 import { unreachable, separate_file_extension } from "@cocalc/util/misc";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { exec } from "@cocalc/frontend/frame-editors/generic/client";
 import { canonical_language } from "@cocalc/jupyter/redux/store";
 import {

--- a/src/packages/frontend/frame-editors/latex-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/actions.ts
@@ -22,7 +22,7 @@ import { delay } from "awaiting";
 import * as CodeMirror from "codemirror";
 import { normalize as path_normalize } from "path";
 import { debounce, union } from "lodash";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { fromJS, List, Map } from "immutable";
 import { once } from "@cocalc/util/async-utils";
 import { project_api } from "../generic/client";

--- a/src/packages/frontend/frame-editors/latex-editor/pdfjs-doc-cache.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/pdfjs-doc-cache.ts
@@ -20,7 +20,7 @@ and things just grow badly (user has tons of docs open).
 const MAX_PAGES = 1000;
 
 import LRU from "lru-cache";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { versions } from "@cocalc/cdn";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 import "pdfjs-dist/webpack";

--- a/src/packages/frontend/frame-editors/qmd-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/qmd-editor/actions.ts
@@ -8,7 +8,7 @@ Quarto Editor Actions
 */
 
 import { path_split } from "@cocalc/util/misc";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { Set } from "immutable";
 import { debounce } from "lodash";
 import { redux } from "../../app-framework";

--- a/src/packages/frontend/frame-editors/qmd-editor/qmd-converter.ts
+++ b/src/packages/frontend/frame-editors/qmd-editor/qmd-converter.ts
@@ -8,7 +8,7 @@ Convert Quarto Markdown file (similar to Rmd) to html or pdf
 */
 
 import { path_split } from "@cocalc/util/misc";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { exec, ExecOutput } from "../generic/client";
 
 export const convert: (opts: Opts) => Promise<ExecOutput> =

--- a/src/packages/frontend/frame-editors/rmd-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/rmd-editor/actions.ts
@@ -7,7 +7,7 @@
 R Markdown Editor Actions
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { debounce } from "lodash";
 import { Set } from "immutable";
 import { Actions as MarkdownActions } from "../markdown-editor/actions";

--- a/src/packages/frontend/frame-editors/rmd-editor/rmd-converter.ts
+++ b/src/packages/frontend/frame-editors/rmd-editor/rmd-converter.ts
@@ -7,7 +7,7 @@
 Convert R Markdown file to hidden Markdown file, then read.
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { path_split } from "@cocalc/util/misc";
 import { exec, ExecOutput } from "../generic/client";
 

--- a/src/packages/frontend/frame-editors/rst-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/rst-editor/actions.ts
@@ -7,7 +7,7 @@
 Rst Editor Actions
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { Actions as CodeEditorActions } from "../code-editor/actions";
 import { print_html } from "../frame-tree/print";
 import { convert } from "./rst2html";

--- a/src/packages/frontend/frame-editors/whiteboard-editor/elements/code/actions.ts
+++ b/src/packages/frontend/frame-editors/whiteboard-editor/elements/code/actions.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 import { redux } from "@cocalc/frontend/app-framework";
 import { JupyterEditorActions } from "@cocalc/frontend/frame-editors/jupyter-editor/actions";

--- a/src/packages/frontend/frame-editors/wiki-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/wiki-editor/actions.ts
@@ -7,7 +7,7 @@
 Media wiki Editor Actions
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { Actions as MarkdownActions } from "../markdown-editor/actions";
 import { convert } from "./wiki2html";
 import { FrameTree } from "../frame-tree/types";

--- a/src/packages/frontend/frame-editors/x11-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/actions.ts
@@ -18,7 +18,7 @@ import type { Channel } from "@cocalc/comm/websocket/types";
 import { Map, Set as immutableSet, fromJS } from "immutable";
 import { project_api } from "../generic/client";
 import { set_buffer, get_buffer } from "../../copy-paste-buffer";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { callback, delay } from "awaiting";
 import { assertDefined } from "@cocalc/util/misc";
 import {

--- a/src/packages/frontend/frame-editors/x11-editor/xpra-client.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/xpra-client.ts
@@ -7,7 +7,7 @@
 
 import { join } from "path";
 import { retry_until_success } from "@cocalc/util/async-utils";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { ConnectionStatus } from "../frame-tree/types";
 import { Client } from "./xpra/client";
 import { Surface } from "./xpra/surface";

--- a/src/packages/frontend/frame-editors/x11-editor/xpra-server.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/xpra-server.ts
@@ -8,7 +8,7 @@ Control backend Xpra server daemon
 */
 
 import { exec, ExecOutput, ExecOpts } from "../generic/client";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { MAX_WIDTH, MAX_HEIGHT } from "./xpra/surface";
 import { splitlines, split } from "@cocalc/util/misc";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";

--- a/src/packages/frontend/lib/server-stats.ts
+++ b/src/packages/frontend/lib/server-stats.ts
@@ -5,7 +5,7 @@
 
 import { join } from "path";
 import LRU from "lru-cache";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 
 type Stats = {

--- a/src/packages/frontend/package.json
+++ b/src/packages/frontend/package.json
@@ -66,7 +66,6 @@
     "antd": "^5.11.3",
     "antd-img-crop": "^4.12.2",
     "async": "^2.6.3",
-    "async-await-utils": "^3.0.1",
     "audio-extensions": "^0.0.0",
     "awaiting": "^3.0.0",
     "bootbox": "^4.4.0",

--- a/src/packages/frontend/project/fetch-directory-listing.ts
+++ b/src/packages/frontend/project/fetch-directory-listing.ts
@@ -3,7 +3,7 @@ import type { ProjectActions } from "@cocalc/frontend/project_actions";
 import { trunc_middle, uuid } from "@cocalc/util/misc";
 import { get_directory_listing2 as get_directory_listing } from "./directory-listing";
 import { fromJS } from "immutable";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 //const log = (...args) => console.log("fetchDirectoryListing", ...args);
 const log = (..._args) => {};

--- a/src/packages/frontend/project/websocket/api.ts
+++ b/src/packages/frontend/project/websocket/api.ts
@@ -22,7 +22,7 @@ import type {
 } from "@cocalc/util/code-formatter";
 import { syntax2tool } from "@cocalc/util/code-formatter";
 import { DirectoryListingEntry } from "@cocalc/util/types";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { Channel, Mesg, NbconvertParams } from "@cocalc/comm/websocket/types";
 import call from "@cocalc/sync/client/call";
 

--- a/src/packages/frontend/project/websocket/connect.ts
+++ b/src/packages/frontend/project/websocket/connect.ts
@@ -12,7 +12,7 @@ wat once, and hence we make many Primus websocket connections
 simultaneously to the same domain.  It does work, but not without an ugly hack.
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { callback, delay } from "awaiting";
 import { ajax, globalEval } from "jquery";
 import { join } from "path";

--- a/src/packages/frontend/projects/table.ts
+++ b/src/packages/frontend/projects/table.ts
@@ -1,4 +1,4 @@
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { COCALC_MINIMAL } from "../fullscreen";
 import { parse_query } from "@cocalc/sync/table/util";
 import { once } from "@cocalc/util/async-utils";

--- a/src/packages/frontend/site-licenses/site-license-public-info.tsx
+++ b/src/packages/frontend/site-licenses/site-license-public-info.tsx
@@ -5,7 +5,7 @@
 
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { Alert, Button, Popconfirm, Popover, Table, Tag, Tooltip } from "antd";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { isEqual } from "lodash";
 
 import Export from "@cocalc/frontend/purchases/export";

--- a/src/packages/frontend/site-licenses/util.ts
+++ b/src/packages/frontend/site-licenses/util.ts
@@ -7,7 +7,7 @@ import LRU from "lru-cache";
 
 import { SCHEMA } from "@cocalc/util/db-schema";
 import { copy, trunc_left } from "@cocalc/util/misc";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { query } from "../frame-editors/generic/client";
 import { SiteLicensePublicInfo } from "./types";
 

--- a/src/packages/hub/package.json
+++ b/src/packages/hub/package.json
@@ -25,7 +25,6 @@
     "@types/react": "^18.0.26",
     "@types/uuid": "^8.3.1",
     "async": "^1.5.2",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "basic-auth": "^2.0.1",
     "bindings": "^1.3.0",

--- a/src/packages/hub/proxy/target.ts
+++ b/src/packages/hub/proxy/target.ts
@@ -8,7 +8,7 @@ to this target or the target project isn't running.
 
 import { ProjectControlFunction } from "@cocalc/server/projects/control";
 import { NamedServerName } from "@cocalc/util/types/servers";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import LRU from "lru-cache";
 import getLogger from "../logger";
 import { database } from "../servers/database";

--- a/src/packages/jupyter/blobs/disk.ts
+++ b/src/packages/jupyter/blobs/disk.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import LRU from "lru-cache";
 import { readFileSync, statSync, writeFileSync } from "node:fs";
 import { mkdir, readFile, readdir, stat, unlink } from "node:fs/promises";

--- a/src/packages/jupyter/kernel/kernel.ts
+++ b/src/packages/jupyter/kernel/kernel.ts
@@ -27,7 +27,7 @@ if (DEBUG) {
 // Also exit-hook is hard to import from commonjs.
 import nodeCleanup from "node-cleanup";
 import type { Channels, MessageType } from "@nteract/messaging";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { callback, delay } from "awaiting";
 import { createMainChannel } from "enchannel-zmq-backend";
 import { EventEmitter } from "node:events";

--- a/src/packages/jupyter/package.json
+++ b/src/packages/jupyter/package.json
@@ -45,7 +45,6 @@
     "@nteract/messaging": "^7.0.20",
     "@types/better-sqlite3": "^7.6.4",
     "@types/node-cleanup": "^2.1.2",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "better-sqlite3": "^8.3.0",
     "debug": "^4.3.2",

--- a/src/packages/jupyter/pool/pool.ts
+++ b/src/packages/jupyter/pool/pool.ts
@@ -8,7 +8,7 @@ Launching and managing Jupyter kernels in a pool for
 performance.
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { delay } from "awaiting";
 import json from "json-stable-stringify";
 import nodeCleanup from "node-cleanup";

--- a/src/packages/jupyter/redux/actions.ts
+++ b/src/packages/jupyter/redux/actions.ts
@@ -23,7 +23,7 @@ export const COMPUTE_THRESH_MS = 15 * 1000;
 
 declare const localStorage: any;
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import * as immutable from "immutable";
 import { Actions } from "@cocalc/util/redux/Actions";
 import { three_way_merge } from "@cocalc/sync/editor/generic/util";

--- a/src/packages/jupyter/stateless-api/kernel.ts
+++ b/src/packages/jupyter/stateless-api/kernel.ts
@@ -5,7 +5,7 @@ import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import getLogger from "@cocalc/backend/logger";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 const log = getLogger("jupyter:stateless-api:kernel");
 

--- a/src/packages/next/lib/landing/software-specs.ts
+++ b/src/packages/next/lib/landing/software-specs.ts
@@ -3,7 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
 import { keys, map, sortBy, zipObject } from "lodash";
 import { promises } from "node:fs";
 import { basename } from "node:path";
@@ -13,6 +12,7 @@ import {
   SoftwareEnvNames,
 } from "@cocalc/util/consts/software-envs";
 import { hours_ago } from "@cocalc/util/relative-time";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import withCustomize from "lib/with-customize";
 import { SOFTWARE_FALLBACK, SOFTWARE_URLS } from "./software-data";
 import {
@@ -66,14 +66,14 @@ async function fetchInventory(): Promise<SoftwareEnvironments> {
     return await makeObject(
       SOFTWARE_ENV_NAMES,
       async (name) =>
-        await file2json(`${localSpec}/software-inventory-${name}.json`)
+        await file2json(`${localSpec}/software-inventory-${name}.json`),
     );
   }
   try {
     // download the files for the newest information from the server
     const ret = await makeObject(
       SOFTWARE_ENV_NAMES,
-      async (name) => await downloadInventoryJson(name)
+      async (name) => await downloadInventoryJson(name),
     );
     return ret;
   } catch (err) {
@@ -110,7 +110,7 @@ async function getSoftwareInfo(name: SoftwareEnvNames): Promise<EnvData> {
 
 async function getSoftwareInfoLang(
   name: SoftwareEnvNames,
-  lang: LanguageName
+  lang: LanguageName,
 ): Promise<{
   inventory: ComputeInventory[LanguageName];
   components: ComputeComponents[LanguageName];
@@ -172,7 +172,7 @@ function getLanguageExecutables({ lang, inventory }): string[] {
 // this is for the server side getServerSideProps function
 export async function withCustomizedAndSoftwareSpec(
   context,
-  lang: LanguageName | "executables"
+  lang: LanguageName | "executables",
 ) {
   const { name } = context.params;
 
@@ -200,7 +200,7 @@ export async function withCustomizedAndSoftwareSpec(
     // this is instant because specs are already in the cache
     const { inventory, components, timestamp } = await getSoftwareInfoLang(
       name,
-      lang
+      lang,
     );
     customize.props.inventory = inventory;
     customize.props.components = components;

--- a/src/packages/next/package.json
+++ b/src/packages/next/package.json
@@ -64,7 +64,6 @@
     "@vscode/vscode-languagedetection": "^1.0.22",
     "antd": "^5.11.3",
     "antd-img-crop": "^4.12.2",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "base-64": "^1.0.0",
     "basic-auth": "^2.0.1",

--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       '@types/debug':
         specifier: ^4.1.7
         version: 4.1.7
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1(supports-color@9.3.1)
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
@@ -172,9 +169,6 @@ importers:
       async:
         specifier: ^1.5.2
         version: 1.5.2
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
@@ -183,7 +177,7 @@ importers:
         version: 8.3.0
       debug:
         specifier: ^4.3.2
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       immutable:
         specifier: ^4.3.0
         version: 4.3.0
@@ -198,7 +192,7 @@ importers:
         version: 7.14.1
       node-fetch:
         specifier: 2.6.7
-        version: 2.6.7(encoding@0.1.13)
+        version: 2.6.7
       pg:
         specifier: ^8.7.1
         version: 8.8.0
@@ -286,19 +280,19 @@ importers:
         version: 1.2.1
       '@jupyter-widgets/base':
         specifier: ^4.1.1
-        version: 4.1.1(crypto@1.0.1)(encoding@0.1.13)
+        version: 4.1.1(crypto@1.0.1)
       '@jupyter-widgets/controls':
         specifier: ^3.1.0
-        version: 3.1.1(crypto@1.0.1)(encoding@0.1.13)
+        version: 3.1.1(crypto@1.0.1)
       '@jupyter-widgets/output':
         specifier: ^4.1.0
-        version: 4.1.1(crypto@1.0.1)(encoding@0.1.13)
+        version: 4.1.1(crypto@1.0.1)
       '@lumino/widgets':
         specifier: ^1.31.1
         version: 1.36.0(crypto@1.0.1)
       '@microlink/react-json-view':
         specifier: ^1.22.2
-        version: 1.22.2(@types/react@18.0.26)(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)
+        version: 1.22.2(@types/react@18.0.26)(react-dom@18.2.0)(react@18.2.0)
       '@react-hook/mouse-position':
         specifier: ^4.1.3
         version: 4.1.3(react@18.2.0)
@@ -329,9 +323,6 @@ importers:
       async:
         specifier: ^2.6.3
         version: 2.6.4
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       audio-extensions:
         specifier: ^0.0.0
         version: 0.0.0
@@ -469,7 +460,7 @@ importers:
         version: 1.0.1
       k3d:
         specifier: ^2.14.1
-        version: 2.15.2(crypto@1.0.1)(encoding@0.1.13)
+        version: 2.15.2(crypto@1.0.1)
       katex:
         specifier: ^0.16.4
         version: 0.16.4
@@ -517,7 +508,7 @@ importers:
         version: 3.1.0
       pdfjs-dist:
         specifier: ^3.2.146
-        version: 3.2.146(encoding@0.1.13)
+        version: 3.2.146
       pegjs:
         specifier: ^0.10.0
         version: 0.10.0
@@ -777,9 +768,6 @@ importers:
       async:
         specifier: ^1.5.2
         version: 1.5.2
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
@@ -809,7 +797,7 @@ importers:
         version: 2.8.5
       debug:
         specifier: ^4.3.2
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -857,7 +845,7 @@ importers:
         version: 15.1.0
       parse-domain:
         specifier: ^5.0.0
-        version: 5.0.0(encoding@0.1.13)
+        version: 5.0.0
       passport:
         specifier: ^0.6.0
         version: 0.6.0
@@ -979,9 +967,6 @@ importers:
       '@types/node-cleanup':
         specifier: ^2.1.2
         version: 2.1.2
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
@@ -990,7 +975,7 @@ importers:
         version: 8.3.0
       debug:
         specifier: ^4.3.2
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       enchannel-zmq-backend:
         specifier: ^9.1.23
         version: 9.1.23(rxjs@6.6.7)
@@ -1091,9 +1076,6 @@ importers:
       antd-img-crop:
         specifier: ^4.12.2
         version: 4.12.2(antd@5.11.3)(react-dom@18.2.0)(react@18.2.0)
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1230,9 +1212,6 @@ importers:
       '@types/uuid':
         specifier: ^8.3.1
         version: 8.3.4
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1250,7 +1229,7 @@ importers:
         version: 3.0.0
       debug:
         specifier: ^4.3.2
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       diskusage:
         specifier: ^1.1.3
         version: 1.1.3
@@ -1368,13 +1347,13 @@ importers:
         version: link:../util
       '@google-ai/generativelanguage':
         specifier: ^1.1.0
-        version: 1.1.0(encoding@0.1.13)
+        version: 1.1.0
       '@google-cloud/compute':
         specifier: ^4.0.1
-        version: 4.0.1(encoding@0.1.13)
+        version: 4.0.1
       '@google-cloud/monitoring':
         specifier: ^4.0.0
-        version: 4.0.0(encoding@0.1.13)
+        version: 4.0.0
       '@google/generative-ai':
         specifier: ^0.1.3
         version: 0.1.3
@@ -1435,9 +1414,6 @@ importers:
       async:
         specifier: ^1.5.2
         version: 1.5.2
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       await-spawn:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1470,7 +1446,7 @@ importers:
         version: 1.17.3
       google-auth-library:
         specifier: ^9.4.1
-        version: 9.4.1(encoding@0.1.13)
+        version: 9.4.1
       gpt3-tokenizer:
         specifier: ^1.1.5
         version: 1.1.5
@@ -1503,7 +1479,7 @@ importers:
         version: 3.2.1
       parse-domain:
         specifier: ^5.0.0
-        version: 5.0.0(encoding@0.1.13)
+        version: 5.0.0
       passport:
         specifier: ^0.6.0
         version: 0.6.0
@@ -1800,15 +1776,12 @@ importers:
       async:
         specifier: ^1.5.2
         version: 1.5.2
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       events:
         specifier: 3.3.0
         version: 3.3.0
@@ -1830,7 +1803,7 @@ importers:
         version: 18.16.14
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.3(@babel/core@7.18.13)(jest@29.7.0)(typescript@5.3.3)
+        version: 29.0.3(@babel/core@7.23.7)(jest@29.7.0)(typescript@5.3.3)
 
   sync-client:
     dependencies:
@@ -1852,15 +1825,12 @@ importers:
       '@types/primus':
         specifier: ^7.3.6
         version: 7.3.6
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       cookie:
         specifier: ^0.5.0
         version: 0.5.0
       debug:
         specifier: ^4.3.2
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       primus:
         specifier: ^8.0.7
         version: 8.0.7
@@ -1975,9 +1945,6 @@ importers:
       async:
         specifier: ^1.5.2
         version: 1.5.2
-      async-await-utils:
-        specifier: ^3.0.1
-        version: 3.0.1
       awaiting:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1986,7 +1953,7 @@ importers:
         version: 1.11.7
       debug:
         specifier: ^4.3.2
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       events:
         specifier: 3.3.0
         version: 3.3.0
@@ -2226,6 +2193,7 @@ packages:
   /@babel/compat-data@7.21.7:
     resolution: {integrity: sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/compat-data@7.22.9:
     resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
@@ -2256,29 +2224,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/core@7.18.13(supports-color@9.3.1):
-    resolution: {integrity: sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.5
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.18.13)
-      '@babel/helper-module-transforms': 7.21.5(supports-color@9.3.1)
-      '@babel/helpers': 7.21.5(supports-color@9.3.1)
-      '@babel/parser': 7.21.8
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5(supports-color@9.3.1)
-      '@babel/types': 7.21.5
-      convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.3.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/core@7.21.4:
     resolution: {integrity: sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==}
@@ -2295,7 +2241,7 @@ packages:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2318,7 +2264,7 @@ packages:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.4
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2346,6 +2292,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core@7.23.2:
     resolution: {integrity: sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==}
@@ -2385,7 +2332,7 @@ packages:
       '@babel/traverse': 7.23.7
       '@babel/types': 7.23.6
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2400,6 +2347,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.23.0:
     resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
@@ -2424,6 +2372,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
@@ -2438,6 +2387,7 @@ packages:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/helper-compilation-targets@7.21.5(@babel/core@7.18.13):
     resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
@@ -2451,6 +2401,7 @@ packages:
       browserslist: 4.22.1
       lru-cache: 5.1.1
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-compilation-targets@7.22.15:
     resolution: {integrity: sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==}
@@ -2488,24 +2439,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-create-class-features-plugin@7.18.13(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.18.9(supports-color@9.3.1)
-      '@babel/helper-split-export-declaration': 7.22.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.23.7):
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
@@ -2534,6 +2468,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.1.0
+    dev: true
 
   /@babel/helper-define-polyfill-provider@0.3.2(@babel/core@7.18.13):
     resolution: {integrity: sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==}
@@ -2549,22 +2484,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-define-polyfill-provider@0.3.2(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-compilation-targets': 7.22.15
-      '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@9.3.1)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.8
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/helper-environment-visitor@7.22.20:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
@@ -2575,25 +2495,27 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/helper-function-name@7.23.0:
     resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.15
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
 
   /@babel/helper-member-expression-to-functions@7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/helper-member-expression-to-functions@7.23.0:
     resolution: {integrity: sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==}
@@ -2613,7 +2535,7 @@ packages:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
 
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
@@ -2629,22 +2551,7 @@ packages:
       '@babel/types': 7.23.4
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-module-transforms@7.21.5(supports-color@9.3.1):
-    resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
-      '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.2(supports-color@9.3.1)
-      '@babel/types': 7.23.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.18.13):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
@@ -2658,6 +2565,7 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+    dev: true
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.21.4):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
@@ -2679,7 +2587,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.8(supports-color@9.3.1)
+      '@babel/core': 7.21.8
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -2718,6 +2626,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -2729,6 +2638,7 @@ packages:
   /@babel/helper-plugin-utils@7.22.5:
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
@@ -2743,21 +2653,7 @@ packages:
       '@babel/types': 7.23.4
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-wrap-function': 7.18.11(supports-color@9.3.1)
-      '@babel/types': 7.23.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/helper-replace-supers@7.18.9:
     resolution: {integrity: sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==}
@@ -2770,19 +2666,7 @@ packages:
       '@babel/types': 7.23.4
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-replace-supers@7.18.9(supports-color@9.3.1):
-    resolution: {integrity: sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.23.2(supports-color@9.3.1)
-      '@babel/types': 7.23.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/helper-replace-supers@7.22.20(@babel/core@7.23.7):
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
@@ -2800,13 +2684,14 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
 
   /@babel/helper-skip-transparent-expression-wrappers@7.18.9:
     resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
@@ -2815,18 +2700,11 @@ packages:
       '@babel/types': 7.23.4
     dev: true
 
-  /@babel/helper-split-export-declaration@7.18.6:
-    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.23.4
-    dev: false
-
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
 
   /@babel/helper-string-parser@7.23.4:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
@@ -2854,18 +2732,7 @@ packages:
       '@babel/types': 7.23.4
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-wrap-function@7.18.11(supports-color@9.3.1):
-    resolution: {integrity: sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-function-name': 7.23.0
-      '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.2(supports-color@9.3.1)
-      '@babel/types': 7.23.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/helpers@7.21.5:
     resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
@@ -2876,17 +2743,7 @@ packages:
       '@babel/types': 7.23.4
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helpers@7.21.5(supports-color@9.3.1):
-    resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.2(supports-color@9.3.1)
-      '@babel/types': 7.23.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/helpers@7.23.2:
     resolution: {integrity: sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==}
@@ -2907,6 +2764,7 @@ packages:
       '@babel/types': 7.23.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers@7.23.7:
     resolution: {integrity: sha512-6AMnjCoC8wjqBzDHkuqpa7jAKwvMo4dC+lr/TFBz+ucfulO1XMpDnwWPGBNwClOKZ8h6xn5N81W/R5OrcKtCbQ==}
@@ -2932,6 +2790,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/parser@7.23.0:
     resolution: {integrity: sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==}
@@ -2963,6 +2822,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-AHrP9jadvH7qlOj6PINbgSuphjQUAK7AOT7DPjBo9EHoLhQTnnK5u45e1Hd4DbSQEO9nqPWtQ89r+XEOWFScKg==}
@@ -2974,6 +2834,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.18.13)
+    dev: true
 
   /@babel/plugin-proposal-async-generator-functions@7.18.10(@babel/core@7.18.13):
     resolution: {integrity: sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==}
@@ -2989,22 +2850,7 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.18.13)
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-proposal-async-generator-functions@7.18.10(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.18.13)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -3017,19 +2863,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-create-class-features-plugin': 7.18.13(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/helper-plugin-utils': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-class-static-block@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
@@ -3044,64 +2878,7 @@ packages:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.18.13)
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-proposal-class-static-block@7.18.6(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-static-block instead.
-    peerDependencies:
-      '@babel/core': ^7.12.0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-create-class-features-plugin': 7.18.13(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.18.13)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/plugin-proposal-decorators@7.18.10(@babel/core@7.18.13):
-    resolution: {integrity: sha512-wdGTwWF5QtpTY/gbBtQLAiCnoxfD4qMbN87NYZle1dOZ9Os8Y6zXcKrIaOU8W+TIvFUWVGG9tUgNww3CjXRVVw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-create-class-features-plugin': 7.18.13(@babel/core@7.18.13)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.18.9
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/plugin-syntax-decorators': 7.18.6(@babel/core@7.18.13)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/plugin-proposal-decorators@7.18.10(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-wdGTwWF5QtpTY/gbBtQLAiCnoxfD4qMbN87NYZle1dOZ9Os8Y6zXcKrIaOU8W+TIvFUWVGG9tUgNww3CjXRVVw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-create-class-features-plugin': 7.18.13(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.18.9(supports-color@9.3.1)
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/plugin-syntax-decorators': 7.18.6(@babel/core@7.18.13)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/plugin-proposal-do-expressions@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-ddToGCONJhCuL+l4FhtGnKl5ZYCj9fDVFiqiCdQDpeIbVn/NvMeSib+7T1/rk08jRafae4qNiP8OnJyuqlsuYA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-do-expressions': 7.18.6(@babel/core@7.18.13)
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
@@ -3113,17 +2890,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.18.13)
-
-  /@babel/plugin-proposal-export-default-from@7.18.10(@babel/core@7.18.13):
-    resolution: {integrity: sha512-5H2N3R2aQFxkV4PIBUR/i7PUSwgTZjouJKzI8eKswfIjT0PhvzkPn0t0wIS5zn6maQuvtT0t1oHtMUz61LOuow==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-default-from': 7.18.6(@babel/core@7.18.13)
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
@@ -3134,45 +2901,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.18.13)
-
-  /@babel/plugin-proposal-function-bind@7.18.9(@babel/core@7.18.13):
-    resolution: {integrity: sha512-9RfxqKkRBCCT0xoBl9AqieCMscJmSAL9HYixGMWH549jUpT9csWWK/HEYZEx9t9iW/PRSXgX95x9bDlgtAJGFA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-function-bind': 7.18.6(@babel/core@7.18.13)
-    dev: false
-
-  /@babel/plugin-proposal-function-sent@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-UdaOKPOLPt0O+Xu26tnw6oAZMLXhk+yMrXOzn6kAzTHBnWHJsoN1hlrgxFAQ+FRLS0ql1oYIQ2phvoFzmN3GMw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-wrap-function': 7.18.11
-      '@babel/plugin-syntax-function-sent': 7.18.6(@babel/core@7.18.13)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/plugin-proposal-function-sent@7.18.6(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-UdaOKPOLPt0O+Xu26tnw6oAZMLXhk+yMrXOzn6kAzTHBnWHJsoN1hlrgxFAQ+FRLS0ql1oYIQ2phvoFzmN3GMw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-wrap-function': 7.18.11(supports-color@9.3.1)
-      '@babel/plugin-syntax-function-sent': 7.18.6(@babel/core@7.18.13)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
@@ -3183,6 +2912,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.18.13)
+    dev: true
 
   /@babel/plugin-proposal-logical-assignment-operators@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==}
@@ -3193,6 +2923,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.18.13)
+    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -3203,6 +2934,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.18.13)
+    dev: true
 
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
@@ -3213,6 +2945,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.18.13)
+    dev: true
 
   /@babel/plugin-proposal-object-rest-spread@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-kDDHQ5rflIeY5xl69CEqGEZ0KY369ehsCIEbTGb4siHG5BE9sga/T0r0OUwyZNLMmZE79E1kbsqAjwFCW4ds6Q==}
@@ -3227,6 +2960,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.18.13)
       '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.18.13)
+    dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -3238,6 +2972,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.18.13)
+    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
@@ -3249,17 +2984,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.18.13)
-
-  /@babel/plugin-proposal-pipeline-operator@7.18.9(@babel/core@7.18.13):
-    resolution: {integrity: sha512-Pc33e6m8f4MJhRXVCUwiKZNtEm+W2CUPHIL0lyJNtkp+w6d75CLw3gsBKQ81VAMUgT9jVPIEU8gwJ5nJgmJ1Ag==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-pipeline-operator': 7.18.6(@babel/core@7.18.13)
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
@@ -3273,20 +2998,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-create-class-features-plugin': 7.18.13(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/helper-plugin-utils': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
@@ -3302,33 +3014,7 @@ packages:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.18.13)
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.18.13(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.18.13)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/plugin-proposal-throw-expressions@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-WHOrJyhGoGrdtW480L79cF7Iq/gZDZ/z6OqK7mVyFR5I37dTpog/wNgb6hmaM3HYZtULEJl++7VaMWkNZsOcHg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-throw-expressions': 7.18.6(@babel/core@7.18.13)
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -3340,6 +3026,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-create-regexp-features-plugin': 7.18.6(@babel/core@7.18.13)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.18.13):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -3348,6 +3035,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -3392,6 +3080,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.2):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -3419,26 +3108,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-syntax-decorators@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-fqyLgjcxf/1yhyZ6A+yo1u9gJ7eleFQod2lkaUsF9DQ7sbbY3Ligym3L0+I2c0WmqNKDpoD9UTb1AKP3qRMOAQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-do-expressions@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-kTogvOsjBTVOSZtkkziiXB5hwGXqwhq2gBXDaiWVruRLDT7C2GqfbsMnicHJ7ePq2GE8UJeWS34YbNP6yDhwUA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
+    dev: true
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.18.13):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -3447,16 +3117,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-syntax-export-default-from@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-Kr//z3ujSVNx6E9z9ih5xXXMqK07VVTuqPmqGe6Mss/zW5XPeLZeSDZoP9ab/hT4wPKqAgjl2PnhPrcpk8Seew==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
+    dev: true
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.18.13):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -3465,26 +3126,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-syntax-function-bind@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-wZN0Aq/AScknI9mKGcR3TpHdASMufFGaeJgc1rhPmLtZ/PniwjePSh8cfh8tXMB3U4kh/3cRKrLjDtedejg8jQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-function-sent@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-f3OJHIlFIkg+cP1Hfo2SInLhsg0pz2Ikmgo7jMdIIKC+3jVXQlHB0bgSapOWxeWI0SU28qIWmfn5ZKu1yPJHkg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
+    dev: true
 
   /@babel/plugin-syntax-import-assertions@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-/DU3RXad9+bZwrgWJQKbr39gYbJpLJHezqEzRzi/BHRlJ9zsQb4CK2CA/5apllXNomwA1qHwzvHl+AdEmC5krQ==}
@@ -3494,15 +3136,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.18.13):
-    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
+    dev: true
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -3529,6 +3163,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -3585,6 +3220,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -3611,6 +3247,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -3637,6 +3274,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -3663,6 +3301,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -3689,6 +3328,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -3715,6 +3355,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -3734,16 +3375,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-pipeline-operator@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-pFtIdQomJtkTHWcNsGXhjJ5YUkL+AxJnP4G+Ol85UO6uT2fpHTPYLLE5bBeRA9cxf25qa/VKsJ3Fi67Gyqe3rA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.18.13):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
@@ -3752,16 +3383,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-syntax-throw-expressions@7.18.6(@babel/core@7.18.13):
-    resolution: {integrity: sha512-rp1CqEZXGv1z1YZ3qYffBH3rhnOxrTwQG8fh2yqulTurwv9zu3Gthfd+niZBLSOi1rY6146TgF+JmVeDXaX4TQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
+    dev: true
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.18.13):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -3771,6 +3393,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -3820,6 +3443,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
@@ -3833,20 +3457,7 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.18.13)
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.18.13)(supports-color@9.3.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
@@ -3856,6 +3467,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-block-scoping@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-5sDIJRV1KtQVEbt/EIBwGy4T01uYIo4KRB3VUqzkhrAIOGx7AoctL9+Ux88btY0zXdDyPJ9mW+bg+v+XEkGmtw==}
@@ -3865,6 +3477,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-classes@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==}
@@ -3883,25 +3496,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-transform-classes@7.18.9(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.18.9(supports-color@9.3.1)
-      '@babel/helper-split-export-declaration': 7.22.6
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
@@ -3911,6 +3506,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-destructuring@7.18.13(@babel/core@7.18.13):
     resolution: {integrity: sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==}
@@ -3920,6 +3516,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
@@ -3930,6 +3527,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-create-regexp-features-plugin': 7.18.6(@babel/core@7.18.13)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
@@ -3939,6 +3537,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
@@ -3949,6 +3548,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.18.13):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
@@ -3958,6 +3558,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
@@ -3969,6 +3570,7 @@ packages:
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
@@ -3978,6 +3580,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
@@ -3987,6 +3590,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-modules-amd@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-Pra5aXsmTsOnjM3IajS8rTaLCy++nGM4v3YR4esk5PCsyg9z8NA5oQLwxzMUtDBd8F+UmVza3VxoAaWCbzH1rg==}
@@ -3998,6 +3602,7 @@ packages:
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.18.13)
       '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==}
@@ -4010,6 +3615,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==}
@@ -4035,6 +3641,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.20
       babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
 
   /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
@@ -4045,6 +3652,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.18.13)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-UmEOGF8XgaIqD74bC8g7iV3RYj8lMf0Bw7NJzvnS9qQhM4mg+1WHKotUIdjxgD2RGrgFLZZPCFPFj3P/kVDYhg==}
@@ -4055,6 +3663,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-create-regexp-features-plugin': 7.18.6(@babel/core@7.18.13)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
@@ -4064,6 +3673,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
@@ -4076,19 +3686,7 @@ packages:
       '@babel/helper-replace-supers': 7.18.9
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.18.9(supports-color@9.3.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/plugin-transform-parameters@7.18.8(@babel/core@7.18.13):
     resolution: {integrity: sha512-ivfbE3X2Ss+Fj8nnXvKJS6sjRG4gzwPMsP+taZC+ZzEGjAYlvENixmt1sZ5Ca6tWls+BlKSGKPJ6OOXvXCbkFg==}
@@ -4098,6 +3696,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
@@ -4107,6 +3706,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-react-jsx@7.20.7(@babel/core@7.18.13):
     resolution: {integrity: sha512-Tfq7qqD+tRj3EoDhY00nn2uP2hsRxgYGi5mLQ5TimKav0a9Lrpd4deE+fcLXU8zFYRjlKPHZhpCvfEA6qnBxqQ==}
@@ -4131,6 +3731,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.0
+    dev: true
 
   /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
@@ -4140,6 +3741,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -4149,6 +3751,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-spread@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-39Q814wyoOPtIB/qGopNIL9xDChOE1pNU0ZY5dO0owhiVt/5kFm4li+/bBtwc7QotG0u5EPzqhZdjMtmqBqyQA==}
@@ -4159,6 +3762,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
@@ -4168,6 +3772,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
@@ -4177,6 +3782,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.18.13):
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
@@ -4186,6 +3792,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-typescript@7.23.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-39hCCOl+YUAyMOu6B9SmUTiHUU0t/CxJNUmY3qRdJujbqi+lrQcL11ysYUsAvFWPBdhihrv1z0oRG84Yr3dODQ==}
@@ -4208,6 +3815,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.18.13):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
@@ -4218,6 +3826,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-create-regexp-features-plugin': 7.18.6(@babel/core@7.18.13)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/polyfill@7.12.1:
     resolution: {integrity: sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==}
@@ -4311,92 +3920,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/preset-env@7.18.10(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-wVxs1yjFdW3Z/XkNfXKoblxoHgbtUF7/l3PvvP4m02Qz9TZ6uZGxRVYjSQeR87oQmHco9zWitW5J82DJ7sCjvA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.21.7
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.18.13)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.15
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-async-generator-functions': 7.18.10(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-class-static-block': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-object-rest-spread': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-private-property-in-object': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.18.13)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.18.13)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.18.13)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-import-assertions': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.18.13)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.18.13)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.18.13)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.18.13)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-async-to-generator': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-block-scoping': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-classes': 7.18.9(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-destructuring': 7.18.13(@babel/core@7.18.13)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.18.13)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-modules-amd': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-modules-commonjs': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-modules-systemjs': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.18.13)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-regenerator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-spread': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.18.13)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.18.13)
-      '@babel/preset-modules': 0.1.5(@babel/core@7.18.13)
-      '@babel/types': 7.21.5
-      babel-plugin-polyfill-corejs2: 0.3.2(@babel/core@7.18.13)(supports-color@9.3.1)
-      babel-plugin-polyfill-corejs3: 0.5.3(@babel/core@7.18.13)(supports-color@9.3.1)
-      babel-plugin-polyfill-regenerator: 0.4.0(@babel/core@7.18.13)(supports-color@9.3.1)
-      core-js-compat: 3.24.1
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/preset-modules@0.1.5(@babel/core@7.18.13):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
@@ -4409,6 +3933,7 @@ packages:
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.18.13)
       '@babel/types': 7.23.4
       esutils: 2.0.3
+    dev: true
 
   /@babel/preset-typescript@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-17oIGVlqz6CchO9RFYn5U6ZpWRZIngayYCtrPRSgANSwC2V1Jb+iP74nVxzzXJte8b8BYxrL1yY96xfhTBrNNQ==}
@@ -4423,14 +3948,6 @@ packages:
       '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.7)
       '@babel/plugin-transform-typescript': 7.23.4(@babel/core@7.23.7)
     dev: true
-
-  /@babel/runtime-corejs2@7.18.9:
-    resolution: {integrity: sha512-l057ZarpDX2QnXM89ViR2BgRFgTy2l5UFGDt0SbInhim1N/ljBgPeTJV0kRG1/Bo7CkHfYfrNNwTeQ2CPph9xQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.13.11
-    dev: false
 
   /@babel/runtime@7.18.9:
     resolution: {integrity: sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==}
@@ -4472,14 +3989,15 @@ packages:
       '@babel/code-frame': 7.23.4
       '@babel/parser': 7.23.4
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.23.4
-      '@babel/parser': 7.23.4
-      '@babel/types': 7.23.4
+      '@babel/code-frame': 7.23.5
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
 
   /@babel/traverse@7.21.5:
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
@@ -4497,24 +4015,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/traverse@7.21.5(supports-color@9.3.1):
-    resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.23.4
-      '@babel/generator': 7.23.0
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.23.4
-      '@babel/types': 7.23.4
-      debug: 4.3.4(supports-color@9.3.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /@babel/traverse@7.23.2:
     resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
@@ -4528,7 +4029,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.4
       '@babel/types': 7.23.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4549,6 +4050,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.23.7:
     resolution: {integrity: sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==}
@@ -4562,7 +4064,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.6
       '@babel/types': 7.23.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4574,6 +4076,7 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.23.0:
     resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
@@ -4632,7 +4135,7 @@ packages:
       awaiting: 3.0.0
       cheerio: 1.0.0-rc.12
       csv-parse: 5.5.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4754,31 +4257,31 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@google-ai/generativelanguage@1.1.0(encoding@0.1.13):
+  /@google-ai/generativelanguage@1.1.0:
     resolution: {integrity: sha512-GQG67TUM9CD//R/HrOSrPSFygiBBqGo38IdaGZ4XejxLdw3wryetPkUMvuioCvgx7ZlV2ONNrQUh8m6m1Lp5ng==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      google-gax: 4.0.4(encoding@0.1.13)
+      google-gax: 4.0.4
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: false
 
-  /@google-cloud/compute@4.0.1(encoding@0.1.13):
+  /@google-cloud/compute@4.0.1:
     resolution: {integrity: sha512-9/kzXFNTmEh8UqNdt8G5NdtfIyAfVYG+7yagk/rh2mh/XFynDGW4DXIYvrWIcMns8HSZxrUgNyNDPva+BUp14w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      google-gax: 4.0.4(encoding@0.1.13)
+      google-gax: 4.0.4
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: false
 
-  /@google-cloud/monitoring@4.0.0(encoding@0.1.13):
+  /@google-cloud/monitoring@4.0.0:
     resolution: {integrity: sha512-7HBEWbusYzcaNr6aZHqM4sUmqYS7BCh5VashxHrurXU45yTwiYgfmqhHd4P1yO5J/zpVEDXPZBI+a+8nacQoqw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      google-gax: 4.0.4(encoding@0.1.13)
+      google-gax: 4.0.4
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5325,16 +4828,16 @@ packages:
     resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
 
   /@juggle/resize-observer@3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: false
 
-  /@jupyter-widgets/base@4.1.1(crypto@1.0.1)(encoding@0.1.13):
+  /@jupyter-widgets/base@4.1.1(crypto@1.0.1):
     resolution: {integrity: sha512-bw3Qib1FbUaRXjXol0HcjzYnKzEvmevGXyXjxIiVXGIG43cwMipFLwL9mPa7RWUim/5u1H+XzGdWpfyNj4zdDA==}
     dependencies:
-      '@jupyterlab/services': 6.5.2(crypto@1.0.1)(encoding@0.1.13)
+      '@jupyterlab/services': 6.5.2(crypto@1.0.1)
       '@lumino/coreutils': 1.12.1(crypto@1.0.1)
       '@lumino/messaging': 1.10.3
       '@lumino/widgets': 1.36.0(crypto@1.0.1)
@@ -5351,10 +4854,10 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@jupyter-widgets/controls@3.1.1(crypto@1.0.1)(encoding@0.1.13):
+  /@jupyter-widgets/controls@3.1.1(crypto@1.0.1):
     resolution: {integrity: sha512-zo+LZYqn/rIQc9o9TiPO5WX8n7g/jN8eFCwP0tjg6tRfv5Tl/uvdcByv1pIyFm/qB5fsn6k01NKrAc6NlKh2SQ==}
     dependencies:
-      '@jupyter-widgets/base': 4.1.1(crypto@1.0.1)(encoding@0.1.13)
+      '@jupyter-widgets/base': 4.1.1(crypto@1.0.1)
       '@lumino/algorithm': 1.9.2
       '@lumino/domutils': 1.8.2
       '@lumino/messaging': 1.10.3
@@ -5371,10 +4874,10 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@jupyter-widgets/output@4.1.1(crypto@1.0.1)(encoding@0.1.13):
+  /@jupyter-widgets/output@4.1.1(crypto@1.0.1):
     resolution: {integrity: sha512-XYNabDT3MtPGNAx1yLFYHn9mJTqGWqRRsejyJkv1KrAlUhJJQTJwvoBInP2OdaGAUMk8n6pE16qzzQcCS1+Qog==}
     dependencies:
-      '@jupyter-widgets/base': 4.1.1(crypto@1.0.1)(encoding@0.1.13)
+      '@jupyter-widgets/base': 4.1.1(crypto@1.0.1)
     transitivePeerDependencies:
       - bufferutil
       - crypto
@@ -5416,7 +4919,7 @@ packages:
       - crypto
     dev: false
 
-  /@jupyterlab/services@6.5.2(crypto@1.0.1)(encoding@0.1.13):
+  /@jupyterlab/services@6.5.2(crypto@1.0.1):
     resolution: {integrity: sha512-3uiOZpIsx7o1we/QDj9tfEkw3fwFlk018OPYfo1nRFg/Xl1B+9cOHQJtFzDpIIAIdNDNsYyIK8RergTsnjP5FA==}
     dependencies:
       '@jupyterlab/coreutils': 5.5.2(crypto@1.0.1)
@@ -5429,7 +4932,7 @@ packages:
       '@lumino/disposable': 1.10.3
       '@lumino/polling': 1.11.3(crypto@1.0.1)
       '@lumino/signaling': 1.11.0
-      node-fetch: 2.6.7(encoding@0.1.13)
+      node-fetch: 2.6.7
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
@@ -5597,6 +5100,26 @@ packages:
       mapbox-gl: 1.10.1
     dev: false
 
+  /@mapbox/node-pre-gyp@1.0.10:
+    resolution: {integrity: sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      detect-libc: 2.0.2
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.6.7
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.5.4
+      tar: 6.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+    optional: true
+
   /@mapbox/node-pre-gyp@1.0.10(encoding@0.1.13):
     resolution: {integrity: sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==}
     hasBin: true
@@ -5614,6 +5137,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
     optional: true
 
   /@mapbox/point-geometry@0.1.0:
@@ -5639,13 +5163,13 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
-  /@microlink/react-json-view@1.22.2(@types/react@18.0.26)(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0):
+  /@microlink/react-json-view@1.22.2(@types/react@18.0.26)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-liJzdlbspT5GbEuPffw4jzZfXOypKLK1Er9br03T31bAaIi/WptZqpcJaXPi7OmwC7v/YYczCkmAS7WaEfItPQ==}
     peerDependencies:
       react: '>= 15'
       react-dom: '>= 15'
     dependencies:
-      flux: 4.0.3(encoding@0.1.13)(react@18.2.0)
+      flux: 4.0.3(react@18.2.0)
       react: 18.2.0
       react-base16-styling: 0.6.0
       react-dom: 18.2.0(react@18.2.0)
@@ -5751,7 +5275,7 @@ packages:
       '@types/xml-encryption': 1.2.2
       '@types/xml2js': 0.4.12
       '@xmldom/xmldom': 0.8.10
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       xml-crypto: 3.2.0
       xml-encryption: 3.0.2
       xml2js: 0.5.0
@@ -6690,7 +6214,6 @@ packages:
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-    dev: false
 
   /@types/json-stable-stringify@1.0.34:
     resolution: {integrity: sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==}
@@ -6792,7 +6315,6 @@ packages:
     resolution: {integrity: sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /@types/node@9.6.61:
     resolution: {integrity: sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ==}
@@ -7448,7 +6970,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     requiresBuild: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -7456,7 +6978,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7819,60 +7341,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /async-await-utils@3.0.1:
-    resolution: {integrity: sha512-X4dTVZN23638AkQiGxLkJhtx/qcM7vZQn9zliJHBipl60YOf1jMRhmFYcOQrWG5zD0R6sTOn2EKJ+IFmXMjw5g==}
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-decorators': 7.18.10(@babel/core@7.18.13)
-      '@babel/plugin-proposal-do-expressions': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-export-default-from': 7.18.10(@babel/core@7.18.13)
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-function-bind': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-function-sent': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-pipeline-operator': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-throw-expressions': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.18.13)
-      '@babel/preset-env': 7.18.10(@babel/core@7.18.13)
-      '@babel/runtime-corejs2': 7.18.9
-      verror: 1.10.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /async-await-utils@3.0.1(supports-color@9.3.1):
-    resolution: {integrity: sha512-X4dTVZN23638AkQiGxLkJhtx/qcM7vZQn9zliJHBipl60YOf1jMRhmFYcOQrWG5zD0R6sTOn2EKJ+IFmXMjw5g==}
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-decorators': 7.18.10(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-do-expressions': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-export-default-from': 7.18.10(@babel/core@7.18.13)
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-function-bind': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-function-sent': 7.18.6(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-pipeline-operator': 7.18.9(@babel/core@7.18.13)
-      '@babel/plugin-proposal-throw-expressions': 7.18.6(@babel/core@7.18.13)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.18.13)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.18.13)
-      '@babel/preset-env': 7.18.10(@babel/core@7.18.13)(supports-color@9.3.1)
-      '@babel/runtime-corejs2': 7.18.9
-      verror: 1.10.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /async-validator@1.11.5:
     resolution: {integrity: sha512-XNtCsMAeAH1pdLMEg1z8/Bb3a8cdCbui9QbJATRFHHHW5kT6+NPI3zSVQUXgikTFITzsg+kYY5NTWhM2Orwt9w==}
     dev: false
@@ -7950,7 +7418,7 @@ packages:
   /axios@0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -7958,7 +7426,7 @@ packages:
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8022,6 +7490,7 @@ packages:
     resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
     dependencies:
       object.assign: 4.1.4
+    dev: true
 
   /babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
@@ -8067,19 +7536,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  /babel-plugin-polyfill-corejs2@0.3.2(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.22.9
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.18.13)(supports-color@9.3.1)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /babel-plugin-polyfill-corejs3@0.5.3(@babel/core@7.18.13):
     resolution: {integrity: sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==}
@@ -8091,18 +7548,7 @@ packages:
       core-js-compat: 3.24.1
     transitivePeerDependencies:
       - supports-color
-
-  /babel-plugin-polyfill-corejs3@0.5.3(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.18.13)(supports-color@9.3.1)
-      core-js-compat: 3.24.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /babel-plugin-polyfill-regenerator@0.4.0(@babel/core@7.18.13):
     resolution: {integrity: sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==}
@@ -8113,17 +7559,7 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.18.13)
     transitivePeerDependencies:
       - supports-color
-
-  /babel-plugin-polyfill-regenerator@0.4.0(@babel/core@7.18.13)(supports-color@9.3.1):
-    resolution: {integrity: sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13(supports-color@9.3.1)
-      '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.18.13)(supports-color@9.3.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /babel-plugin-transform-remove-imports@1.7.0(@babel/core@7.21.4):
     resolution: {integrity: sha512-gprmWf6ry5qrnxMyiDaxZpXzZJP6R9FRA+p0AImLIWRmSEGtlKcFprHKeGMZYkII9rJR6Q1hYou+n1fk6rWf2g==}
@@ -8621,6 +8057,20 @@ packages:
       element-size: 1.1.1
     dev: false
 
+  /canvas@2.11.2:
+    resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@mapbox/node-pre-gyp': 1.0.10
+      nan: 2.17.0
+      simple-get: 3.1.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+    optional: true
+
   /canvas@2.11.2(encoding@0.1.13):
     resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
     engines: {node: '>=6'}
@@ -8632,6 +8082,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
     optional: true
 
   /capture-stack-trace@1.0.2:
@@ -9271,6 +8722,7 @@ packages:
     dependencies:
       browserslist: 4.22.1
       semver: 7.0.0
+    dev: true
 
   /core-js-pure@3.27.1:
     resolution: {integrity: sha512-BS2NHgwwUppfeoqOXqi08mUqS5FiZpuRuJJpKsaME7kJz0xxuk0xkhDdfMIlP/zLa80krBqss1LtD7f889heAw==}
@@ -9357,7 +8809,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     dev: false
-    bundledDependencies: false
 
   /create-server@1.0.2:
     resolution: {integrity: sha512-hie+Kyero+jxt6dwKhLKtN23qSNiMn8mNIEjTjwzaZwH2y4tr4nYloeFrpadqV+ZqV9jQ15t3AKotaK8dOo45w==}
@@ -9365,10 +8816,10 @@ packages:
       connected: 0.0.2
     dev: false
 
-  /cross-fetch@3.1.5(encoding@0.1.13):
+  /cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
-      node-fetch: 2.6.7(encoding@0.1.13)
+      node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -9707,6 +9158,17 @@ packages:
     dependencies:
       ms: 2.1.2
     dev: false
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -10989,10 +10451,10 @@ packages:
       bser: 2.1.1
     dev: true
 
-  /fbemitter@3.0.0(encoding@0.1.13):
+  /fbemitter@3.0.0:
     resolution: {integrity: sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==}
     dependencies:
-      fbjs: 3.0.4(encoding@0.1.13)
+      fbjs: 3.0.4
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -11001,10 +10463,10 @@ packages:
     resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
     dev: false
 
-  /fbjs@3.0.4(encoding@0.1.13):
+  /fbjs@3.0.4:
     resolution: {integrity: sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==}
     dependencies:
-      cross-fetch: 3.1.5(encoding@0.1.13)
+      cross-fetch: 3.1.5
       fbjs-css-vars: 1.0.2
       loose-envify: 1.4.0
       object-assign: 4.1.1
@@ -11109,16 +10571,26 @@ packages:
       dtype: 2.0.0
     dev: false
 
-  /flux@4.0.3(encoding@0.1.13)(react@18.2.0):
+  /flux@4.0.3(react@18.2.0):
     resolution: {integrity: sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==}
     peerDependencies:
       react: ^15.0.2 || ^16.0.0 || ^17.0.0
     dependencies:
-      fbemitter: 3.0.0(encoding@0.1.13)
-      fbjs: 3.0.4(encoding@0.1.13)
+      fbemitter: 3.0.0
+      fbjs: 3.0.4
       react: 18.2.0
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: false
 
   /follow-redirects@1.15.2(debug@4.3.4):
@@ -11130,7 +10602,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     dev: false
 
   /font-atlas@2.1.0:
@@ -11297,24 +10769,24 @@ packages:
       wide-align: 1.1.5
     optional: true
 
-  /gaxios@6.1.1(encoding@0.1.13):
+  /gaxios@6.1.1:
     resolution: {integrity: sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==}
     engines: {node: '>=14'}
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.2
       is-stream: 2.0.1
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: false
 
-  /gcp-metadata@6.1.0(encoding@0.1.13):
+  /gcp-metadata@6.1.0:
     resolution: {integrity: sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==}
     engines: {node: '>=14'}
     dependencies:
-      gaxios: 6.1.1(encoding@0.1.13)
+      gaxios: 6.1.1
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
@@ -11639,22 +11111,22 @@ packages:
     resolution: {integrity: sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==}
     dev: false
 
-  /google-auth-library@9.4.1(encoding@0.1.13):
+  /google-auth-library@9.4.1:
     resolution: {integrity: sha512-Chs7cuzDuav8W/BXOoRgSXw4u0zxYtuqAHETDR5Q6dG1RwNwz7NUKjsDDHAsBV3KkiiJBtJqjbzy1XU1L41w1g==}
     engines: {node: '>=14'}
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.1.1(encoding@0.1.13)
-      gcp-metadata: 6.1.0(encoding@0.1.13)
-      gtoken: 7.0.1(encoding@0.1.13)
+      gaxios: 6.1.1
+      gcp-metadata: 6.1.0
+      gtoken: 7.0.1
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: false
 
-  /google-gax@4.0.4(encoding@0.1.13):
+  /google-gax@4.0.4:
     resolution: {integrity: sha512-Yoey/ABON2HaTUIRUt5tTQAvwQ6E/2etSyFXwHNVcYtIiYDpKix7G4oorZdkp17gFiYovzRCRhRZYrfdCgRK9Q==}
     engines: {node: '>=14'}
     dependencies:
@@ -11663,8 +11135,8 @@ packages:
       '@types/long': 4.0.2
       abort-controller: 3.0.0
       duplexify: 4.1.2
-      google-auth-library: 9.4.1(encoding@0.1.13)
-      node-fetch: 2.6.7(encoding@0.1.13)
+      google-auth-library: 9.4.1
+      node-fetch: 2.6.7
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.0
       protobufjs: 7.2.5
@@ -11723,11 +11195,11 @@ packages:
     resolution: {integrity: sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==}
     dev: false
 
-  /gtoken@7.0.1(encoding@0.1.13):
+  /gtoken@7.0.1:
     resolution: {integrity: sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      gaxios: 6.1.1(encoding@0.1.13)
+      gaxios: 6.1.1
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
@@ -12159,7 +11631,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12190,7 +11662,7 @@ packages:
     requiresBuild: true
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12199,7 +11671,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12731,7 +12203,6 @@ packages:
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
-    dev: true
 
   /istanbul-lib-hook@3.0.0:
     resolution: {integrity: sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==}
@@ -12766,10 +12237,10 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/parser': 7.23.4
+      '@babel/core': 7.23.7
+      '@babel/parser': 7.23.6
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -12820,8 +12291,8 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
-      istanbul-lib-coverage: 3.2.0
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
@@ -13641,7 +13112,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.18.13
+      '@types/node': 18.19.4
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -13704,7 +13175,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.18.13
+      '@types/node': 18.19.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -13931,6 +13402,7 @@ packages:
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
+    dev: true
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -14097,10 +13569,10 @@ packages:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
     dev: false
 
-  /k3d@2.15.2(crypto@1.0.1)(encoding@0.1.13):
+  /k3d@2.15.2(crypto@1.0.1):
     resolution: {integrity: sha512-jtIKxXdGRWNg+HG1ZrhN4PbYI920Q+wgOlD3CxargXItjSyu/ycFrN0Xky1l9d0bi5iPpX5zNeD8TOgXGtTFjg==}
     dependencies:
-      '@jupyter-widgets/base': 4.1.1(crypto@1.0.1)(encoding@0.1.13)
+      '@jupyter-widgets/base': 4.1.1(crypto@1.0.1)
       fflate: 0.7.4
       file-saver: 2.0.5
       katex: 0.15.6
@@ -15237,6 +14709,18 @@ packages:
     resolution: {integrity: sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==}
     dev: false
 
+  /node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
   /node-fetch@2.6.7(encoding@0.1.13):
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -15248,8 +14732,10 @@ packages:
     dependencies:
       encoding: 0.1.13
       whatwg-url: 5.0.0
+    dev: true
+    optional: true
 
-  /node-fetch@2.7.0(encoding@0.1.13):
+  /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
@@ -15258,7 +14744,6 @@ packages:
       encoding:
         optional: true
     dependencies:
-      encoding: 0.1.13
       whatwg-url: 5.0.0
     dev: false
 
@@ -15523,6 +15008,7 @@ packages:
       define-properties: 1.1.4
       has-symbols: 1.0.3
       object-keys: 1.1.1
+    dev: true
 
   /object.entries@1.1.6:
     resolution: {integrity: sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==}
@@ -15733,12 +15219,12 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
-  /parse-domain@5.0.0(encoding@0.1.13):
+  /parse-domain@5.0.0:
     resolution: {integrity: sha512-sjvhVD0seIF3IquDLsbOE+6nekYyPzj4mGOMv4r9HIXalOjtTXb1uTZwtpQyp0myIoi9++w2eDqYOlCT5ic3+Q==}
     hasBin: true
     dependencies:
       is-ip: 3.1.0
-      node-fetch: 2.6.7(encoding@0.1.13)
+      node-fetch: 2.6.7
       punycode: 2.1.1
     transitivePeerDependencies:
       - encoding
@@ -15761,7 +15247,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.23.4
+      '@babel/code-frame': 7.23.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -15938,7 +15424,7 @@ packages:
     deprecated: For versions >= 4, please use scopped package @node-saml/passport-saml
     dependencies:
       '@xmldom/xmldom': 0.7.9
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       passport-strategy: 1.0.0
       xml-crypto: 2.1.5
       xml-encryption: 2.0.0
@@ -16046,6 +15532,17 @@ packages:
       sha.js: 2.4.11
     dev: true
 
+  /pdfjs-dist@3.2.146:
+    resolution: {integrity: sha512-wy1OB/v75usRD1LqgxBUWC+ZOiKTmG5J8c2z9XVFrVSSWiVbSuseNojmvFa/TT0pYtcFmkL4zn6KaxvqfPYMRg==}
+    dependencies:
+      web-streams-polyfill: 3.2.1
+    optionalDependencies:
+      canvas: 2.11.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /pdfjs-dist@3.2.146(encoding@0.1.13):
     resolution: {integrity: sha512-wy1OB/v75usRD1LqgxBUWC+ZOiKTmG5J8c2z9XVFrVSSWiVbSuseNojmvFa/TT0pYtcFmkL4zn6KaxvqfPYMRg==}
     dependencies:
@@ -16055,6 +15552,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
 
   /pegjs@0.10.0:
     resolution: {integrity: sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==}
@@ -17829,9 +17327,11 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       regenerate: 1.4.2
+    dev: true
 
   /regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+    dev: true
 
   /regenerator-runtime@0.11.1:
     resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
@@ -17851,6 +17351,7 @@ packages:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
     dependencies:
       '@babel/runtime': 7.23.4
+    dev: true
 
   /regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
@@ -17875,15 +17376,18 @@ packages:
       regjsparser: 0.8.4
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.0.0
+    dev: true
 
   /regjsgen@0.6.0:
     resolution: {integrity: sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==}
+    dev: true
 
   /regjsparser@0.8.4:
     resolution: {integrity: sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==}
     hasBin: true
     dependencies:
       jsesc: 0.5.0
+    dev: true
 
   /regl-error2d@2.0.12:
     resolution: {integrity: sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==}
@@ -18122,7 +17626,7 @@ packages:
     resolution: {integrity: sha512-24kaFMd3wCnT3n4uPnsQh90ZSV8OISpfTFXJ00Wi+/oD2OPrp63EQ8hznk6rhxdlpwx2QBhQSDz2Fg46ki852g==}
     engines: {node: '>=14'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       extend: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -18293,7 +17797,7 @@ packages:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.15
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
 
@@ -18344,6 +17848,7 @@ packages:
   /semver@7.0.0:
     resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
     hasBin: true
+    dev: true
 
   /semver@7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
@@ -19473,40 +18978,6 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
 
-  /ts-jest@29.0.3(@babel/core@7.18.13)(jest@29.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.13
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.16.14)
-      jest-util: 29.5.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.0
-      typescript: 5.3.3
-      yargs-parser: 21.1.1
-    dev: true
-
   /ts-jest@29.0.3(@babel/core@7.23.2)(jest@29.6.1)(typescript@5.2.2):
     resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -19790,6 +19261,7 @@ packages:
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
+    dev: true
 
   /unicode-match-property-ecmascript@2.0.0:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
@@ -19797,14 +19269,17 @@ packages:
     dependencies:
       unicode-canonical-property-names-ecmascript: 2.0.0
       unicode-property-aliases-ecmascript: 2.0.0
+    dev: true
 
   /unicode-match-property-value-ecmascript@2.0.0:
     resolution: {integrity: sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==}
     engines: {node: '>=4'}
+    dev: true
 
   /unicode-property-aliases-ecmascript@2.0.0:
     resolution: {integrity: sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==}
     engines: {node: '>=4'}
+    dev: true
 
   /unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
@@ -20526,7 +20001,7 @@ packages:
     dependencies:
       '@wwa/statvfs': 1.1.18
       awaiting: 3.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       port-get: 1.0.0
       ws: 8.13.0
     transitivePeerDependencies:

--- a/src/packages/project/lean/lean.ts
+++ b/src/packages/project/lean/lean.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
+
 import { callback, delay } from "awaiting";
 import * as lean_client from "lean-client-js-node";
 import { isEqual } from "lodash";
@@ -12,6 +12,7 @@ import { EventEmitter } from "node:events";
 import type { Client } from "@cocalc/project/client";
 import { once } from "@cocalc/util/async-utils";
 import { close } from "@cocalc/util/misc";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 type SyncString = any;
 type LeanServer = any;

--- a/src/packages/project/named-servers/index.ts
+++ b/src/packages/project/named-servers/index.ts
@@ -6,7 +6,7 @@
 import { getLogger } from "@cocalc/project/logger";
 import * as message from "@cocalc/util/message";
 import { NamedServerName } from "@cocalc/util/types/servers";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { start } from "./control";
 
 const winston = getLogger("named-servers");

--- a/src/packages/project/package.json
+++ b/src/packages/project/package.json
@@ -33,7 +33,6 @@
     "@types/lodash": "^4.14.202",
     "@types/primus": "^7.3.6",
     "@types/uuid": "^8.3.1",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "body-parser": "^1.19.0",
     "commander": "^7.2.0",

--- a/src/packages/project/sage_session.ts
+++ b/src/packages/project/sage_session.ts
@@ -7,8 +7,7 @@
 Start the Sage server and also get a new socket connection to it.
 */
 
-import { reuseInFlight } from "async-await-utils/hof";
-
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { getLogger } from "@cocalc/backend/logger";
 import processKill from "@cocalc/backend/misc/process-kill";
 import { abspath } from "@cocalc/backend/misc_node";

--- a/src/packages/project/sync/project-info.ts
+++ b/src/packages/project/sync/project-info.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { close } from "@cocalc/util/misc";
 import { SyncTable } from "@cocalc/sync/table";
 import { get_ProjectInfoServer } from "../project-info";

--- a/src/packages/project/sync/project-status.ts
+++ b/src/packages/project/sync/project-status.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { close } from "@cocalc/util/misc";
 import { SyncTable } from "@cocalc/sync/table";
 import {

--- a/src/packages/project/sync/server.ts
+++ b/src/packages/project/sync/server.ts
@@ -58,7 +58,7 @@ const _ = set_debug;
 
 import { init_syncdoc } from "./sync-doc";
 import { key, register_synctable } from "./open-synctables";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { once } from "@cocalc/util/async-utils";
 import { delay } from "awaiting";
 import { close, deep_copy, len } from "@cocalc/util/misc";

--- a/src/packages/server/compute/control.ts
+++ b/src/packages/server/compute/control.ts
@@ -34,7 +34,7 @@ import type {
 import { getTargetState } from "@cocalc/util/db-schema/compute-servers";
 import { STATE_INFO } from "@cocalc/util/db-schema/compute-servers";
 import { delay } from "awaiting";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { setProjectApiKey, deleteProjectApiKey } from "./project-api-key";
 import getPool from "@cocalc/database/pool";
 import { isEqual } from "lodash";

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -64,7 +64,6 @@
     "@types/passport-google-oauth20": "^2.0.11",
     "@types/sanitize-html": "^2.3.1",
     "async": "^1.5.2",
-    "async-await-utils": "^3.0.1",
     "await-spawn": "^4.0.2",
     "awaiting": "^3.0.0",
     "axios": "^1.4.0",

--- a/src/packages/server/projects/connection/connect.ts
+++ b/src/packages/server/projects/connection/connect.ts
@@ -9,7 +9,7 @@ This will also try to start the project up to about a minute.
 
 import getLogger from "@cocalc/backend/logger";
 import { getProject } from "@cocalc/server/projects/control";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { delay } from "awaiting";
 import { cancelAll } from "./handle-query";
 import initialize from "./initialize";

--- a/src/packages/server/stripe/client.ts
+++ b/src/packages/server/stripe/client.ts
@@ -3,7 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { reuseInFlight } from "async-await-utils/hof";
 import { callback } from "awaiting";
 import Stripe from "stripe";
 export { Stripe };
@@ -18,6 +17,7 @@ import type { PostgreSQL } from "@cocalc/database/postgres/types";
 import getPrivateProfile from "@cocalc/server/accounts/profile/private";
 import { callback2 } from "@cocalc/util/async-utils";
 import * as message from "@cocalc/util/message";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import stripeName from "@cocalc/util/stripe/name";
 import { InvoicesData } from "@cocalc/util/types/stripe";
 import { available_upgrades, get_total_upgrades } from "@cocalc/util/upgrades";

--- a/src/packages/sync-client/lib/index.ts
+++ b/src/packages/sync-client/lib/index.ts
@@ -27,7 +27,7 @@ import ProjectClient from "./project-client";
 import debug from "debug";
 import { bind_methods, isValidUUID, uuid } from "@cocalc/util/misc";
 import { project } from "@cocalc/api-client";
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 interface Options {
   project_id: string;

--- a/src/packages/sync-client/package.json
+++ b/src/packages/sync-client/package.json
@@ -8,7 +8,12 @@
     "./*": "./dist/*.js",
     "./lib/*": "./dist/lib/*.js"
   },
-  "files": ["dist/**", "bin/**", "README.md", "package.json"],
+  "files": [
+    "dist/**",
+    "bin/**",
+    "README.md",
+    "package.json"
+  ],
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "build": "npx tsc --build",
@@ -16,7 +21,10 @@
     "tsc": "npx tsc --watch --pretty --preserveWatchOutput"
   },
   "author": "SageMath, Inc.",
-  "keywords": ["cocalc", "jupyter"],
+  "keywords": [
+    "cocalc",
+    "jupyter"
+  ],
   "license": "SEE LICENSE.md",
   "dependencies": {
     "@cocalc/api-client": "workspace:*",
@@ -25,7 +33,6 @@
     "@cocalc/sync": "workspace:*",
     "@cocalc/util": "workspace:*",
     "@types/primus": "^7.3.6",
-    "async-await-utils": "^3.0.1",
     "cookie": "^0.5.0",
     "debug": "^4.3.2",
     "primus": "^8.0.7",

--- a/src/packages/sync/client/synctable-project.ts
+++ b/src/packages/sync/client/synctable-project.ts
@@ -8,10 +8,11 @@ Synctable that uses the project websocket rather than the database.
 */
 
 import { delay } from "awaiting";
-import { reuseInFlight } from "async-await-utils/hof";
-import { synctable_no_database, SyncTable } from "@cocalc/sync/table";
+
+import { SyncTable, synctable_no_database } from "@cocalc/sync/table";
 import { once, retry_until_success } from "@cocalc/util/async-utils";
 import { assertDefined } from "@cocalc/util/misc";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import type { AppClient } from "./types";
 
 // Always wait at least this long between connect attempts.  This

--- a/src/packages/sync/editor/generic/sync-doc.ts
+++ b/src/packages/sync/editor/generic/sync-doc.ts
@@ -49,7 +49,7 @@ const CURSOR_THROTTLE_MS = 750;
 
 type XPatch = any;
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { SyncTable } from "@cocalc/sync/table/synctable";
 import {
   callback2,

--- a/src/packages/sync/package.json
+++ b/src/packages/sync/package.json
@@ -33,7 +33,6 @@
     "@types/debug": "^4.1.7",
     "@types/lodash": "^4.14.202",
     "async": "^1.5.2",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "debug": "^4.3.4",
     "events": "3.3.0",

--- a/src/packages/sync/table/synctable.ts
+++ b/src/packages/sync/table/synctable.ts
@@ -54,7 +54,7 @@ function is_fatal(err: string): boolean {
   return err.indexOf("FATAL") != -1;
 }
 
-import { reuseInFlight } from "async-await-utils/hof";
+import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 import { Changefeed } from "./changefeed";
 import { parse_query, to_key } from "./util";

--- a/src/packages/util/async-utils.ts
+++ b/src/packages/util/async-utils.ts
@@ -16,7 +16,8 @@ The two helpful async/await libraries I found are:
 */
 
 import * as awaiting from "awaiting";
-import { reuseInFlight } from "async-await-utils/hof";
+
+import { reuseInFlight } from "./reuse-in-flight";
 
 // turns a function of opts, which has a cb input into
 // an async function that takes an opts with no cb as input; this is just like

--- a/src/packages/util/package.json
+++ b/src/packages/util/package.json
@@ -39,7 +39,6 @@
     "@cocalc/util": "workspace:*",
     "@types/debug": "^4.1.7",
     "async": "^1.5.2",
-    "async-await-utils": "^3.0.1",
     "awaiting": "^3.0.0",
     "dayjs": "^1.11.7",
     "debug": "^4.3.2",

--- a/src/packages/util/reuse-in-flight.test.ts
+++ b/src/packages/util/reuse-in-flight.test.ts
@@ -1,0 +1,170 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2024 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { delay } from "awaiting";
+
+import { reuseInFlight } from "./reuse-in-flight";
+
+const BASIC_DURATION_MS = 100;
+
+describe("reuseInFlight", () => {
+  test("no args", async () => {
+    let counter = 0;
+
+    async function incrementing() {
+      await delay(BASIC_DURATION_MS);
+      const result = counter;
+      counter += 1;
+      return result;
+    }
+
+    const reused = reuseInFlight(incrementing);
+
+    // The idea is: call reused more than once while it is still sitting in the "delay"
+    const res = await Promise.all([
+      reused(),
+      delay(BASIC_DURATION_MS * 0.3).then(() => reused()),
+      delay(BASIC_DURATION_MS * 0.7).then(() => reused()),
+      delay(BASIC_DURATION_MS * 1.1).then(() => reused()),
+      delay(BASIC_DURATION_MS * 1.4).then(() => reused()),
+      delay(BASIC_DURATION_MS * 2.2).then(() => reused()),
+    ]);
+
+    expect(res).toStrictEqual([0, 0, 0, 1, 1, 2]);
+  });
+
+  test("different args", async () => {
+    let counter = [0, 0];
+
+    async function incrementing(x: 0 | 1) {
+      await delay(BASIC_DURATION_MS);
+      const result = counter[x];
+      counter[x] += 1;
+      return result;
+    }
+
+    const reused = reuseInFlight(incrementing);
+
+    // addiitonally to the above, we call reused with different args and expect more 0s
+    const res = await Promise.all([
+      reused(0),
+      reused(1),
+      delay(BASIC_DURATION_MS * 0.3).then(() => reused(0)),
+      delay(BASIC_DURATION_MS * 0.3).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 0.7).then(() => reused(0)),
+      delay(BASIC_DURATION_MS * 1.1).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 1.4).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 2.2).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 2.2).then(() => reused(0)),
+    ]);
+
+    expect(res).toStrictEqual([0, 0, 0, 0, 0, 1, 1, 2, 1]);
+  });
+
+  test("ignoreSingleUndefined", async () => {
+    let counter = 0;
+
+    async function incrementing() {
+      await delay(BASIC_DURATION_MS);
+      const result = counter;
+      counter += 1;
+      return result;
+    }
+
+    const valid = reuseInFlight(incrementing);
+    const ignored = reuseInFlight(incrementing, {
+      ignoreSingleUndefined: true,
+    });
+
+    const res1 = await Promise.all([
+      valid(),
+      delay(0.3 * BASIC_DURATION_MS).then(valid), // different, because [undefined] is not []
+      delay(0.4 * BASIC_DURATION_MS).then(() => valid()),
+    ]);
+
+    const consoleWarnMock = jest.spyOn(console, "warn").mockImplementation();
+    try {
+      // but with ignoreSingleUndefined all 3 are the same, hence return 2
+      const res2 = await Promise.all([
+        ignored(),
+        delay(0.3 * BASIC_DURATION_MS).then(ignored),
+        delay(0.4 * BASIC_DURATION_MS).then(() => ignored()),
+      ]);
+
+      expect(consoleWarnMock).toHaveBeenCalledTimes(1);
+      expect(consoleWarnMock).toHaveBeenCalledWith(
+        "Ignoring single undefined arg (reuseInFlight)",
+      );
+
+      expect(res1).toStrictEqual([0, 1, 0]);
+      expect(res2).toStrictEqual([2, 2, 2]);
+    } finally {
+      consoleWarnMock.mockRestore();
+    }
+  });
+
+  test("good key", async () => {
+    let sum = 0;
+
+    async function incrementing(x: number) {
+      await delay(BASIC_DURATION_MS);
+      const result = sum;
+      sum += x;
+      return result;
+    }
+
+    const mockFn = jest.fn();
+
+    // we create a "good key", the one from the implementation
+    const reused = reuseInFlight(incrementing, {
+      createKey: (x) => {
+        const key = JSON.stringify(x);
+        mockFn("key", key);
+        return key;
+      },
+    });
+
+    const res = await Promise.all([
+      reused(1, 44),
+      reused(1),
+      delay(BASIC_DURATION_MS * 0.3).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 0.3).then(() => reused(3)),
+      delay(BASIC_DURATION_MS * 1.1).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 1.1).then(() => reused(1)),
+    ]);
+
+    // as a reference, how two args are serialized
+    expect(mockFn).toHaveBeenCalledTimes(6);
+    expect(mockFn).toHaveBeenNthCalledWith(1, "key", "[1,44]");
+
+    expect(res).toStrictEqual([0, 1, 1, 2, 5, 5]);
+  });
+
+  test("bad key", async () => {
+    let sum = 0;
+
+    async function incrementing(x: number) {
+      await delay(BASIC_DURATION_MS);
+      const result = sum;
+      sum += x;
+      return result;
+    }
+
+    // we create a "bad key"
+    const reused = reuseInFlight(incrementing, {
+      createKey: () => "foo",
+    });
+
+    const res = await Promise.all([
+      reused(1, 44),
+      delay(BASIC_DURATION_MS * 0.3).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 0.3).then(() => reused(3)),
+      delay(BASIC_DURATION_MS * 1.1).then(() => reused(1)),
+      delay(BASIC_DURATION_MS * 1.1).then(() => reused(1)),
+    ]);
+
+    expect(res).toStrictEqual([0, 0, 0, 1, 1]);
+  });
+});

--- a/src/packages/util/reuse-in-flight.ts
+++ b/src/packages/util/reuse-in-flight.ts
@@ -1,0 +1,65 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2024 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+// This code is a fork of the ISC licensed https://github.com/masotime/async-await-utils
+// Only for the reuseInFlight function without any dependencies.
+
+interface Config {
+  createKey: (args: any[]) => string;
+  ignoreSingleUndefined: boolean;
+}
+
+const DEFAULT_CONFIG: Config = {
+  createKey(args) {
+    return JSON.stringify(args);
+  },
+  ignoreSingleUndefined: false,
+} as const;
+
+// for a given Promise-generating function, track each execution by the stringified
+// arguments. if the function is called again with the same arguments, then instead
+// of generating a new promise, an existing in-flight promise is used instead. This
+// prevents unnecessary repetition of async function calls while the same function
+// is still in flight.
+export function reuseInFlight<T>(
+  asyncFn: (...args: any[]) => Promise<T>,
+  configArg: Partial<Config> = {},
+) {
+  const config: Config = { ...DEFAULT_CONFIG, ...configArg };
+
+  const inflight: Record<string, Promise<T>> = {};
+
+  return function debounced(...args: any[]): Promise<T> {
+    if (
+      config.ignoreSingleUndefined &&
+      args.length === 1 &&
+      args[0] === undefined
+    ) {
+      console.warn("Ignoring single undefined arg (reuseInFlight)");
+      args = [];
+    }
+
+    const key = config.createKey(args);
+
+    if (!Object.prototype.hasOwnProperty.call(inflight, key)) {
+      // WE DO NOT AWAIT, we are storing the promise itself
+      inflight[key] = asyncFn(...args).then(
+        (results) => {
+          // self invalidate
+          delete inflight[key];
+          return results;
+        },
+        (err) => {
+          // still self-invalidate, then rethrow
+          delete inflight[key];
+          throw err;
+        },
+      );
+    }
+
+    // ... and return it
+    return inflight[key] as Promise<T>;
+  };
+}


### PR DESCRIPTION
# Description

* typescript version of reuseInFlight based on the one in async-await-utils
   * with even more tests than there are upstream
* removing async-await-utils and all it's dependencies (outdated and a lot)
* changing imports

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
