### PR TITLE
#7412: Added social media links to landing page footer when deployed to cocalc.com

### DIFF
--- a/src/packages/next/components/landing/footer.tsx
+++ b/src/packages/next/components/landing/footer.tsx
@@ -3,13 +3,14 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Layout, Space } from "antd";
+import { Flex, Layout, Space } from "antd";
 
 import A from "components/misc/A";
 import Logo from "components/logo";
 import { useCustomize } from "lib/customize";
 import Contact from "./contact";
 import { CSS, Paragraph } from "components/misc";
+import SocialMediaIconList from "./social-media-icon-list";
 
 const STYLE: CSS = {
   textAlign: "center",
@@ -81,7 +82,7 @@ export default function Footer() {
           )}
           {contactEmail && (
             <Item>
-              <Contact showEmail={false} />
+              <Contact showEmail={false}/>
             </Item>
           )}
           {imprint && (
@@ -109,7 +110,27 @@ export default function Footer() {
           </Item>
         </Paragraph>
         <Paragraph>
-          <Logo type="rectangular" width={200} />
+          <Flex
+            align="center"
+            justify="space-around"
+            wrap="wrap"
+          >
+            <Logo type="rectangular" width={200}/>
+            {
+              isCommercial && (
+                <SocialMediaIconList
+                  links={{
+                    facebook: "https://www.facebook.com/CoCalcOnline",
+                    github: "https://github.com/sagemathinc/cocalc",
+                    linkedin: "https://www.linkedin.com/company/sagemath-inc./",
+                    twitter: "https://twitter.com/cocalc_com",
+                    youtube: "https://www.youtube.com/c/SagemathCloud",
+                  }}
+                  iconFontSize={32}
+                />
+              )
+            }
+          </Flex>
         </Paragraph>
       </Space>
     </Layout.Footer>

--- a/src/packages/next/components/landing/social-media-icon-list.tsx
+++ b/src/packages/next/components/landing/social-media-icon-list.tsx
@@ -40,7 +40,6 @@ const SocialMediaIconList = (props: SocialMediaIconListProps) => {
       align="center"
       wrap="wrap"
       style={{
-        width: "100%",
         fontSize: `${iconFontSize}px`,
         ...style,
       }}>
@@ -51,7 +50,7 @@ const SocialMediaIconList = (props: SocialMediaIconListProps) => {
             href={links[mediaType]}
             target="_blank"
             style={{
-              width: `${iconFontSize + 12}px`,
+              width: `${iconFontSize + 16}px`,
               color: COLORS.GRAY,
             }}
           >


### PR DESCRIPTION
# Description

On cocalc.com:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/7e6592dd-ccf7-4b45-affa-43e17cc6d091)

On prem (or local):

![image](https://github.com/sagemathinc/cocalc/assets/17204901/17bb940a-2833-4d29-9cca-45295e008123)
