### PR TITLE
frontend/flyout/new: different algorithm

### DIFF
--- a/src/packages/frontend/project/new/file-type-selector.tsx
+++ b/src/packages/frontend/project/new/file-type-selector.tsx
@@ -36,7 +36,7 @@ interface Props {
   mode?: "flyout" | "full";
   selectedExt?: string;
   filename: string;
-  makeNewFilename?: () => void;
+  makeNewFilename?: (ext: string) => void;
 }
 
 // Use Rows and Cols to append more buttons to this class.
@@ -95,7 +95,7 @@ export function FileTypeSelector({
             btnActive={btnActive}
             grid={[sm, md]}
             filename={filename}
-            makeNewFilename={makeNewFilename}
+            makeNewFilename={() => makeNewFilename?.("ipynb")}
           />
           {renderSageWS()}
           {renderLaTeX()}
@@ -178,7 +178,7 @@ export function FileTypeSelector({
   }
 
   function renderServers() {
-    if (disabledFeatures?.servers) return;
+    if (disabledFeatures?.servers || mode === "flyout") return;
 
     return (
       <>

--- a/src/packages/frontend/project/new/new-file-dropdown.tsx
+++ b/src/packages/frontend/project/new/new-file-dropdown.tsx
@@ -23,6 +23,7 @@ interface Props {
   title?: string;
   showDown?: boolean;
   button?: boolean;
+  cacheKey?: string;
 }
 
 export function NewFileDropdown({
@@ -31,6 +32,7 @@ export function NewFileDropdown({
   title = "More file types...",
   showDown = true,
   button = true,
+  cacheKey = ""
 }: Props) {
   // TODO maybe filter by configuration.get("main", {disabled_ext: undefined}) ?
   const items = React.useMemo((): MenuItems => {
@@ -46,7 +48,7 @@ export function NewFileDropdown({
       }
     }
     return extensions.map(dropdown_item);
-  }, keys(file_associations));
+  }, [...keys(file_associations), cacheKey]);
 
   function dropdown_item(ext: string) {
     const data = file_options("x." + ext);
@@ -83,11 +85,7 @@ export function NewFileDropdown({
               </span>
             </Button>
 
-            <DropdownMenu
-              size="large"
-              button={button}
-              items={items}
-            />
+            <DropdownMenu size="large" button={button} items={items} />
           </Button.Group>
         </span>
       );

--- a/src/packages/frontend/project/utils.ts
+++ b/src/packages/frontend/project/utils.ts
@@ -75,7 +75,7 @@ export class NewFilenames {
   // generate a new filename, by optionally avoiding the keys in the dictionary
   public gen(
     type?: NewFilenameTypes,
-    avoid?: { [name: string]: boolean }
+    avoid?: { [name: string]: boolean },
   ): string {
     type = this.sanitize_type(type);
     // reset the enumeration if type changes
@@ -87,7 +87,7 @@ export class NewFilenames {
       // ignore all extensions in avoid "set", if we do not know the file extension
       if (this.effective_ext == null) {
         const noexts = Object.keys(avoid).map(
-          (x) => separate_file_extension(x).name
+          (x) => separate_file_extension(x).name,
         );
         avoid = Object.assign({}, ...noexts.map((x) => ({ [x]: true })));
       }
@@ -142,7 +142,7 @@ export class NewFilenames {
         // e.g. for python, join using "_"
         let fn = tokens.join(this.filler());
         if (fullname && this.ext != null && this.ext !== "") {
-          fn += `.${this.ext}`;
+          fn += this.ext === "/" ? "/" : `.${this.ext}`;
         }
         return fn;
     }
@@ -176,7 +176,9 @@ export class NewFilenames {
         // the "Spec" for file associations makes sure that "name" != null
         // but for unkown files "name" == "" → fallback "file"
         const name = info.name;
-        return name === "" ? ["file"] : name.toLowerCase().split(" ");
+        return name === ""
+          ? ["file"]
+          : name.replace(/\//g, "_").toLowerCase().split(" ");
     }
   }
 
@@ -244,7 +246,7 @@ export function normalize(path: string): string {
 // test, if the given file exists and has nonzero size
 export async function file_nonzero_size(
   project_id: string,
-  path: string
+  path: string,
 ): Promise<boolean> {
   const f = path_split(path);
   try {
@@ -268,7 +270,7 @@ export function url_fullpath(project_id: string, path: string): string {
     "projects",
     project_id,
     "files",
-    `${encode_path(path)}`
+    `${encode_path(path)}`,
   );
 }
 


### PR DESCRIPTION
# Description

This changes the overall behavior, hopefully to the better. It combines the single click auto-generated filename of the large new page with the explicit type dropdown from the explorer's new dropdown + entering a name. other changes involve how manually setting an extension via the filename works fine now, prioritizing some extensions in the dropdown, help info, and some cosmetic changes


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
