### PR TITLE
Fixes 7397. "Cancel" button when creating news item now correctly redirects back to the main news page.

### DIFF
--- a/src/packages/util/news.ts
+++ b/src/packages/util/news.ts
@@ -9,7 +9,7 @@ import { NewsItem } from "./types/news";
 // https://www.semrush.com/blog/what-is-a-url-slug/
 // The main point here is to have a URL that contains unique information and is human readable.
 export function slugURL(news?: Pick<NewsItem, "id" | "title">): string {
-  if (!news) return "/news";
+  if (!news || !news.title || !news.id) return "/news";
   const { title, id } = news;
   const shortTitle = title
     .toLowerCase()


### PR DESCRIPTION
# Description

To test:

1) Begin to create a news item.
2) Click the "Cancel" button.
3) Verify the user is redirected to `/news`.