### PR TITLE
frontend/llm: refactor and fix OpenAI vs Custom OpenAI

### DIFF
--- a/src/packages/frontend/editors/markdown-input/mentionable-users.tsx
+++ b/src/packages/frontend/editors/markdown-input/mentionable-users.tsx
@@ -13,7 +13,6 @@ import { redux, useMemo, useTypedRedux } from "@cocalc/frontend/app-framework";
 import AnthropicAvatar from "@cocalc/frontend/components/anthropic-avatar";
 import GoogleGeminiLogo from "@cocalc/frontend/components/google-gemini-avatar";
 import MistralAvatar from "@cocalc/frontend/components/mistral-avatar";
-import OllamaAvatar from "@cocalc/frontend/components/ollama-avatar";
 import OpenAIAvatar from "@cocalc/frontend/components/openai-avatar";
 import { LLMModelPrice } from "@cocalc/frontend/frame-editors/llm/llm-selector";
 import { useProjectContext } from "@cocalc/frontend/project/context";
@@ -37,6 +36,7 @@ import {
 } from "@cocalc/util/db-schema/llm-utils";
 import { cmp, timestamp_cmp, trunc_middle } from "@cocalc/util/misc";
 import { CustomLLMPublic } from "@cocalc/util/types/llm";
+import { LanguageModelVendorAvatar } from "../../components/language-model-icon";
 import { Item as CompleteItem } from "./complete";
 
 // we make the show_llm_main_menu field required, to avoid forgetting to set it ;-)
