### PR TITLE
frontend/x11: fix fallout of using our own reuseInFlight

### DIFF
--- a/src/packages/frontend/course/configuration/actions.ts
+++ b/src/packages/frontend/course/configuration/actions.ts
@@ -30,7 +30,7 @@ export class ConfigurationActions {
   constructor(course_actions: CourseActions) {
     this.course_actions = course_actions;
     this.push_missing_handouts_and_assignments = reuseInFlight(
-      this.push_missing_handouts_and_assignments,
+      this.push_missing_handouts_and_assignments.bind(this),
     );
   }
 

--- a/src/packages/frontend/frame-editors/code-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/code-editor/actions.ts
@@ -220,7 +220,7 @@ export class Actions<
       this as unknown as Actions<CodeEditorState>,
     );
 
-    this.format = reuseInFlight(this.format);
+    this.format = reuseInFlight(this.format.bind(this));
 
     this.set_resize = debounce(this.set_resize.bind(this), 20, {
       leading: false,

--- a/src/packages/frontend/frame-editors/x11-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/actions.ts
@@ -55,7 +55,7 @@ export class Actions extends BaseActions<X11EditorState> {
 
   async _init2(): Promise<void> {
     await this.check_capabilities();
-    this.launch = reuseInFlight(this.launch);
+    this.launch = reuseInFlight(this.launch.bind(this));
     this.setState({ windows: Map() });
     this.init_client();
     this.init_new_x11_frame();
@@ -65,7 +65,7 @@ export class Actions extends BaseActions<X11EditorState> {
       this.set_error(
         // TODO: should retry instead (?)
         err +
-          " -- you might need to refresh your browser or close and open this file."
+          " -- you might need to refresh your browser or close and open this file.",
       );
     }
   }
@@ -88,7 +88,7 @@ export class Actions extends BaseActions<X11EditorState> {
 
       // next, we check for specific apps
       const x11_conf = (await proj_actions.init_configuration(
-        "x11"
+        "x11",
       )) as X11Configuration;
       if (x11_conf == null) return false;
       // from here, we know that we have x11 status information
@@ -202,7 +202,7 @@ export class Actions extends BaseActions<X11EditorState> {
           .set(wid, fromJS({ wid, title, is_modal }));
         this.setState({ windows });
         this.update_x11_tabs();
-      }
+      },
     );
 
     this.client.on("window:destroy", (wid: number) => {
@@ -326,12 +326,12 @@ export class Actions extends BaseActions<X11EditorState> {
   set_focused_window_in_frame(
     id: string,
     wid: number,
-    do_not_ensure = false
+    do_not_ensure = false,
   ): void {
     const modal_wids = this.get_modal_wids();
     if (modal_wids.size > 0 && !modal_wids.has(wid)) {
       this.set_error(
-        "Close any modal tabs before switching to a non-modal tab."
+        "Close any modal tabs before switching to a non-modal tab.",
       );
       return;
     }

--- a/src/packages/frontend/frame-editors/x11-editor/xpra-client.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/xpra-client.ts
@@ -6,21 +6,21 @@
 // Use Xpra to provide X11 server.
 
 import { join } from "path";
+import { throttle } from "underscore";
+
+import { alert_message } from "@cocalc/frontend/alerts";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { open_new_tab } from "@cocalc/frontend/misc";
 import { retry_until_success } from "@cocalc/util/async-utils";
+import { close, hash_string } from "@cocalc/util/misc";
 import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 import { ConnectionStatus } from "../frame-tree/types";
+import { ExecOutput, touch, touch_project } from "../generic/client";
+import { ExecOpts0, XpraServer } from "./xpra-server";
 import { Client } from "./xpra/client";
 import { Surface } from "./xpra/surface";
-import { XpraServer, ExecOpts0 } from "./xpra-server";
-import { ExecOutput } from "../generic/client";
-import { touch, touch_project } from "../generic/client";
-import { throttle } from "underscore";
-import { open_new_tab } from "../../misc";
 import { is_copy } from "./xpra/util";
-import { alert_message } from "@cocalc/frontend/alerts";
 const sha1 = require("sha1");
-import { close, hash_string } from "@cocalc/util/misc";
-import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
 
 const BASE_DPI: number = 96;
 
@@ -63,7 +63,7 @@ export class XpraClient extends EventEmitter {
   constructor(options: Options) {
     super();
     this.record_active = throttle(this.record_active.bind(this), 30000);
-    this.connect = reuseInFlight(this.connect);
+    this.connect = reuseInFlight(this.connect.bind(this));
     this.options = options;
     this.init_display();
     this.client = new Client();
@@ -166,7 +166,7 @@ export class XpraClient extends EventEmitter {
       appBasePath,
       this.options.project_id,
       "server",
-      `${port}`
+      `${port}`,
     );
     const uri = `wss${origin}${path}`;
     const dpi = Math.round(BASE_DPI * window.devicePixelRatio);
@@ -183,11 +183,11 @@ export class XpraClient extends EventEmitter {
     this.client.on("overlay:destroy", this.overlay_destroy.bind(this));
     this.client.on(
       "notification:create",
-      this.handle_notification_create.bind(this)
+      this.handle_notification_create.bind(this),
     );
     this.client.on(
       "notification:destroy",
-      this.handle_notification_destroy.bind(this)
+      this.handle_notification_destroy.bind(this),
     );
     this.client.on("ws:status", this.ws_status.bind(this));
     this.client.on("key", this.record_active);
@@ -326,7 +326,7 @@ export class XpraClient extends EventEmitter {
         "window:create",
         surface.wid,
         surface.metadata.title,
-        !!surface.metadata["modal"]
+        !!surface.metadata["modal"],
       );
     }
   }
@@ -337,7 +337,7 @@ export class XpraClient extends EventEmitter {
     wid: number,
     width: number,
     height: number,
-    frame_scale: number = 1
+    frame_scale: number = 1,
   ): void {
     //console.log("resize_window", wid, width, height, frame_scale);
     const surface: Surface | undefined = this.client.findSurface(wid);
@@ -510,7 +510,7 @@ export class XpraClient extends EventEmitter {
     }
     this.idle_interval = setInterval(
       this.idle_timeout_if_inactive.bind(this),
-      idle_timeout / 2
+      idle_timeout / 2,
     );
   }
 

--- a/src/packages/frontend/frame-editors/x11-editor/xpra-server.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/xpra-server.ts
@@ -42,11 +42,11 @@ export class XpraServer {
       console.warn("xpra: Failed to get hostname.");
     }
     this.display = opts.display;
-    this.start = reuseInFlight(this.start);
-    this.stop = reuseInFlight(this.stop);
-    this.get_port = reuseInFlight(this.get_port);
-    this.get_hostname = reuseInFlight(this.get_hostname);
-    this.pgrep = reuseInFlight(this.pgrep);
+    this.start = reuseInFlight(this.start.bind(this));
+    this.stop = reuseInFlight(this.stop.bind(this));
+    this.get_port = reuseInFlight(this.get_port.bind(this));
+    this.get_hostname = reuseInFlight(this.get_hostname.bind(this));
+    this.pgrep = reuseInFlight(this.pgrep.bind(this));
   }
 
   destroy(): void {

--- a/src/packages/project/lean/lean.ts
+++ b/src/packages/project/lean/lean.ts
@@ -3,7 +3,6 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-
 import { callback, delay } from "awaiting";
 import * as lean_client from "lean-client-js-node";
 import { isEqual } from "lodash";
@@ -41,7 +40,7 @@ export class Lean extends EventEmitter {
 
   constructor(client: Client) {
     super();
-    this.server = reuseInFlight(this.server);
+    this.server = reuseInFlight(this.server.bind(this));
     this.client = client;
     this.dbg = this.client.dbg("LEAN SERVER");
     this.running = {};
@@ -71,8 +70,8 @@ export class Lean extends EventEmitter {
       new lean_client.ProcessTransport(
         "lean",
         process.env.HOME ? process.env.HOME : ".", // satisfy typescript.
-        ["-M 4096"]
-      )
+        ["-M 4096"],
+      ),
     );
     this._server.error.on((err) => this.dbg("error:", err));
     this._server.allMessages.on((allMessages) => {
@@ -98,7 +97,7 @@ export class Lean extends EventEmitter {
           "messages for ",
           path,
           new_messages[path],
-          this._state.paths[path]
+          this._state.paths[path],
         );
         // length 0 is a special case needed when going from pos number of messages to none.
         if (
@@ -139,7 +138,7 @@ export class Lean extends EventEmitter {
             this.dbg(
               "server",
               path,
-              " changed while running, so running again"
+              " changed while running, so running again",
             );
             this.paths[path].on_change();
           }
@@ -191,7 +190,7 @@ export class Lean extends EventEmitter {
         this.dbg(
           "sync",
           path,
-          "skipping sync document is empty (and LEAN behaves weird in this case)"
+          "skipping sync document is empty (and LEAN behaves weird in this case)",
         );
         this.emit("sync", path, syncstring.hash_of_live_version());
         return;
@@ -256,7 +255,7 @@ export class Lean extends EventEmitter {
   async info(
     path: string,
     line: number,
-    column: number
+    column: number,
   ): Promise<lean_client.InfoResponse> {
     this.dbg("info", path, line, column);
     if (!this.paths[path]) {
@@ -270,7 +269,7 @@ export class Lean extends EventEmitter {
     path: string,
     line: number,
     column: number,
-    skipCompletions?: boolean
+    skipCompletions?: boolean,
   ): Promise<lean_client.CompleteResponse> {
     this.dbg("complete", path, line, column);
     if (!this.paths[path]) {

--- a/src/packages/project/sync/project-status.ts
+++ b/src/packages/project/sync/project-status.ts
@@ -23,13 +23,13 @@ class ProjectStatusTable {
   constructor(
     table: SyncTable,
     logger: { debug: Function },
-    project_id: string
+    project_id: string,
   ) {
     this.status_handler = this.status_handler.bind(this);
     this.project_id = project_id;
     this.logger = logger;
     this.log("register");
-    this.publish = reuseInFlight(this.publish_impl);
+    this.publish = reuseInFlight(this.publish_impl.bind(this));
     this.table = table;
     this.table.on("closed", () => this.close());
     // initializing project status server + reacting when it has something to say
@@ -56,7 +56,7 @@ class ProjectStatusTable {
       this.log(
         `ProjectStatusTable '${
           this.state
-        }' and table is ${this.table?.get_state()}`
+        }' and table is ${this.table?.get_state()}`,
       );
     }
   }
@@ -80,12 +80,12 @@ let project_status_table: ProjectStatusTable | undefined = undefined;
 export function register_project_status_table(
   table: SyncTable,
   logger: any,
-  project_id: string
+  project_id: string,
 ): void {
   logger.debug("register_project_status_table");
   if (project_status_table != null) {
     logger.debug(
-      "register_project_status_table: cleaning up an already existing one"
+      "register_project_status_table: cleaning up an already existing one",
     );
     project_status_table.close();
   }


### PR DESCRIPTION
# Description

see title, also binding all other wrapped method calls, just to avoid surprises … in any case, with that I can run X11 apps in my dev project, format code, etc.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
