### PR TITLE
frontend/next: change all doc chatgpt.html links + feature page tweaks

### DIFF
--- a/src/packages/database/settings/customize.ts
+++ b/src/packages/database/settings/customize.ts
@@ -29,6 +29,8 @@ export interface Customize {
   logoRectangularURL?: string;
   splashImage?: string;
   indexInfo?: string;
+  imprint?: string;
+  policies?: string;
   shareServer?: boolean;
   landingPages?: boolean;
   dns?: string;
@@ -48,6 +50,15 @@ export interface Customize {
   sandboxProjectId?: string;
   verifyEmailAddresses?: boolean;
   strategies: Strategy[];
+  openaiEnabled?: boolean;
+  googleVertexaiEnabled?: boolean;
+  mistralEnabled?: boolean;
+  anthropicEnabled?: boolean;
+  ollamaEnabled?: boolean;
+  neuralSearchEnabled?: boolean;
+  jupyterApiEnabled?: boolean;
+  computeServersEnabled?: boolean;
+  githubProjectId?: string;
 }
 
 const fallback = (a?: string, b?: string): string =>
@@ -141,8 +152,12 @@ export default async function getCustomize(): Promise<Customize> {
     // true if openai integration is enabled -- this impacts the UI only, and can be
     // turned on and off independently of whether there is an api key set.
     openaiEnabled: settings.openai_enabled,
-    // same for google vertex (exposed as gemini)
+    // same for google vertex (exposed as gemini), and others
     googleVertexaiEnabled: settings.google_vertexai_enabled,
+    mistralEnabled: settings.mistral_enabled,
+    anthropicEnabled: settings.anthropic_enabled,
+    ollamaEnabled: settings.ollama_enabled,
+
     neuralSearchEnabled: settings.neural_search_enabled,
 
     // if extra Jupyter API functionality for sandboxed ephemeral code execution is available.
@@ -157,7 +172,7 @@ export default async function getCustomize(): Promise<Customize> {
     strategies,
 
     verifyEmailAddresses: settings.verify_emails && settings.email_enabled,
-  } as Customize;
+  };
 
   return cachedCustomize;
 }

--- a/src/packages/frontend/frame-editors/llm/title-bar-button-tour.tsx
+++ b/src/packages/frontend/frame-editors/llm/title-bar-button-tour.tsx
@@ -1,12 +1,15 @@
 import { Button, Checkbox, Tour } from "antd";
 import type { TourProps } from "antd";
+import { useState } from "react";
+
 import { Icon } from "@cocalc/frontend/components/icon";
 import { redux, useRedux } from "@cocalc/frontend/app-framework";
-import { useState } from "react";
 import { A } from "@cocalc/frontend/components/A";
 import track from "@cocalc/frontend/user-tracking";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
+import { DOC_AI } from "@cocalc/util/consts/ui";
 
