### PR TITLE
7473: Added `meta` tags to support the Open Graph protocol when sharing news links.

### DIFF
--- a/src/packages/frontend/markdown/index.ts
+++ b/src/packages/frontend/markdown/index.ts
@@ -14,6 +14,7 @@ in other code directly, e.g, in supporting use of the slate editor.
 export * from "./types";
 export * from "./table-of-contents";
 
+import * as cheerio from "cheerio";
 import MarkdownIt from "markdown-it";
 import emojiPlugin from "markdown-it-emoji";
 import { checkboxPlugin } from "./checkbox-plugin";
@@ -169,4 +170,8 @@ export function markdown_to_html_frontmatter(s: string): MD2html {
 
 export function markdown_to_html(s: string, options?: Options): string {
   return process(s, "default", options).html;
+}
+
+export function markdown_to_cheerio(s: string, options?: Options) {
+  return cheerio.load(`<div>${markdown_to_html(s, options)}</div>`);
 }

--- a/src/packages/next/components/news/news.tsx
+++ b/src/packages/next/components/news/news.tsx
@@ -57,9 +57,9 @@ export function News(props: Props) {
   const { id, url, tags, title, date, channel, text, future, hide } = news;
   const dateStr = useDateStr(news, historyMode);
   const permalink = slugURL(news);
-  const { kucalc, dns } = useCustomize();
+  const { kucalc, siteURL } = useCustomize();
   const isCoCalcCom = kucalc === KUCALC_COCALC_COM;
-  const showShareLinks = typeof dns === "string" && isCoCalcCom;
+  const showShareLinks = typeof siteURL === "string" && isCoCalcCom;
 
   const bottomLinkStyle: CSS = {
     color: COLORS.ANTD_LINK_BLUE,
@@ -113,7 +113,7 @@ export function News(props: Props) {
     }
   }
 
-  function reanderOpenLink() {
+  function renderOpenLink() {
     return (
       <A
         key="permalink"
@@ -129,15 +129,14 @@ export function News(props: Props) {
   }
 
   function shareLinks(text = false) {
+    const newsLink = encodeURIComponent(`${siteURL}${permalink}`);
     return (
       <Space size="middle" direction="horizontal">
         <A
           key="tweet"
           href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
             title,
-          )}&url=${encodeURIComponent(
-            `https://${dns}${permalink}`,
-          )}&via=cocalc_com`}
+          )}&url=${newsLink}&via=cocalc_com`}
           style={{ color: COLORS.ANTD_LINK_BLUE, ...bottomLinkStyle }}
         >
           <Icon name="twitter" />
@@ -145,9 +144,7 @@ export function News(props: Props) {
         </A>
         <A
           key="facebook"
-          href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
-            `https://${dns}${permalink}`,
-          )}`}
+          href={`https://www.facebook.com/sharer/sharer.php?u=${newsLink}`}
           style={{ ...bottomLinkStyle }}
         >
           <Icon name="facebook-filled" />
@@ -155,9 +152,7 @@ export function News(props: Props) {
         </A>
         <A
           key="linkedin"
-          href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
-            `https://${dns}${permalink}`,
-          )}`}
+          href={`https://www.linkedin.com/sharing/share-offsite/?url=${newsLink}`}
           style={{ ...bottomLinkStyle }}
         >
           <Icon name="linkedin-filled" />
@@ -168,7 +163,7 @@ export function News(props: Props) {
   }
 
   function actions() {
-    const actions = [reanderOpenLink()];
+    const actions = [renderOpenLink()];
     if (url) actions.push(readMoreLink());
     if (showEdit) actions.push(editLink());
     if (showShareLinks) actions.push(shareLinks());


### PR DESCRIPTION
# Description

This pull requests adds a slew of `meta` tags to each news item. Here's an example of what those look like:

```html
<head>
...
        <meta property="og:type" content="article"/>
        <meta property="og:title" content="Another News Test"/>
        <meta property="og:url" content="https://localhost/news/another-news-test-8"/>
        <meta property="og:image" content="https://picsum.photos/536/354"/>
        <meta property="article:published_time" content="2024-04-14T02:46:27.000Z"/>
        <meta property="article:modified_time" content="2024-04-28T22:13:25.000Z"/>
...
</head>
```

...and LinkedIn's Post Inspector seems to pick up these tags as expected:

![image](https://github.com/sagemathinc/cocalc/assets/17204901/1591944f-c972-4360-97a8-632171a89e5a)


# Test Instructions

If you're developing on a publicly-available server, you can simply click the LinkedIn "share" link on a news item with an embedded image. Otherwise, you'll probably need to use something like `ngrok` to forward your local development port so that <social media site>'s servers can see your news post.
