### PR TITLE
frontend/llm assistant: pre-select the first preset and process input

### DIFF
--- a/src/packages/frontend/frame-editors/llm/context.tsx
+++ b/src/packages/frontend/frame-editors/llm/context.tsx
@@ -23,7 +23,7 @@ export default function Context({ value, info }) {
       </b>
     );
   }
-  if (info == "md" || info == "markdown") {
+  if (info === "md" || info === "markdown") {
     return (
       <StaticMarkdown
         value={trunc_middle(value, MAX_SIZE, MISSING)}

--- a/src/packages/frontend/frame-editors/llm/create-chat.ts
+++ b/src/packages/frontend/frame-editors/llm/create-chat.ts
@@ -50,7 +50,7 @@ export async function createChatMessage(
   frameId: string,
   options: Options,
   input: string | undefined,
-) {
+): Promise<{ input: string; message: string }> {
   let { codegen } = options;
   const { command, model } = options;
 


### PR DESCRIPTION
# Description

fixing  #7539 by pre-selecting the first prompt template + some cleanups. also not showing "no context" if there is no derived `input`.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
