### PR TITLE
7474: Migrated `src/packages/{database,jupyter,project,static,sync,terminal,util}` test scripts to use TypeScript.

### DIFF
--- a/src/packages/database/jest.config.js
+++ b/src/packages/database/jest.config.js
@@ -1,12 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  moduleDirectories: ["dist", "node_modules"],
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig-dist.json'
-    }
-  }
 };

--- a/src/packages/database/package.json
+++ b/src/packages/database/package.json
@@ -50,7 +50,7 @@
     "build": "../node_modules/.bin/tsc  --build && coffee -c -o dist/ ./",
     "clean": "rm -rf dist",
     "tsc": "../node_modules/.bin/tsc --watch  --pretty --preserveWatchOutput",
-    "test": "../node_modules/.bin/jest dist/",
+    "test": "pnpm exec jest",
     "prepublishOnly": "pnpm test"
   },
   "repository": {

--- a/src/packages/jupyter/jest.config.js
+++ b/src/packages/jupyter/jest.config.js
@@ -1,12 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  moduleDirectories: ["dist", "node_modules"],
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig-dist.json'
-    }
-  }
 };

--- a/src/packages/jupyter/package.json
+++ b/src/packages/jupyter/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "build": "../node_modules/.bin/tsc --build",
-    "test": "pnpm exec jest dist",
+    "test": "pnpm exec jest",
     "tsc": "../node_modules/.bin/tsc --watch --pretty --preserveWatchOutput"
   },
   "files": [

--- a/src/packages/next/package.json
+++ b/src/packages/next/package.json
@@ -34,7 +34,7 @@
     "clean": "rm -rf node_modules .next dist",
     "start": "unset PGHOST; pnpm exec next start",
     "start-project": "unset PGHOST PGUSER COCALC_ROOT; export PORT=5000 BASE_PATH=/$COCALC_PROJECT_ID/port/5000; echo https://cocalc.com$BASE_PATH; pnpm start",
-    "test": "pnpm exec tsc --build tsconfig-dist.json && NODE_ENV='dev' pnpm exec jest ./dist && NODE_ENV='production' pnpm exec jest ./dist/lib/api/framework.test.js",
+    "test": "NODE_ENV='dev' pnpm exec jest && NODE_ENV='production' pnpm exec jest ./lib/api/framework.test.ts",
     "prepublishOnly": "pnpm test",
     "patch-openapi": "sed -i '/^interface NrfOasData {/s/^interface/export interface/' node_modules/next-rest-framework/dist/index.d.ts",
     "generate-openapi": "cd dist && rm -f public && ln -sf ../public public && NODE_ENV='dev' NODE_PATH=`pwd` npx next-rest-framework generate",

--- a/src/packages/project/jest.config.js
+++ b/src/packages/project/jest.config.js
@@ -1,12 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  moduleDirectories: ["dist", "node_modules"],
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig-dist.json'
-    }
-  }
 };

--- a/src/packages/project/package.json
+++ b/src/packages/project/package.json
@@ -77,7 +77,7 @@
     "start": "NODE_OPTIONS='--trace-warnings --unhandled-rejections=strict --enable-source-maps' pnpm cocalc-project",
     "build": "../node_modules/.bin/tsc --build",
     "tsc": "../node_modules/.bin/tsc  --watch  --pretty --preserveWatchOutput",
-    "test": "COCALC_PROJECT_ID=812abe34-a382-4bd1-9071-29b6f4334f03 COCALC_USERNAME=user ../node_modules/.bin/jest  dist/",
+    "test": "COCALC_PROJECT_ID=812abe34-a382-4bd1-9071-29b6f4334f03 COCALC_USERNAME=user pnpm exec jest",
     "prepublishOnly": "pnpm test",
     "clean": "rm -rf dist"
   },

--- a/src/packages/static/jest.config.js
+++ b/src/packages/static/jest.config.js
@@ -1,12 +1,9 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  moduleDirectories: ["dist", "node_modules"],
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig-dist.json'
-    }
+  moduleNameMapper: {
+    ".+\\.(svg|css)$": "identity-obj-proxy"
   }
 };

