### PR TITLE
Fixes 7412. Social media footer now displays below CoCalc logo.

### DIFF
--- a/src/packages/next/components/landing/footer.tsx
+++ b/src/packages/next/components/landing/footer.tsx
@@ -113,7 +113,7 @@ export default function Footer() {
           <Flex
             align="center"
             justify="space-around"
-            wrap="wrap"
+            vertical
           >
             <Logo type="rectangular" width={200}/>
             {


### PR DESCRIPTION
# Description

New layout:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/bb250ce6-eae3-49c2-bcf9-1232495fa8eb)
