### PR TITLE
LLM tweaks for chat and jupyter tools

### DIFF
--- a/src/packages/frontend/account/useLanguageModelSetting.tsx
+++ b/src/packages/frontend/account/useLanguageModelSetting.tsx
@@ -39,19 +39,23 @@ export function useLanguageModelSetting(
   }, [other_settings]);
 
   function setLLM(llm: LanguageService) {
-    if (selectableLLMs.includes(llm as any)) {
-      redux
-        .getActions("account")
-        .set_other_settings(SETTINGS_LANGUAGE_MODEL_KEY, llm);
-    }
-
-    // check if LLM is a key in the Ollama TypedMap
-    if (isOllamaLLM(llm) && ollama?.get(fromOllamaModel(llm))) {
-      redux
-        .getActions("account")
-        .set_other_settings(SETTINGS_LANGUAGE_MODEL_KEY, llm);
-    }
+    setDefaultLLM(llm, selectableLLMs, ollama);
   }
 
   return [llm, setLLM];
+}
+
+export function setDefaultLLM(llm: LanguageService, selectableLLMs, ollama) {
+  if (selectableLLMs.includes(llm as any)) {
+    redux
+      .getActions("account")
+      .set_other_settings(SETTINGS_LANGUAGE_MODEL_KEY, llm);
+  }
+
+  // check if LLM is a key in the Ollama TypedMap
+  if (isOllamaLLM(llm) && ollama?.get(fromOllamaModel(llm))) {
+    redux
+      .getActions("account")
+      .set_other_settings(SETTINGS_LANGUAGE_MODEL_KEY, llm);
+  }
 }

--- a/src/packages/frontend/antd-bootstrap.tsx
+++ b/src/packages/frontend/antd-bootstrap.tsx
@@ -450,7 +450,9 @@ export function Panel(props: {
     <AntdCard
       style={style}
       title={props.header}
-      headStyle={{ color: "#333", backgroundColor: "#f5f5f5" }}
+      styles={{
+        header: { color: COLORS.GRAY_DD, backgroundColor: COLORS.GRAY_LLL },
+      }}
     >
       {props.children}
     </AntdCard>

--- a/src/packages/frontend/chat/actions.ts
+++ b/src/packages/frontend/chat/actions.ts
@@ -7,6 +7,7 @@ import { List, Seq, fromJS, Map as immutableMap } from "immutable";
 import { debounce } from "lodash";
 import { Optional } from "utility-types";
 
+import { setDefaultLLM } from "@cocalc/frontend/account/useLanguageModelSetting";
 import { Actions, redux } from "@cocalc/frontend/app-framework";
 import { History as LanguageModelHistory } from "@cocalc/frontend/client/types";
 import type {
@@ -1069,6 +1070,13 @@ export class ChatActions extends Actions<ChatState> {
       llm,
       dateLimit: date0,
     });
+
+    if (llm != null) {
+      const customizeStore = redux.getStore("customize");
+      const selectableLLMs = customizeStore.get("selectable_llms");
+      const ollama = customizeStore.get("ollama");
+      setDefaultLLM(llm, selectableLLMs, ollama);
+    }
   }
 }
 

