### PR TITLE
#7250: `Vouchers` link in store now routes to `/vouchers` instead of `/store/vouchers`.

### DIFF
--- a/src/packages/next/components/store/menu.tsx
+++ b/src/packages/next/components/store/menu.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useContext } from 'react';
-import { Menu, MenuProps, Flex, Typography } from "antd";
+import { Menu, MenuProps, Typography, Flex } from "antd";
 import { useRouter } from "next/router";
 
 import { currency } from "@cocalc/util/misc";
@@ -19,20 +19,27 @@ const styles: { [k: string]: React.CSSProperties } = {
   menuBookend: {
     height: "100%",
     whiteSpace: "nowrap",
+    flexGrow: 1,
+    textAlign: "end"
   },
   menu: {
     width: "100%",
     height: "100%",
-    border: 0
+    border: 0,
   },
-  menuContainer: {
+  menuRoot: {
     marginBottom: "24px",
-    whiteSpace: "nowrap",
     alignItems: "center",
     border: 0,
     borderBottom: "1px solid rgba(5, 5, 5, 0.06)",
     boxShadow: "none",
-  }
+  },
+  menuContainer: {
+    alignItems: "center",
+    whiteSpace: "nowrap",
+    maxWidth: "100%",
+    flexGrow: 1,
+  },
 };
 
 export interface ConfigMenuProps {
@@ -43,8 +50,9 @@ export default function ConfigMenu({ main }: ConfigMenuProps) {
   const router = useRouter();
   const { balance } = useContext(StoreBalanceContext);
 
-  const handleMenuItemSelect: MenuProps['onSelect'] = ({ keyPath }) => {
-    router.push(`/store/${keyPath[0]}`, undefined, {
+  const handleMenuItemSelect: MenuProps["onSelect"] = ({ keyPath }) => {
+    const url = keyPath[0] === "vouchers" ? "/vouchers" : `/store/${keyPath[0]}`;
+    router.push(url, undefined, {
       scroll: false,
     });
   }
@@ -78,15 +86,17 @@ export default function ConfigMenu({ main }: ConfigMenuProps) {
   ];
 
   return (
-    <Flex gap="middle" justify="space-between" style={styles.menuContainer}>
-      <Text strong style={styles.menuBookend}>Store</Text>
-      <Menu
-        mode="horizontal"
-        selectedKeys={main ? [main] : undefined}
-        style={styles.menu}
-        onSelect={handleMenuItemSelect}
-        items={items}
-      />
+    <Flex gap="middle" justify="space-between" style={styles.menuRoot} wrap="wrap">
+      <Flex style={styles.menuContainer} align="center">
+        <Text strong>Store</Text>
+        <Menu
+          mode="horizontal"
+          selectedKeys={main ? [main] : undefined}
+          style={styles.menu}
+          onSelect={handleMenuItemSelect}
+          items={items}
+        />
+      </Flex>
       <Text strong style={styles.menuBookend}>
         {balance !== undefined ? `Balance: ${currency(balance)}` : null}
       </Text>

--- a/src/packages/next/pages/vouchers/index.tsx
+++ b/src/packages/next/pages/vouchers/index.tsx
@@ -41,6 +41,13 @@ export default function Overview({ customize }) {
               </div>
             </div>
             <OverviewRow>
+              <Product
+                href={"/store/vouchers"}
+                icon="shopping-cart"
+                title="Buy Vouchers"
+              >
+                Create voucher codes that you can share, resell, or use later.
+              </Product>
               <Product icon="gift2" title="Redeem a Voucher" href="/redeem">
                 Redeem a voucher code to add{" "}
                 <A href="/settings/purchases">money</A> or{" "}
@@ -60,13 +67,6 @@ export default function Overview({ customize }) {
                 title="Your Vouchers"
               >
                 Browse all vouchers you have created and see their status.
-              </Product>
-              <Product
-                href={"/store/vouchers"}
-                icon="shopping-cart"
-                title="Create New Vouchers"
-              >
-                Create voucher codes that you can share, resell, or use later.
               </Product>
             </OverviewRow>
             {profile?.is_admin && (


### PR DESCRIPTION
 Store navbar is also now responsive.

**Feedback Request**

This PR implements the behavior exactly as suggested [in this comment](https://github.com/sagemathinc/cocalc/issues/7250#issuecomment-1930476991). Another possibility would be to slightly rename the existing menu option to be consistent with the updated Voucher Center link, and then to simply add an extra link in the store view to the Voucher Center:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/44e497eb-91d5-40b8-a5fc-05e51c4594a8)

This has the advantage of consistent rendering for menu options in the Store, preserves existing behavior, and adds the Voucher Center as its own hyperlink.

Happy to go either way.
