### PR TITLE
frontend/jupyter: show placeholder text in empty code cell

### DIFF
--- a/src/packages/frontend/client/openai.ts
+++ b/src/packages/frontend/client/openai.ts
@@ -46,6 +46,7 @@ export class LLMClient {
     return await this.queryLanguageModel(opts);
   }
 
+  // ATTN/TODO: startExplicitly seems to be broken
   public languageModelStream(opts, startExplicitly = false): ChatStream {
     const chatStream = new ChatStream();
     (async () => {

--- a/src/packages/frontend/jupyter/cell.tsx
+++ b/src/packages/frontend/jupyter/cell.tsx
@@ -6,20 +6,22 @@
 /*
 React component that describes a single cella
 */
-
 import { Map } from "immutable";
-import { React, Rendered, useDelayedRender } from "../app-framework";
-import { clear_selection } from "../misc/clear-selection";
+
+import {
+  React,
+  Rendered,
+  useDelayedRender,
+} from "@cocalc/frontend/app-framework";
+import { Icon, Tip } from "@cocalc/frontend/components";
+import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
+import { clear_selection } from "@cocalc/frontend/misc/clear-selection";
 import { COLORS } from "@cocalc/util/theme";
-import { INPUT_PROMPT_COLOR } from "./prompt/base";
-import { Icon, Tip } from "../components";
+import { JupyterActions } from "./browser-actions";
 import { CellInput } from "./cell-input";
 import { CellOutput } from "./cell-output";
-
-import { JupyterActions } from "./browser-actions";
-import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
-
 import { NBGraderMetadata } from "./nbgrader/cell-metadata";
+import { INPUT_PROMPT_COLOR } from "./prompt/base";
 
 interface Props {
   cell: Map<string, any>; // TODO: types
@@ -148,8 +150,8 @@ export const Cell: React.FC<Props> = React.memo((props) => {
       return;
     }
     frameActions.current?.set_mode("escape");
-    frameActions.current?.set_cur_id(id);
     frameActions.current?.unselect_all_cells();
+    frameActions.current?.set_cur_id(id);
   }
 
   function double_click(event: any): void {

--- a/src/packages/frontend/jupyter/codemirror-editor.tsx
+++ b/src/packages/frontend/jupyter/codemirror-editor.tsx
@@ -9,18 +9,18 @@ declare const $: any;
 
 import { SAVE_DEBOUNCE_MS } from "../frame-editors/code-editor/const";
 
-import LRU from "lru-cache";
 import { delay } from "awaiting";
-import { React, useRef, usePrevious } from "../app-framework";
-import * as underscore from "underscore";
+import CodeMirror from "codemirror";
 import { Map as ImmutableMap } from "immutable";
+import LRU from "lru-cache";
+import { CSSProperties, MutableRefObject, useEffect, useState } from "react";
+import * as underscore from "underscore";
+
+import { React, usePrevious, useRef } from "@cocalc/frontend/app-framework";
+import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
+import { COLORS } from "@cocalc/util/theme";
 import { Complete, Actions as CompleteActions } from "./complete";
 import { Cursors } from "./cursors";
-import CodeMirror from "codemirror";
-import { CSSProperties, MutableRefObject, useEffect, useState } from "react";
-
-import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
-import { EditorFunctions } from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/actions";
 
 // We cache a little info about each Codemirror editor we make here,
 // so we can restore it when we make the same one again.  Due to
@@ -32,10 +32,10 @@ interface CachedInfo {
 
 const cache = new LRU<string, CachedInfo>({ max: 1000 });
 
-const STYLE: React.CSSProperties = {
+export const STYLE: React.CSSProperties = {
   width: "100%",
   overflow: "hidden",
-  border: "1px solid #cfcfcf",
+  border: `1px solid ${COLORS.GRAY_L}`,
   borderRadius: "5px",
   padding: "5px",
   lineHeight: "1.21429em",
@@ -56,13 +56,13 @@ export interface Actions extends CompleteActions {
   introspect_at_pos: (
     code: string,
     level: 0 | 1,
-    pos: { ch: number; line: number }
+    pos: { ch: number; line: number },
   ) => Promise<void>;
   complete: (
     code: string,
     pos?: { line: number; ch: number } | number,
     id?: string,
-    offset?: any
+    offset?: any,
   ) => Promise<boolean>;
   save: () => Promise<void>;
 }
@@ -198,7 +198,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   // for the whiteboard.  It's only used there, and is a miracle it partly
   // works at all...  I wonder if CodeMirror 6 would be better?
   const [containerHeight, setContainerHeight] = useState<string | undefined>(
-    undefined
+    undefined,
   );
   const innerDivRef = useRef<any>();
   useEffect(() => {
@@ -310,7 +310,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
           cell_list_div.scrollTop(
             scroll -
               (cell_list_top - cm.current.cursorCoords(true, "window").top) -
-              20
+              20,
           );
         }
       }
@@ -525,7 +525,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
           top,
           left,
           gutter,
-        }
+        },
       );
       if (!show_dialog) {
         frameActions.current?.set_mode("edit");
@@ -553,7 +553,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   // NOTE: init_codemirror is VERY expensive, e.g., on the order of 10's of ms.
   function init_codemirror(
     options: ImmutableMap<string, any>,
-    value: string
+    value: string,
   ): void {
     if (cm.current != null) return;
     const node = cm_ref.current;

--- a/src/packages/frontend/jupyter/insert-cell/index.tsx
+++ b/src/packages/frontend/jupyter/insert-cell/index.tsx
@@ -16,12 +16,12 @@ import { Button, Space, Tooltip } from "antd";
 import { ReactNode, useState } from "react";
 
 import { redux, useFrameContext } from "@cocalc/frontend/app-framework";
+import AIAvatar from "@cocalc/frontend/components/ai-avatar";
 import { Icon } from "@cocalc/frontend/components/icon";
 import { IS_TOUCH } from "@cocalc/frontend/feature";
 import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
 import { unreachable } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
-import AIAvatar from "../../components/ai-avatar";
 import { JupyterActions } from "../browser-actions";
 import ChatGPTPopover from "./ai-cell-generator";
 import { insertCell, pasteCell } from "./util";
@@ -54,7 +54,7 @@ export function InsertCell({
       .getStore("projects")
       .hasLanguageModelEnabled(project_id, "generate-cell");
   const frameActions = useNotebookFrameActions();
-  const [showChatGPT, setShowChatGPT] = useState<boolean>(false);
+  const [showAICellGen, setShowAICellGen] = useState<boolean>(false);
 
   if (IS_TOUCH && position === "above") {
     // TODO: Inserting cells via hover and click does not make sense
@@ -69,7 +69,7 @@ export function InsertCell({
     e.preventDefault();
     e.stopPropagation();
     if (haveChatGTP && (e.altKey || e.metaKey)) {
-      setShowChatGPT(true);
+      setShowAICellGen(true);
       return;
     }
     const type =
@@ -89,7 +89,7 @@ export function InsertCell({
         pasteCell({ frameActions, actions, id, position });
         break;
       case "chatgpt":
-        setShowChatGPT(true);
+        setShowAICellGen(true);
         break;
       default:
         unreachable(type);
@@ -108,13 +108,13 @@ export function InsertCell({
         ...(position === "below"
           ? ({ marginBottom: `${BTN_HEIGHT}px` } as const)
           : {}),
-        ...(showChatGPT ? { backgroundColor: COLORS.FG_BLUE } : {}),
+        ...(showAICellGen ? { backgroundColor: COLORS.FG_BLUE } : {}),
       }}
-      onClick={showChatGPT ? undefined : handleBarClick}
+      onClick={showAICellGen ? undefined : handleBarClick}
     >
       <ChatGPTPopover
-        setShowChatGPT={setShowChatGPT}
-        showChatGPT={showChatGPT}
+        setShowChatGPT={setShowAICellGen}
+        showChatGPT={showAICellGen}
         actions={actions}
         frameActions={frameActions}
         id={id}
@@ -123,7 +123,7 @@ export function InsertCell({
         <div
           className="cocalc-jupyter-insert-cell-controls"
           style={
-            showChatGPT || position === "below"
+            showAICellGen || position === "below"
               ? {
                   visibility: "visible",
                   opacity: 1,

--- a/src/packages/frontend/jupyter/insert-cell/util.ts
+++ b/src/packages/frontend/jupyter/insert-cell/util.ts
@@ -12,7 +12,7 @@ export function insertCell({
   actions;
   type: "code" | "markdown";
   id: string; // id relative to which we insert
-  position: "above" | "below";
+  position: "above" | "below" | "replace";
   content?: string;
 }): string | undefined {
   if (frameActions.current == null) {
@@ -20,7 +20,10 @@ export function insertCell({
     return;
   }
   frameActions.current.set_cur_id(id);
-  const new_id = frameActions.current.insert_cell(position == "above" ? -1 : 1);
+  const new_id =
+    position === "replace"
+      ? id
+      : frameActions.current.insert_cell(position === "above" ? -1 : 1);
   frameActions.current.set_cur_id(new_id);
 
   if (content) {


### PR DESCRIPTION
# Description

This is surprisingly hard and I spent way more time on this than I anticipated.

* The first and solved obvious detail is to show the cell generation dialog and to start inserting the output into the current cell.
* When I select an empty cell, it shows codemirror with a cursor, other cells aren't active. So, showing this only for a selected (?) cell but not in edit mode is kind of pointless, because this almost never happens to me.
* instead, this shows it for all empty code cells, similar to what I saw with colab in our video calls (it doesn't show any of that for me over here in the EU, though)
* related to focus/selected, the remaining problem is that clicking on a cell the usual way should change it to edit mode. I can't figure out how this works. The `click_on_cell` function is getting called, but doesn't switch the cell to edit mode.
* it also adds a checkbox if the previous cell should be included or not

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
