### PR TITLE
Moved landing page sign in/sign up buttons up and to the left

### DIFF
--- a/src/packages/next/components/landing/content.tsx
+++ b/src/packages/next/components/landing/content.tsx
@@ -229,6 +229,7 @@ export default function Content(props: Props) {
                 {description}
               </Title>
             )}
+            <SignIn startup={startup ?? title} hideFree={true} />
           </Space>
         </Col>
         <Col sm={14} xs={24}>
@@ -237,9 +238,6 @@ export default function Content(props: Props) {
           {renderBelowImage()}
         </Col>
         {subtitle && renderSubtitleBelow()}
-        <Col lg={24}>
-          <SignIn startup={startup ?? title} hideFree={true} />
-        </Col>
       </Row>
     </div>
   );


### PR DESCRIPTION
…to increase visibility of compute server banner (as discussed in chat).

Old:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/8a3b8020-b477-44e6-9be5-4ac26996c4f7)


New:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/3791159f-ca3e-4601-a301-b4e7ae6fde7f)

