### PR TITLE
next/store: warnings for low/high cpu/mem and tweaking profiles

### DIFF
--- a/src/packages/next/components/store/quota-config-presets.tsx
+++ b/src/packages/next/components/store/quota-config-presets.tsx
@@ -47,7 +47,8 @@ type PresetEntries = {
 
 // some constants to keep text and preset in sync
 const STANDARD_CPU = 1;
-const STANDARD_RAM = 2;
+const STANDARD_RAM = 3;
+const LARGE_RAM = 8;
 const STANDARD_DISK = 3;
 
 const WARN_SELECT_NUMBER_PROJECTS = (
@@ -126,7 +127,7 @@ export const PRESETS: PresetEntries = {
       </>
     ),
     cpu: 1,
-    ram: 2 * STANDARD_RAM,
+    ram: STANDARD_RAM + 1,
     disk: 2 * STANDARD_DISK,
     uptime: "medium",
     member: true,
@@ -161,7 +162,7 @@ export const PRESETS: PresetEntries = {
       </>
     ),
     cpu: 1,
-    ram: 6,
+    ram: 2 * STANDARD_RAM,
     disk: 15,
     uptime: "medium",
     member: true,
@@ -189,7 +190,7 @@ export const PRESETS: PresetEntries = {
       </>
     ),
     cpu: 1,
-    ram: 6,
+    ram: LARGE_RAM,
     disk: 10,
     uptime: "day",
     member: true,
@@ -208,7 +209,7 @@ export const PRESETS: PresetEntries = {
       </>
     ),
     cpu: 2,
-    ram: 8,
+    ram: LARGE_RAM,
     disk: 10,
     uptime: "medium",
     member: true,

--- a/src/packages/next/components/store/site-license.tsx
+++ b/src/packages/next/components/store/site-license.tsx
@@ -7,26 +7,28 @@
 Create a new site license.
 */
 import { Form, Input } from "antd";
+import { isEmpty } from "lodash";
 import { useEffect, useRef, useState } from "react";
-import PaygInfo from "./payg-info";
+
 import { Icon } from "@cocalc/frontend/components/icon";
 import { get_local_storage } from "@cocalc/frontend/misc/local-storage";
 import { CostInputPeriod } from "@cocalc/util/licenses/purchase/types";
+import { computeCost } from "@cocalc/util/licenses/store/compute-cost";
+import { Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
 import Loading from "components/share/loading";
 import SiteName from "components/share/site-name";
 import apiPost from "lib/api/post";
 import { MAX_WIDTH } from "lib/config";
 import { useScrollY } from "lib/use-scroll-y";
-import { isEmpty } from "lodash";
 import { useRouter } from "next/router";
 import { AddBox } from "./add-box";
 import { ApplyLicenseToProject } from "./apply-license-to-project";
-import { computeCost } from "@cocalc/util/licenses/store/compute-cost";
 import { InfoBar } from "./cost-info-bar";
 import { MemberHostingAndIdleTimeout } from "./member-idletime";
+import PaygInfo from "./payg-info";
 import { QuotaConfig } from "./quota-config";
-import { PRESET_MATCH_FIELDS, PRESETS, Presets } from "./quota-config-presets";
+import { PRESETS, PRESET_MATCH_FIELDS, Presets } from "./quota-config-presets";
 import { decodeFormValues, encodeFormValues } from "./quota-query-params";
 import { Reset } from "./reset";
 import { RunLimit } from "./run-limit";
@@ -34,7 +36,6 @@ import { SignInToPurchase } from "./sign-in-to-purchase";
 import { TitleDescription } from "./title-description";
 import { ToggleExplanations } from "./toggle-explanations";
 import { UsageAndDuration } from "./usage-and-duration";
-import { Paragraph, Title } from "components/misc";
 
 const DEFAULT_PRESET: Presets = "standard";
 


### PR DESCRIPTION
# Description

This is a quick idea I had. The license configurator will explicitly warn about maybe a bad experience with a low memory choice, and also warn about picking a compute server or VM instead of a high memory or cpu cores choice. This gives immediate feedback very early, right where the choice happens. It's also conditional on the action of the user, hence due to being dynamic it is more visible.

… and of course, params and the text in detail could be adjusted.

## high cpu/ram

![Screenshot from 2024-05-08 18-18-38](https://github.com/sagemathinc/cocalc/assets/207405/cdd9aed0-f40f-4d15-af1b-067fe8ab9931)

## low mem

![Screenshot from 2024-05-08 18-18-01](https://github.com/sagemathinc/cocalc/assets/207405/cb9044dc-caa1-4560-a34c-5488a4395a15)

## otherwise, no warnings, this is the default config (3gb ram)

![Screenshot from 2024-05-08 18-27-48](https://github.com/sagemathinc/cocalc/assets/207405/b4e71caf-c12c-4598-addd-f052e25e0f48)




## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
