### PR TITLE
store/dedicated/vm: add note about startup delay

### DIFF
--- a/src/packages/next/components/store/dedicated.tsx
+++ b/src/packages/next/components/store/dedicated.tsx
@@ -4,10 +4,10 @@
  */
 
 /*
-Create a new site license.
+Create a new dedicated vm/disk site license.
 */
 
-import { Divider, Form, Input, Radio, Select, Typography } from "antd";
+import { Alert, Divider, Form, Input, Radio, Select, Typography } from "antd";
 import { sortBy } from "lodash";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
@@ -740,6 +740,19 @@ function CreateDedicatedResource({ showInfoBar = false, noAccount = false }) {
     );
   }
 
+  function renderStartupWarning() {
+    if (formType !== "vm") return;
+    return (
+      <Form.Item label="Warning">
+        <Alert
+          type="warning"
+          showIcon
+          message="It takes about 15 minutes to start a Dedicated VM. Until then, the project will not be able to start."
+        />
+      </Form.Item>
+    );
+  }
+
   return (
     <div>
       <InfoBar
@@ -783,6 +796,7 @@ function CreateDedicatedResource({ showInfoBar = false, noAccount = false }) {
             {renderConfiguration()}
 
             <TitleDescription showExplanations={showExplanations} form={form} />
+            {renderStartupWarning()}
             {renderCost()}
           </>
         )}


### PR DESCRIPTION
# Description

adds a note to the vm purchase page about the startup delay right after the purchase

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
