### PR TITLE
#7531: [Site license page] Updated site license page 

### DIFF
--- a/src/packages/next/components/store/quota-config-presets.tsx
+++ b/src/packages/next/components/store/quota-config-presets.tsx
@@ -21,11 +21,12 @@ export type Presets =
 
 // Fields to be used to match a configured license against a pre-existing preset.
 //
-export const PRESET_MATCH_FIELDS = {
-  cpu: "CPU",
+export const PRESET_MATCH_FIELDS: Record<string, string> = {
+  cpu: "CPU count",
   disk: "disk space",
   ram: "memory",
-  uptime: "uptime",
+  uptime: "idle timeout",
+  member: "member hosting",
 };
 
 export interface Preset {
@@ -36,8 +37,8 @@ export interface Preset {
   cpu: number;
   ram: number;
   disk: number;
-  uptime?: Uptime;
-  member?: boolean;
+  uptime: Uptime;
+  member: boolean;
 }
 
 type PresetEntries = {
@@ -89,6 +90,7 @@ export const PRESETS: PresetEntries = {
     ram: STANDARD_RAM,
     disk: STANDARD_DISK,
     uptime: "short",
+    member: true,
   },
   //   student: {
   //     icon: "meh",
@@ -127,6 +129,7 @@ export const PRESETS: PresetEntries = {
     ram: 2 * STANDARD_RAM,
     disk: 2 * STANDARD_DISK,
     uptime: "medium",
+    member: true,
   },
   instructor: {
     icon: "highlighter",
@@ -161,6 +164,7 @@ export const PRESETS: PresetEntries = {
     ram: 6,
     disk: 15,
     uptime: "medium",
+    member: true,
   },
   research: {
     icon: "rocket",
@@ -188,6 +192,7 @@ export const PRESETS: PresetEntries = {
     ram: 6,
     disk: 10,
     uptime: "day",
+    member: true,
   },
   development: {
     icon: "settings",
@@ -206,6 +211,7 @@ export const PRESETS: PresetEntries = {
     ram: 8,
     disk: 10,
     uptime: "medium",
+    member: true,
   },
   /*budget: {
     icon: "wallet",

--- a/src/packages/next/components/store/quota-config.tsx
+++ b/src/packages/next/components/store/quota-config.tsx
@@ -25,6 +25,7 @@ import {
 const { Text } = Typography;
 
 const EXPERT_CONFIG = "Expert configuration";
+const listFormat = new Intl.ListFormat("en");
 
 interface Props {
   showExplanations: boolean;
@@ -82,7 +83,9 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
   }
 
   /**
-   * When a quota is changed, we warn the user that the preset was adjusted. (the text updates, though, since it rerenders every time). Explanation in the details could make no sense, though – that's why this is added.
+   * When a quota is changed, we warn the user that the preset was adjusted.
+   * (the text updates, though, since it rerenders every time). Explanation in
+   * the details could make no sense, though – that's why this is added.
    */
   function presetWasAdjusted() {
     setPresetAdjusted?.(true);
@@ -202,9 +205,9 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
       );
     }
 
-    const memberValue = form.getFieldValue("member");
-    const quotaConfig = form.getFieldsValue(Object.keys(PRESET_MATCH_FIELDS));
-    if (Object.values(quotaConfig).includes(null) || memberValue == null) {
+    const quotaConfig: Record<string, string> = form.getFieldsValue(Object.keys(PRESET_MATCH_FIELDS));
+    const invalidConfigValues = Object.keys(quotaConfig).filter((field) => quotaConfig[field] == null);
+    if (invalidConfigValues.length) {
       return;
     }
 
@@ -221,7 +224,7 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
     const presetDiff = Object.keys(PRESET_MATCH_FIELDS).reduce(
       (diff, presetField) => {
         if (presetData[presetField] !== quotaConfig[presetField]) {
-          diff.push(presetField);
+          diff.push(PRESET_MATCH_FIELDS[presetField]);
         }
 
         return diff;
@@ -245,8 +248,7 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
 
     function renderProvides() {
       if (preset) {
-        const { cpu, disk, ram, uptime } = PRESETS[preset];
-        const memberValue = form.getFieldValue("member");
+        const { cpu, disk, ram, uptime, member } = PRESETS[preset];
 
         const basic = (
           <>
@@ -260,7 +262,7 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
         );
 
         const mh =
-          memberValue === false ? (
+          member === false ? (
             <Text strong>member hosting is disabled</Text>
           ) : null;
 
@@ -287,14 +289,14 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
 
     function presetIsAdjusted() {
       if (!presetAdjusted || !presetDiff.length) return;
-      const lf = new Intl.ListFormat("en");
       return (
         <Typography style={{ marginBottom: "10px" }}>
           <Text type="warning">
-            The current license differs from the <b>{lf.format(presetDiff)} </b>
-            configuration for the currently selected preset. By clicking any of
-            the above buttons, you can ensure your license configuration matches
-            the original preset configuration.
+            The currently configured license differs from the selected preset in
+            <b> {listFormat.format(presetDiff)}</b>.
+
+            By clicking any of the above buttons, you can ensure your license
+            configuration matches the original preset configuration.
           </Text>
         </Typography>
       );
@@ -337,9 +339,9 @@ export const QuotaConfig: React.FC<Props> = (props: Props) => {
     if (val == null || setPreset == null) return;
     setPreset(val);
     setPresetAdjusted?.(false);
-    const preset = PRESETS[val];
-    if (preset != null) {
-      const { cpu, ram, disk, uptime = "short", member = true } = preset;
+    const presetData = PRESETS[val];
+    if (presetData != null) {
+      const { cpu, ram, disk, uptime = "short", member = true } = presetData;
       form.setFieldsValue({ uptime, member, cpu, ram, disk });
     }
     onChange();

--- a/src/packages/next/components/store/site-license.tsx
+++ b/src/packages/next/components/store/site-license.tsx
@@ -36,6 +36,8 @@ import { ToggleExplanations } from "./toggle-explanations";
 import { UsageAndDuration } from "./usage-and-duration";
 import { Paragraph, Title } from "components/misc";
 
+const DEFAULT_PRESET: Presets = "standard";
+
 const STYLE: React.CSSProperties = {
   marginTop: "15px",
   maxWidth: MAX_WIDTH,
@@ -135,7 +137,7 @@ function CreateSiteLicense({ showInfoBar = false, noAccount = false }) {
   const [form] = Form.useForm();
   const router = useRouter();
 
-  const [preset, setPreset] = useState<Presets | null>("standard");
+  const [preset, setPreset] = useState<Presets | null>(DEFAULT_PRESET);
   const [presetAdjusted, setPresetAdjusted] = useState<boolean>(false);
 
   /**
@@ -194,8 +196,6 @@ function CreateSiteLicense({ showInfoBar = false, noAccount = false }) {
           if (item.product == "site-license") {
             form.setFieldsValue({ ...item.description, type: "regular" });
           }
-
-          setConfigMode("expert");
         } catch (err) {
           setCartError(err.message);
         } finally {
@@ -205,13 +205,17 @@ function CreateSiteLicense({ showInfoBar = false, noAccount = false }) {
       })();
     } else {
       const vals = decodeFormValues(router, "regular");
-      const dflt = PRESETS["standard"];
+      const dflt = PRESETS[DEFAULT_PRESET];
       if (isEmpty(vals)) {
-        form.setFieldsValue({ ...dflt, preset: "standard" });
+        form.setFieldsValue({
+          ...dflt,
+        });
       } else {
         // we have to make sure cpu, mem and disk are set, otherwise there is no "cost"
-        form.setFieldsValue({ ...dflt, ...vals });
-        setConfigMode("expert");
+        form.setFieldsValue({
+          ...dflt,
+          ...vals,
+        });
       }
     }
     onLicenseChange();


### PR DESCRIPTION
…to consistently render presets view by default. Updated presets to explicitly include member hosting (before, they included it implicitly). Preset diff text is now a bit clearer.

# Description



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