--- a/src/packages/static/package.json
+++ b/src/packages/static/package.json
@@ -18,7 +18,7 @@
     "webpack-measure-prod": "COCALC_OUTPUT=dist-prod-measure MEASURE=true pnpm webpack-prod",
     "build": "pnpm run build-dev && ./production-build.py",
     "build-dev": "pnpm run copy-css && cd src && ../../node_modules/.bin/tsc --build ",
-    "test": "../node_modules/.bin/jest dist-ts",
+    "test": "pnpm exec jest",
     "prepublishOnly": "pnpm test"
   },
   "repository": {
@@ -40,11 +40,6 @@
   "license": "SEE LICENSE.md",
   "bugs": {
     "url": "https://github.com/sagemathinc/cocalc/issues"
-  },
-  "jest": {
-    "moduleNameMapper": {
-      ".+\\.(svg|css)$": "identity-obj-proxy"
-    }
   },
   "homepage": "https://github.com/sagemathinc/cocalc/tree/master/src/packages/static",
   "dependencies": {

--- a/src/packages/sync/jest.config.js
+++ b/src/packages/sync/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     "@cocalc/util/dmp": "<rootDir>/../util/dist/dmp",
     "@cocalc/util/misc": "<rootDir>/../util/dist/misc",
   },
-  testMatch: ["**/__tests__/**/*.[tj]s?(x)", "**/?(*.)+(spec|test).[tj]s?(x)"],
+  testMatch: ["**/__tests__/**/*.[t]s?(x)", "**/?(*.)+(spec|test).[t]s?(x)"],
   testPathIgnorePatterns: ["/node_modules/"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
 };

--- a/src/packages/sync/package.json
+++ b/src/packages/sync/package.json
@@ -12,7 +12,7 @@
     "preinstall": "npx only-allow pnpm",
     "build": "../node_modules/.bin/tsc --build",
     "tsc": "../node_modules/.bin/tsc --watch --pretty --preserveWatchOutput",
-    "test": "../node_modules/.bin/jest ./dist",
+    "test": "pnpm exec jest",
     "prepublishOnly": "pnpm test"
   },
   "files": [

--- a/src/packages/terminal/jest.config.js
+++ b/src/packages/terminal/jest.config.js
@@ -1,12 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  moduleDirectories: ["dist", "node_modules"],
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig-dist.json'
-    }
-  }
 };

--- a/src/packages/terminal/package.json
+++ b/src/packages/terminal/package.json
@@ -8,7 +8,7 @@
     "build": "../node_modules/.bin/tsc --build",
     "clean": "rm -rf dist node_modules",
     "_test_doc_": "--runInBand -- serial only because crashes when running all tests across all packages",
-    "test": "pnpm exec jest dist --runInBand  --forceExit ",
+    "test": "pnpm exec jest --runInBand  --forceExit ",
     "tsc": "../node_modules/.bin/tsc --watch --pretty --preserveWatchOutput"
   },
   "files": [

--- a/src/packages/util/jest.config.js
+++ b/src/packages/util/jest.config.js
@@ -1,12 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  moduleDirectories: ["dist", "node_modules"],
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig-dist.json'
-    }
-  }
 };

--- a/src/packages/util/package.json
+++ b/src/packages/util/package.json
@@ -17,7 +17,7 @@
     "preinstall": "npx only-allow pnpm",
     "build": "pnpm exec tsc --build",
     "tsc": "pnpm exec tsc  --watch  --pretty --preserveWatchOutput",
-    "test": "pnpm exec jest dist",
+    "test": "pnpm exec jest",
     "prepublishOnly": "pnpm test"
   },
   "files": [


### PR DESCRIPTION
# Description

These tests all pass on my machine (from the `src` directory, I ran `pnpm clean && pnpm make-dev && pnpm test`), but I'd recommend waiting for a successful GitHub build before merging just in case there are breaking differences between dev/build servers.

Note that `src/packages/hub` cannot be migrated until that module no longer mixes CoffeeScript and TypeScript.