### PR TITLE
frontend/md/slate: integrate AI formula

### DIFF
--- a/src/packages/frontend/editors/slate/format/insert-ai-formula.ts
+++ b/src/packages/frontend/editors/slate/format/insert-ai-formula.ts
@@ -1,0 +1,26 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
+ */
+
+import { Transforms } from "slate";
+
+import { alert_message } from "@cocalc/frontend/alerts";
+import { ai_gen_formula } from "@cocalc/frontend/codemirror/extensions/ai-formula";
+import { SlateEditor } from "../types";
+import { getFocus } from "./commands";
+
+export async function insertAIFormula(
+  editor: SlateEditor,
+  project_id: string,
+): Promise<void> {
+  try {
+    const formula = await ai_gen_formula({ mode: "md", project_id });
+    // We insert at what is likely the focus, rather than trying to
+    // focus, since focusing is erratic (especially with firefox).
+    Transforms.insertText(editor, formula, { at: getFocus(editor) });
+  } catch (err) {
+    alert_message({ type: "error", message: err.errorFields[0]?.errors });
+    return;
+  }
+}

--- a/src/packages/frontend/editors/slate/types.ts
+++ b/src/packages/frontend/editors/slate/types.ts
@@ -1,6 +1,7 @@
-import { ReactEditor } from "./slate-react";
 import { Range } from "slate";
+
 import { SyncString } from "@cocalc/sync/editor/string";
+import { ReactEditor } from "./slate-react";
 
 export interface SlateEditor extends ReactEditor {
   ignoreNextOnChange?: boolean;
@@ -44,7 +45,7 @@ export interface Actions {
     cursor?: boolean,
     focus?: boolean,
     id?: string,
-    ch?: number
+    ch?: number,
   ) => Promise<void>;
   save?: (explicit: boolean) => Promise<void>;
   change_font_size?: (delta?: number, id?: string, zoom?: number) => void;

--- a/src/packages/frontend/frame-editors/markdown-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/markdown-editor/actions.ts
@@ -7,31 +7,31 @@
 Markdown Editor Actions
 */
 
-import { debounce } from "lodash";
-import { delay } from "awaiting";
+import {
+  TableOfContentsEntry,
+  TableOfContentsEntryList,
+} from "@cocalc/frontend/components";
+import { scrollToHeading } from "@cocalc/frontend/editors/slate/control";
+import { SlateEditor } from "@cocalc/frontend/editors/slate/editable-markdown";
+import { formatAction as slateFormatAction } from "@cocalc/frontend/editors/slate/format";
+import {
+  markdownPositionToSlatePoint,
+  scrollIntoView as scrollSlateIntoView,
+  slatePointToMarkdownPosition,
+} from "@cocalc/frontend/editors/slate/sync";
 import { toggle_checkbox } from "@cocalc/frontend/editors/task-editor/desc-rendering";
+import { parseTableOfContents } from "@cocalc/frontend/markdown";
+import { open_new_tab } from "@cocalc/frontend/misc";
+import { delay } from "awaiting";
+import { fromJS } from "immutable";
 import $ from "jquery";
+import { debounce } from "lodash";
 import {
   Actions as CodeEditorActions,
   CodeEditorState,
 } from "../code-editor/actions";
 import { print_html } from "../frame-tree/print";
 import { FrameTree } from "../frame-tree/types";
-import { scrollToHeading } from "@cocalc/frontend/editors/slate/control";
-import { SlateEditor } from "@cocalc/frontend/editors/slate/editable-markdown";
-import { formatAction as slateFormatAction } from "@cocalc/frontend/editors/slate/format";
-import {
-  TableOfContentsEntryList,
-  TableOfContentsEntry,
-} from "@cocalc/frontend/components";
-import { fromJS } from "immutable";
-import { parseTableOfContents } from "@cocalc/frontend/markdown";
-import {
-  markdownPositionToSlatePoint,
-  slatePointToMarkdownPosition,
-  scrollIntoView as scrollSlateIntoView,
-} from "@cocalc/frontend/editors/slate/sync";
-import { open_new_tab } from "@cocalc/frontend/misc";
 
 interface MarkdownEditorState extends CodeEditorState {
   custom_pdf_error_message: string; // currently used only in rmd editor, but we could easily add pdf output to the markdown editor
@@ -58,7 +58,7 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
 
     this._syncstring.on(
       "change",
-      debounce(this.updateTableOfContents.bind(this), 1500)
+      debounce(this.updateTableOfContents.bind(this), 1500),
     );
   }
 
@@ -153,7 +153,7 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
       super.format_action(cmd, args, force_main);
       return;
     }
-    slateFormatAction(this.slateEditors[id], cmd, args);
+    slateFormatAction(this.slateEditors[id], cmd, args, this.project_id);
   }
 
   public getSlateEditor(id?: string): SlateEditor | undefined {
@@ -172,13 +172,13 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
   }
 
   public async show_table_of_contents(
-    _id: string | undefined = undefined
+    _id: string | undefined = undefined,
   ): Promise<void> {
     const id = this.show_focused_frame_of_type(
       "markdown_table_of_contents",
       "col",
       true,
-      1 / 3
+      1 / 3,
     );
     // the click to select TOC focuses the active id back on the notebook
     await delay(0);
@@ -198,7 +198,9 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
       // There is no table of contents frame so don't update that info.
       return;
     }
-    const contents = fromJS(parseTableOfContents(this._syncstring.to_str())) as any;
+    const contents = fromJS(
+      parseTableOfContents(this._syncstring.to_str()),
+    ) as any;
     this.setState({ contents });
   }
 
@@ -229,7 +231,7 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
 
   private async sync_cm_to_slate(
     id: string,
-    editor_actions: Actions
+    editor_actions: Actions,
   ): Promise<void> {
     const cm = editor_actions._cm[id];
     if (cm == null) return;
@@ -275,7 +277,7 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
       true,
       false,
       undefined,
-      pos.ch
+      pos.ch,
     );
   }
 
@@ -298,7 +300,7 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
 
   languageModelGetText(
     frameId: string,
-    scope: "selection" | "cell" | "all" = "all"
+    scope: "selection" | "cell" | "all" = "all",
   ): string {
     const node = this._get_frame_node(frameId);
     if (node?.get("type") == "cm") {
@@ -313,7 +315,7 @@ export class Actions extends CodeEditorActions<MarkdownEditorState> {
         if (ed.selectionIsCollapsed()) {
           // if collapsed it could still be a void element, in which case we grab it.
           for (const x of fragment) {
-            if (x?.['isVoid']) {
+            if (x?.["isVoid"]) {
               return ed.getSourceValue(fragment);
             }
           }


### PR DESCRIPTION
# Description

I discovered that the slate editors AI formula menu needs a different code. This adds the same popup component, and also some extra lines to surface the `project_id`.

So, with that, I can insert a formula – the only thing that it does not do is to convert the markdown `$..$` string to the formula. You have to press space once to get it. I don't know how to do this, but in any case, at least the dialog shows up and it does insert something.


![Screenshot from 2024-03-19 12-47-45](https://github.com/sagemathinc/cocalc/assets/207405/2eedb6b8-3381-4caa-9cff-51d7fb0eef05)

… and after insert formula → refocus cursor → space:

![Screenshot from 2024-03-19 12-48-10](https://github.com/sagemathinc/cocalc/assets/207405/6ec0f2ea-f282-460b-9dc0-577aa3dc22e6)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
