### PR TITLE
#7301: [Site license page] 

### DIFF
--- a/src/packages/next/components/store/quota-config-presets.tsx
+++ b/src/packages/next/components/store/quota-config-presets.tsx
@@ -19,6 +19,15 @@ export type Presets =
   | "development";
 //| "budget";
 
+// Fields to be used to match a configured license against a pre-existing preset.
+//
+export const PRESET_MATCH_FIELDS = {
+  cpu: "CPU",
+  disk: "disk space",
+  ram: "memory",
+  uptime: "uptime",
+};
+
 export interface Preset {
   icon?: IconName;
   name: string;
@@ -72,13 +81,14 @@ export const PRESETS: PresetEntries = {
         You can run two or three Jupyter Notebooks in the same project at the
         same time, given they do not require a large amount of memory. This
         quota is fine for editing LaTeX documents, working with Sage Worksheets,
-        and all other document types as well. {STANDARD_DISK}G of disk space are
+        and all other document types. {STANDARD_DISK}G of disk space are
         also sufficient to store many files and a few small datasets.
       </>
     ),
     cpu: STANDARD_CPU,
     ram: STANDARD_RAM,
     disk: STANDARD_DISK,
+    uptime: "short",
   },
   //   student: {
   //     icon: "meh",
@@ -104,11 +114,11 @@ export const PRESETS: PresetEntries = {
     descr: "covers student projects with extra resources",
     details: (
       <>
-        This quota preset is very similar as the "Student" quota, although
-        students will get a bit more ram and disk space.{" "}
+        This quota preset is very similar to the "Student" quota, although
+        students are allowed a bit more ram and disk space.{" "}
         {WARN_SELECT_NUMBER_PROJECTS} The increased idle-timeout will keep their
-        notebooks and worksheets a bit longer running, while not in active use.
-        Choose this schema, if you plan to let them run data and memory
+        notebooks and worksheets running for a bit longer while not in active
+        use. Choose this schema if you plan to let students run data and memory
         intensive calculations, e.g. data-science, machine-learning, etc.{" "}
         {APPLY_LICENSE_COURSE_CONFIG}
       </>
@@ -159,12 +169,12 @@ export const PRESETS: PresetEntries = {
     details: (
       <>
         This configuration allows the project to run many Jupyter Notebooks and
-        Worksheets at once or run computations that require plenty of memory. An
-        idle-timeout of one day is sufficient to not interrupt your work and you
-        can also run calculations, which take a while to complete. Increasing
-        the disk space quota allows you to store larger datasets as well. If you
-        need vastly more disk space, you can also get a{" "}
-        <A href={"/store/dedicated?type=disk"}>dedicated disk</A>.
+        Worksheets at once or to run memory-intensive computations. An
+        idle-timeout of one day is sufficient to not interrupt your work; you
+        can also execute long-running calculations with this configuration.
+        Increasing the disk space quota also allows you to store larger
+        datasets. If you need vastly more disk space, you can additionally
+        purchase a{" "} <A href={"/store/dedicated?type=disk"}>dedicated disk</A>.
       </>
     ),
     cpu: 1,
@@ -178,8 +188,8 @@ export const PRESETS: PresetEntries = {
     descr: "is suitable for software development",
     details: (
       <>
-        This configuration helps with parallelizing build tasks across more than
-        one CPU, increases the amount of memory and also disk space.
+        This configuration allows for parallelized build tasks across more than
+        one CPU with an increased the amount of memory and disk space.
       </>
     ),
     cpu: 2,

--- a/src/packages/next/components/store/quota-config.tsx
+++ b/src/packages/next/components/store/quota-config.tsx
@@ -15,7 +15,7 @@ import {
 import { Col, Divider, Form, Radio, Row, Space, Tabs, Typography } from "antd";
 import A from "components/misc/A";
 import IntegerSlider from "components/misc/integer-slider";
-import { PRESETS, Preset, Presets } from "./quota-config-presets";
+import { PRESETS, Preset, Presets, PRESET_MATCH_FIELDS } from "./quota-config-presets";
 
 const { Text } = Typography;
 
@@ -193,20 +193,11 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
       );
     }
 
-    const cpuValue = form.getFieldValue("cpu");
-    const ramValue = form.getFieldValue("ram");
-    const diskValue = form.getFieldValue("disk");
     const memberValue = form.getFieldValue("member");
-    const uptimeValue = form.getFieldValue("uptime");
-
-    if (
-      cpuValue == null ||
-      ramValue == null ||
-      diskValue == null ||
-      memberValue == null ||
-      uptimeValue == null
-    )
+    const quotaConfig = form.getFieldsValue(Object.keys(PRESET_MATCH_FIELDS));
+    if (Object.values(quotaConfig).includes(null) || memberValue == null) {
       return;
+    }
 
     const presetData: Preset = PRESETS[preset];
     if (presetData == null) {
@@ -216,7 +207,20 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
         </div>
       );
     }
-    const { name, descr, details } = presetData;
+    const {
+      name,
+      descr,
+      details,
+    } = presetData;
+
+    const presetDiff = Object.keys(PRESET_MATCH_FIELDS).reduce(
+      (diff, presetField) => {
+        if (presetData[presetField] !== quotaConfig[presetField]) {
+          diff.push(presetField);
+        }
+
+        return diff;
+      }, [] as string[]);
 
     function presetDescription() {
       if (!descr) {
@@ -233,52 +237,65 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
     }
 
     function renderProvides() {
-      const basic = (
-        <>
-          provides up to{" "}
-          <Text strong>
-            {cpuValue} CPU {plural(cpuValue, "core")}
-          </Text>
-          , <Text strong>{ramValue}G memory</Text>, and{" "}
-          <Text strong>{diskValue}G disk space</Text> for each project.
-        </>
-      );
+      if (preset) {
+        const {
+          cpu,
+          disk,
+          ram,
+          uptime,
+        } = PRESETS[preset];
+        const memberValue = form.getFieldValue("member");
 
-      const mh =
-        memberValue === false ? (
-          <Text strong>member hosting is disabled</Text>
-        ) : null;
-
-      const ut =
-        uptimeValue !== "short" ? (
+        const basic = (
           <>
-            {mh != null ? " and" : ""} the project's{" "}
+            provides up to{" "}
             <Text strong>
-              idle timeout is {displaySiteLicense(uptimeValue)}
+              {cpu} CPU {plural(cpu, "core")}
             </Text>
+            , <Text strong>{ram}G memory</Text>, and{" "}
+            <Text strong>{disk}G disk space</Text> for each project.
           </>
-        ) : null;
+        );
 
-      const any = mh != null || ut != null;
+        const mh =
+          memberValue === false ? (
+            <Text strong>member hosting is disabled</Text>
+          ) : null;
 
-      return (
-        <>
-          {basic} {any ? "Additionally, " : ""}
-          {mh}
-          {ut}
-          {any ? "." : ""}
-        </>
-      );
+        const ut = uptime &&
+          uptime !== "short" ? (
+            <>
+              {mh != null ? " and" : ""} the project's{" "}
+              <Text strong>
+                idle timeout is {displaySiteLicense(uptime)}
+              </Text>
+            </>
+          ) : null;
+
+        const any = mh != null || ut != null;
+
+        return (
+          <>
+            {basic} {any ? "Additionally, " : ""}
+            {mh}
+            {ut}
+            {any ? "." : ""}
+          </>
+        );
+      }
     }
 
     function presetIsAdjusted() {
-      if (!presetAdjusted) return;
+      if (!presetAdjusted || !presetDiff.length) return;
+      const lf = new Intl.ListFormat('en');
       return (
         <Typography style={{ marginBottom: "10px" }}>
           <Text type="warning">
-            The preset has been adjusted and parts of the description might no
-            longer be applicable. If you select another one, your modifications
-            will be reset.
+            The current license differs from the <b>{lf.format(presetDiff)} </b>
+            configuration for the currently selected preset.
+
+            By clicking any of the above buttons, you can ensure your license
+            configuration matches the original preset configuration.
           </Text>
         </Typography>
       );
@@ -300,8 +317,7 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
     return (
       <Text type="secondary">
         After selecting a preset, feel free to fine tune the selection in the "
-        {EXPERT_CONFIG}" or change the "Member hosting" or the "Idle timeout"
-        configuration below. Subsequent preset selections will reset your
+        {EXPERT_CONFIG}" tab. Subsequent preset selections will reset your
         adjustments.
       </Text>
     );
@@ -334,12 +350,12 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
     return (
       <>
         <Form.Item label="Presets" shouldUpdate={true} extra={presetExtra()}>
-          <Radio.Group onChange={onPresetChange} value={preset}>
+          <Radio.Group value={preset}>
             <Space size={[5, 5]} wrap>
               {Object.keys(PRESETS).map((p) => {
                 const presetData = PRESETS[p];
                 return (
-                  <Radio.Button key={p} value={p}>
+                  <Radio.Button onClick={onPresetChange} key={p} value={p}>
                     <Icon name={presetData.icon ?? "arrow-up"} />{" "}
                     {presetData.name}
                   </Radio.Button>


### PR DESCRIPTION
# Description

This pull request fixes #7301 and consists of three changes to the site license page in the CoCalc Store:

1) Member hosting and idle timeout are now hidden behind expert configuration.
2) License configuration is now matched against pre-existing presets.
3) When a license configuration is set via editing a license from the shopping cart, the `Expert configuration` tab is now opened by default. 

## Test Instructions

1) Navigate to the `/store/site-license` page and configure any preset license. Click `Expert configuration`, modify some values, and verify that a warning message is shown which details specific fields that differ from the selected preset.
2) Refresh the page, and verify the warning message is still there.
3) Select any preset (including the currently selected one) and refresh the page. Verify that the `Expert configuration` tab is shown, and that the correct preset is selected when the `Quota presets` tab is selected.
4) If desired, repeat the above for a license which is edited from a user's shopping cart.