### PR TITLE
ux/7532: Extracted landing page link rendering logic to a single source of truth.

### DIFF
--- a/src/packages/next/components/landing/footer.tsx
+++ b/src/packages/next/components/landing/footer.tsx
@@ -55,76 +55,131 @@ interface FooterColumn {
 
 export default function Footer() {
   const {
+    contactEmail,
+    onCoCalcCom,
     organizationName,
     organizationURL,
+    enabledPages,
     termsOfServiceURL,
-    contactEmail,
-    landingPages,
-    imprint,
-    onCoCalcCom,
-    isCommercial,
-    imprintOrPolicies,
-    shareServer,
   } = useCustomize();
 
   const footerColumns: Array<FooterColumn> = [
     {
       header: "Product",
       links: [
-        { text: "Store", url: "/store", hide: !isCommercial },
-        { text: "Features", url: "/features" },
-        { text: "Licenses", url: "/licenses" },
-        { text: "Pricing", url: "/pricing", hide: !isCommercial },
-        { text: "On Premises", url: "/pricing/onprem", hide: !onCoCalcCom },
         {
-          text: "System Status",
+          text: "Store", url: "/store",
+          hide: !enabledPages?.store,
+        },
+        {
+          text: "Features",
+          url: "/features",
+          hide: !enabledPages?.features,
+        },
+        {
+          text: "Licenses",
+          url: "/licenses",
+          hide: !enabledPages?.licenses,
+        },
+        {
+          text: "Pricing",
+          url: "/pricing",
+          hide: !enabledPages?.pricing,
+        },
+        {
+          text: "On Premises",
+          url: "/pricing/onprem",
+          hide: !enabledPages?.onPrem,
+        },
+        {
+          text: "System Activity",
+          url: "/info/status",
+          hide: !enabledPages?.systemActivity,
+        },
+        {
+          text: "Status",
           url: "https://status.cocalc.com/",
-          hide: !onCoCalcCom,
+          hide: !enabledPages?.status,
         },
       ],
     },
     {
       header: "Resources",
       links: [
-        { text: "Documentation", url: "/info/doc" },
+        {
+          text: "Documentation",
+          url: "/info/doc",
+          hide: !enabledPages?.info,
+        },
         {
           text: "Compute Servers",
           url: "https://doc.cocalc.com/compute_server.html",
-          hide: !isCommercial,
+          hide: !enabledPages?.compute,
         },
         {
           text: "Public Share",
           url: "/share/public_paths/page/1",
-          hide: !shareServer,
+          hide: !enabledPages?.share,
         },
-        { text: "Software", url: "/software", hide: !landingPages },
-        { text: "System Monitor", url: "/info/status" },
-        { text: "Support", url: "/support" },
+        {
+          text: "Software",
+          url: "/software",
+          hide: !enabledPages?.software,
+        },
+        {
+          text: "Support",
+          url: "/support",
+          hide: !enabledPages?.support,
+        },
       ],
     },
     {
       header: "Company",
       links: [
-        { text: "About", url: "/about", hide: !landingPages },
-        { text: "Contact", url: contactEmail || "", hide: !contactEmail },
-        { text: "Events", url: "/about/events" },
-        { text: "Team", url: "/about/team", hide: !landingPages },
-        { text: "Imprint", url: "/policies/imprint", hide: !imprint },
-        { text: "News", url: "/news" },
+        {
+          text: "About",
+          url: "/about",
+          hide: !enabledPages?.about.index,
+        },
+        {
+          text: "Contact",
+          url: contactEmail || "",
+          hide: !enabledPages?.contact,
+        },
+        {
+          text: "Events",
+          url: "/about/events",
+          hide: !enabledPages?.about.events,
+        },
+        {
+          text: "Team",
+          url: "/about/team",
+          hide: !enabledPages?.about.team,
+        },
+        {
+          text: "Imprint",
+          url: "/policies/imprint",
+          hide: !enabledPages?.policies.imprint,
+        },
+        {
+          text: "News",
+          url: "/news",
+          hide: !enabledPages?.news,
+        },
         {
           text: "Policies",
           url: "/policies",
-          hide: !(landingPages || imprintOrPolicies),
+          hide: !enabledPages?.policies.index,
         },
         {
           text: "Terms of Service",
           url: termsOfServiceURL || "",
-          hide: landingPages || !termsOfServiceURL,
+          hide: !enabledPages?.termsOfService,
         },
         {
           text: organizationName || "Company",
           url: organizationURL || "",
-          hide: !organizationURL,
+          hide: !enabledPages?.organization,
         },
       ],
     },
@@ -170,7 +225,7 @@ export default function Footer() {
               style={LOGO_COLUMN_STYLE}
             >
               <Logo type="rectangular" width={150} />
-              {isCommercial && (
+              {onCoCalcCom && (
                 <SocialMediaIconList
                   links={{
                     facebook: "https://www.facebook.com/CoCalcOnline",

--- a/src/packages/next/components/landing/header.tsx
+++ b/src/packages/next/components/landing/header.tsx
@@ -48,16 +48,13 @@ interface Props {
 export default function Header(props: Props) {
   const { page, subPage, softwareEnv, runnableTag } = props;
   const {
-    isCommercial,
-    anonymousSignup,
     siteName,
     termsOfServiceURL,
-    shareServer,
-    landingPages,
     account,
     onCoCalcCom,
     openaiEnabled,
     jupyterApiEnabled,
+    enabledPages,
   } = useCustomize();
 
   if (basePath == null) return null;
@@ -144,32 +141,31 @@ export default function Header(props: Props) {
             Your Projects
           </a>
         )}
-        {landingPages && (
-          <>
-            {isCommercial && (
-              <A
-                href="/store"
-                style={page == "store" ? SelectedStyle : LinkStyle}
-              >
-                Store
-              </A>
-            )}
-            <A
-              href="/features/"
-              style={page == "features" ? SelectedStyle : LinkStyle}
-            >
-              Features
-            </A>
-            {/* <A
-              href="/software"
-              style={page == "software" ? SelectedStyle : LinkStyle}
-            >
-              Software
-            </A>
-            */}
-          </>
+        {enabledPages?.store && (
+          <A
+            href="/store"
+            style={page == "store" ? SelectedStyle : LinkStyle}
+          >
+            Store
+          </A>
         )}
-        {!landingPages && termsOfServiceURL && (
+        {enabledPages?.features && (
+          <A
+            href="/features/"
+            style={page == "features" ? SelectedStyle : LinkStyle}
+          >
+            Features
+          </A>
+        )}
+        {/* supportedRoutes?.software && (
+          <A
+            href="/software"
+            style={page == "software" ? SelectedStyle : LinkStyle}
+          >
+            Software
+          </A>
+        )*/}
+        {enabledPages?.legal && (
           <A
             style={LinkStyle}
             href={termsOfServiceURL}
@@ -178,14 +174,16 @@ export default function Header(props: Props) {
             Legal
           </A>
         )}
-        <A
-          style={page == "info" ? SelectedStyle : LinkStyle}
-          href="/info"
-          title="Documentation and links to resources for learning more about CoCalc"
-        >
-          Docs
-        </A>
-        {shareServer && (
+        {enabledPages?.info && (
+          <A
+            style={page == "info" ? SelectedStyle : LinkStyle}
+            href="/info"
+            title="Documentation and links to resources for learning more about CoCalc"
+          >
+            Docs
+          </A>
+        )}
+        {enabledPages?.share && (
           <Link
             href={"/share/public_paths/page/1"}
             style={page == "share" ? SelectedStyle : LinkStyle}
@@ -194,21 +192,25 @@ export default function Header(props: Props) {
             Share
           </Link>
         )}
-        <A
-          style={page == "support" ? SelectedStyle : LinkStyle}
-          href="/support"
-          title="Create and view support tickets"
-        >
-          Support
-        </A>{" "}
-        <A
-          style={page == "news" ? SelectedStyle : LinkStyle}
-          href="/news"
-          title={`News about ${siteName}`}
-        >
-          News
-        </A>{" "}
-        {landingPages && (
+        {enabledPages?.support && (
+          <A
+            style={page == "support" ? SelectedStyle : LinkStyle}
+            href="/support"
+            title="Create and view support tickets"
+          >
+            Support
+          </A>
+        )}
+        {enabledPages?.news && (
+          <A
+            style={page == "news" ? SelectedStyle : LinkStyle}
+            href="/news"
+            title={`News about ${siteName}`}
+          >
+            News
+          </A>
+        )}
+        {enabledPages?.about.index && (
           <A
             style={page == "about" ? SelectedStyle : LinkStyle}
             href="/about"
@@ -239,7 +241,7 @@ export default function Header(props: Props) {
             </A>
           </>
         )}
-        {!account && anonymousSignup && (
+        {enabledPages?.auth.try && (
           <A
             style={page == "try" ? SelectedStyle : LinkStyle}
             href={"/auth/try"}

--- a/src/packages/next/lib/customize.ts
+++ b/src/packages/next/lib/customize.ts
@@ -6,6 +6,42 @@
 import { createContext, useContext } from "react";
 import type { Customize as ServerCustomize } from "@cocalc/database/settings/customize";
 
+interface EnabledPageBranch {
+  [key: string]: boolean | undefined | EnabledPageBranch;
+}
+
+interface EnabledPageTree extends EnabledPageBranch {
+  auth: {
+    try: boolean | undefined,
+  };
+  about: {
+    index: boolean | undefined,
+    events: boolean | undefined,
+    team: boolean | undefined,
+  };
+  compute: boolean | undefined;
+  contact: boolean | undefined;
+  features: boolean | undefined;
+  info: boolean | undefined;
+  legal: boolean | undefined;
+  licenses: boolean | undefined;
+  news: boolean | undefined;
+  onPrem: boolean | undefined;
+  organization: boolean | undefined;
+  policies: {
+    index: boolean | undefined;
+    imprint: boolean | undefined;
+  }
+  pricing: boolean | undefined;
+  share: boolean | undefined;
+  software: boolean | undefined;
+  store: boolean | undefined;
+  support: boolean | undefined;
+  systemActivity: boolean | undefined;
+  status: boolean | undefined;
+  termsOfService: boolean | undefined;
+}
+
 interface Customize extends ServerCustomize {
   account?: {
     account_id: string;
@@ -31,6 +67,7 @@ interface Customize extends ServerCustomize {
 
   jupyterApiEnabled?: boolean; // backend configured to use a pool of projects for sandboxed ephemeral jupyter code execution
   computeServersEnabled?: boolean; // backend configured to run on external compute servers
+  enabledPages?: EnabledPageTree; // tree structure which specifies supported routes for this install
 }
 
 const CustomizeContext = createContext<Partial<Customize>>({});


### PR DESCRIPTION
# Description

I'm opening this as a draft for now so that we can go over the business logic that dictates which page links should appear when. Once the business logic is satisfactory, this PR is ready to merge.

The link rendering logic has been consolidated to a single source of truth so that business logic is all in one place; see https://github.com/sagemathinc/cocalc/compare/master...schrodingersket:ux/7429?expand=1#diff-53c6b656252dc3b6591f8121477a8c83492b50363c59fc139ed2619d04c0d135R78 for the current configuration, which mirrors the existing logic as much as possible.

Fixes #7532.
