### PR TITLE
frontend/paygo/llm: fix mistral price schema display

### DIFF
--- a/src/packages/frontend/purchases/pay-as-you-go/cost.tsx
+++ b/src/packages/frontend/purchases/pay-as-you-go/cost.tsx
@@ -4,12 +4,13 @@ Render the cost of a pay-as-you-go service.
 This gets the cost once via an api call, then uses the cached cost afterwards (until
 user refreshes browser), since costs change VERY rarely.
 */
-
-import type { Service } from "@cocalc/util/db-schema/purchase-quotas";
+import { Alert, Spin, Table, Tooltip } from "antd";
 import LRU from "lru-cache";
 import { useEffect, useState } from "react";
+
 import { webapp_client } from "@cocalc/frontend/webapp-client";
-import { Alert, Spin, Table, Tooltip } from "antd";
+import { isLanguageModelService } from "@cocalc/util/db-schema/llm-utils";
+import type { Service } from "@cocalc/util/db-schema/purchase-quotas";
 import { currency } from "@cocalc/util/misc";
 import MoneyStatistic from "../money-statistic";
 
@@ -54,9 +55,9 @@ export default function Cost({ service, inline }: Props) {
 
   if (service == "project-upgrade") {
     return <ProjectUpgradeCost cost={cost} />;
-  } else if (service.startsWith("openai-gpt")) {
+  } else if (isLanguageModelService(service)) {
     return (
-      <OpenAiCost
+      <LLMServiceCost
         prompt_tokens={cost.prompt_tokens}
         completion_tokens={cost.completion_tokens}
       />
@@ -179,7 +180,7 @@ function PricePerUnit({ value, unit, month }: { value; unit; month? }) {
   return body;
 }
 
-function OpenAiCost({ prompt_tokens, completion_tokens }) {
+function LLMServiceCost({ prompt_tokens, completion_tokens }) {
   const inputPrice = currency(prompt_tokens * 1000, 3);
   const outputPrice = currency(completion_tokens * 1000, 3);
   const columns = [

--- a/src/packages/frontend/purchases/pay-as-you-go/modal.tsx
+++ b/src/packages/frontend/purchases/pay-as-you-go/modal.tsx
@@ -1,16 +1,17 @@
 import { Alert, Modal } from "antd";
 import { useRef } from "react";
+
 import { useActions, useTypedRedux } from "@cocalc/frontend/app-framework";
-import type { Service } from "@cocalc/util/db-schema/purchase-quotas";
 import { Icon } from "@cocalc/frontend/components/icon";
-import QuotaConfig from "../quota-config";
-import { webapp_client } from "@cocalc/frontend/webapp-client";
-import ServiceTag from "../service";
-import Cost from "./cost";
 import { load_target } from "@cocalc/frontend/history";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
+import type { Service } from "@cocalc/util/db-schema/purchase-quotas";
 import { QUOTA_SPEC } from "@cocalc/util/db-schema/purchase-quotas";
 import MoneyStatistic from "../money-statistic";
+import QuotaConfig from "../quota-config";
+import ServiceTag from "../service";
 import { zIndexPayAsGo as zIndex } from "../zindex";
+import Cost from "./cost";
 
 // Ensure the billing Actions and Store are created, which are needed for purchases, etc., to work...
 import "@cocalc/frontend/billing/actions";


### PR DESCRIPTION
# Description

properly check the type of service by using by using `isLanguageModelService` + some renaming

![Screenshot from 2024-03-18 11-02-52](https://github.com/sagemathinc/cocalc/assets/207405/e9065c71-2e81-487a-8e61-0487188c28fe)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
