### PR TITLE
Supporting Rstudio Server

### DIFF
--- a/src/packages/comm/project-configuration.ts
+++ b/src/packages/comm/project-configuration.ts
@@ -28,6 +28,7 @@ export interface MainCapabilities {
   jupyter: boolean | Capabilities;
   formatting: Capabilities; // yapf & co.
   hashsums: Capabilities;
+  rserver: boolean;
   latex: boolean;
   sage: boolean;
   sage_version?: number[];
@@ -49,6 +50,7 @@ export interface Available {
   jupyter_lab: boolean;
   jupyter_notebook: boolean;
   jupyter: boolean;
+  rserver: boolean; // RStudio Server
   x11: boolean;
   latex: boolean;
   sage: boolean;
@@ -69,6 +71,7 @@ export const NO_AVAIL: Readonly<Available> = {
   jupyter_lab: false,
   jupyter_notebook: false,
   jupyter: false,
+  rserver: false,
   sage: false,
   latex: false,
   rmd: false,
@@ -89,6 +92,7 @@ export const ALL_AVAIL: Readonly<Available> = {
   jupyter_lab: true,
   jupyter_notebook: true,
   jupyter: true,
+  rserver: true,
   sage: true,
   latex: true,
   rmd: true,

--- a/src/packages/frontend/course/configuration/customize-student-project-functionality.tsx
+++ b/src/packages/frontend/course/configuration/customize-student-project-functionality.tsx
@@ -3,6 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { Button, Card, Checkbox } from "antd";
+import { isEqual } from "lodash";
+
 import {
   React,
   redux,
@@ -13,8 +16,6 @@ import {
 } from "@cocalc/frontend/app-framework";
 import { Icon, Tip } from "@cocalc/frontend/components";
 import type { StudentProjectFunctionality } from "@cocalc/util/db-schema/projects";
-import { Button, Card, Checkbox } from "antd";
-import { isEqual } from "lodash";
 export type { StudentProjectFunctionality };
 
 interface Option {
@@ -67,6 +68,12 @@ const OPTIONS: Option[] = [
     title: "Pluto Julia notebook server",
     description:
       "Disable the user interface for running a pluto server in student projects.  Pluto lets you run Julia notebooks from a project.",
+  },
+  {
+    name: "disableRServer",
+    title: "RStudio Server",
+    description:
+      "Disable the user interface for running an RStudio server in student projects.  RStudio is an IDE for R.",
   },
   {
     name: "disableTerminals",

--- a/src/packages/frontend/project/named-server-panel.tsx
+++ b/src/packages/frontend/project/named-server-panel.tsx
@@ -20,10 +20,10 @@ import {
 import LinkRetry from "@cocalc/frontend/components/link-retry";
 import { useStudentProjectFunctionality } from "@cocalc/frontend/course";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import track from "@cocalc/frontend/user-tracking";
 import { capitalize } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { NamedServerName } from "@cocalc/util/types/servers";
-import track from "@cocalc/frontend/user-tracking";
 import { useAvailableFeatures } from "./use-available-features";
 
 interface Server {
@@ -70,6 +70,12 @@ code completion, snippets, code refactoring, and embedded Git.`,
     usesBasePath: false,
     icon: "julia",
   },
+  rserver: {
+    longName: "RStudio Server",
+    description: `RStudio Server is an integrated development environment (IDE) for R.`,
+    usesBasePath: false,
+    icon: "r",
+  },
 } as const;
 
 interface Props {
@@ -77,13 +83,13 @@ interface Props {
   name: NamedServerName;
 }
 
-function getServerInfo(name: string) {
+function getServerInfo(name: NamedServerName): Server {
   return (
     SPEC[name] ?? {
       icon: "server",
       longName: `${capitalize(name)} Server`,
       description: `The ${capitalize(
-        name
+        name,
       )} server runs from your project. It does not yet
           support multiple users or TimeTravel, but fully supports most other
           features and extensions of ${name}.`,
@@ -102,28 +108,34 @@ export const NamedServerPanel: React.FC<Props> = ({
 
   let body;
   if (
-    name == "jupyterlab" &&
+    name === "jupyterlab" &&
     student_project_functionality.disableJupyterLabServer
   ) {
     body =
       "Disabled. Please contact your instructor if you need to use Jupyter Lab";
   } else if (
-    name == "jupyter" &&
+    name === "jupyter" &&
     student_project_functionality.disableJupyterClassicServer
   ) {
     body =
       "Disabled. Please contact your instructor if you need to use Jupyter Classic.";
   } else if (
-    name == "code" &&
+    name === "code" &&
     student_project_functionality.disableVSCodeServer
   ) {
     body =
       "Disabled. Please contact your instructor if you need to use VS Code.";
   } else if (
-    name == "pluto" &&
+    name === "pluto" &&
     student_project_functionality.disablePlutoServer
   ) {
     body = "Disabled. Please contact your instructor if you need to use Pluto.";
+  } else if (
+    name === "rserver" &&
+    student_project_functionality.disableRServer
+  ) {
+    body =
+      "Disabled. Please contact your instructor if you need to use RStudio.";
   } else {
     body = (
       <>
@@ -165,7 +177,7 @@ export function serverURL(project_id: string, name: NamedServerName): string {
       appBasePath,
       project_id,
       SPEC[name]?.usesBasePath ? "port" : "server",
-      name
+      name,
     ) + "/"
   );
 }
@@ -182,25 +194,30 @@ export function ServerLink({
   const available = useAvailableFeatures(project_id);
   const { icon, longName } = getServerInfo(name);
   if (
-    name == "jupyterlab" &&
+    name === "jupyterlab" &&
     (!available.jupyter_lab ||
       student_project_functionality.disableJupyterLabServer)
   ) {
     return null;
   } else if (
-    name == "jupyter" &&
+    name === "jupyter" &&
     (!available.jupyter_notebook ||
       student_project_functionality.disableJupyterClassicServer)
   ) {
     return null;
   } else if (
-    name == "code" &&
+    name === "code" &&
     (!available.vscode || student_project_functionality.disableVSCodeServer)
   ) {
     return null;
   } else if (
-    name == "pluto" &&
+    name === "pluto" &&
     (!available.julia || student_project_functionality.disablePlutoServer)
+  ) {
+    return null;
+  } else if (
+    name === "rserver" &&
+    (!available.rserver || student_project_functionality.disableRServer)
   ) {
     return null;
   } else {

--- a/src/packages/frontend/project/new/types.ts
+++ b/src/packages/frontend/project/new/types.ts
@@ -3,7 +3,7 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { TypedMap } from "../../app-framework";
+import { TypedMap } from "@cocalc/frontend/app-framework";
 
 export type AvailableFeatures = TypedMap<{
   sage: boolean;

--- a/src/packages/frontend/project/page/flyouts/servers.tsx
+++ b/src/packages/frontend/project/page/flyouts/servers.tsx
@@ -6,23 +6,21 @@
 import { Divider, Space } from "antd";
 
 import { Icon, Paragraph, Title } from "@cocalc/frontend/components";
-import { ServerLink } from "@cocalc/frontend/project/named-server-panel";
-import { SagewsControl } from "../../settings/sagews-control";
-import { FIX_BORDER } from "../common";
-import { FLYOUT_PADDING } from "./consts";
 import {
-  computeServersEnabled,
-  ComputeServers,
   ComputeServerDocs,
+  ComputeServers,
+  computeServersEnabled,
 } from "@cocalc/frontend/compute";
+import { ServerLink } from "@cocalc/frontend/project/named-server-panel";
+import { FIX_BORDER } from "@cocalc/frontend/project/page/common";
+import { SagewsControl } from "@cocalc/frontend/project/settings/sagews-control";
+import { NAMED_SERVER_NAMES } from "@cocalc/util/types/servers";
+import { FLYOUT_PADDING } from "./consts";
 
 export function ServersFlyout({ project_id, wrap }) {
-  const servers = [
-    <ServerLink key="jupyterlab" name="jupyterlab" project_id={project_id} />,
-    <ServerLink key="jupyter" name="jupyter" project_id={project_id} />,
-    <ServerLink key="code" name="code" project_id={project_id} />,
-    <ServerLink key="pluto" name="pluto" project_id={project_id} />,
-  ].filter((s) => s != null);
+  const servers = NAMED_SERVER_NAMES.map((name) => (
+    <ServerLink key={name} name={name} project_id={project_id} />
+  )).filter((s) => s != null);
 
   function renderEmbeddedServers() {
     return (

--- a/src/packages/frontend/project/page/flyouts/servers.tsx
+++ b/src/packages/frontend/project/page/flyouts/servers.tsx
@@ -61,18 +61,26 @@ export function ServersFlyout({ project_id, wrap }) {
     );
   }
 
-  return wrap(
-    <>
-      {computeServersEnabled() && (
-        <div>
+  function renderComputeServers() {
+    if (!computeServersEnabled()) return;
+
+    return (
+      <>
+        <div style={{ padding: FLYOUT_PADDING }}>
           <Title level={5}>
             <ComputeServerDocs style={{ float: "right" }} />
             <Icon name="servers" /> Compute Servers
           </Title>
           <ComputeServers project_id={project_id} />
         </div>
-      )}
-      <Divider />
+        <Divider />
+      </>
+    );
+  }
+
+  return wrap(
+    <>
+      {renderComputeServers()}
       {renderEmbeddedServers()}
       {renderSageServerControl()}
     </>,

--- a/src/packages/frontend/project/servers/project-servers.tsx
+++ b/src/packages/frontend/project/servers/project-servers.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Col, Divider, Modal, Row } from "antd";
+import { Gutter } from "antd/es/grid/row";
 
 import { useState } from "@cocalc/frontend/app-framework";
 import { A, Icon, Paragraph, Text, Title } from "@cocalc/frontend/components";
@@ -14,7 +15,6 @@ import {
 } from "@cocalc/frontend/compute";
 import { HelpEmailLink } from "@cocalc/frontend/customize";
 import { NamedServerName } from "@cocalc/util/types/servers";
-import { Gutter } from "antd/es/grid/row";
 import { NamedServerPanel } from "../named-server-panel";
 import { NewFileButton } from "../new/new-file-button";
 import { SagewsControl } from "../settings/sagews-control";

--- a/src/packages/frontend/project/servers/project-servers.tsx
+++ b/src/packages/frontend/project/servers/project-servers.tsx
@@ -4,21 +4,22 @@
  */
 
 import { Col, Divider, Modal, Row } from "antd";
-import { Gutter } from "antd/es/grid/row";
+
 import { useState } from "@cocalc/frontend/app-framework";
 import { A, Icon, Paragraph, Text, Title } from "@cocalc/frontend/components";
+import {
+  ComputeServerDocs,
+  ComputeServers,
+  computeServersEnabled,
+} from "@cocalc/frontend/compute";
 import { HelpEmailLink } from "@cocalc/frontend/customize";
 import { NamedServerName } from "@cocalc/util/types/servers";
+import { Gutter } from "antd/es/grid/row";
 import { NamedServerPanel } from "../named-server-panel";
 import { NewFileButton } from "../new/new-file-button";
 import { SagewsControl } from "../settings/sagews-control";
 import { useAvailableFeatures } from "../use-available-features";
 import { ICON_NAME, ROOT_STYLE, TITLE } from "./consts";
-import {
-  computeServersEnabled,
-  ComputeServers,
-  ComputeServerDocs,
-} from "@cocalc/frontend/compute";
 
 // Antd's 24 grid system
 const md = 6;
@@ -48,13 +49,14 @@ export function ProjectServers(props: Props) {
     !available.jupyter_notebook &&
     !available.jupyter_lab &&
     !available.vscode &&
-    !available.julia;
+    !available.julia &&
+    !available.rserver;
 
   function renderNamedServers(): JSX.Element {
     return (
       <>
         <Row gutter={gutter} style={newRowStyle}>
-          {available.jupyter_notebook && (
+          {available.jupyter_notebook ? (
             <Col sm={sm} md={md}>
               <NewFileButton
                 name={"Jupyter Classic..."}
@@ -63,8 +65,8 @@ export function ProjectServers(props: Props) {
                 on_click={() => toggleShowNamedServer("jupyter")}
               />
             </Col>
-          )}
-          {available.jupyter_lab && (
+          ) : null}
+          {available.jupyter_lab ? (
             <Col sm={sm} md={md}>
               <NewFileButton
                 name={"JupyterLab..."}
@@ -73,8 +75,8 @@ export function ProjectServers(props: Props) {
                 on_click={() => toggleShowNamedServer("jupyterlab")}
               />
             </Col>
-          )}
-          {available.vscode && (
+          ) : null}
+          {available.vscode ? (
             <Col sm={sm} md={md}>
               <NewFileButton
                 name={"VS Code..."}
@@ -83,8 +85,8 @@ export function ProjectServers(props: Props) {
                 on_click={() => toggleShowNamedServer("code")}
               />
             </Col>
-          )}
-          {available.julia && (
+          ) : null}
+          {available.julia ? (
             <Col sm={sm} md={md}>
               <NewFileButton
                 name={"Pluto..."}
@@ -93,7 +95,17 @@ export function ProjectServers(props: Props) {
                 on_click={() => toggleShowNamedServer("pluto")}
               />
             </Col>
-          )}
+          ) : null}
+          {available.rserver ? (
+            <Col sm={sm} md={md}>
+              <NewFileButton
+                name={"RStudio..."}
+                icon={"r"}
+                active={showNamedServer === "rserver"}
+                on_click={() => toggleShowNamedServer("rserver")}
+              />
+            </Col>
+          ) : null}
           {noServers && (
             <Col sm={sm} md={md}>
               <NewFileButton

--- a/src/packages/frontend/project/settings/project-capabilites.tsx
+++ b/src/packages/frontend/project/settings/project-capabilites.tsx
@@ -3,17 +3,18 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import React from "react";
-import { sortBy, keys } from "lodash";
-import { SettingBox, A, Icon, Loading } from "@cocalc/frontend/components";
-import { redux, Rendered, useTypedRedux } from "@cocalc/frontend/app-framework";
-import { Project } from "./types";
-import * as misc from "@cocalc/util/misc";
-import { Button } from "antd";
 import { ReloadOutlined } from "@ant-design/icons";
-import { tool2display } from "@cocalc/util/code-formatter";
+import { Button } from "antd";
+import { keys, sortBy } from "lodash";
+import React from "react";
+
+import { Rendered, redux, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { A, Icon, Loading, SettingBox } from "@cocalc/frontend/components";
 import { CUSTOM_SOFTWARE_HELP_URL } from "@cocalc/frontend/custom-software/util";
+import { tool2display } from "@cocalc/util/code-formatter";
+import * as misc from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
+import { Project } from "./types";
 
 declare let DEBUG;
 
@@ -29,11 +30,11 @@ export const ProjectCapabilities: React.FC<ReactProps> = React.memo(
 
     const available_features = useTypedRedux(
       { project_id },
-      "available_features"
+      "available_features",
     );
     const configuration_loading = useTypedRedux(
       { project_id },
-      "configuration_loading"
+      "configuration_loading",
     );
     const configuration = useTypedRedux({ project_id }, "configuration");
 
@@ -52,11 +53,12 @@ export const ProjectCapabilities: React.FC<ReactProps> = React.memo(
         ["pandoc", "File format conversions via pandoc"],
         ["vscode", "VSCode editor"],
         ["julia", "Julia programming language"],
+        ["rserver", "RStudio Server"],
       ];
       const features: JSX.Element[] = [];
       let any_nonavail = false;
       for (const [key, display] of Array.from(
-        sortBy(feature_map, (f) => f[1])
+        sortBy(feature_map, (f) => f[1]),
       )) {
         const available = avail[key];
         any_nonavail = !available;
@@ -78,7 +80,7 @@ export const ProjectCapabilities: React.FC<ReactProps> = React.memo(
             <dd>
               {display} {extra}
             </dd>
-          </React.Fragment>
+          </React.Fragment>,
         );
       }
 
@@ -123,7 +125,7 @@ export const ProjectCapabilities: React.FC<ReactProps> = React.memo(
             <dd>
               <b>{tool}</b> for {misc.to_human_list(langs)}
             </dd>
-          </React.Fragment>
+          </React.Fragment>,
         );
       }
 
@@ -229,7 +231,7 @@ export const ProjectCapabilities: React.FC<ReactProps> = React.memo(
       );
     }
   },
-  dont_render
+  dont_render,
 );
 
 function dont_render(prev, next) {

--- a/src/packages/frontend/project_configuration.ts
+++ b/src/packages/frontend/project_configuration.ts
@@ -128,6 +128,7 @@ export function is_available(configuration?: ProjectConfiguration): Available {
       jupyter_lab: kernelspec && !!jupyter.lab,
       jupyter_notebook: kernelspec && !!jupyter.notebook,
       jupyter: kernelspec,
+      rserver: !!capabilities.rserver,
       sage: !!capabilities.sage,
       latex: !!capabilities.latex,
       rmd: !!capabilities.rmd,

--- a/src/packages/hub/projects.coffee
+++ b/src/packages/hub/projects.coffee
@@ -88,7 +88,7 @@ class Project
 
     # async function
     named_server_port: (name) =>
-        @dbg("named_server_port(name=${name})")
+        @dbg("named_server_port(name=#{name})")
         resp = await callback2(@call, {mesg : message.named_server_port(name:name), timeout : 30})
         @dbg("named_server_port #{resp.port}")
         return resp.port

--- a/src/packages/hub/proxy/handle-upgrade.ts
+++ b/src/packages/hub/proxy/handle-upgrade.ts
@@ -1,13 +1,14 @@
 // Websocket support
 
-import LRU from "lru-cache";
 import { createProxyServer } from "http-proxy";
-import { versionCheckFails } from "./version";
-import { getTarget } from "./target";
-import getLogger from "../logger";
-import { stripBasePath } from "./util";
-import stripRememberMeCookie from "./strip-remember-me-cookie";
+import LRU from "lru-cache";
 import { getEventListeners } from "node:events";
+
+import getLogger from "@cocalc/hub/logger";
+import stripRememberMeCookie from "./strip-remember-me-cookie";
+import { getTarget } from "./target";
+import { stripBasePath } from "./util";
+import { versionCheckFails } from "./version";
 
 const logger = getLogger("proxy:handle-upgrade");
 

--- a/src/packages/project/configuration.ts
+++ b/src/packages/project/configuration.ts
@@ -177,6 +177,13 @@ async function get_julia(): Promise<boolean> {
   return await have("julia");
 }
 
+// rserver is the name of the executable to start the RStudio Server.
+// In a default Linux installation, it is not in the PATH – therefore add a symlink pointing to it.
+// At the time of writing this, it was here: /usr/lib/rstudio-server/bin/rserver
+async function get_rserver(): Promise<boolean> {
+  return await have("rserver");
+}
+
 // check if we can read that json file.
 // if it exists, show the corresponding button in "Files".
 async function get_library(): Promise<boolean> {
@@ -262,6 +269,7 @@ async function capabilities(): Promise<MainCapabilities> {
     vscode,
     julia,
     homeDirectory,
+    rserver,
   ] = await Promise.all([
     get_formatting(),
     get_latex(hashsums),
@@ -277,9 +285,11 @@ async function capabilities(): Promise<MainCapabilities> {
     get_vscode(),
     get_julia(),
     get_homeDirectory(),
+    get_rserver(),
   ]);
   const caps: MainCapabilities = {
     jupyter,
+    rserver,
     formatting,
     hashsums,
     latex,

--- a/src/packages/project/named-servers/control.ts
+++ b/src/packages/project/named-servers/control.ts
@@ -44,11 +44,8 @@ export async function start(name: NamedServerName): Promise<number> {
   const p = await paths(name);
   await writeFile(p.port, `${port}`);
   await writeFile(p.command, `#!/bin/sh\n${cmd}\n`);
-  const child =
-    name === "rserver"
-      ? // this is a script, hence we run it with sh
-        exec(`/bin/sh ${p.command}`, { cwd: process.env.HOME })
-      : exec(cmd, { cwd: process.env.HOME });
+
+  const child = exec(cmd, { cwd: process.env.HOME });
   await writeFile(p.pid, `${child.pid}`);
   return port;
 }
@@ -61,7 +58,7 @@ async function getCommand(
 ): Promise<string> {
   const { stdout, stderr } = await paths(name);
   const spec = getSpec(name);
-  const cmd = spec(ip, port, base);
+  const cmd: string = await spec(ip, port, base);
   return `${cmd} 1>${stdout} 2>${stderr}`;
 }
 

--- a/src/packages/project/named-servers/list.ts
+++ b/src/packages/project/named-servers/list.ts
@@ -63,6 +63,7 @@ const JUPYTERLAB_MSGS =
 async function rserver(_ip: string, port: number, basePath: string) {
   // tmp: this is used to write a small config file and then use it
   const tmp = join(process.env.TMP ?? "/tmp", "rserver");
+  await mkdir(tmp, { recursive: true });
   const home = process.env.HOME ?? "/home/user";
   // ATTN: by trial and error I learned this must be in the home dir (not tmp) – otherwise silent crash
   // Also, that dir name has a length limit (unknown), does not work for nested dev-in-project

--- a/src/packages/project/named-servers/list.ts
+++ b/src/packages/project/named-servers/list.ts
@@ -14,9 +14,17 @@ To add another one, define a new entry in SPEC:
   use process.env so that the env can influence command line options.
 */
 
+import { exec } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
 import { NamedServerName } from "@cocalc/util/types/servers";
 
-type CommandFunction = (ip: string, port: number, basePath: string) => string;
+type CommandFunction = (
+  ip: string,
+  port: number,
+  basePath: string,
+) => Promise<string>;
 
 // Disables JupyterLab RTC since it is still very buggy, unfortunately.
 /*
@@ -52,43 +60,54 @@ const JUPYTERLAB_DATA =
 const JUPYTERLAB_MSGS =
   process.env.COCALC_JUPYTER_LAB_iopub_msg_rate_limit ?? 50;
 
-function rserver(ip: string, port: number, basePath: string) {
+async function rserver(_ip: string, port: number, basePath: string) {
   // tmp: this is used to write a small config file and then use it
-  const tmp = `${process.env.TMP ?? "/tmp"}/rserver`;
+  const tmp = join(process.env.TMP ?? "/tmp", "rserver");
+  const home = process.env.HOME ?? "/home/user";
+  // ATTN: by trial and error I learned this must be in the home dir (not tmp) – otherwise silent crash
+  // Also, that dir name has a length limit (unknown), does not work for nested dev-in-project
+  const data = join(home, ".config", "rserver");
+  const data_db = join(data, "db");
+  // This creates the tmp dir, and the data dir, and the data/db dir
+  await mkdir(data_db, { recursive: true });
+  const db_conf = join(tmp, "db.conf");
+  await writeFile(db_conf, `provider=sqlite\ndirectory=${data_db}`);
 
-  // watch out, this will be prefixed with #!/bin/sh and piped into stdout/stderr
-  // www-root-path needs the trailing slash and it must be "server", not "port"
-  return `\
-PORT="${port}"
-TMP="${tmp}"
-DATA="$HOME/.config/rserver"
-mkdir -p "$TMP/rserver"
-mkdir -p "$DATA"
+  // ATTN: it's tempting to add --www-address=${ip} \
+  // to tell it where to listen to, but for some reason that doesn't work. Hence $ip is ignored.
+  // The default is 0.0.0.0, which works (and it's fine, because we proxy it anyway).
 
-cat <<EOF > "$TMP/db.conf"
-provider=sqlite
-directory=$DATA/db
-EOF
+  // Check, if the user $USER exists in /etc/passwd using grep. If not, call the user "user".
+  // Just process.env.USER does not work in development, i.e. when the "random id" user does not exist.
+  const user = await new Promise<string>((resolve) => {
+    const name = process.env.USER ?? "user";
+    exec(`grep "^${name}:" /etc/passwd`, (err) => {
+      resolve(err ? "user" : name);
+    });
+  });
 
-export DISABLE_AUTH=true
-rserver \
---server-daemonize=0 \
---auth-none=1 \
---auth-encrypt-password=0 \
---server-user=$USER \
---database-config-file="$TMP/db.conf" \
---server-data-dir="$DATA" \
---server-working-dir="$HOME" \
---www-address=${ip} \
---www-port=$PORT \
---www-root-path="${basePath}/" \
---server-pid-file="$TMP/rserver.pid"`;
+  // watch out, this will be prefixed with #!/bin/sh and piped into stdout/stderr files
+  // part from that, rserver must be in the $PATH
+  // see note at project/configuration::get_rserver
+  return [
+    `rserver`,
+    `--server-daemonize=0`,
+    `--auth-none=1`,
+    `--auth-encrypt-password=0`,
+    `--server-user=${user}`,
+    `--database-config-file="${db_conf}"`,
+    `--server-data-dir="${data}"`,
+    `--server-working-dir="${process.env.HOME}"`,
+    `--www-port=${port}`,
+    `--www-root-path="${basePath}/"`, // www-root-path needs the trailing slash and it must be "server", not "port"
+    `--server-pid-file="${join(tmp, "rserver.pid")}"`,
+  ].join(" ");
 }
 
 const SPEC: { [name in NamedServerName]: CommandFunction } = {
-  code: (ip: string, port: number) =>
+  code: async (ip: string, port: number) =>
     `code-server --bind-addr=${ip}:${port} --auth=none`,
-  jupyter: (ip: string, port: number, basePath: string) =>
+  jupyter: async (ip: string, port: number, basePath: string) =>
     [
       `jupyter notebook`,
       `--port-retries=0`,
@@ -101,7 +120,7 @@ const SPEC: { [name in NamedServerName]: CommandFunction } = {
       `--NotebookApp.mathjax_url=/cdn/mathjax/MathJax.js`,
       `--NotebookApp.base_url=${basePath} --ip=${ip} --port=${port}`,
     ].join(" "),
-  jupyterlab: (ip: string, port: number, basePath: string) =>
+  jupyterlab: async (ip: string, port: number, basePath: string) =>
     [
       "jupyter lab",
       `--port-retries=0`, // don't try another port, only the one we specified will work
@@ -120,7 +139,7 @@ const SPEC: { [name in NamedServerName]: CommandFunction } = {
       `--port=${port}`,
       `${JUPYTERLAB_RTC ? "--collaborative" : ""}`,
     ].join(" "),
-  pluto: (ip: string, port: number) =>
+  pluto: async (ip: string, port: number) =>
     `echo 'import Pluto; Pluto.run(launch_browser=false, require_secret_for_access=false, host="${ip}", port=${port})' | julia`,
   rserver,
 } as const;

--- a/src/packages/project/named-servers/list.ts
+++ b/src/packages/project/named-servers/list.ts
@@ -57,6 +57,7 @@ function rserver(ip: string, port: number, basePath: string) {
   const tmp = `${process.env.TMP ?? "/tmp"}/rserver`;
 
   // watch out, this will be prefixed with #!/bin/sh and piped into stdout/stderr
+  // www-root-path needs the trailing slash and it must be "server", not "port"
   return `\
 PORT="${port}"
 TMP="${tmp}"
@@ -69,18 +70,19 @@ provider=sqlite
 directory=$DATA/db
 EOF
 
-exec env DISABLE_AUTH=true rserver \\
-    --server-daemonize=0 \\
-    --auth-none=1 \\
-    --auth-encrypt-password=0 \\
-    --server-user=$USER \\
-    --database-config-file="$TMP/db.conf" \\
-    --server-data-dir="$DATA" \\
-    --server-working-dir="$HOME" \\
-    --www-address=${ip} \\
-    --www-port=$PORT \\
-    --www-root-path="${basePath}/" \\
-    --server-pid-file="$TMP/rserver.pid"`;
+export DISABLE_AUTH=true
+rserver \
+--server-daemonize=0 \
+--auth-none=1 \
+--auth-encrypt-password=0 \
+--server-user=$USER \
+--database-config-file="$TMP/db.conf" \
+--server-data-dir="$DATA" \
+--server-working-dir="$HOME" \
+--www-address=${ip} \
+--www-port=$PORT \
+--www-root-path="${basePath}/" \
+--server-pid-file="$TMP/rserver.pid"`;
 }
 
 const SPEC: { [name in NamedServerName]: CommandFunction } = {

--- a/src/packages/util/db-schema/projects.ts
+++ b/src/packages/util/db-schema/projects.ts
@@ -547,7 +547,6 @@ Table({
   },
 });
 
-
 export interface ProjectStatus {
   "project.pid"?: number; // pid of project server process
   "hub-server.port"?: number; // port of tcp server that is listening for conn from hub
@@ -620,6 +619,7 @@ export interface StudentProjectFunctionality {
   disableJupyterClassicServer?: boolean;
   disableJupyterClassicMode?: boolean;
   disableJupyterLabServer?: boolean;
+  disableRServer?: boolean;
   disableVSCodeServer?: boolean;
   disablePlutoServer?: boolean;
   disableTerminals?: boolean;

--- a/src/packages/util/types/servers.ts
+++ b/src/packages/util/types/servers.ts
@@ -4,4 +4,13 @@
  */
 
 // used by frontend and project backend
-export type NamedServerName = "jupyter" | "jupyterlab" | "code" | "pluto";
+
+export const NAMED_SERVER_NAMES = [
+  "jupyter",
+  "jupyterlab",
+  "code",
+  "pluto",
+  "rserver",
+] as const;
+
+export type NamedServerName = (typeof NAMED_SERVER_NAMES)[number];


### PR DESCRIPTION
# Description

- [x] one-click rstudio server

~~Unfortunately I'm stuck. For whatever reason, such a named port does not work.~~

Interestingly, it is impossible to run this in a dev environment.

Deployment: hub first (for the proxy magic), then static, and then project (only when the configuration detects rserver, it will show it in the frontend)

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
