### PR TITLE
frontend/latex+md: AI text -> formula button

### DIFF
--- a/src/packages/frontend/codemirror/extensions/ai-formula.tsx
+++ b/src/packages/frontend/codemirror/extensions/ai-formula.tsx
@@ -1,0 +1,274 @@
+import { Button, Divider, Input, Modal, Space } from "antd";
+
+import { useLanguageModelSetting } from "@cocalc/frontend/account/useLanguageModelSetting";
+import { redux, useEffect, useState } from "@cocalc/frontend/app-framework";
+import {
+  HelpIcon,
+  Markdown,
+  Paragraph,
+  Title,
+  Text,
+} from "@cocalc/frontend/components";
+import { LanguageModelVendorAvatar } from "@cocalc/frontend/components/language-model-icon";
+import ModelSwitch, {
+  modelToName,
+} from "@cocalc/frontend/frame-editors/chatgpt/model-switch";
+import { show_react_modal } from "@cocalc/frontend/misc";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import { unreachable } from "@cocalc/util/misc";
+import { isFreeModel } from "@cocalc/util/db-schema/openai";
+
+// TODO: markdown md
+type Mode = "tex" | "md";
+
+interface Opts {
+  mode: Mode;
+  text?: string;
+  project_id: string;
+}
+
+export async function ai_gen_formula({
+  mode,
+  text = "",
+  project_id,
+}: Opts): Promise<string> {
+  return await show_react_modal((cb) => (
+    <AiGenFormula mode={mode} text={text} project_id={project_id} cb={cb} />
+  ));
+}
+
+interface Props extends Opts {
+  cb: (err?: string, result?: string) => void;
+}
+
+function AiGenFormula({ mode, text = "", project_id, cb }: Props) {
+  const [model, setModel] = useLanguageModelSetting();
+  const [input, setInput] = useState<string>(text);
+  const [formula, setFormula] = useState<string>("");
+  const [generating, setGenerating] = useState<boolean>(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const enabled = redux
+    .getStore("projects")
+    .hasLanguageModelEnabled(project_id);
+
+  function getPrompt() {
+    const description = input || text;
+    switch (mode) {
+      case "tex":
+        return `Convert the following plain-text description of a formula to a LaTeX formula in a *.tex file. Assume the package  amsmath is available. Only return the LaTeX formula in a single code snippet, delimited by $ or $$. Do not add any explanations:\n\n${description}`;
+      case "md":
+        return `Convert the following plain-text description of a formula to a LaTeX formula in a markdown file. Only return the LaTeX formula in a single code snippet, delimited by $ or $$. Do not add any explanations:\n\n${description}`;
+      default:
+        unreachable(mode);
+    }
+  }
+
+  function wrapFormula(tex: string = "") {
+    // wrap single-line formulas in $...$
+    // if it is multiline, wrap in \begin{equation}...\end{equation}
+    // but only wrap if actually necessary
+    tex = tex.trim();
+    if (tex.split("\n").length > 1) {
+      if (tex.includes("\\begin{")) {
+        return tex;
+      } else if (tex.startsWith("$$") && tex.endsWith("$$")) {
+        return tex;
+      } else {
+        return `\\begin{equation}\n${tex}\n\\end{equation}`;
+      }
+    } else {
+      if (tex.startsWith("$") && tex.endsWith("$")) {
+        return tex;
+      } else if (tex.startsWith("\\(") && tex.endsWith("\\)")) {
+        return tex;
+      } else {
+        return `$${tex}$`;
+      }
+    }
+  }
+
+  function processFormula(formula: string) {
+    let tex = "";
+    // iterate over all lines in formula. save everything between the first ``` and last ``` in tex
+    let inCode = false;
+    for (const line of formula.split("\n")) {
+      if (line.startsWith("```")) {
+        inCode = !inCode;
+      } else if (inCode) {
+        tex += line + "\n";
+      }
+    }
+    // we found nothing -> the entire formula string is the tex code
+    if (!tex) {
+      tex = formula;
+    }
+    setFormula(tex);
+  }
+
+  async function doGenerate() {
+    try {
+      setError(undefined);
+      setGenerating(true);
+      const tex = await webapp_client.openai_client.chatgpt({
+        input: getPrompt(),
+        project_id,
+        tag: `generate-formula-${mode}`,
+        model,
+        system: null,
+      });
+      processFormula(tex);
+    } catch (err) {
+      setError(err.message || err.toString());
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  // Start the query immediately, if the user had selected some text … and it's a free model
+  useEffect(() => {
+    if (text && isFreeModel(model)) {
+      doGenerate();
+    }
+  }, [text]);
+
+  function renderTitle() {
+    return (
+      <>
+        <Title level={4}>
+          <LanguageModelVendorAvatar model={model} /> Generate LaTeX Formula
+          using {modelToName(model)}
+        </Title>
+        {enabled ? (
+          <>
+            Select language model:{" "}
+            <ModelSwitch
+              project_id={project_id}
+              size="small"
+              model={model}
+              setModel={setModel}
+            />
+          </>
+        ) : undefined}
+      </>
+    );
+  }
+
+  function renderContent() {
+    const help = (
+      <HelpIcon title="Usage">
+        <Paragraph>
+          You can either enter the description in various ways:
+          <ul>
+            <li>
+              a natural language description like{" "}
+              <Text code>drake equation</Text>,
+            </li>
+            <li>
+              or simple algebraic notation like{" "}
+              <Text code>(a+b)^2 = a^2 + 2 a b + b^2</Text>,
+            </li>
+            <li>
+              or a combination of both:{" "}
+              <Text code>integral from 0 to infinity of (1+sin(x))/x^2 dx</Text>
+              .
+            </li>
+          </ul>
+          By clicking the "Insert button", the generated LaTeX formula will be
+          inserted at the current cursor position.
+        </Paragraph>
+        <Paragraph>
+          Prior to opening this dialog, you can even select a portion of your
+          text – this will be used as your description and the AI language model
+          will be queried immediately.
+        </Paragraph>
+      </HelpIcon>
+    );
+    return (
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Paragraph style={{ marginBottom: 0 }}>
+          Use the selected AI language model to generate a LaTeX formula from a
+          description. {help}
+        </Paragraph>
+        <Space.Compact style={{ width: "100%" }}>
+          <Input
+            allowClear
+            disabled={generating}
+            placeholder={
+              "Describe the formula in natural language and/or algebraic notation."
+            }
+            prefix={help}
+            defaultValue={text}
+            onChange={(e) => setInput(e.target.value)}
+            onPressEnter={doGenerate}
+          />
+          <Button
+            loading={generating}
+            onClick={doGenerate}
+            type={formula ? "default" : "primary"}
+          >
+            Generate
+          </Button>
+        </Space.Compact>
+        {formula ? (
+          <>
+            <Paragraph code>{formula}</Paragraph>
+            <Space direction="horizontal" size="middle">
+              Preview:
+              <Markdown value={wrapFormula(formula)} />
+            </Space>
+          </>
+        ) : undefined}
+        {error ? <Paragraph type="danger">{error}</Paragraph> : undefined}
+        {mode === "tex" ? (
+          <>
+            <Divider />
+            <Paragraph type="secondary">
+              Note: You might have to ensure that{" "}
+              <code>{"\\usepackage{amsmath}"}</code> is loaded in the preamble.
+            </Paragraph>
+          </>
+        ) : undefined}
+      </Space>
+    );
+  }
+
+  function renderButtons() {
+    return (
+      <div>
+        <Button onClick={onCancel}>Cancel</Button>
+        <Button
+          type={formula ? "primary" : "default"}
+          disabled={!formula}
+          onClick={() => cb(undefined, wrapFormula(formula))}
+        >
+          Insert formula
+        </Button>
+      </div>
+    );
+  }
+
+  function renderBody() {
+    if (!enabled) {
+      return <div>AI language models are disabled.</div>;
+    }
+    return renderContent();
+  }
+
+  function onCancel() {
+    cb(undefined, text);
+  }
+
+  return (
+    <Modal
+      title={renderTitle()}
+      open
+      footer={renderButtons()}
+      onCancel={onCancel}
+      centered
+      width={"70vw"}
+    >
+      {renderBody()}
+    </Modal>
+  );
+}

--- a/src/packages/frontend/codemirror/extensions/edit-selection.ts
+++ b/src/packages/frontend/codemirror/extensions/edit-selection.ts
@@ -12,6 +12,7 @@ import {
   commands as EDIT_COMMANDS,
 } from "../../editors/editor-button-bar";
 import { markdown_to_html } from "../../markdown";
+import { ai_gen_formula } from "./ai-formula";
 
 /*
 Apply an edit to the selected text in an editor; works with one or more
@@ -28,11 +29,13 @@ CodeMirror.defineExtension(
     cmd: string;
     args?: string | number;
     mode?: string;
+    project_id?: string;
   }): Promise<void> {
     opts = defaults(opts, {
       cmd: required,
       args: undefined,
       mode: undefined,
+      project_id: undefined,
     });
     // @ts-ignore
     const cm = this;
@@ -53,7 +56,7 @@ CodeMirror.defineExtension(
     const default_mode = opts.mode ?? cm.get_edit_mode();
     const canonical_mode = (name) => sagews_canonical_mode(name, default_mode);
 
-    const { args, cmd } = opts;
+    const { args, cmd, project_id } = opts;
 
     // FUTURE: will have to make this more sophisticated, so it can
     // deal with nesting, spans, etc.
@@ -363,6 +366,13 @@ CodeMirror.defineExtension(
             done = true;
           }
           break;
+
+        case "ai_formula":
+          if (project_id != null) {
+            src = await ai_gen_formula({ mode, text: src, project_id });
+          }
+          done = true;
+          break;
       }
 
       if (!done) {
@@ -373,7 +383,7 @@ CodeMirror.defineExtension(
         }
 
         // TODO: should we show an alert or something??
-        console.warn("not implemented");
+        console.warn(`not implemented. cmd='${cmd}' mode='${mode1}'`);
         continue;
       }
 

--- a/src/packages/frontend/codemirror/extensions/insert-image.tsx
+++ b/src/packages/frontend/codemirror/extensions/insert-image.tsx
@@ -3,12 +3,12 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import * as CodeMirror from "codemirror";
 import { Button, Form, Input, Modal } from "antd";
+import * as CodeMirror from "codemirror";
 
-import { show_react_modal } from "../../misc";
-import { Icon } from "../../components";
-import { alert_message } from "../../alerts";
+import { alert_message } from "@cocalc/frontend/alerts";
+import { Icon } from "@cocalc/frontend/components";
+import { show_react_modal } from "@cocalc/frontend/misc";
 
 export interface Options {
   url: string;
@@ -91,7 +91,7 @@ function insert_image(mode: string, opts: Options): string {
 }
 
 export async function get_insert_image_opts_from_user(
-  note = ""
+  note = "",
 ): Promise<undefined | Options> {
   const opts = await show_react_modal((cb) => {
     return (

--- a/src/packages/frontend/frame-editors/code-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/code-editor/actions.ts
@@ -1996,7 +1996,7 @@ export class Actions<
       // format bar only makes sense when some cm is there...
       return;
     }
-    await cm.edit_selection({ cmd, args });
+    await cm.edit_selection({ cmd, args, project_id: this.project_id });
     if (this._state !== "closed") {
       cm.focus();
       this.set_syncstring_to_codemirror();

--- a/src/packages/frontend/frame-editors/frame-tree/commands/format-commands.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/commands/format-commands.tsx
@@ -1,9 +1,13 @@
-import { addEditorMenus } from "./editor-menus";
-import { FONT_SIZES } from "@cocalc/frontend/editors/editor-button-bar";
-import { FONT_FACES } from "@cocalc/frontend/editors/editor-button-bar";
+import { range } from "lodash";
+
+import AIAvatar from "@cocalc/frontend/components/ai-avatar";
 import ColorPicker from "@cocalc/frontend/components/color-picker";
 import { HeadingContent } from "@cocalc/frontend/components/heading-menu";
-import { range } from "lodash";
+import {
+  FONT_FACES,
+  FONT_SIZES,
+} from "@cocalc/frontend/editors/editor-button-bar";
+import { addEditorMenus } from "./editor-menus";
 
 const FORMAT_SPEC = {
   equation: {
@@ -17,6 +21,12 @@ const FORMAT_SPEC = {
     label: "Displayed Equation",
     title: "Insert display LaTeX math equation.",
     icon: <span>$$</span>,
+  },
+  ai_formula: {
+    button: "Formula",
+    label: "AI Generated Formula",
+    title: "Insert AI generated formula.",
+    icon: <AIAvatar size={16} />,
   },
   bold: { icon: "bold", title: "Make selected text bold" },
   italic: { icon: "italic", title: "Make selected text italics" },
@@ -110,7 +120,7 @@ const FORMAT_MENUS = {
   insert: {
     label: "Insert",
     pos: 1.3,
-    math: ["equation", "display_equation"],
+    math: ["equation", "display_equation", "ai_formula"],
     lists: ["insertunorderedlist", "insertorderedlist"],
     objects: [
       "table",

--- a/src/packages/frontend/frame-editors/generic/codemirror-plugins.ts
+++ b/src/packages/frontend/frame-editors/generic/codemirror-plugins.ts
@@ -24,6 +24,7 @@ declare module "codemirror" {
       cmd: string;
       args?: any;
       mode?: string;
+      project_id?: string;
       cb?: Function; // called after done; if there is a dialog, this could be a while.
     }): void;
   }

--- a/src/packages/frontend/frame-editors/latex-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/editor.ts
@@ -8,20 +8,20 @@ Spec for editing LaTeX documents.
 */
 
 import { set } from "@cocalc/util/misc";
+import { IS_IOS, IS_IPAD } from "../../feature";
+import { CodemirrorEditor } from "../code-editor/codemirror-editor";
 import { createEditor } from "../frame-tree/editor";
 import { EditorDescription } from "../frame-tree/types";
-import { PDFJS } from "./pdfjs";
-import { PDFEmbed } from "./pdf-embed";
-import { CodemirrorEditor } from "../code-editor/codemirror-editor";
-import { Build } from "./build";
-import { ErrorsAndWarnings } from "./errors-and-warnings";
-import { LatexWordCount } from "./latex-word-count";
+import { TableOfContents } from "../markdown-editor/table-of-contents";
 import { SETTINGS_SPEC } from "../settings/editor";
 import { terminal } from "../terminal-editor/editor";
 import { time_travel } from "../time-travel-editor/editor";
+import { Build } from "./build";
+import { ErrorsAndWarnings } from "./errors-and-warnings";
+import { LatexWordCount } from "./latex-word-count";
+import { PDFEmbed } from "./pdf-embed";
+import { PDFJS } from "./pdfjs";
 import { pdf_path } from "./util";
-import { IS_IOS, IS_IPAD } from "../../feature";
-import { TableOfContents } from "../markdown-editor/table-of-contents";
 
 export const pdfjsCommands = set([
   "print",
@@ -68,6 +68,7 @@ const EDITOR_SPEC = {
       "download_pdf",
     ]),
     buttons: set([
+      "format-ai_formula",
       "sync",
       "format-header",
       "format-text",


### PR DESCRIPTION
# Description

Ref #7265 for latex. This also works in Markdown, and hence also in Rmd. I don't know if this menu entry appears elsewhere, though.

![Screenshot from 2024-02-09 15-42-24](https://github.com/sagemathinc/cocalc/assets/207405/dae8389f-df5d-4bde-b1d2-79e6053fcfe2)


## explicit use

[2024.02.09-ai-formula-2.webm](https://github.com/sagemathinc/cocalc/assets/207405/93026d0d-e609-4a02-8ad5-bdf765fe1b53)

## selecting text + button

If this is tied with a keyboard shortcut, it's almost magical. (and it only does the immediate query, if it is a free model)

[2024.02.09-ai-formula.webm](https://github.com/sagemathinc/cocalc/assets/207405/20c5c77b-743b-4fa8-8c13-a22d27f090bc)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