--- a/src/packages/frontend/chat/actions.ts
+++ b/src/packages/frontend/chat/actions.ts
@@ -1023,9 +1023,7 @@ export class ChatActions extends Actions<ChatState> {
 
     const txtFull = [
       "<details><summary>Chat history</summary>",
-      ...history.map(
-        ({ author, content }) => `${author}:\n${stripMentions(content)}`,
-      ),
+      ...history.map(({ author, content }) => `${author}:\n${content}`),
       "</details>",
     ].join("\n\n");
 
@@ -1043,7 +1041,6 @@ export class ChatActions extends Actions<ChatState> {
 
     if (returnInfo) {
       const tokens = numTokensUpperBound(prompt, getMaxTokens(model));
-      console.log(prompt);
       return { prompt, tokens, truncated: txtFull != txt };
     } else {
       this.send_chat({

--- a/src/packages/frontend/chat/chat-log.tsx
+++ b/src/packages/frontend/chat/chat-log.tsx
@@ -48,7 +48,11 @@ export function ChatLog(props: Readonly<Props>) {
   const messages = useRedux(["messages"], project_id, path) as ChatMessages;
   const fontSize = useRedux(["font_size"], project_id, path);
   const scrollToBottom = useRedux(["scrollToBottom"], project_id, path);
-  const llm_cost: [number, number] = useRedux(["llm_cost"], project_id, path);
+  const llm_cost_reply: [number, number] = useRedux(
+    ["llm_cost_reply"],
+    project_id,
+    path,
+  );
 
   // see similar code in task list:
   const selectedHashtags0 = useRedux(["selectedHashtags"], project_id, path);
@@ -206,7 +210,7 @@ export function ChatLog(props: Readonly<Props>) {
                 allowReply={
                   messages.getIn([sortedDates[index + 1], "reply_to"]) == null
                 }
-                llm_cost={llm_cost}
+                llm_cost_reply={llm_cost_reply}
               />
             </div>
           );

--- a/src/packages/frontend/chat/chat-log.tsx
+++ b/src/packages/frontend/chat/chat-log.tsx
@@ -48,6 +48,7 @@ export function ChatLog(props: Readonly<Props>) {
   const messages = useRedux(["messages"], project_id, path) as ChatMessages;
   const fontSize = useRedux(["font_size"], project_id, path);
   const scrollToBottom = useRedux(["scrollToBottom"], project_id, path);
+  const llm_cost: [number, number] = useRedux(["llm_cost"], project_id, path);
 
   // see similar code in task list:
   const selectedHashtags0 = useRedux(["selectedHashtags"], project_id, path);
@@ -205,6 +206,7 @@ export function ChatLog(props: Readonly<Props>) {
                 allowReply={
                   messages.getIn([sortedDates[index + 1], "reply_to"]) == null
                 }
+                llm_cost={llm_cost}
               />
             </div>
           );

--- a/src/packages/frontend/chat/chatroom.tsx
+++ b/src/packages/frontend/chat/chatroom.tsx
@@ -38,7 +38,7 @@ import { history_path } from "@cocalc/util/misc";
 import { ChatActions } from "./actions";
 import { ChatLog } from "./chat-log";
 import ChatInput from "./input";
-import { LLMCostEstimation } from "./llm-cost-estimation";
+import { LLMCostEstimationChat } from "./llm-cost-estimation";
 import { INPUT_HEIGHT, markChatAsReadIfUnseen } from "./utils";
 import VideoChatButton from "./video/launch-button";
 
@@ -417,7 +417,7 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
             }}
           >
             <div style={{ flex: 1 }} />
-            <LLMCostEstimation
+            <LLMCostEstimationChat
               llm_cost={llm_cost_room}
               compact
               style={{

--- a/src/packages/frontend/chat/chatroom.tsx
+++ b/src/packages/frontend/chat/chatroom.tsx
@@ -95,7 +95,11 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
   const search = useRedux(["search"], project_id, path);
   const messages = useRedux(["messages"], project_id, path);
   const today: boolean = useRedux(["today"], project_id, path);
-  const llm_cost: [number, number] = useRedux(["llm_cost"], project_id, path);
+  const llm_cost_room: [number, number] = useRedux(
+    ["llm_cost_room"],
+    project_id,
+    path,
+  );
 
   const submitMentionsRef = useRef<Function>();
   const scrollToBottomRef = useRef<any>(null);
@@ -394,6 +398,9 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
               height={INPUT_HEIGHT}
               onChange={(value) => {
                 actions.set_input(value);
+                const reply =
+                  submitMentionsRef.current?.({ chatgpt: true }) ?? value;
+                actions?.llm_estimate_cost(reply, "room");
               }}
               submitMentionsRef={submitMentionsRef}
               syncdb={actions.syncdb}
@@ -409,12 +416,17 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
               marginBottom: "0",
             }}
           >
-            <LLMCostEstimation
-              llm_cost={llm_cost}
-              compact
-              style={{ fontSize: "85%", textAlign: "center" }}
-            />
             <div style={{ flex: 1 }} />
+            <LLMCostEstimation
+              llm_cost={llm_cost_room}
+              compact
+              style={{
+                flex: 0,
+                fontSize: "85%",
+                textAlign: "center",
+                margin: "0 0 5px 0",
+              }}
+            />
             <Button
               onClick={on_send_button_click}
               disabled={input.trim() === "" || is_uploading}

--- a/src/packages/frontend/chat/chatroom.tsx
+++ b/src/packages/frontend/chat/chatroom.tsx
@@ -35,8 +35,10 @@ import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
 import { SaveButton } from "@cocalc/frontend/frame-editors/frame-tree/save-button";
 import { sanitize_html_safe } from "@cocalc/frontend/misc";
 import { history_path } from "@cocalc/util/misc";
+import { ChatActions } from "./actions";
 import { ChatLog } from "./chat-log";
 import ChatInput from "./input";
+import { LLMCostEstimation } from "./llm-cost-estimation";
 import { INPUT_HEIGHT, markChatAsReadIfUnseen } from "./utils";
 import VideoChatButton from "./video/launch-button";
 
@@ -72,7 +74,7 @@ interface Props {
 }
 
 export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
-  const actions = useActions(project_id, path);
+  const actions: ChatActions = useActions(project_id, path);
 
   const is_uploading = useRedux(["is_uploading"], project_id, path);
   const is_saving = useRedux(["is_saving"], project_id, path);
@@ -92,7 +94,8 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
 
   const search = useRedux(["search"], project_id, path);
   const messages = useRedux(["messages"], project_id, path);
-  const today = useRedux(["today"], project_id, path);
+  const today: boolean = useRedux(["today"], project_id, path);
+  const llm_cost: [number, number] = useRedux(["llm_cost"], project_id, path);
 
   const submitMentionsRef = useRef<Function>();
   const scrollToBottomRef = useRef<any>(null);
@@ -124,7 +127,8 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
   }
 
   function render_preview_message(): JSX.Element | undefined {
-    if (input.length == 0 || preview.length == 0) return;
+    if (!is_preview) return;
+    if (input.length === 0 || preview.length === 0) return;
     const value = sanitize_html_safe(preview);
 
     return (
@@ -373,7 +377,7 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
             scrollToBottomRef={scrollToBottomRef}
             mode={"standalone"}
           />
-          {is_preview && render_preview_message()}
+          {render_preview_message()}
         </div>
         <div style={{ display: "flex", marginBottom: "5px", overflow: "auto" }}>
           <div
@@ -405,6 +409,11 @@ export const ChatRoom: React.FC<Props> = ({ project_id, path }) => {
               marginBottom: "0",
             }}
           >
+            <LLMCostEstimation
+              llm_cost={llm_cost}
+              compact
+              style={{ fontSize: "85%", textAlign: "center" }}
+            />
             <div style={{ flex: 1 }} />
             <Button
               onClick={on_send_button_click}

--- a/src/packages/frontend/chat/input.tsx
+++ b/src/packages/frontend/chat/input.tsx
@@ -21,7 +21,7 @@ import type { SyncDB } from "@cocalc/sync/editor/db";
 interface Props {
   on_send: (value: string) => void;
   onChange: (string) => void;
-  syncdb: SyncDB;
+  syncdb: SyncDB | undefined;
   date: number; // ms since epoch of when this message was first sent; set to 0 for editing new message. set to -time (negative time) to respond to message at time!
   input?: string;
   on_paste?: (e) => void;
@@ -67,7 +67,7 @@ export default function ChatInput({
   );
   const [input, setInput] = useState<string>(() => {
     const dbInput = syncdb
-      .get_one({
+      ?.get_one({
         event: "draft",
         sender_id,
         date,
@@ -119,6 +119,7 @@ export default function ChatInput({
     SAVE_DEBOUNCE_MS,
     { leading: true },
   );
+
   useEffect(() => {
     if (syncdb == null) return;
     const onSyncdbChange = () => {

--- a/src/packages/frontend/chat/llm-cost-estimation.tsx
+++ b/src/packages/frontend/chat/llm-cost-estimation.tsx
@@ -27,7 +27,9 @@ export function LLMCostEstimation({
   const cost = isFree ? (
     <>Free</>
   ) : compact ? (
-    <Tooltip title={range}>${(sum / 2).toFixed(2)}</Tooltip>
+    <Tooltip title={<>Estimated cost of calling the LLM: {range}</>}>
+      ~${(sum / 2).toFixed(2)}
+    </Tooltip>
   ) : (
     <>{range}</>
   );

--- a/src/packages/frontend/chat/llm-cost-estimation.tsx
+++ b/src/packages/frontend/chat/llm-cost-estimation.tsx
@@ -1,0 +1,65 @@
+import { Tooltip } from "antd";
+
+import { CSS } from "@cocalc/frontend/app-framework";
+import { HelpIcon, Paragraph } from "@cocalc/frontend/components";
+import { ESTIMATION_HELP_TEXT } from "@cocalc/frontend/misc/llm-cost-estimation";
+
+export function LLMCostEstimation({
+  llm_cost,
+  compact,
+  style,
+}: {
+  llm_cost?: [number, number] | null;
+  compact: boolean; // only mean is shown
+  style?: CSS;
+}) {
+  if (!llm_cost) return null;
+
+  const [min, max] = llm_cost;
+  const sum = min + max;
+  if (min == null || max == null || isNaN(sum)) return null;
+  const isFree = min === 0 && max === 0;
+  const range = (
+    <>
+      ${min.toFixed(2)} - ${max.toFixed(2)}
+    </>
+  );
+  const cost = isFree ? (
+    <>Free</>
+  ) : compact ? (
+    <Tooltip title={range}>${(sum / 2).toFixed(2)}</Tooltip>
+  ) : (
+    <>{range}</>
+  );
+
+  return (
+    <Paragraph
+      type="secondary"
+      style={{
+        whiteSpace: "nowrap",
+        ...style,
+      }}
+    >
+      {cost}{" "}
+      <HelpIcon title={"LLM Cost Estimation"}>
+        <Paragraph>
+          This chat message mentions a language model or replies in a thread.
+          This means, right after sending the message, the message and the
+          content of the current thread will be sent to the LLM for processing.
+          Then, the LLM will start replying to your message.
+        </Paragraph>
+        <Paragraph>
+          {isFree ? (
+            <>This model is free to use.</>
+          ) : (
+            <>
+              The estimate for this call is between ${min.toFixed(2)} and $
+              {max.toFixed(2)}.
+            </>
+          )}
+        </Paragraph>
+        {ESTIMATION_HELP_TEXT}
+      </HelpIcon>
+    </Paragraph>
+  );
+}

--- a/src/packages/frontend/chat/llm-cost-estimation.tsx
+++ b/src/packages/frontend/chat/llm-cost-estimation.tsx
@@ -43,7 +43,7 @@ export function LLMCostEstimation({
       }}
     >
       {cost}{" "}
-      <HelpIcon title={"LLM Cost Estimation"}>
+      <HelpIcon title={"LLM Cost Estimation"} placement={"topLeft"}>
         <Paragraph>
           This chat message mentions a language model or replies in a thread.
           This means, right after sending the message, the message and the

--- a/src/packages/frontend/chat/llm-cost-estimation.tsx
+++ b/src/packages/frontend/chat/llm-cost-estimation.tsx
@@ -4,7 +4,7 @@ import { CSS } from "@cocalc/frontend/app-framework";
 import { HelpIcon, Paragraph } from "@cocalc/frontend/components";
 import { ESTIMATION_HELP_TEXT } from "@cocalc/frontend/misc/llm-cost-estimation";
 
-export function LLMCostEstimation({
+export function LLMCostEstimationChat({
   llm_cost,
   compact,
   style,

--- a/src/packages/frontend/chat/message.tsx
+++ b/src/packages/frontend/chat/message.tsx
@@ -132,11 +132,11 @@ interface Props {
   is_folded?: boolean; // if true, only show the reply_to root message
   is_thread_body: boolean;
 
-  llm_cost?: [number, number] | null;
+  llm_cost_reply?: [number, number] | null;
 }
 
 export default function Message(props: Props) {
-  const { is_thread, is_folded, is_thread_body, mode, llm_cost } = props;
+  const { is_thread, is_folded, is_thread_body, mode, llm_cost_reply } = props;
 
   const hideTooltip =
     useTypedRedux("account", "other_settings").get("hide_file_popovers") ??
@@ -649,7 +649,12 @@ export default function Message(props: Props) {
           date={-date}
           onChange={(value) => {
             replyMessageRef.current = value;
-            props.actions?.llm_estimate_cost(value, props.message.toJS());
+            const reply = replyMentionsRef.current?.() ?? value;
+            props.actions?.llm_estimate_cost(
+              reply,
+              "reply",
+              props.message.toJS(),
+            );
           }}
           placeholder={"Reply to the above message..."}
         />
@@ -669,7 +674,7 @@ export default function Message(props: Props) {
             Cancel
           </Button>
           <LLMCostEstimation
-            llm_cost={llm_cost}
+            llm_cost={llm_cost_reply}
             compact={false}
             style={{ display: "inline-block", marginLeft: "10px" }}
           />
@@ -923,7 +928,7 @@ function RegenerateLLM({ actions, date }: RegenerateLLMProps) {
     <Dropdown.Button
       menu={{ items: entries, style: { overflow: "auto", maxHeight: "50vh" } }}
       size="small"
-      style={{ display: "inline" }}
+      style={{ display: "inline", whiteSpace: "nowrap" }}
       icon={<Icon name="angle-down" />}
       trigger={["click"]}
       onClick={() => {

--- a/src/packages/frontend/chat/message.tsx
+++ b/src/packages/frontend/chat/message.tsx
@@ -841,7 +841,7 @@ export default function Message(props: Props) {
           key={"blankcolumn"}
           style={{ textAlign: reverseRowOrdering ? "left" : "right" }}
         >
-          {hideTooltip ? (
+          {true || hideTooltip ? (
             button
           ) : (
             <Tooltip

--- a/src/packages/frontend/chat/message.tsx
+++ b/src/packages/frontend/chat/message.tsx
@@ -45,6 +45,7 @@ import { ChatActions } from "./actions";
 import { getUserName } from "./chat-log";
 import { History, HistoryFooter, HistoryTitle } from "./history";
 import ChatInput from "./input";
+import { LLMCostEstimation } from "./llm-cost-estimation";
 import { Name } from "./name";
 import { Time } from "./time";
 import { ChatMessageTyped, Mode } from "./types";
@@ -130,10 +131,12 @@ interface Props {
   is_thread?: boolean; // if true, there is a thread starting in a reply_to message
   is_folded?: boolean; // if true, only show the reply_to root message
   is_thread_body: boolean;
+
+  llm_cost?: [number, number] | null;
 }
 
 export default function Message(props: Props) {
-  const { is_thread, is_folded, is_thread_body, mode } = props;
+  const { is_thread, is_folded, is_thread_body, mode, llm_cost } = props;
 
   const hideTooltip =
     useTypedRedux("account", "other_settings").get("hide_file_popovers") ??
@@ -186,6 +189,7 @@ export default function Message(props: Props) {
   const submitMentionsRef = useRef<Function>();
 
   const [replying, setReplying] = useState<boolean>(false);
+
   const replyMessageRef = useRef<string>("");
   const replyMentionsRef = useRef<Function>();
 
@@ -645,6 +649,7 @@ export default function Message(props: Props) {
           date={-date}
           onChange={(value) => {
             replyMessageRef.current = value;
+            props.actions?.llm_estimate_cost(value, props.message.toJS());
           }}
           placeholder={"Reply to the above message..."}
         />
@@ -663,6 +668,11 @@ export default function Message(props: Props) {
           >
             Cancel
           </Button>
+          <LLMCostEstimation
+            llm_cost={llm_cost}
+            compact={false}
+            style={{ display: "inline-block", marginLeft: "10px" }}
+          />
         </div>
       </div>
     );

--- a/src/packages/frontend/chat/message.tsx
+++ b/src/packages/frontend/chat/message.tsx
@@ -1065,6 +1065,7 @@ function SummarizeThread({
             tokens={tokens}
             paragraph={true}
             type="secondary"
+            maxOutputTokens={short ? 200 : undefined}
           />
         </div>
       )}

--- a/src/packages/frontend/chat/message.tsx
+++ b/src/packages/frontend/chat/message.tsx
@@ -959,21 +959,23 @@ function RegenerateLLM({ actions, date, style }: RegenerateLLMProps) {
 
   return (
     <Tooltip title="Regenerating the response will send the thread to the language model again and replace this answer. Select a different language model to see, if it has a better response. Previous answers are kept in the history of that message.">
-      <Dropdown.Button
+      <Dropdown
         menu={{
           items: entries,
           style: { overflow: "auto", maxHeight: "50vh" },
         }}
-        size="small"
-        style={{ display: "inline", whiteSpace: "nowrap", ...style }}
-        icon={<Icon name="angle-down" />}
         trigger={["click"]}
-        onClick={() => {
-          actions.regenerateLLMResponse(new Date(date));
-        }}
       >
-        <Icon name="refresh" /> Regenerate
-      </Dropdown.Button>
+        <Button
+          size="small"
+          style={{ display: "inline", whiteSpace: "nowrap", ...style }}
+        >
+          <Space>
+            <Icon name="refresh" /> Regenerate
+            <Icon name="chevron-down" />
+          </Space>
+        </Button>
+      </Dropdown>
     </Tooltip>
   );
 }

--- a/src/packages/frontend/chat/side-chat.tsx
+++ b/src/packages/frontend/chat/side-chat.tsx
@@ -10,7 +10,7 @@ import { user_activity } from "../tracker";
 import type { ChatActions } from "./actions";
 import { ChatLog } from "./chat-log";
 import ChatInput from "./input";
-import { LLMCostEstimation } from "./llm-cost-estimation";
+import { LLMCostEstimationChat } from "./llm-cost-estimation";
 import { INPUT_HEIGHT, markChatAsReadIfUnseen } from "./utils";
 import VideoChatButton from "./video/launch-button";
 
@@ -166,7 +166,7 @@ export default function SideChat({ project_id, path, style }: Props) {
             >
               Cancel
             </Button> */}
-            <LLMCostEstimation
+            <LLMCostEstimationChat
               compact
               llm_cost={llm_cost_room}
               style={{ margin: "5px" }}

--- a/src/packages/frontend/chat/store.ts
+++ b/src/packages/frontend/chat/store.ts
@@ -34,7 +34,7 @@ export interface ChatState {
   // whenever this changes and is defined, do a scroll.
   //  scrollToBottom = 0 -- scroll to the bottom
   //  scrollToBottom = ms since epoch -- scroll to the bottom of that thread
-  scrollToBottom?: number;
+  scrollToBottom?: number | null;
   today: boolean;
   llm_cost_room?: [number, number] | null;
   llm_cost_reply?: [number, number] | null;

--- a/src/packages/frontend/chat/store.ts
+++ b/src/packages/frontend/chat/store.ts
@@ -35,6 +35,8 @@ export interface ChatState {
   //  scrollToBottom = 0 -- scroll to the bottom
   //  scrollToBottom = ms since epoch -- scroll to the bottom of that thread
   scrollToBottom?: number;
+  today: boolean;
+  llm_cost?: [number, number] | null;
 }
 
 export class ChatStore extends Store<ChatState> {
@@ -59,6 +61,7 @@ export class ChatStore extends Store<ChatState> {
       unsent_user_mentions: List() as any,
       is_uploading: false,
       font_size: redux.getStore("account").get("font_size"),
+      today: false,
     };
   };
 }

--- a/src/packages/frontend/chat/store.ts
+++ b/src/packages/frontend/chat/store.ts
@@ -36,7 +36,8 @@ export interface ChatState {
   //  scrollToBottom = ms since epoch -- scroll to the bottom of that thread
   scrollToBottom?: number;
   today: boolean;
-  llm_cost?: [number, number] | null;
+  llm_cost_room?: [number, number] | null;
+  llm_cost_reply?: [number, number] | null;
 }
 
 export class ChatStore extends Store<ChatState> {

--- a/src/packages/frontend/client/llm.ts
+++ b/src/packages/frontend/client/llm.ts
@@ -83,6 +83,13 @@ export class LLMClient {
   }): Promise<string> {
     system ??= getSystemPrompt(model, path);
 
+    // remove all date entries from all history objects
+    if (history != null) {
+      for (const h of history) {
+        delete h.date;
+      }
+    }
+
     if (!redux.getStore("projects").hasLanguageModelEnabled(project_id, tag)) {
       throw new Error(
         `Language model support is not currently enabled ${

--- a/src/packages/frontend/client/types.ts
+++ b/src/packages/frontend/client/types.ts
@@ -1,6 +1,7 @@
 export interface Message {
   role: "assistant" | "user" | "system";
   content: string;
+  date?: Date; // remove the date when sending to the server
 }
 
 export type History = Message[];

--- a/src/packages/frontend/components/help-icon.tsx
+++ b/src/packages/frontend/components/help-icon.tsx
@@ -8,6 +8,7 @@ Display a ? "help" icon, which -- when clicked -- shows a help tip
 */
 
 import { Button, Popover } from "antd";
+import type { TooltipPlacement } from "antd/es/tooltip";
 import { CSSProperties } from "react";
 
 import { CSS, React, useState } from "@cocalc/frontend/app-framework";
@@ -20,6 +21,7 @@ interface Props {
   maxWidth?: string; // default is 50vw
   style?: CSSProperties;
   extra?: string;
+  placement?: TooltipPlacement;
 }
 
 export const HelpIcon: React.FC<Props> = ({
@@ -28,6 +30,7 @@ export const HelpIcon: React.FC<Props> = ({
   children,
   maxWidth = "50vw",
   extra = "",
+  placement,
 }: Props) => {
   const [open, setOpen] = useState<boolean>(false);
 
@@ -39,6 +42,7 @@ export const HelpIcon: React.FC<Props> = ({
 
   return (
     <Popover
+      placement={placement}
       content={
         <div onClick={(e) => e.stopPropagation()} style={{ maxWidth }}>
           {children}

--- a/src/packages/frontend/components/popconfirm-keyboard.tsx
+++ b/src/packages/frontend/components/popconfirm-keyboard.tsx
@@ -7,13 +7,17 @@ trickiery that I didn't think would be possible:
    https://www.phind.com/search?cache=d621f94c-5428-4a34-961c-d8a75c987a3c
 */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Popconfirm } from "antd";
 
 import { copy_without } from "@cocalc/util/misc";
 
 export default function PopconfirmKeyboard(props) {
   const [visible, setVisible] = useState<boolean>(false);
+
+  useEffect(() => {
+    props.onVisibilityChange?.(visible);
+  }, [visible]);
 
   const handleKeyDown = (e) => {
     if (e.key === "Enter") {

--- a/src/packages/frontend/components/setting-box.tsx
+++ b/src/packages/frontend/components/setting-box.tsx
@@ -53,7 +53,7 @@ export function SettingBox(props: Props) {
       extra={close != null ? <CloseX2 close={close} /> : undefined}
       type="inner"
       style={{ ...STYLE, ...style }}
-      bodyStyle={bodyStyle}
+      styles={{ body: bodyStyle }}
     >
       {children}
     </Card>

--- a/src/packages/frontend/compute/select-server.tsx
+++ b/src/packages/frontend/compute/select-server.tsx
@@ -260,7 +260,9 @@ export default function SelectServer({
       title={
         title ??
         `This is open ${
-          !value ? "on the default shared resources" : `on compute server ${value}`
+          !value
+            ? "on the default shared resources"
+            : `on compute server ${value}`
         }.`
       }
     >
@@ -268,7 +270,7 @@ export default function SelectServer({
         disabled={disabled}
         allowClear
         size={size}
-        bordered={false}
+        variant={"borderless"}
         placeholder={
           <span style={{ color: avatar_fontcolor(background) }}>
             <Icon name="server" style={{ fontSize: "13pt" }} />{" "}

--- a/src/packages/frontend/course/nbgrader/scores.tsx
+++ b/src/packages/frontend/course/nbgrader/scores.tsx
@@ -59,7 +59,7 @@ export const NbgraderScores: React.FC<Props> = (props: Props) => {
 
   function render_info_for_file(
     filename: string,
-    scores: NotebookScores | string
+    scores: NotebookScores | string,
   ): Rendered {
     return (
       <div key={filename} style={{ marginBottom: "5px" }}>
@@ -73,7 +73,7 @@ export const NbgraderScores: React.FC<Props> = (props: Props) => {
     actions.assignments.open_file_in_collected_assignment(
       assignment_id,
       student_id,
-      filename
+      filename,
     );
   }
 
@@ -100,7 +100,7 @@ export const NbgraderScores: React.FC<Props> = (props: Props) => {
 
   function render_scores_for_file(
     filename: string,
-    scores: NotebookScores | string
+    scores: NotebookScores | string,
   ): Rendered {
     if (typeof scores == "string") {
       return (
@@ -157,14 +157,14 @@ export const NbgraderScores: React.FC<Props> = (props: Props) => {
       filename,
       id,
       score,
-      true
+      true,
     );
   }
 
   function render_assigned_score(
     filename: string,
     id: string,
-    score: Score
+    score: Score,
   ): Rendered {
     if (!score.manual) {
       return <>{score.score ?? "?"}</>;
@@ -266,7 +266,7 @@ export const NbgraderScores: React.FC<Props> = (props: Props) => {
       style={{ marginTop: "5px", backgroundColor }}
       extra={render_more_toggle(action_required)}
       title={render_title(score, points, error)}
-      bodyStyle={show_all ? {} : { padding: 0 }}
+      styles={{ body: show_all ? {} : { padding: 0 } }}
     >
       {render_show_all()}
     </Card>

--- a/src/packages/frontend/editors/markdown-input/mentions.ts
+++ b/src/packages/frontend/editors/markdown-input/mentions.ts
@@ -3,9 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
+import { redux } from "@cocalc/frontend/app-framework";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { original_path } from "@cocalc/util/misc";
-import { redux } from "../../app-framework";
-import { webapp_client } from "../../webapp-client";
 
 interface Mention {
   account_id: string;
@@ -16,7 +16,7 @@ interface Mention {
 export async function submit_mentions(
   project_id: string,
   path: string,
-  mentions: Mention[]
+  mentions: Mention[],
 ): Promise<void> {
   const source = redux.getStore("account")?.get("account_id");
   if (source == null) {

--- a/src/packages/frontend/editors/markdown-input/multimode.tsx
+++ b/src/packages/frontend/editors/markdown-input/multimode.tsx
@@ -3,7 +3,7 @@ Edit with either plain text input **or** WYSIWYG slate-based input.
 */
 
 import { Popover, Radio } from "antd";
-import { fromJS, Map as ImmutableMap } from "immutable";
+import { Map as ImmutableMap, fromJS } from "immutable";
 import LRU from "lru-cache";
 import {
   CSSProperties,
@@ -16,6 +16,7 @@ import {
   useState,
 } from "react";
 
+import { Icon } from "@cocalc/frontend/components";
 import { EditableMarkdown } from "@cocalc/frontend/editors/slate/editable-markdown";
 import "@cocalc/frontend/editors/slate/elements/math/math-widget";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
@@ -25,7 +26,6 @@ import { get_local_storage, set_local_storage } from "@cocalc/frontend/misc";
 import { FragmentId } from "@cocalc/frontend/misc/fragment-id";
 import { COLORS } from "@cocalc/util/theme";
 import { BLURED_STYLE, FOCUSED_STYLE, MarkdownInput } from "./component";
-import { Icon } from "@cocalc/frontend/components";
 
 // NOTE: on mobile there is very little suppport for "editor" = "slate", but
 // very good support for "markdown", hence the default below.
@@ -373,7 +373,7 @@ export default function MultiMarkdownInput(props: Props) {
           </div>
         )}
       </div>
-      {mode == "markdown" && (
+      {mode === "markdown" ? (
         <MarkdownInput
           divRef={editorDivRef}
           selectionRef={selectionRef}
@@ -418,8 +418,8 @@ export default function MultiMarkdownInput(props: Props) {
           compact={compact}
           dirtyRef={dirtyRef}
         />
-      )}
-      {mode == "editor" && (
+      ) : undefined}
+      {mode === "editor" ? (
         <div
           style={{
             height: height ?? "100%",
@@ -501,7 +501,7 @@ export default function MultiMarkdownInput(props: Props) {
             dirtyRef={dirtyRef}
           />
         </div>
-      )}
+      ) : undefined}
     </div>
   );
 }

--- a/src/packages/frontend/editors/slate/editable-markdown.tsx
+++ b/src/packages/frontend/editors/slate/editable-markdown.tsx
@@ -941,9 +941,9 @@ export const EditableMarkdown: React.FC<Props> = React.memo((props: Props) => {
     <ChangeContext.Provider value={{ change, editor }}>
       <div
         ref={divRef}
-        className={noVfill || height == "auto" ? undefined : "smc-vfill"}
+        className={noVfill || height === "auto" ? undefined : "smc-vfill"}
         style={{
-          overflow: noVfill || height == "auto" ? undefined : "auto",
+          overflow: noVfill || height === "auto" ? undefined : "auto",
           backgroundColor: "white",
           ...style,
           height,

--- a/src/packages/frontend/frame-editors/crm-editor/users/user.tsx
+++ b/src/packages/frontend/frame-editors/crm-editor/users/user.tsx
@@ -19,7 +19,7 @@ export default function User({
   return (
     <Card
       style={{ margin: "5px" }}
-      headStyle={{ backgroundColor: "#eee" }}
+      styles={{ header: { backgroundColor: "#eee" } }}
       title={
         <>
           {banned && (

--- a/src/packages/frontend/frame-editors/crm-editor/views/view.tsx
+++ b/src/packages/frontend/frame-editors/crm-editor/views/view.tsx
@@ -63,7 +63,7 @@ export default function View({
 
   const fields = useMemo(
     () => allColumns.map(({ dataIndex }) => dataIndex),
-    [allColumns]
+    [allColumns],
   );
   const [orderFields, setOrderFields] = useOrderFields({ id, fields });
 
@@ -296,10 +296,7 @@ export default function View({
       break;
     case "retention":
       body = (
-        <RetentionView
-          retention={retention}
-          setRetention={setRetention}
-        />
+        <RetentionView retention={retention} setRetention={setRetention} />
       );
       break;
     default:
@@ -363,7 +360,7 @@ export default function View({
               height: "100%",
             }}
             title={header}
-            bodyStyle={{ flex: 1 }}
+            styles={{ body: { flex: 1 } }}
           >
             {body}
           </Card>

--- a/src/packages/frontend/frame-editors/llm/create-chat.ts
+++ b/src/packages/frontend/frame-editors/llm/create-chat.ts
@@ -1,8 +1,9 @@
 import getChatActions from "@cocalc/frontend/chat/get-actions";
 import { backtickSequence } from "@cocalc/frontend/markdown/util";
+import type { LanguageModel } from "@cocalc/util/db-schema/llm-utils";
 import { capitalize } from "@cocalc/util/misc";
 import { Actions, CodeEditorState } from "../code-editor/actions";
-import { modelToMention, type LanguageModel } from "./llm-selector";
+import { modelToMention } from "./llm-selector";
 
 export interface Options {
   codegen?: boolean;

--- a/src/packages/frontend/frame-editors/llm/help-me-fix.tsx
+++ b/src/packages/frontend/frame-editors/llm/help-me-fix.tsx
@@ -5,6 +5,7 @@ If chatgpt is disabled or not available it renders as null.
 
 import { Alert, Button } from "antd";
 import { CSSProperties, useState } from "react";
+import useAsyncEffect from "use-async-effect";
 
 import { useLanguageModelSetting } from "@cocalc/frontend/account/useLanguageModelSetting";
 import getChatActions from "@cocalc/frontend/chat/get-actions";
@@ -13,12 +14,11 @@ import { Icon } from "@cocalc/frontend/components/icon";
 import PopconfirmKeyboard from "@cocalc/frontend/components/popconfirm-keyboard";
 import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 import { RawPrompt } from "@cocalc/frontend/jupyter/llm/raw-prompt";
+import { LLMCostEstimation } from "@cocalc/frontend/misc/llm-cost-estimation";
 import type { ProjectsStore } from "@cocalc/frontend/projects/store";
 import { trunc, trunc_left, trunc_middle } from "@cocalc/util/misc";
 import LLMSelector, { modelToMention, modelToName } from "./llm-selector";
 import shortenError from "./shorten-error";
-import { LLMCostEstimation } from "../../misc/llm-cost-estimation";
-import useAsyncEffect from "use-async-effect";
 
 interface Props {
   error: string | (() => string); // the error it produced. This is viewed as code.
@@ -213,7 +213,7 @@ export async function getHelp({
   setTimeout(() => actions.scrollToBottom(), 100);
   await actions.send_chat({
     input: message,
-    tag: `help-me-fix${tag ? ":" + tag : ""}`,
+    tag: `help-me-fix${tag ? `:${tag}` : ""}`,
     noNotification: true,
   });
 }

--- a/src/packages/frontend/frame-editors/llm/llm-selector.tsx
+++ b/src/packages/frontend/frame-editors/llm/llm-selector.tsx
@@ -18,6 +18,7 @@ import {
   fromOllamaModel,
   getLLMCost,
   getLLMPriceRange,
+  isCoreLanguageModel,
   isFreeModel,
   isOllamaLLM,
   model2service,
@@ -205,14 +206,18 @@ export default function LLMSelector({
 
     const [input, output] = [500, 300];
     const { min, max } = getLLMPriceRange(input, output, llm_markup);
-    const { prompt_tokens: model_input, completion_tokens: model_output } =
-      getLLMCost(model, llm_markup);
 
-    const selected = isFreeModel(model, is_cocalc_com)
-      ? "free"
-      : `about $${round2up(input * model_input + output * model_output).toFixed(
-          2,
-        )}`;
+    function calcSelected() {
+      if (isFreeModel(model, is_cocalc_com) || !isCoreLanguageModel(model)) {
+        return "free";
+      } else {
+        const { prompt_tokens: model_input, completion_tokens: model_output } =
+          getLLMCost(model, llm_markup);
+        return `about $${round2up(
+          input * model_input + output * model_output,
+        ).toFixed(2)}`;
+      }
+    }
 
     return (
       <>
@@ -226,8 +231,8 @@ export default function LLMSelector({
         <Paragraph>
           Assuming a typical usage involves {input} input tokens and {output}{" "}
           output tokens, the price across all models ranges from $
-          {min.toFixed(2)} to ${max.toFixed(2)} per usage, and is {selected} for
-          the selected model {modelToName(model)}.
+          {min.toFixed(2)} to ${max.toFixed(2)} per usage, and is{" "}
+          {calcSelected()} for the selected model {modelToName(model)}.
         </Paragraph>
       </>
     );

--- a/src/packages/frontend/frame-editors/llm/llm-selector.tsx
+++ b/src/packages/frontend/frame-editors/llm/llm-selector.tsx
@@ -7,7 +7,6 @@ import { HelpIcon, Paragraph, Text } from "@cocalc/frontend/components";
 import { LanguageModelVendorAvatar } from "@cocalc/frontend/components/language-model-icon";
 import {
   ANTHROPIC_MODELS,
-  DEFAULT_MODEL,
   GOOGLE_MODELS,
   LLMServiceName,
   LLM_DESCR,
@@ -26,9 +25,6 @@ import {
 } from "@cocalc/util/db-schema/llm-utils";
 import type { OllamaPublic } from "@cocalc/util/types/llm";
 import { round2up } from "@cocalc/util/misc";
-
-export { DEFAULT_MODEL };
-export type { LanguageModel };
 
 type SizeType = ConfigProviderProps["componentSize"];
 

--- a/src/packages/frontend/frame-editors/llm/llm-selector.tsx
+++ b/src/packages/frontend/frame-editors/llm/llm-selector.tsx
@@ -1,9 +1,9 @@
 import type { SelectProps } from "antd";
-import { Select, Tag, Tooltip } from "antd";
+import { Select, Space, Tag, Tooltip } from "antd";
 import type { ConfigProviderProps } from "antd/lib/config-provider";
 
 import { CSS, redux, useTypedRedux } from "@cocalc/frontend/app-framework";
-import { Text } from "@cocalc/frontend/components";
+import { HelpIcon, Paragraph, Text } from "@cocalc/frontend/components";
 import { LanguageModelVendorAvatar } from "@cocalc/frontend/components/language-model-icon";
 import {
   ANTHROPIC_MODELS,
@@ -44,6 +44,8 @@ export default function LLMSelector({
   size = "middle",
   project_id,
 }: Props) {
+  const is_cocalc_com = useTypedRedux("customize", "is_cocalc_com");
+
   // ATTN: you cannot use useProjectContext because this component is used outside a project context
   // when it is opened via an error in the gutter of a latex document. (I don't know why, maybe fixable)
   const projectsStore = redux.getStore("projects");
@@ -198,18 +200,46 @@ export default function LLMSelector({
     return ret;
   }
 
+  function renderHelp() {
+    return (
+      <HelpIcon title={"Language Model Selection"}>
+        <>
+          <Paragraph>
+            This selector determines which language model will be used to
+            generate the response. You can select from a variety of models, each
+            with its own strengths and weaknesses. Your choice will become the
+            default the next time you use an LLM.
+          </Paragraph>
+          {is_cocalc_com ? (
+            <Paragraph>
+              The models marked as "{FREE}" do not incur any charges. However,
+              they are rate limited to avoid abuse. The more capable models are
+              marked "{PAID}" and charged by the number of tokens – i.e.
+              "pay-as-you-go" – and do not have rate limitations. Usually, these
+              charges are very small!
+            </Paragraph>
+          ) : undefined}
+          <Paragraph></Paragraph>
+        </>
+      </HelpIcon>
+    );
+  }
+
   // all models selectable here must be in selectableLLMs(default: USER_SELECTABLE_LANGUAGE_MODELS) + the custom ones from the Ollama configuration
   return (
-    <Select
-      dropdownStyle={style}
-      size={size}
-      value={model}
-      onChange={setModel}
-      style={{ width: 300 }}
-      optionLabelProp={"display"}
-      popupMatchSelectWidth={false}
-      options={getOptions()}
-    />
+    <Space direction="horizontal" style={{ whiteSpace: "nowrap" }}>
+      <Select
+        dropdownStyle={style}
+        size={size}
+        value={model}
+        onChange={setModel}
+        style={{ width: 300 }}
+        optionLabelProp={"display"}
+        popupMatchSelectWidth={false}
+        options={getOptions()}
+      />
+      {renderHelp()}
+    </Space>
   );
 }
 
@@ -227,6 +257,9 @@ export function modelToMention(model: LanguageModel): string {
     model,
   )} >@${modelToName(model)}</span>`;
 }
+
+const FREE = "free";
+const PAID = "paid";
 
 export function LLMModelPrice({
   model,
@@ -247,11 +280,11 @@ export function LLMModelPrice({
 
   return isFreeModel(model, is_cocalc_com) ? (
     <Tag color="success" {...props}>
-      free
+      {FREE}
     </Tag>
   ) : (
     <Tag color="error" {...props}>
-      paid
+      {PAID}
     </Tag>
   );
 }

--- a/src/packages/frontend/frame-editors/llm/title-bar-button-tour.tsx
+++ b/src/packages/frontend/frame-editors/llm/title-bar-button-tour.tsx
@@ -1,13 +1,15 @@
-import { Button, Checkbox, Tour } from "antd";
-import type { TourProps } from "antd";
-import { Icon } from "@cocalc/frontend/components/icon";
 import { redux, useRedux } from "@cocalc/frontend/app-framework";
-import { useState } from "react";
 import { A } from "@cocalc/frontend/components/A";
-import track from "@cocalc/frontend/user-tracking";
+import { Icon } from "@cocalc/frontend/components/icon";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
+import track from "@cocalc/frontend/user-tracking";
+import type { TourProps } from "antd";
+import { Button, Checkbox, Tour } from "antd";
+import { useState } from "react";
 
 const NAME = "chatgpt-title-bar-button";
+
+const URL = "https://doc.cocalc.com/chatgpt.html";
 
 export default function TitleBarButtonTour({
   describeRef,
@@ -20,10 +22,7 @@ export default function TitleBarButtonTour({
   const [open, setOpen] = useState<boolean>(false);
   if (IS_MOBILE || tours?.includes("all") || tours?.includes(NAME)) {
     return (
-      <A
-        href="https://doc.cocalc.com/chatgpt.html"
-        style={{ fontSize: "10pt" }}
-      >
+      <A href={URL} style={{ fontSize: "10pt" }}>
         <Icon name="external-link" /> Docs
       </A>
     );
@@ -32,15 +31,15 @@ export default function TitleBarButtonTour({
     {
       title: (
         <>
-          ChatGPT <A href="https://doc.cocalc.com/chatgpt.html">(docs)</A>
+          Large Language Model Assistant <A href={URL}>(docs)</A>
         </>
       ),
       description: (
         <div>
-          This tour shows you how ChatGPT helps you become more productive with
-          Jupyter notebooks, Python, LaTeX, and more. This feature will save you
-          time and improve your results in all your projects, homework, and
-          learning experiences.
+          This tour shows you how large language models (LLMs) help you be more
+          productive with Jupyter notebooks, Python, LaTeX, and more. This
+          feature will save you time and improve your results in all your
+          projects, homework, and learning experiences.
         </div>
       ),
     },
@@ -77,11 +76,11 @@ export default function TitleBarButtonTour({
       title: <>Choose Your Context</>,
       description: (
         <div>
-          Select a part of your document and to send it in your request to
-          ChatGPT. You can also copy as much as possible from your document to
-          the message by clicking "All." If you just want to ask a general
-          question, click "None." This provides the most flexible, user-friendly
-          options for sharing parts of your document with ChatGPT.
+          Select a part of your document and to send it in your request to the
+          selected language model. You can also copy as much as possible from
+          your document to the message by clicking "All." If you just want to
+          ask a general question, click "None." This provides the most flexible,
+          user-friendly options for sharing parts of your document with the LLM.
         </div>
       ),
       target: scopeRef.current,
@@ -91,8 +90,8 @@ export default function TitleBarButtonTour({
       description: (
         <div>
           This shows you what will be sent along with your question. This
-          guarantees that you're asking the question that you want and gives
-          ChatGPT the context it needs to provide the best response it can.
+          guarantees that you're asking the question that you want and gives the
+          selected LLM the context it needs to provide the best response it can.
         </div>
       ),
       target: contextRef.current,
@@ -105,12 +104,12 @@ export default function TitleBarButtonTour({
       ),
       description: (
         <div>
-          Finish your process by submitting your question to ChatGPT. In a few
-          seconds, the AI will answer in a chatroom that appears off to the
-          right. If the result is useful, you can then copy and paste it back
-          into your document, or ask follow-up questions to refine your results.
-          This will help you get unstuck, complete your projects and homework
-          with ease, and increase your productivity.
+          Finish your process by submitting your question to the selected LLM.
+          In a few seconds, the AI will answer in a chatroom that appears off to
+          the right. If the result is useful, you can then copy and paste it
+          back into your document, or ask follow-up questions to refine your
+          results. This will help you get unstuck, complete your projects and
+          homework with ease, and increase your productivity.
           <hr />
           <Checkbox
             onChange={(e) => {

--- a/src/packages/frontend/frame-editors/llm/title-bar-button.tsx
+++ b/src/packages/frontend/frame-editors/llm/title-bar-button.tsx
@@ -13,13 +13,17 @@ import { Alert, Button, Input, Popover, Radio, Space, Tooltip } from "antd";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useLanguageModelSetting } from "@cocalc/frontend/account/useLanguageModelSetting";
+import { useTypedRedux } from "@cocalc/frontend/app-framework";
 import {
   Icon,
   IconName,
+  Paragraph,
   Title,
   VisibleMDLG,
 } from "@cocalc/frontend/components";
 import AIAvatar from "@cocalc/frontend/components/ai-avatar";
+import { LLMCostEstimation } from "@cocalc/frontend/misc/llm-cost-estimation";
+import { getMaxTokens } from "@cocalc/util/db-schema/llm-utils";
 import { capitalize } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { Actions } from "../code-editor/actions";
@@ -139,6 +143,7 @@ export default function LanguageModelTitleBarButton({
   setShowDialog,
   noLabel,
 }: Props) {
+  const is_cocalc_com = useTypedRedux("customize", "is_cocalc_com");
   const [error, setError] = useState<string>("");
   const [custom, setCustom] = useState<string>("");
   const frameType = actions._get_frame_type(id);
@@ -151,6 +156,8 @@ export default function LanguageModelTitleBarButton({
   const [scope, setScope] = useState<Scope | "all">(() =>
     showDialog ? getScope(id, actions) : "all",
   );
+  const [tokens, setTokens] = useState<number>(0);
+
   const describeRef = useRef<any>(null);
   const buttonsRef = useRef<any>(null);
   const scopeRef = useRef<any>(null);
@@ -184,7 +191,13 @@ export default function LanguageModelTitleBarButton({
       // don't waste time on update if it is not visible.
       return;
     }
-    const { input, inputOrig } = await updateInput(actions, id, scope, model);
+    const { input, inputOrig, tokens } = await updateInput(
+      actions,
+      id,
+      scope,
+      model,
+    );
+    setTokens(tokens);
     setInput(input);
     setTruncated(
       Math.round(
@@ -195,7 +208,7 @@ export default function LanguageModelTitleBarButton({
     );
     setTruncatedReason(
       `Input truncated from ${inputOrig.length} to ${input.length} characters.${
-        model == "gpt-3.5-turbo"
+        getMaxTokens(model) < 5000 // cutoff between GPT 3.5 and GPT 4
           ? "  Try using a different model with a bigger context size."
           : ""
       }`,
@@ -245,166 +258,182 @@ export default function LanguageModelTitleBarButton({
     actions.focus();
   };
 
-  return (
-    <Popover
-      title={
-        <div style={{ fontSize: "18px" }}>
-          <Button
-            onClick={() => {
-              setShowDialog(false);
-              setError("");
-              actions.focus();
-            }}
-            type="text"
-            style={{ float: "right", color: COLORS.GRAY_M }}
-          >
-            <Icon name="times" />
-          </Button>
-          <div style={{ float: "right" }}>
-            <TitleBarButtonTour
-              describeRef={describeRef}
-              buttonsRef={buttonsRef}
-              scopeRef={scopeRef}
-              contextRef={contextRef}
-              submitRef={submitRef}
-            />
-          </div>
-          <Title level={4}>
-            <AIAvatar size={22} /> What would you like to do using{" "}
-            {modelToName(model)}?
-          </Title>
-          Switch model:{" "}
-          <LLMSelector
-            project_id={project_id}
-            model={model}
-            setModel={setModel}
+  function renderTitle() {
+    return (
+      <div style={{ fontSize: "18px" }}>
+        <Button
+          onClick={() => {
+            setShowDialog(false);
+            setError("");
+            actions.focus();
+          }}
+          type="text"
+          style={{ float: "right", color: COLORS.GRAY_M }}
+        >
+          <Icon name="times" />
+        </Button>
+        <div style={{ float: "right" }}>
+          <TitleBarButtonTour
+            describeRef={describeRef}
+            buttonsRef={buttonsRef}
+            scopeRef={scopeRef}
+            contextRef={contextRef}
+            submitRef={submitRef}
           />
         </div>
-      }
-      open={visible && showDialog}
-      content={() => {
-        return (
-          <Space
-            direction="vertical"
-            style={{ width: "800px", maxWidth: "90vw" }}
-          >
-            <div ref={describeRef}>
-              <Input.TextArea
-                allowClear
-                autoFocus
-                style={{ flex: 1 }}
-                placeholder={"What you want to do..."}
-                value={custom}
-                onChange={(e) => {
-                  setCustom(e.target.value);
-                  setTag("");
-                  if (e.target.value) {
-                    setDescription(getCustomDescription(frameType));
-                  } else {
-                    setDescription("");
-                  }
-                }}
-                onPressEnter={(e) => {
-                  if (e.shiftKey) {
-                    doIt();
-                  }
-                }}
-                autoSize={{ minRows: 2, maxRows: 10 }}
-              />
-            </div>
-            {showOptions && (
-              <>
-                <div
-                  ref={buttonsRef}
-                  style={{ overflowX: "auto", textAlign: "center" }}
-                >
-                  or{" "}
-                  <Button.Group style={{ marginLeft: "5px" }}>
-                    {PRESETS.map((preset) => (
-                      <Button
-                        type={preset.tag == tag ? "primary" : undefined}
-                        key={preset.tag}
-                        onClick={() => {
-                          setTag(preset.tag);
-                          setDescription(preset.description);
-                          setCustom(preset.command);
-                        }}
-                        disabled={querying}
-                      >
-                        <Icon name={preset.icon} />
-                        {preset.label}
-                      </Button>
-                    ))}
-                  </Button.Group>
-                </div>
-              </>
-            )}
-            {showOptions && (
-              <div
-                style={{
-                  marginTop: "5px",
-                  color: "#444",
-                  maxHeight: "40vh",
-                  display: "flex",
-                  flexDirection: "column",
-                }}
-              >
-                <div style={{ marginBottom: "5px" }} ref={scopeRef}>
-                  {truncated < 100 ? (
-                    <Tooltip title={truncatedReason}>
-                      <div style={{ float: "right" }}>
-                        Truncated ({truncated}% remains)
-                      </div>
-                    </Tooltip>
-                  ) : (
-                    <div style={{ float: "right" }}>
-                      NOT Truncated (100% included)
-                    </div>
-                  )}
-                  {modelToName(model)} will see:
-                  <Radio.Group
-                    size="small"
-                    style={{ margin: "0 10px" }}
-                    value={scope}
-                    onChange={(e) => {
-                      const scope = e.target.value;
-                      setScope(scope);
-                    }}
-                    options={scopeOptions}
-                    optionType="button"
-                    buttonStyle="solid"
-                  />
-                  <Button size="small" type="text" onClick={doUpdateInput}>
-                    <Icon name="refresh" /> Update
-                  </Button>
-                </div>
-                <div ref={contextRef} style={{ overflowY: "auto" }}>
-                  <Context
-                    value={input}
-                    info={actions.languageModelGetLanguage()}
-                  />
-                </div>
-              </div>
-            )}{" "}
-            {description}
-            <div style={{ textAlign: "center" }} ref={submitRef}>
+        <Title level={4}>
+          <AIAvatar size={22} /> What would you like to do using{" "}
+          {modelToName(model)}?
+        </Title>
+        Select model:{" "}
+        <LLMSelector
+          project_id={project_id}
+          model={model}
+          setModel={setModel}
+        />
+      </div>
+    );
+  }
+
+  function renderOptions() {
+    if (!showOptions) return;
+    return (
+      <>
+        <div
+          ref={buttonsRef}
+          style={{ overflowX: "auto", textAlign: "center" }}
+        >
+          or{" "}
+          <Button.Group style={{ marginLeft: "5px" }}>
+            {PRESETS.map((preset) => (
               <Button
-                disabled={querying || (!tag && !custom.trim())}
-                type="primary"
-                size="large"
-                onClick={doIt}
+                type={preset.tag == tag ? "primary" : undefined}
+                key={preset.tag}
+                onClick={() => {
+                  setTag(preset.tag);
+                  setDescription(preset.description);
+                  setCustom(preset.command);
+                }}
+                disabled={querying}
               >
-                <Icon
-                  name={querying ? "spinner" : "paper-plane"}
-                  spin={querying}
-                />{" "}
-                Ask {modelToName(model)} (shift+enter)
+                <Icon name={preset.icon} />
+                {preset.label}
               </Button>
-            </div>
-            {error && <Alert type="error" message={error} />}
-          </Space>
-        );
-      }}
+            ))}
+          </Button.Group>
+        </div>
+      </>
+    );
+  }
+
+  function renderShowOptions() {
+    if (!showOptions) return;
+
+    return (
+      <div
+        style={{
+          marginTop: "5px",
+          color: COLORS.GRAY_D,
+          maxHeight: "40vh",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div style={{ marginBottom: "5px" }} ref={scopeRef}>
+          {truncated < 100 ? (
+            <Tooltip title={truncatedReason}>
+              <div style={{ float: "right" }}>
+                Truncated ({truncated}% remains)
+              </div>
+            </Tooltip>
+          ) : (
+            <div style={{ float: "right" }}>NOT Truncated (100% included)</div>
+          )}
+          {modelToName(model)} will see:
+          <Radio.Group
+            size="small"
+            style={{ margin: "0 10px" }}
+            value={scope}
+            onChange={(e) => {
+              const scope = e.target.value;
+              setScope(scope);
+            }}
+            options={scopeOptions}
+            optionType="button"
+            buttonStyle="solid"
+          />
+          <Button size="small" type="text" onClick={doUpdateInput}>
+            <Icon name="refresh" /> Update
+          </Button>
+        </div>
+        <div ref={contextRef} style={{ overflowY: "auto" }}>
+          <Context value={input} info={actions.languageModelGetLanguage()} />
+        </div>
+      </div>
+    );
+  }
+
+  function renderCostEstimation() {
+    if (!is_cocalc_com || tokens === 0) return;
+    return (
+      <div style={{ textAlign: "center" }}>
+        <LLMCostEstimation model={model} tokens={tokens} type="secondary" />
+      </div>
+    );
+  }
+
+  function renderContent() {
+    return (
+      <Space direction="vertical" style={{ width: "800px", maxWidth: "90vw" }}>
+        <Paragraph ref={describeRef}>
+          <Input.TextArea
+            allowClear
+            autoFocus
+            style={{ flex: 1 }}
+            placeholder={"What you want to do..."}
+            value={custom}
+            onChange={(e) => {
+              setCustom(e.target.value);
+              setTag("");
+              if (e.target.value) {
+                setDescription(getCustomDescription(frameType));
+              } else {
+                setDescription("");
+              }
+            }}
+            onPressEnter={(e) => {
+              if (e.shiftKey) {
+                doIt();
+              }
+            }}
+            autoSize={{ minRows: 2, maxRows: 10 }}
+          />
+        </Paragraph>
+        {renderOptions()}
+        {renderShowOptions()}
+        {description}
+        {renderCostEstimation()}
+        <Paragraph style={{ textAlign: "center" }} ref={submitRef}>
+          <Button
+            disabled={querying || (!tag && !custom.trim())}
+            type="primary"
+            size="large"
+            onClick={doIt}
+          >
+            <Icon name={querying ? "spinner" : "paper-plane"} spin={querying} />{" "}
+            Ask {modelToName(model)} (shift+enter)
+          </Button>
+        </Paragraph>
+        {error ? <Alert type="error" message={error} /> : undefined}
+      </Space>
+    );
+  }
+
+  return (
+    <Popover
+      title={renderTitle()}
+      open={visible && showDialog}
+      content={renderContent}
     >
       <Button
         style={buttonStyle}
@@ -418,7 +447,7 @@ export default function LanguageModelTitleBarButton({
         <span ref={buttonRef}>
           <AIAvatar
             size={18}
-            iconColor="#333"
+            iconColor={COLORS.AI_ASSISTANT_TXT}
             style={{ top: "-2px", marginRight: "1px" }}
           />
           {noLabel ? (
@@ -439,21 +468,22 @@ async function updateInput(
   id,
   scope,
   model: LanguageModel,
-): Promise<{ input: string; inputOrig: string }> {
-  if (scope == "none") {
-    return { input: "", inputOrig: "" };
+): Promise<{ input: string; inputOrig: string; tokens: number }> {
+  if (scope === "none") {
+    return { input: "", inputOrig: "", tokens: 0 };
   }
   let input = actions.languageModelGetContext(id, scope);
   const inputOrig = input;
+  // Truncate input (also this MUST be a lazy import):
+  const { truncateMessage, getMaxTokens, numTokensUpperBound } = await import(
+    "@cocalc/frontend/misc/llm"
+  );
   if (input.length > 2000) {
-    // Truncate input (also this MUST be a lazy import):
-    const { truncateMessage, getMaxTokens } = await import(
-      "@cocalc/frontend/misc/llm"
-    );
     const maxTokens = getMaxTokens(model) - 1000; // 1000 tokens reserved for output and the prompt below.
     input = truncateMessage(input, maxTokens);
   }
-  return { input, inputOrig };
+  const tokens = numTokensUpperBound(input, getMaxTokens(model));
+  return { input, inputOrig, tokens };
 }
 
 function getScope(id, actions: Actions): Scope {

--- a/src/packages/frontend/frame-editors/llm/title-bar-button.tsx
+++ b/src/packages/frontend/frame-editors/llm/title-bar-button.tsx
@@ -23,13 +23,13 @@ import {
 } from "@cocalc/frontend/components";
 import AIAvatar from "@cocalc/frontend/components/ai-avatar";
 import { LLMCostEstimation } from "@cocalc/frontend/misc/llm-cost-estimation";
-import { getMaxTokens } from "@cocalc/util/db-schema/llm-utils";
+import { LanguageModel, getMaxTokens } from "@cocalc/util/db-schema/llm-utils";
 import { capitalize } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { Actions } from "../code-editor/actions";
 import Context from "./context";
 import { Options } from "./create-chat";
-import LLMSelector, { LanguageModel, modelToName } from "./llm-selector";
+import LLMSelector, { modelToName } from "./llm-selector";
 import TitleBarButtonTour from "./title-bar-button-tour";
 import type { Scope } from "./types";
 

--- a/src/packages/frontend/frame-editors/markdown-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/markdown-editor/editor.ts
@@ -86,6 +86,7 @@ const EDITOR_SPEC = {
       "increase_font_size",
       "sync",
       "show_table_of_contents",
+      "format-ai_formula",
       "format-header",
       "format-text",
       "format-font",

--- a/src/packages/frontend/jupyter/llm/cell-tool.tsx
+++ b/src/packages/frontend/jupyter/llm/cell-tool.tsx
@@ -388,8 +388,7 @@ export function LLMCellTool({
     const txtStyle: CSS = is_current
       ? {
           color: COLORS.AI_ASSISTANT_FONT,
-          // this makes it bold without "moving around"
-          textShadow: `1px 0 0 ${COLORS.AI_ASSISTANT_FONT}`,
+          fontWeight: "bold",
         }
       : {};
 

--- a/src/packages/frontend/jupyter/llm/cell-tool.tsx
+++ b/src/packages/frontend/jupyter/llm/cell-tool.tsx
@@ -61,6 +61,10 @@ const TARGET_LANGS = [
   "SageMath",
   "Julia",
   "Octave",
+  // LaTeX: the package is parsed from between the brackets, keep them!
+  "LaTeX (algorithm2e)",
+  "LaTeX (algpseudocodex)",
+  "LaTeX (algorithmicx)",
   "JavaScript",
   "C/C++",
   "Java",
@@ -186,10 +190,19 @@ const ACTIONS: { [mode in Mode]: LLMTool } = {
   translate: {
     icon: "translation-outlined",
     descr: "Translate the code in that cell to another language using AI.",
-    prompt: ({ language, target = "R" }) =>
-      `Your task is to translate the provided ${capitalize(
+    prompt: ({ language, target = "R" }) => {
+      let detail = "";
+      if (target.startsWith("LaTeX")) {
+        const pkgRe = /\\((.*?)\\)/g;
+        const pkg = target.match(pkgRe)?.[1] ?? "algorithm2e";
+        detail = ` using package "${pkg}". Wrap the LaTeX code in a codeblock and briefly explain how to insert it`;
+        target = "LaTeX";
+      }
+
+      return `Your task is to translate the provided ${capitalize(
         language,
-      )} code to ${target}.`,
+      )} code to ${target}${detail}.`;
+    },
   },
 } as const;
 
@@ -200,7 +213,7 @@ export function LLMCellTool({
   llmTools,
   is_current,
 }: Props) {
-  const { actions: project_actions } = useProjectContext();
+  const { actions: project_actions, onCoCalcCom } = useProjectContext();
   const { project_id, path } = useFrameContext();
   const [isQuerying, setIsQuerying] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
@@ -699,9 +712,11 @@ export function LLMCellTool({
           . The language model replies and you can continue the conversation in
           the same thread.
         </Paragraph>
-        <Paragraph style={{ textAlign: "right" }}>
-          <LLMCostEstimation model={model} tokens={tokens} />
-        </Paragraph>
+        {onCoCalcCom ? (
+          <Paragraph>
+            <LLMCostEstimation model={model} tokens={tokens} />
+          </Paragraph>
+        ) : undefined}
       </>
     );
   }

--- a/src/packages/frontend/landing-page/util.ts
+++ b/src/packages/frontend/landing-page/util.ts
@@ -5,7 +5,7 @@
 
 // Maybe should go in app-framework ... ?
 
-import { redux } from "../app-framework";
+import { redux } from "@cocalc/frontend/app-framework";
 
 export function actions(name: string): any {
   const a = redux.getActions(name);

--- a/src/packages/frontend/misc/llm-cost-estimation.tsx
+++ b/src/packages/frontend/misc/llm-cost-estimation.tsx
@@ -31,46 +31,57 @@ The maximum (just use the "MAX" function, easier than the median) is at almost t
 That's the basis for the number 100 and 1000 below!
 */
 
-
-export const ESTIMATION_HELP_TEXT = (<><Paragraph>
-  The cost of calling a large language model is based on the number of
-  tokens. A token can be thought of as a piece of a word. For example,
-  the word "cat" is one token, while "unbelievable" breaks down into
-  three tokens: "un", "believe", "able".
-</Paragraph>
-<Paragraph>
-  The total cost of your interaction depends on the number of tokens in
-  your message and the LLM's reply. Please note that the exact cost is
-  variable for each query. We're unable to predict the precise charge
-  for each interaction, as it depends on the specific number tokens.
-</Paragraph></>)
+export const ESTIMATION_HELP_TEXT = (
+  <>
+    <Paragraph>
+      The cost of calling a large language model is based on the number of
+      tokens. A token can be thought of as a piece of a word. For example, the
+      word "cat" is one token, while "unbelievable" breaks down into three
+      tokens: "un", "believe", "able".
+    </Paragraph>
+    <Paragraph>
+      The total cost of your interaction depends on the number of tokens in your
+      message and the LLM's reply. Please note that the exact cost is variable
+      for each query. We're unable to predict the precise charge for each
+      interaction, as it depends on the specific number tokens.
+    </Paragraph>
+    <Paragraph>
+      You can see your recent language model charges in Account → Purchases.
+    </Paragraph>
+  </>
+);
 
 export function LLMCostEstimation({
   model,
   tokens, // Note: use the "await imported" numTokensUpperBound function to get the number of tokens
   type,
+  maxOutputTokens,
 }: {
   model: LanguageModel;
   tokens: number;
   type?: BaseType;
+  maxOutputTokens?: number;
 }) {
   const isCoCalcCom = useTypedRedux("customize", "is_cocalc_com");
   const llm_markup = useTypedRedux("customize", "llm_markup");
 
   if (isFreeModel(model, isCoCalcCom)) {
-    return (
-      <Text style={{ textAlign: "right" }}>This model is free to use.</Text>
-    );
+    return <Wrapper type={type}>This model is free to use.</Wrapper>;
   }
 
-  const { min, max } = calcMinMaxEstimation(tokens, model, llm_markup);
+  const { min, max } = calcMinMaxEstimation(
+    tokens,
+    model,
+    llm_markup,
+    maxOutputTokens,
+  );
 
   const minTxt = round2down(min).toFixed(2);
   const maxTxt = round2up(max).toFixed(2);
   return (
-    <Text style={{ textAlign: "right" }} type={type}>
+    <Wrapper type={type}>
       Estimated cost: ${minTxt} to ${maxTxt}{" "}
-      <HelpIcon title="LLM Cost Estimation">
+      <HelpIcon title="LLM Cost Estimation" placement={"topLeft"}>
         {ESTIMATION_HELP_TEXT}
         <Paragraph>
           The estimated price range is based on an estimate for the number of
@@ -78,6 +89,14 @@ export function LLMCostEstimation({
           the total cost could be slightly higher.
         </Paragraph>
       </HelpIcon>
+    </Wrapper>
+  );
+}
+
+function Wrapper({ children, type }) {
+  return (
+    <Text style={{ textAlign: "right" }} type={type}>
+      {children}
     </Text>
   );
 }
@@ -86,12 +105,16 @@ export function calcMinMaxEstimation(
   tokens: number,
   model,
   llm_markup,
+  maxTokens: number = 1000,
 ): { min: number; max: number } {
-  const { prompt_tokens, completion_tokens } = getLLMCost(model, llm_markup);
+  const { prompt_tokens: tokIn, completion_tokens: tokOut } = getLLMCost(
+    model,
+    llm_markup,
+  );
   // NOTE: see explanation about for lower/upper number.
   // It could go up to the model's output token limit (i.e. even 2000)
-  const min = tokens * prompt_tokens + 100 * completion_tokens;
-  const max = tokens * prompt_tokens + 1000 * completion_tokens;
+  const min = tokens * tokIn + (maxTokens / 10) * tokOut;
+  const max = tokens * tokIn + maxTokens * tokOut;
 
   return { min, max };
 }

--- a/src/packages/frontend/misc/llm-cost-estimation.tsx
+++ b/src/packages/frontend/misc/llm-cost-estimation.tsx
@@ -1,3 +1,5 @@
+import { BaseType } from "antd/es/typography/Base";
+
 import { useTypedRedux } from "@cocalc/frontend/app-framework";
 import { HelpIcon, Paragraph, Text } from "@cocalc/frontend/components";
 import {
@@ -32,9 +34,11 @@ That's the basis for the number 100 and 1000 below!
 export function LLMCostEstimation({
   model,
   tokens, // Note: use the "await imported" numTokensUpperBound function to get the number of tokens
+  type,
 }: {
   model: LanguageModel;
   tokens: number;
+  type?: BaseType;
 }) {
   const isCoCalcCom = useTypedRedux("customize", "is_cocalc_com");
   const llm_markup = useTypedRedux("customize", "llm_markup");
@@ -53,7 +57,7 @@ export function LLMCostEstimation({
   const txt1 = round2down(cost1).toFixed(2);
   const txt2 = round2up(cost2).toFixed(2);
   return (
-    <Text style={{ textAlign: "right" }}>
+    <Text style={{ textAlign: "right" }} type={type}>
       Estimated cost: ${txt1} to ${txt2}{" "}
       <HelpIcon title="LLM Cost Estimation">
         <Paragraph>

--- a/src/packages/frontend/misc/llm-cost-estimation.tsx
+++ b/src/packages/frontend/misc/llm-cost-estimation.tsx
@@ -56,17 +56,23 @@ export function LLMCostEstimation({
   tokens, // Note: use the "await imported" numTokensUpperBound function to get the number of tokens
   type,
   maxOutputTokens,
+  paragraph = false,
 }: {
   model: LanguageModel;
   tokens: number;
   type?: BaseType;
   maxOutputTokens?: number;
+  paragraph?: boolean;
 }) {
   const isCoCalcCom = useTypedRedux("customize", "is_cocalc_com");
   const llm_markup = useTypedRedux("customize", "llm_markup");
 
   if (isFreeModel(model, isCoCalcCom)) {
-    return <Wrapper type={type}>This model is free to use.</Wrapper>;
+    return (
+      <Wrapper type={type} paragraph={paragraph}>
+        This model is free to use.
+      </Wrapper>
+    );
   }
 
   const { min, max } = calcMinMaxEstimation(
@@ -79,7 +85,7 @@ export function LLMCostEstimation({
   const minTxt = round2down(min).toFixed(2);
   const maxTxt = round2up(max).toFixed(2);
   return (
-    <Wrapper type={type}>
+    <Wrapper type={type} paragraph={paragraph}>
       Estimated cost: ${minTxt} to ${maxTxt}{" "}
       <HelpIcon title="LLM Cost Estimation" placement={"topLeft"}>
         {ESTIMATION_HELP_TEXT}
@@ -93,11 +99,12 @@ export function LLMCostEstimation({
   );
 }
 
-function Wrapper({ children, type }) {
+function Wrapper({ children, type, paragraph }) {
+  const C = paragraph ? Paragraph : Text;
   return (
-    <Text style={{ textAlign: "right" }} type={type}>
+    <C style={{ textAlign: "right" }} type={type}>
       {children}
-    </Text>
+    </C>
   );
 }
 

--- a/src/packages/frontend/misc/llm-cost-estimation.tsx
+++ b/src/packages/frontend/misc/llm-cost-estimation.tsx
@@ -73,8 +73,9 @@ export function LLMCostEstimation({
           for each interaction, as it depends on the specific number tokens.
         </Paragraph>
         <Paragraph>
-          The given range is based on a typical interaction. In rare situations,
-          the total cost could be a bit higher.
+          The estimated price range is based on an estimate for the number of
+          input tokens and typical amounts of output tokens. In rare situations,
+          the total cost could be slightly higher.
         </Paragraph>
       </HelpIcon>
     </Text>

--- a/src/packages/frontend/misc/llm-cost-estimation.tsx
+++ b/src/packages/frontend/misc/llm-cost-estimation.tsx
@@ -31,6 +31,20 @@ The maximum (just use the "MAX" function, easier than the median) is at almost t
 That's the basis for the number 100 and 1000 below!
 */
 
+
+export const ESTIMATION_HELP_TEXT = (<><Paragraph>
+  The cost of calling a large language model is based on the number of
+  tokens. A token can be thought of as a piece of a word. For example,
+  the word "cat" is one token, while "unbelievable" breaks down into
+  three tokens: "un", "believe", "able".
+</Paragraph>
+<Paragraph>
+  The total cost of your interaction depends on the number of tokens in
+  your message and the LLM's reply. Please note that the exact cost is
+  variable for each query. We're unable to predict the precise charge
+  for each interaction, as it depends on the specific number tokens.
+</Paragraph></>)
+
 export function LLMCostEstimation({
   model,
   tokens, // Note: use the "await imported" numTokensUpperBound function to get the number of tokens
@@ -49,29 +63,15 @@ export function LLMCostEstimation({
     );
   }
 
-  const { prompt_tokens, completion_tokens } = getLLMCost(model, llm_markup);
-  // NOTE: see explanation about for lower/upper number.
-  // It could go up to the model's output token limit (i.e. even 2000)
-  const cost1 = tokens * prompt_tokens + 100 * completion_tokens;
-  const cost2 = tokens * prompt_tokens + 1000 * completion_tokens;
-  const txt1 = round2down(cost1).toFixed(2);
-  const txt2 = round2up(cost2).toFixed(2);
+  const { min, max } = calcMinMaxEstimation(tokens, model, llm_markup);
+
+  const minTxt = round2down(min).toFixed(2);
+  const maxTxt = round2up(max).toFixed(2);
   return (
     <Text style={{ textAlign: "right" }} type={type}>
-      Estimated cost: ${txt1} to ${txt2}{" "}
+      Estimated cost: ${minTxt} to ${maxTxt}{" "}
       <HelpIcon title="LLM Cost Estimation">
-        <Paragraph>
-          The cost of calling a large language model is based on the number of
-          tokens. A token can be thought of as a piece of a word. For example,
-          the word "cat" is one token, while "unbelievable" breaks down into
-          three tokens: "un", "believe", "able".
-        </Paragraph>
-        <Paragraph>
-          The total cost of your interaction depends on the number of tokens in
-          your message and the LLM's reply. Please note that the exact cost is
-          variable for each query. We're unable to predict the precise charge
-          for each interaction, as it depends on the specific number tokens.
-        </Paragraph>
+        {ESTIMATION_HELP_TEXT}
         <Paragraph>
           The estimated price range is based on an estimate for the number of
           input tokens and typical amounts of output tokens. In rare situations,
@@ -80,4 +80,18 @@ export function LLMCostEstimation({
       </HelpIcon>
     </Text>
   );
+}
+
+export function calcMinMaxEstimation(
+  tokens: number,
+  model,
+  llm_markup,
+): { min: number; max: number } {
+  const { prompt_tokens, completion_tokens } = getLLMCost(model, llm_markup);
+  // NOTE: see explanation about for lower/upper number.
+  // It could go up to the model's output token limit (i.e. even 2000)
+  const min = tokens * prompt_tokens + 100 * completion_tokens;
+  const max = tokens * prompt_tokens + 1000 * completion_tokens;
+
+  return { min, max };
 }

--- a/src/packages/frontend/notifications/notification-news.tsx
+++ b/src/packages/frontend/notifications/notification-news.tsx
@@ -71,7 +71,8 @@ export function NewsPanel(props: NewsPanelProps) {
       .sort((a: any, b: any) => -cmp_Date(a.date, b.date)) as any;
     // if any entry in data is unread, then anyUnread is true
     const anyUnread = data.some(
-      (n: any) => news_read_until == null || n?.date.getTime() > news_read_until
+      (n: any) =>
+        news_read_until == null || n?.date.getTime() > news_read_until,
     );
     return [data, anyUnread];
   }, [news, filter, news_read_until]);
@@ -170,8 +171,10 @@ export function NewsPanel(props: NewsPanelProps) {
     <Card
       title={<Title level={4}>News</Title>}
       extra={renderNewsPanelExtra()}
-      headStyle={{ backgroundColor: COLORS.GRAY_LLL }}
-      bodyStyle={{ padding: "0px" }}
+      styles={{
+        header: { backgroundColor: COLORS.GRAY_LLL },
+        body: { padding: "0px" },
+      }}
     >
       <List
         itemLayout="horizontal"

--- a/src/packages/frontend/project/directory-selector.tsx
+++ b/src/packages/frontend/project/directory-selector.tsx
@@ -209,11 +209,13 @@ export default function DirectorySelector({
         backgroundColor: "white",
         ...style,
       }}
-      bodyStyle={{
-        maxHeight: "50vh",
-        overflow: "scroll",
-        whiteSpace: "nowrap",
-        ...bodyStyle,
+      styles={{
+        body: {
+          maxHeight: "50vh",
+          overflow: "scroll",
+          whiteSpace: "nowrap",
+          ...bodyStyle,
+        },
       }}
     >
       {body}

--- a/src/packages/frontend/project/settings/site-license.tsx
+++ b/src/packages/frontend/project/settings/site-license.tsx
@@ -64,7 +64,7 @@ export const SiteLicense: React.FC<Props> = (props: Props) => {
 
   const haveLicenses = useMemo(
     () => (site_license?.size ?? 0) > 0,
-    [site_license]
+    [site_license],
   );
 
   // all licenses known to the client, not just for the project
@@ -110,7 +110,7 @@ export const SiteLicense: React.FC<Props> = (props: Props) => {
       const license = managed_licenses?.get(license_id)?.toJS();
       if (license != null && license.quota != null && isBoostLicense(license)) {
         const boostGroup = licenseToGroupKey(
-          license as SiteLicenseQuotaSetting // we check that license.quota is not null above
+          license as SiteLicenseQuotaSetting, // we check that license.quota is not null above
         );
         // this ignores any other licenses (e.g. disks), which do not have the boost field
         // for those which are regular licenses, we check if they're compatible with the boost license
@@ -123,7 +123,7 @@ export const SiteLicense: React.FC<Props> = (props: Props) => {
           return regularGroup === boostGroup;
         });
         setBoostWarning(
-          haveCompatible ? "none" : haveRegular ? "incompatible" : "no_other"
+          haveCompatible ? "none" : haveRegular ? "incompatible" : "no_other",
         );
       } else {
         setBoostWarning("none");
@@ -253,7 +253,7 @@ export const SiteLicense: React.FC<Props> = (props: Props) => {
         extra={render_extra()}
         type="inner"
         style={{ marginTop: "15px" }}
-        bodyStyle={{ padding: "0px" }}
+        styles={{ body: { padding: "0px" } }}
       >
         {renderBody()}
       </Card>

--- a/src/packages/frontend/project/settings/upgrade-usage.tsx
+++ b/src/packages/frontend/project/settings/upgrade-usage.tsx
@@ -146,7 +146,7 @@ export const UpgradeUsage: React.FC<Props> = React.memo(
           title="Your upgrade contributions"
           extra={adjust}
           type="inner"
-          bodyStyle={style}
+          styles={{ body: style }}
         >
           {showAdjustor ? render_upgrade_adjustor() : list_user_contributions()}
         </Card>
@@ -270,7 +270,7 @@ export const UpgradeUsage: React.FC<Props> = React.memo(
             // NOTE: there is usually symlink disks/x → /local/... but we can't rely on it,
             // because the project only creates that symlink if there isn't a file/dir already with that name
             project_actions?.open_directory(
-              join(".smc/root/", ROOT, `/${disk.name}/`)
+              join(".smc/root/", ROOT, `/${disk.name}/`),
             );
           }}
         >
@@ -303,7 +303,7 @@ export const UpgradeUsage: React.FC<Props> = React.memo(
           }
           type="inner"
           style={{ marginTop: "15px" }}
-          bodyStyle={{ padding: "10px 0 0 0" }}
+          styles={{ body: { padding: "10px 0 0 0" } }}
         >
           <ul>{render_dedicated_disks_list(disks)}</ul>
         </Card>
@@ -379,5 +379,5 @@ export const UpgradeUsage: React.FC<Props> = React.memo(
         {render_support()}
       </div>
     );
-  }
+  },
 );

--- a/src/packages/next/components/landing/pricing-item.tsx
+++ b/src/packages/next/components/landing/pricing-item.tsx
@@ -19,7 +19,7 @@ export default function PricingItem({ icon, children, title }: Props) {
   return (
     <List.Item style={{ padding: 0 }}>
       <Card
-        headStyle={{ backgroundColor: "#d9edf7" }}
+        styles={{ header: { backgroundColor: "#d9edf7" } }}
         style={{ color: COLORS.GRAY }}
         type="inner"
         title={

--- a/src/packages/server/llm/index.ts
+++ b/src/packages/server/llm/index.ts
@@ -28,6 +28,7 @@ import {
   OpenAIMessages,
   getLLMCost,
   isAnthropicModel,
+  isCoreLanguageModel,
   isFreeModel,
   isGoogleModel,
   isMistralModel,
@@ -205,7 +206,7 @@ async function evaluateImpl({
   if (account_id) {
     const is_cocalc_com =
       (await getServerSettings()).kucalc === KUCALC_COCALC_COM;
-    if (isFreeModel(model, is_cocalc_com)) {
+    if (isFreeModel(model, is_cocalc_com) || !isCoreLanguageModel(model)) {
       // no charge for now...
     } else {
       // charge for ALL other models.

--- a/src/packages/server/purchases/is-purchase-allowed.ts
+++ b/src/packages/server/purchases/is-purchase-allowed.ts
@@ -3,6 +3,7 @@ import { getServerSettings } from "@cocalc/database/settings/server-settings";
 import isValidAccount from "@cocalc/server/accounts/is-valid-account";
 import {
   getMaxCost,
+  isCoreLanguageModel,
   isLanguageModelService,
   service2model,
 } from "@cocalc/util/db-schema/llm-utils";
@@ -190,7 +191,11 @@ async function getCostEstimate(service: Service): Promise<number | undefined> {
     const { pay_as_you_go_openai_markup_percentage } =
       await getServerSettings();
     const model = service2model(service);
-    return getMaxCost(model, pay_as_you_go_openai_markup_percentage);
+    if (isCoreLanguageModel(model)) {
+      return getMaxCost(model, pay_as_you_go_openai_markup_percentage);
+    } else {
+      return undefined;
+    }
   }
 
   switch (service) {

--- a/src/packages/util/db-schema/llm-utils.ts
+++ b/src/packages/util/db-schema/llm-utils.ts
@@ -780,7 +780,7 @@ export interface LLMCost {
 }
 
 export function getLLMCost(
-  model: LanguageModel,
+  model: CoreLanguageModel,
   markup_percentage: number, // a number like "30" would mean that we increase the wholesale price by multiplying by 1.3
 ): LLMCost {
   const x = LLM_COST[model];
@@ -817,7 +817,7 @@ export function getLLMPriceRange(
     const model = LLM_COST[key];
     if (!model || isFreeModel(key, true)) continue;
     const { prompt_tokens, completion_tokens } = getLLMCost(
-      key as LanguageModel,
+      key as CoreLanguageModel,
       markup_percentage,
     );
     const p = prompt * prompt_tokens + output * completion_tokens;
@@ -834,7 +834,7 @@ export function getLLMPriceRange(
 // We can't know the cost until after it happens, so this bound is useful for
 // ensuring user can afford to make a call.
 export function getMaxCost(
-  model: LanguageModel,
+  model: CoreLanguageModel,
   markup_percentage: number,
 ): number {
   const { prompt_tokens, completion_tokens } = getLLMCost(


### PR DESCRIPTION
# Description

- :warning:  This builds on top of  #7471
- add a price estimation to the AI assistant dialog
- add some help to the model selection dialog
- add code→latex translations
- price estimation for chat messages and others
- throttling stream response
- summarize threads
- llm regenerate: a simpler dropdown, also change default llm
- extra: fixing Antd deprecations

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