@@ -259,8 +259,8 @@ function mentionableUsers({
           value,
           label: (
             <span>
-              <OllamaAvatar size={size} /> {conf.display}{" "}
-              <LLMModelPrice model={m} floatRight />
+              <LanguageModelVendorAvatar model={value} size={size} />{" "}
+              {conf.display} <LLMModelPrice model={m} floatRight />
             </span>
           ),
           search: search_term,
@@ -283,8 +283,8 @@ function mentionableUsers({
           value,
           label: (
             <span>
-              <OpenAIAvatar size={size} /> {conf.display}{" "}
-              <LLMModelPrice model={m} floatRight />
+              <LanguageModelVendorAvatar model={value} size={size} />{" "}
+              {conf.display} <LLMModelPrice model={m} floatRight />
             </span>
           ),
           search: search_term,

--- a/src/packages/frontend/frame-editors/llm/components.tsx
+++ b/src/packages/frontend/frame-editors/llm/components.tsx
@@ -6,11 +6,10 @@ export function getCustomLLMGroup() {
   const site_name = customize.get("site_name");
   const organization_name = customize.get("organization_name") ?? "";
   return {
-    title: `These language models on ${site_name} are managed by ${organization_name}`,
+    title: `Managed by ${organization_name || site_name}`,
     label: (
       <>
-        <Text strong>{site_name} language models</Text> – managed by{" "}
-        {organization_name}
+        <Text strong>{site_name} language models</Text>
       </>
     ),
   };

--- a/src/packages/frontend/frame-editors/llm/components.tsx
+++ b/src/packages/frontend/frame-editors/llm/components.tsx
@@ -1,0 +1,17 @@
+import { redux } from "@cocalc/frontend/app-framework";
+import { Text } from "@cocalc/frontend/components";
+
+export function getCustomLLMGroup() {
+  const customize = redux.getStore("customize");
+  const site_name = customize.get("site_name");
+  const organization_name = customize.get("organization_name") ?? "";
+  return {
+    title: `These language models on ${site_name} are managed by ${organization_name}`,
+    label: (
+      <>
+        <Text strong>{site_name} language models</Text> – managed by{" "}
+        {organization_name}
+      </>
+    ),
+  };
+}

--- a/src/packages/frontend/frame-editors/llm/llm-query-dropdown.tsx
+++ b/src/packages/frontend/frame-editors/llm/llm-query-dropdown.tsx
@@ -7,8 +7,8 @@ import { LanguageModelVendorAvatar } from "@cocalc/frontend/components/language-
 import { modelToName } from "@cocalc/frontend/frame-editors/llm/llm-selector";
 import { useAvailableLLMs } from "@cocalc/frontend/frame-editors/llm/use-llm-menu-options";
 import { useProjectContext } from "@cocalc/frontend/project/context";
-import { LLM_PROVIDER } from "@cocalc/util/db-schema/llm-utils";
 import { LLMTools } from "@cocalc/jupyter/types";
+import { LLM_PROVIDER } from "@cocalc/util/db-schema/llm-utils";
 
 interface Props {
   llmTools?: Pick<LLMTools, "model" | "setModel">;
@@ -26,7 +26,7 @@ export function LLMQueryDropdownButton({
   disabled = false,
 }: Props) {
   const { project_id } = useProjectContext();
-  const models = useAvailableLLMs(project_id);
+  const modelsByService = useAvailableLLMs(project_id);
 
   function renderOkText() {
     if (llmTools == null) return <></>;
@@ -40,14 +40,17 @@ export function LLMQueryDropdownButton({
   function getItems(): MenuProps["items"] {
     const ret: MenuProps["items"] = [];
     let first = true;
-    for (const [service, entry] of Object.entries(models)) {
+    for (const [service, entry] of Object.entries(modelsByService)) {
       const { models } = entry;
       if (models.length === 0) continue;
 
       if (!first) ret.push({ type: "divider" });
       first = false;
 
-      const { name, short } = LLM_PROVIDER[service];
+      const { name, short } =
+        service === "custom"
+          ? { name: entry.name, short: entry.desc }
+          : LLM_PROVIDER[service];
       ret.push({
         type: "group",
         label: (
@@ -57,6 +60,7 @@ export function LLMQueryDropdownButton({
           </>
         ),
       });
+
       for (const model of models) {
         const { name, title, desc, price } = model;
         ret.push({

--- a/src/packages/frontend/frame-editors/llm/llm-selector.tsx
+++ b/src/packages/frontend/frame-editors/llm/llm-selector.tsx
@@ -109,7 +109,15 @@ export default function LLMSelector({
 
     if (service === "custom") {
       const { title, label } = getCustomLLMGroup();
-      ret.push({ label, title, options });
+      ret.push({
+        label: (
+          <>
+            {label} – {title}
+          </>
+        ),
+        title: "These language models are configured by the administrators.",
+        options,
+      });
     } else {
       const { name, desc, short } = LLM_PROVIDER[service];
       const label = (

--- a/src/packages/frontend/frame-editors/llm/llm-selector.tsx
+++ b/src/packages/frontend/frame-editors/llm/llm-selector.tsx
@@ -8,7 +8,9 @@ import { LanguageModelVendorAvatar } from "@cocalc/frontend/components/language-
 import {
   ANTHROPIC_MODELS,
   GOOGLE_MODELS,
+  LANGUAGE_MODEL_SERVICES,
   LLMServiceName,
+  LLMServicesAvailable,
   LLM_DESCR,
   LLM_PROVIDER,
   LLM_USERNAMES,
@@ -27,8 +29,9 @@ import {
   toCustomOpenAIModel,
   toOllamaModel,
 } from "@cocalc/util/db-schema/llm-utils";
-import type { CustomLLMPublic } from "@cocalc/util/types/llm";
 import { round2up } from "@cocalc/util/misc";
+import type { CustomLLMPublic } from "@cocalc/util/types/llm";
+import { getCustomLLMGroup } from "./components";
 
 type SizeType = ConfigProviderProps["componentSize"];
 
@@ -54,36 +57,16 @@ export default function LLMSelector({
   // ATTN: you cannot use useProjectContext because this component is used outside a project context
   // when it is opened via an error in the gutter of a latex document. (I don't know why, maybe fixable)
   const projectsStore = redux.getStore("projects");
-  const showOpenAI = projectsStore.hasLanguageModelEnabled(
-    project_id,
-    undefined,
-    "openai",
-  );
-  const showGoogle = projectsStore.hasLanguageModelEnabled(
-    project_id,
-    undefined,
-    "google",
-  );
-  const showMistral = projectsStore.hasLanguageModelEnabled(
-    project_id,
-    undefined,
-    "mistralai",
-  );
-  const showAnthropic = projectsStore.hasLanguageModelEnabled(
-    project_id,
-    undefined,
-    "anthropic",
-  );
-  const showOllama = projectsStore.hasLanguageModelEnabled(
-    project_id,
-    undefined,
-    "ollama",
-  );
-  const showCustomOpenAI = projectsStore.hasLanguageModelEnabled(
-    project_id,
-    undefined,
-    "custom_openai",
-  );
+
+  const show = LANGUAGE_MODEL_SERVICES.reduce((cur, svc) => {
+    cur[svc] = projectsStore.hasLanguageModelEnabled(
+      project_id,
+      undefined,
+      svc,
+    );
+    return cur;
+  }, {}) as LLMServicesAvailable;
+
   const ollama = useTypedRedux("customize", "ollama");
   const custom_openai = useTypedRedux("customize", "custom_openai");
   const selectableLLMs = useTypedRedux("customize", "selectable_llms");
@@ -117,24 +100,29 @@ export default function LLMSelector({
 
   function makeLLMGroup(
     ret: NonNullable<SelectProps["options"]>,
-    service: LLMServiceName,
+    service: LLMServiceName | "custom",
     options,
   ) {
     // there could be "undefined" in the list of options
     options = options?.filter((o) => !!o) as SelectProps["options"];
     if (options?.length === 0) return;
-    const info = LLM_PROVIDER[service];
-    const label = (
-      <>
-        <Text strong>{info.name}</Text> – {info.short}
-      </>
-    );
-    const title = info.desc;
-    ret.push({ label, title, options });
+
+    if (service === "custom") {
+      const { title, label } = getCustomLLMGroup();
+      ret.push({ label, title, options });
+    } else {
+      const { name, desc, short } = LLM_PROVIDER[service];
+      const label = (
+        <>
+          <Text strong>{name}</Text> – {short}
+        </>
+      );
+      ret.push({ label, title: desc, options });
+    }
   }
 
   function appendOpenAI(ret: NonNullable<SelectProps["options"]>): void {
-    if (!showOpenAI) return;
+    if (!show.openai) return;
     makeLLMGroup(
       ret,
       "openai",
@@ -143,7 +131,7 @@ export default function LLMSelector({
   }
 
   function appendGoogle(ret: NonNullable<SelectProps["options"]>): void {
-    if (!showGoogle) return;
+    if (!show.google) return;
     makeLLMGroup(
       ret,
       "google",
@@ -152,7 +140,7 @@ export default function LLMSelector({
   }
 
   function appendMistral(ret: NonNullable<SelectProps["options"]>): void {
-    if (!showMistral) return;
+    if (!show.mistralai) return;
     makeLLMGroup(
       ret,
       "mistralai",
@@ -161,7 +149,7 @@ export default function LLMSelector({
   }
 
   function appendAnthropic(ret: NonNullable<SelectProps["options"]>): void {
-    if (!showAnthropic) return;
+    if (!show.anthropic) return;
     makeLLMGroup(
       ret,
       "anthropic",
@@ -169,10 +157,9 @@ export default function LLMSelector({
     );
   }
 
-  function appendOllama(ret: NonNullable<SelectProps["options"]>): void {
-    if (!showOllama || !ollama) return;
+  function appendOllama(options: NonNullable<SelectProps["options"]>): void {
+    if (!show.ollama || !ollama) return;
 
-    const options: NonNullable<SelectProps["options"]> = [];
     for (const [key, config] of Object.entries<CustomLLMPublic>(
       ollama.toJS(),
     )) {
@@ -200,13 +187,13 @@ export default function LLMSelector({
         ),
       });
     }
-    makeLLMGroup(ret, "ollama", options);
   }
 
-  function appendCustomOpenAI(ret: NonNullable<SelectProps["options"]>): void {
-    if (!showCustomOpenAI || !custom_openai) return;
+  function appendCustomOpenAI(
+    options: NonNullable<SelectProps["options"]>,
+  ): void {
+    if (!show.custom_openai || !custom_openai) return;
 
-    const options: NonNullable<SelectProps["options"]> = [];
     for (const [key, config] of Object.entries<CustomLLMPublic>(
       custom_openai.toJS(),
     )) {
@@ -234,7 +221,6 @@ export default function LLMSelector({
         ),
       });
     }
-    makeLLMGroup(ret, "custom_openai", options);
   }
 
   function getOptions(): SelectProps["options"] {
@@ -243,8 +229,12 @@ export default function LLMSelector({
     appendGoogle(ret);
     appendMistral(ret);
     appendAnthropic(ret);
-    appendOllama(ret);
-    appendCustomOpenAI(ret);
+    const custom: NonNullable<SelectProps["options"]> = [];
+    appendOllama(custom);
+    appendCustomOpenAI(custom);
+    if (custom.length > 0) {
+      makeLLMGroup(ret, "custom", custom);
+    }
     return ret;
   }
 

--- a/src/packages/server/llm/index.ts
+++ b/src/packages/server/llm/index.ts
@@ -65,7 +65,7 @@ export async function evaluate(opts: ChatOptions): Promise<string> {
   // We mainly wrap the high level call to keep all error messages hidden
   const model = opts.model ?? (await getDefaultModel());
   if (!isValidModel(model)) {
-    throw Error(`unsupported model "${model}"`);
+    throw new Error(`unsupported model "${model}"`);
   }
   try {
     return await evaluateImpl(opts);

--- a/src/packages/util/db-schema/llm-utils.ts
+++ b/src/packages/util/db-schema/llm-utils.ts
@@ -1,9 +1,9 @@
 // this contains bits and pieces from the wrongly named openai.ts file
 
+import { isEmpty } from "lodash";
 import LRU from "lru-cache";
 
 import { unreachable } from "@cocalc/util/misc";
-import { isEmpty } from "lodash";
 
 // "Client LLMs" are defined in the user's account settings
 // They directly query an external LLM service.

--- a/src/packages/util/db-schema/llm-utils.ts
+++ b/src/packages/util/db-schema/llm-utils.ts
@@ -203,6 +203,7 @@ export const LANGUAGE_MODEL_SERVICES = [
   "ollama",
   "custom_openai",
 ] as const;
+
 export type LLMServiceName = (typeof LANGUAGE_MODEL_SERVICES)[number];
 
 export type LLMServicesAvailable = Record<LLMServiceName, boolean>;
@@ -212,6 +213,7 @@ interface LLMService {
   short: string; // additional short text next to the company name
   desc: string; // more detailed description
 }
+
 export const LLM_PROVIDER: { [key in LLMServiceName]: LLMService } = {
   openai: {
     name: "OpenAI",
@@ -239,11 +241,11 @@ export const LLM_PROVIDER: { [key in LLMServiceName]: LLMService } = {
     desc: "Ollama helps you to get up and running with large language models, locally.",
   },
   custom_openai: {
-    name: "OpenAI (custom)",
-    short: "OpenAI (custom)",
-    desc: "A custom OpenAI endoint.",
+    name: "OpenAI API",
+    short: "Custom endpoint",
+    desc: "Calls a custom OpenAI API endoint.",
   },
-};
+} as const;
 
 interface ValidLanguageModelNameProps {
   model: string | undefined;

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -6,6 +6,7 @@
 // Default settings to customize a given site, typically a private install of CoCalc.
 
 import jsonic from "jsonic";
+import { isEqual } from "lodash";
 
 import { is_valid_email_address } from "@cocalc/util/misc";
 import {
@@ -15,7 +16,6 @@ import {
   getDefaultLLM,
   isValidModel,
 } from "./llm-utils";
-import { isEqual } from "lodash";
 
 export type ConfigValid = Readonly<string[]> | ((val: string) => boolean);
 
@@ -38,6 +38,7 @@ export const TAGS = [
   "Theme",
   "On-Prem",
 ] as const;
+
 export type Tag = (typeof TAGS)[number];
 
 export type SiteSettingsKeys =
@@ -683,7 +684,7 @@ export const site_settings_conf: SiteSettings = {
   },
   openai_enabled: {
     name: "OpenAI ChatGPT UI",
-    desc: "Controls visibility of UI elements related to ChatGPT integration.  You must **also set your OpenAI API key** below for this functionality to work.",
+    desc: "Controls visibility of UI elements related to OpenAI ChatGPT integration.  You must **also set your OpenAI API key** below for this functionality to work.",
     default: "no",
     valid: only_booleans,
     to_val: to_bool,

--- a/src/packages/util/db-schema/site-settings-extras.ts
+++ b/src/packages/util/db-schema/site-settings-extras.ts
@@ -140,7 +140,7 @@ function custom_llm_valid(value: string): boolean {
 // Ollama and Custom OpenAI have the same schema
 function custom_llm_display(value: string): string {
   const structure =
-    "Must be {[key : string] : {model: string, baseUrl: string, cocalc?: {display?: string, desc?: string, ...}, ...}";
+    "Must be {[key : string] : {model: string, baseUrl: string, cocalc?: {display?: string, desc?: string, icon?: string, ...}, ...}";
   if (isEmpty(value)) {
     return `Empty. ${structure}`;
   }
@@ -312,7 +312,7 @@ export const EXTRAS: SettingsExtras = {
   },
   ollama_configuration: {
     name: "Ollama Configuration",
-    desc: 'Configure Ollama endpoints. e.g. Ollama has "gemma" installed and is available at localhost:11434: `{"gemma" : {"baseUrl": "http://localhost:11434/" , cocalc: {display: "Gemma", desc: "Google\'s Gemma Model"}}`',
+    desc: 'Configure Ollama endpoints. e.g. Ollama has "gemma" installed and is available at localhost:11434: `{"gemma" : {"baseUrl": "http://localhost:11434/" , cocalc: {display: "Gemma", desc: "Google\'s Gemma Model", icon: "https://.../...png"}}`',
     default: "{}",
     multiline: 5,
     show: ollama_enabled,
@@ -324,7 +324,7 @@ export const EXTRAS: SettingsExtras = {
   // This is very similar to the ollama config, but there are small differences in the details.
   custom_openai_configuration: {
     name: "Custom OpenAI Endpoints",
-    desc: 'Configure OpenAI endpoints, queried via [@langchain/openai (Node.js)](https://js.langchain.com/v0.1/docs/integrations/llms/openai/). e.g. `{"myllm" : {"baseUrl": "http://1.2.3.4:5678/" , apiKey: "key...", cocalc: {display: "My LLM", desc: "My custom LLM"}}, "gpt-4o-high": {baseUrl: "https://api.openai.com/v1", temperature: 2, "openAIApiKey": "sk-...", "model": "gpt-4o", cocalc: {display: "High GPT-4 Omni", desc: "GPT 4 Omni High Temp"}}}`',
+    desc: 'Configure OpenAI endpoints, queried via [@langchain/openai (Node.js)](https://js.langchain.com/v0.1/docs/integrations/llms/openai/). e.g. `{"myllm" : {"baseUrl": "http://1.2.3.4:5678/" , apiKey: "key...", cocalc: {display: "My LLM", desc: "My custom LLM", icon: "https://.../...png"}}, "gpt-4o-high": {baseUrl: "https://api.openai.com/v1", temperature: 1.5, "openAIApiKey": "sk-...", "model": "gpt-4o", cocalc: {display: "High GPT-4 Omni", desc: "GPT 4 Omni High Temp"}}}`',
     default: "{}",
     multiline: 5,
     show: custom_openai_enabled,


### PR DESCRIPTION
# Description

There is code that's not general enough or simply wrong. That causes the "openai" setting to interfere with the "custom openai" configuration. The goal is to clean this up, name the categories of the custom LLM integrations in a better way, consolide both custom LLM endpoint options under a common category, etc. This also finishes the support for custom icons of these custom LLM endpoints.

PS: there is no need to deploy this, since there is no change for prod.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