+// ATTN: don't change this string!
 const NAME = "chatgpt-title-bar-button";
 
 export default function TitleBarButtonTour({
@@ -20,10 +23,7 @@ export default function TitleBarButtonTour({
   const [open, setOpen] = useState<boolean>(false);
   if (IS_MOBILE || tours?.includes("all") || tours?.includes(NAME)) {
     return (
-      <A
-        href="https://doc.cocalc.com/chatgpt.html"
-        style={{ fontSize: "10pt" }}
-      >
+      <A href={DOC_AI} style={{ fontSize: "10pt" }}>
         <Icon name="external-link" /> Docs
       </A>
     );
@@ -32,15 +32,15 @@ export default function TitleBarButtonTour({
     {
       title: (
         <>
-          ChatGPT <A href="https://doc.cocalc.com/chatgpt.html">(docs)</A>
+          AI Assistant <A href={DOC_AI}>(docs)</A>
         </>
       ),
       description: (
         <div>
-          This tour shows you how ChatGPT helps you become more productive with
-          Jupyter notebooks, Python, LaTeX, and more. This feature will save you
-          time and improve your results in all your projects, homework, and
-          learning experiences.
+          This tour shows you how the AI Assistant helps you become more
+          productive with Jupyter notebooks, Python, LaTeX, and more. This
+          feature will save you time and improve your results in all your
+          projects, homework, and learning experiences.
         </div>
       ),
     },
@@ -77,11 +77,11 @@ export default function TitleBarButtonTour({
       title: <>Choose Your Context</>,
       description: (
         <div>
-          Select a part of your document and to send it in your request to
-          ChatGPT. You can also copy as much as possible from your document to
-          the message by clicking "All." If you just want to ask a general
-          question, click "None." This provides the most flexible, user-friendly
-          options for sharing parts of your document with ChatGPT.
+          Select a part of your document and to send it in your request to a
+          language model of your choice. You can also copy as much as possible
+          from your document to the message by clicking "All." If you just want
+          to ask a general question, click "None." This provides the most
+          flexible options for processing parts of your document.
         </div>
       ),
       target: scopeRef.current,
@@ -91,8 +91,9 @@ export default function TitleBarButtonTour({
       description: (
         <div>
           This shows you what will be sent along with your question. This
-          guarantees that you're asking the question that you want and gives
-          ChatGPT the context it needs to provide the best response it can.
+          guarantees that you're asking the question that you want and gives the
+          selected language model the context it needs to provide the best
+          response it can.
         </div>
       ),
       target: contextRef.current,
@@ -105,12 +106,12 @@ export default function TitleBarButtonTour({
       ),
       description: (
         <div>
-          Finish your process by submitting your question to ChatGPT. In a few
-          seconds, the AI will answer in a chatroom that appears off to the
-          right. If the result is useful, you can then copy and paste it back
-          into your document, or ask follow-up questions to refine your results.
-          This will help you get unstuck, complete your projects and homework
-          with ease, and increase your productivity.
+          Finish your process by submitting your question to the selected
+          language model. In a few seconds, the AI will answer in a chatroom
+          that appears off to the right. If the result is useful, you can then
+          copy and paste it back into your document, or ask follow-up questions
+          to refine your results. This will help you get unstuck, complete your
+          projects and homework with ease, and increase your productivity.
           <hr />
           <Checkbox
             onChange={(e) => {

--- a/src/packages/next/components/landing/cocalc-com-features.tsx
+++ b/src/packages/next/components/landing/cocalc-com-features.tsx
@@ -26,6 +26,7 @@ import assignments from "public/features/cocalc-course-assignments-2019.png";
 import RTC from "public/features/cocalc-real-time-jupyter.png";
 import ComputeServers from "./compute-servers";
 import { LANDING_HEADER_LEVEL } from "./constants";
+import { DOC_AI } from "@cocalc/util/consts/ui";
 
 // NOTE: This component is only rendered if the onCoCalcCom customization variable is "true"
 export function CoCalcComFeatures() {
@@ -526,14 +527,10 @@ export function CoCalcComFeatures() {
       >
         <Paragraph>
           A wide range of{" "}
-          <A href={"https://doc.cocalc.com/chatgpt.html"}>
-            Generative AI Large Language Models
-          </A>{" "}
-          are highly integrated into {siteName}. This helps you{" "}
-          <A href={"https://doc.cocalc.com/chatgpt.html#jupyter-notebooks"}>
-            fix errors
-          </A>
-          , generate code or LaTeX snippets, summarize documents, and much more.
+          <A href={DOC_AI}>Generative AI Large Language Models</A> are highly
+          integrated into {siteName}. This helps you{" "}
+          <A href={`${DOC_AI}#jupyter-notebooks`}>fix errors</A>, generate code
+          or LaTeX snippets, summarize documents, and much more.
         </Paragraph>
       </Info>
     );

--- a/src/packages/next/pages/features/ai.tsx
+++ b/src/packages/next/pages/features/ai.tsx
@@ -3,11 +3,15 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { Col, Layout, Row } from "antd";
+import { Flex, Layout } from "antd";
 
 import AIAvatar from "@cocalc/frontend/components/ai-avatar";
+import AnthropicAvatar from "@cocalc/frontend/components/anthropic-avatar";
 import GoogleGeminiLogo from "@cocalc/frontend/components/google-gemini-avatar";
+import MistralAvatar from "@cocalc/frontend/components/mistral-avatar";
+import OllamaAvatar from "@cocalc/frontend/components/ollama-avatar";
 import OpenAIAvatar from "@cocalc/frontend/components/openai-avatar";
+import { DOC_AI } from "@cocalc/util/consts/ui";
 import { COLORS } from "@cocalc/util/theme";
 import Content from "components/landing/content";
 import Footer from "components/landing/footer";
@@ -37,7 +41,13 @@ const title = `AI Assistant`;
 const component = title;
 
 export default function AI({ customize }) {
-  const { googleVertexaiEnabled, openaiEnabled } = customize;
+  const {
+    googleVertexaiEnabled,
+    openaiEnabled,
+    mistralEnabled,
+    anthropicEnabled,
+    ollamaEnabled,
+  } = customize;
 
   const iconTxtStyle = {
     fontSize: "20px",
@@ -126,18 +136,20 @@ export default function AI({ customize }) {
                 <Paragraph style={{ marginTop: "20px" }}>
                   There are various places where an AI Assistant appears in
                   CoCalc, as illustrated below and{" "}
-                  <A href="https://doc.cocalc.com/chatgpt.html">
-                    explained in the docs
-                  </A>
-                  .
+                  <A href={DOC_AI}>explained in the docs</A>.
                 </Paragraph>
                 <Paragraph>
                   CoCalc currently supports the following language models:
                 </Paragraph>
                 <Paragraph>
-                  <Row gutter={[30, 30]}>
+                  <Flex
+                    style={{ margin: "20px" }}
+                    justify="space-between"
+                    align="center"
+                    wrap="wrap"
+                  >
                     {openaiEnabled ? (
-                      <Col md={6} offset={6}>
+                      <span style={{ margin: "10px", whiteSpace: "nowrap" }}>
                         <OpenAIAvatar size={32} />{" "}
                         <A
                           href="https://openai.com/chatgpt"
@@ -145,10 +157,10 @@ export default function AI({ customize }) {
                         >
                           OpenAI's ChatGPT
                         </A>
-                      </Col>
+                      </span>
                     ) : undefined}
                     {googleVertexaiEnabled ? (
-                      <Col md={6}>
+                      <span style={{ margin: "10px", whiteSpace: "nowrap" }}>
                         <GoogleGeminiLogo size={32} />{" "}
                         <A
                           href="https://deepmind.google/technologies/gemini/"
@@ -156,9 +168,36 @@ export default function AI({ customize }) {
                         >
                           Google's Gemini
                         </A>
-                      </Col>
+                      </span>
                     ) : undefined}
-                  </Row>
+                    {anthropicEnabled ? (
+                      <span style={{ margin: "10px", whiteSpace: "nowrap" }}>
+                        <AnthropicAvatar size={32} />{" "}
+                        <A
+                          href="https://www.anthropic.com/claude"
+                          style={iconTxtStyle}
+                        >
+                          Anthropic's Claude
+                        </A>
+                      </span>
+                    ) : undefined}
+                    {mistralEnabled ? (
+                      <span style={{ margin: "10px", whiteSpace: "nowrap" }}>
+                        <MistralAvatar size={32} />{" "}
+                        <A href="https://mistral.ai/" style={iconTxtStyle}>
+                          Mistral
+                        </A>
+                      </span>
+                    ) : undefined}
+                    {ollamaEnabled ? (
+                      <span style={{ margin: "10px", whiteSpace: "nowrap" }}>
+                        <OllamaAvatar size={32} />{" "}
+                        <A href="https://ollama.com/" style={iconTxtStyle}>
+                          Ollama
+                        </A>
+                      </span>
+                    ) : undefined}
+                  </Flex>
                 </Paragraph>
               </>
             }
@@ -178,7 +217,7 @@ export default function AI({ customize }) {
             <Paragraph>
               Here, a user learning <A href="https://pytorch.org/">PyTorch</A>{" "}
               asks ChatGPT by{" "}
-              <A href="https://doc.cocalc.com/chatgpt.html#chatgpt-in-chat-rooms-and-side-chat">
+              <A href={`${DOC_AI}#chatgpt-in-chat-rooms-and-side-chat`}>
                 mentioning
               </A>{" "}
               <Text code>@chatgpt</Text> in a{" "}
@@ -208,6 +247,7 @@ export default function AI({ customize }) {
           </Info>
 
           <Info
+            narrow
             title={"Generate Jupyter Cells"}
             icon="jupyter"
             anchor="a-jupyter"

--- a/src/packages/util/consts/ui.ts
+++ b/src/packages/util/consts/ui.ts
@@ -18,3 +18,7 @@ export const SHARE_FLAGS = {
   DISABLED: { unlisted: false, disabled: true, authenticated: false }, // aka PRIVATE
   AUTHENTICATED: { unlisted: false, disabled: false, authenticated: true },
 } as const;
+
+// documentation pages
+
+export const DOC_AI = "https://doc.cocalc.com/ai.html";


### PR DESCRIPTION
# Description

* switch to the ai.html page for docs
* mention all enabled AI models on AI feature page
* some minor tweaks, like, accurately defining the "Customize" type and getting rid of a few too specific "ChatGPT" mentions.



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
