### PR TITLE
#7503: Added check for nullish `created`/`last_edited` timestamps on public share records.

### DIFF
--- a/src/packages/next/components/path/path.tsx
+++ b/src/packages/next/components/path/path.tsx
@@ -71,8 +71,8 @@ export interface PublicPathProps {
   // doesn't use the names. See https://github.com/sagemathinc/cocalc/issues/6115
   redirect?: string;
   jupyter_api: boolean;
-  created?: string; // ISO 8601 string
-  last_edited?: string; // ISO 8601 string
+  created: string|null; // ISO 8601 string
+  last_edited: string|null; // ISO 8601 string
   ogUrl?: string; // Open Graph URL for social media sharing
 }
 

--- a/src/packages/next/lib/share/get-public-path-info.ts
+++ b/src/packages/next/lib/share/get-public-path-info.ts
@@ -113,10 +113,18 @@ export default async function getPublicPathInfo({
       basePath,
       isStarred,
       ...details,
-      created: rows[0].created.toISOString(),
-      last_edited: rows[0].last_edited.toISOString(),
+      created: rows[0].created?.toISOString() ?? null,
+      last_edited: rows[0].last_edited?.toISOString() ?? null,
     };
   } catch (error) {
-    return { id, ...rows[0], relativePath, isStarred, error: error.toString() };
+    return {
+      id,
+      ...rows[0],
+      relativePath,
+      isStarred,
+      created: rows[0].created?.toISOString() ?? null,
+      last_edited: rows[0].last_edited?.toISOString() ?? null,
+      error: error.toString(),
+    };
   }
 }

--- a/src/packages/next/pages/share/public_paths/[...id].tsx
+++ b/src/packages/next/pages/share/public_paths/[...id].tsx
@@ -34,8 +34,12 @@ export default (props: PublicPathProps) => (
         />
       )}
 
-      <meta property="article:published_time" content={props.created} />
-      <meta property="article:modified_time" content={props.last_edited} />
+      {props.created && (
+        <meta property="article:published_time" content={props.created}/>
+      )}
+      {props.last_edited && (
+        <meta property="article:modified_time" content={props.last_edited}/>
+      )}
     </NextHead>
   </>
 );


### PR DESCRIPTION
# Description

This PR updates the corresponding `meta` tags on public share pages to handle null `created`/`last_edited` timestamps, since the database schema allows those columns to be null.

(follow-up to https://github.com/sagemathinc/cocalc/pull/7582).