### PR TITLE
Changed all instances of "GPU's" to "GPUs" (resp. "CPU's")

### DIFF
--- a/src/packages/frontend/compute/compute-servers-alert.tsx
+++ b/src/packages/frontend/compute/compute-servers-alert.tsx
@@ -17,14 +17,14 @@ export default function ComputeServersAlert({ project_id }) {
       type="success"
       showIcon
       icon={<Icon name="servers" />}
-      message=<>Dedicated Compute Servers</>
+      message={<>Dedicated Compute Servers</>}
       description={
         <>
           You can also run Jupyter notebooks, terminals, and commercial software
           on dedicated VM's where you have root permissions. These are charged
           by the second and have up to{" "}
           <strong>
-            11,776GB of RAM, 416 vCPU's, 65TB of disk space, and GPU's.{" "}
+            11,776GB of RAM, 416 vCPUs, 65TB of disk space, and GPUs.{" "}
           </strong>
           <br />
           Click the{" "}

--- a/src/packages/frontend/compute/compute-servers.tsx
+++ b/src/packages/frontend/compute/compute-servers.tsx
@@ -41,7 +41,7 @@ export default function ComputeServers({ project_id }: { project_id: string }) {
         Do you need{" "}
         <strong>
           <A href="https://github.com/sagemathinc/cocalc-howto/blob/main/ollama.md">
-            affordable GPU's
+            affordable GPUs
           </A>
         </strong>
         , <strong>high end VM's</strong>, <strong>root access</strong>,{" "}
@@ -66,8 +66,8 @@ export default function ComputeServers({ project_id }: { project_id: string }) {
             Linux server,
           </li>
           <li>
-            <Icon name="server" /> Dedicated GPU's, hundreds of very fast
-            vCPU's, and thousands of GB of RAM
+            <Icon name="server" /> Dedicated GPUs, hundreds of very fast
+            vCPUs, and thousands of GB of RAM
           </li>
           <li>
             <Icon name="mathematica" /> <Icon name="matlab" />{" "}

--- a/src/packages/frontend/compute/google-cloud-config.tsx
+++ b/src/packages/frontend/compute/google-cloud-config.tsx
@@ -157,7 +157,7 @@ export default function GoogleCloudConfiguration({
     const gpu = configuration.acceleratorType
       ? `${configuration.acceleratorCount ?? 1} ${displayAcceleratorType(
           configuration.acceleratorType,
-        )} ${plural(configuration.acceleratorCount ?? 1, "GPU", "GPU's")}, `
+        )} ${plural(configuration.acceleratorCount ?? 1, "GPU")}, `
       : "";
     // short summary
     return (
@@ -998,13 +998,13 @@ function RamAndCpu({
   if (inline) {
     return (
       <span style={style}>
-        {vcpu} {plural(vcpu, "vCPU", "vCPU's")}, {memory} GB RAM
+        {vcpu} {plural(vcpu, "vCPU")}, {memory} GB RAM
       </span>
     );
   }
   return (
     <div style={{ color: "#666", ...style }}>
-      <b>{plural(vcpu, "vCPU", "vCPU's")}: </b>
+      <b>{plural(vcpu, "vCPU")}: </b>
       <div
         style={{ width: "65px", textAlign: "left", display: "inline-block" }}
       >
@@ -1435,7 +1435,7 @@ function GPU({ priceData, setConfig, configuration, disabled, state, IMAGES }) {
           <div style={{ color: "#666", marginTop: "10px" }}>
             You have selected {acceleratorCount} dedicated{" "}
             <b>{displayAcceleratorType(acceleratorType)}</b>{" "}
-            {plural(acceleratorCount, "GPU", "GPU's")}, with a total of{" "}
+            {plural(acceleratorCount, "GPU")}, with a total of{" "}
             <b>
               {priceData.accelerators[acceleratorType].memory *
                 acceleratorCount}
@@ -1444,7 +1444,7 @@ function GPU({ priceData, setConfig, configuration, disabled, state, IMAGES }) {
             .{" "}
             {acceleratorCount > 1 && (
               <>
-                The {acceleratorCount} GPU's will be available on the same
+                The {acceleratorCount} GPUs will be available on the same
                 server.
               </>
             )}
@@ -1616,7 +1616,7 @@ function ensureZoneIsConsistentWithGPU(priceData, configuration, changes) {
   // Ensure the region/zone is consistent with accelerator type
   const prices = data[configuration.spot ? "spot" : "prices"];
   if (prices[configuration.zone] == null) {
-    // there are no GPU's in the selected zone of the selected type.
+    // there are no GPUs in the selected zone of the selected type.
     // If you just explicitly changed the GPU type, then we fix this by changing the zone.
     if (changes["acceleratorType"] != null) {
       // fix the region and zone

--- a/src/packages/frontend/project/new/file-type-selector.tsx
+++ b/src/packages/frontend/project/new/file-type-selector.tsx
@@ -194,10 +194,10 @@ export function FileTypeSelector({
                 title={"Create a Compute Server"}
                 placement="left"
                 icon={"servers"}
-                tip={"Affordable GPU's and high end dedicate virtual machines."}
+                tip={"Affordable GPUs and high-end dedicated virtual machines."}
               >
                 <NewFileButton
-                  name={"Compute Server: GPU's and VM's"}
+                  name={"Compute Server: GPUs and VM's"}
                   icon="servers"
                   on_click={() => {
                     projectActions?.setState({ create_compute_server: true });

--- a/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
+++ b/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
@@ -196,7 +196,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
               )
             </b>
             {render_explanation(
-              "Google cloud vCPU's shared with other projects (member hosting significantly reduces sharing)"
+              "Google Cloud vCPUs shared with other projects (member hosting significantly reduces sharing)"
             )}
           </Col>
         )}
@@ -292,7 +292,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
               )
             </b>
             {render_explanation(
-              "Google cloud vCPU's NOT shared with other projects.  You can enter a fractional value, e.g., 0.5 for a half dedicated core."
+              "Google Cloud vCPUs NOT shared with other projects.  You can enter a fractional value, e.g., 0.5 for a half dedicated core."
             )}
           </Col>
         )}

--- a/src/packages/next/components/store/overview.tsx
+++ b/src/packages/next/components/store/overview.tsx
@@ -45,7 +45,7 @@ export default function Overview() {
           icon={PAYASYOUGO_ICON}
           title="Pay As You Go Servers"
         >
-          Run Jupyter Notebooks and Linux Terminals on GPU's and high powered
+          Run Jupyter Notebooks and Linux Terminals on GPUs and high-powered
           virtual machines with full admin privileges. Pay only for what you
           actually use.
         </Product>

--- a/src/packages/next/components/store/payg-info.tsx
+++ b/src/packages/next/components/store/payg-info.tsx
@@ -21,8 +21,8 @@ export default function PaygInfo({ what }) {
         <div>
           <ul>
             <li>
-              If you need a large amount of compute power, disk space, GPU's,
-              root privileges or to run commercial software, add a{" "}
+              If you need a large amount of compute power, disk space, GPUs,
+              root privileges, or to run commercial software, add a{" "}
               <A href="https://doc.cocalc.com/compute_server.html">
                 pay as you go compute server to your project
               </A>

--- a/src/packages/next/components/store/quota-config.tsx
+++ b/src/packages/next/components/store/quota-config.tsx
@@ -117,9 +117,9 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
           showExplanations ? (
             <>
               <A href="https://cloud.google.com/compute/docs/faq#virtualcpu">
-                Google cloud vCPU's.
+                Google Cloud vCPUs.
               </A>{" "}
-              To keep prices low, these vCPU's may be shared with other
+              To keep prices low, these vCPUs may be shared with other
               projects, though member hosting very significantly reduces
               competition for CPUs. We also offer{" "}
               <A href={"/store/dedicated?type=vm"}>

--- a/src/packages/next/pages/features/compute-server.tsx
+++ b/src/packages/next/pages/features/compute-server.tsx
@@ -216,7 +216,7 @@ export default function ComputeServer({ customize }) {
               to 65TB of disk space.
             </Paragraph>
             <Paragraph>
-              You can choose one or more T4, L4, and A100 GPU's.
+              You can choose one or more T4, L4, and A100 GPUs.
             </Paragraph>
             <Paragraph>
               Many preconfigured software stacks are available, including

--- a/src/packages/next/pages/pricing/products.tsx
+++ b/src/packages/next/pages/pricing/products.tsx
@@ -106,8 +106,8 @@ function Body({ siteName }): JSX.Element {
         <Icon name="servers" /> Compute Servers
       </Title>
       <Paragraph>
-        You can use Jupyter notebooks and terminals with access to GPU's,
-        hundreds of CPU's, and thousands of GB of RAM by creating{" "}
+        You can use Jupyter notebooks and terminals with access to GPUs,
+        hundreds of CPUs, and thousands of GB of RAM by creating{" "}
         <A href="https://doc.cocalc.com/compute_server.html">compute servers</A>{" "}
         associated to a project.
       </Paragraph>

--- a/src/packages/server/compute/cloud/google-cloud/validate-configuration.ts
+++ b/src/packages/server/compute/cloud/google-cloud/validate-configuration.ts
@@ -111,7 +111,7 @@ export async function validateConfigurationChange({
         (newConfiguration.acceleratorCount ?? 0) >= 1
       )
     ) {
-      // Google cloud automatically adds GPU's in cases like the above,
+      // Google cloud automatically adds GPUs in cases like the above,
       // which is VERY bad and would cost us tons but users nothing!
       // Not checking for this could kill us.
       throw Error("the machine type g2- must have an L4 GPU configured");

--- a/src/packages/util/compute/cloud/google-cloud/compute-cost.ts
+++ b/src/packages/util/compute/cloud/google-cloud/compute-cost.ts
@@ -180,7 +180,7 @@ export function computeAcceleratorCost({ configuration, priceData }) {
   if (!configuration.acceleratorType) {
     return 0;
   }
-  // we have 1 or more GPU's:
+  // we have 1 or more GPUs:
   const acceleratorCount = configuration.acceleratorCount ?? 1;
   // sometimes google has "tesla-" in the name, sometimes they don't,
   // but our pricing data doesn't.

--- a/src/packages/util/db-schema/accounts.ts
+++ b/src/packages/util/db-schema/accounts.ts
@@ -574,7 +574,7 @@ export const TAGS: Tag[] = [
     color: "red",
   },
   {
-    label: "AI / GPU's",
+    label: "AI / GPUs",
     tag: "gpu",
     color: "volcano",
     icon: "gpu",

--- a/src/packages/util/upgrades/quota.ts
+++ b/src/packages/util/upgrades/quota.ts
@@ -271,10 +271,10 @@ const BASE_QUOTAS: RQuota = {
   member_host: false,
   privileged: false, // for elevated docker privileges (FUSE mounting, later more)
   memory_request: 0, // will hold guaranteed RAM in MB
-  cpu_request: 0, // will hold guaranteed min number of vCPU's as a float from 0 to infinity.
+  cpu_request: 0, // will hold guaranteed min number of vCPUs as a float from 0 to infinity.
   disk_quota: DEFAULT_QUOTAS.disk_quota,
   memory_limit: DEFAULT_QUOTAS.memory, // upper bound on RAM in MB
-  cpu_limit: DEFAULT_QUOTAS.cores, // upper bound on vCPU's
+  cpu_limit: DEFAULT_QUOTAS.cores, // upper bound on vCPUs
   idle_timeout: DEFAULT_QUOTAS.mintime, // minimum uptime
   always_running: false, // if true, a service restarts the project if it isn't running
   dedicated_vm: false,


### PR DESCRIPTION
# Description

Just a quick grammar fix changing:

- `GPU's` -> `GPUs`
- `CPU's` -> `CPUs`