### PR TITLE
Removed extraneous `pnpm` dev dependency

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/sagemathinc/cocalc",
   "devDependencies": {
-    "express": "^4.17.1",
-    "pnpm": "^8.15.3"
+    "express": "^4.17.1"
   }
 }


### PR DESCRIPTION
…which causes a dependency issue when developing on CoCalc itself.

# Description

@williamstein - I removed the `pnpm` dependency which I erroneously added to the `devDependencies` block in `src/package.json` a while back. Could you verify that everything runs/builds okay in your environment, and that the `pnpm` does what it's supposed to (i.e., that it's no longer looking for a missing local package) before merging this?