### PR TITLE
frontend/jupyter/cell-bar: show dot when queued to run, instead of time

### DIFF
--- a/src/packages/frontend/jupyter/cell-output-time.tsx
+++ b/src/packages/frontend/jupyter/cell-output-time.tsx
@@ -5,7 +5,8 @@
 
 import { Tooltip } from "antd";
 
-import { TimeAgo } from "@cocalc/frontend/components";
+import { TimeAgo, Icon } from "@cocalc/frontend/components";
+import { COLORS } from "@cocalc/util/theme";
 
 interface CellTimingProps {
   start?: number;
@@ -33,11 +34,24 @@ export default function CellTiming({ start, end }: CellTimingProps) {
         <span>{secondsDisp}</span>
       </Tooltip>
     );
+  } else {
+    return (
+      <Tooltip
+        title={
+          <>
+            This cell was evaluted <TimeAgo date={new Date(start)} /> and has
+            not finished yet.
+          </>
+        }
+      >
+        <Icon
+          name="plus-circle-filled"
+          style={{
+            color: COLORS.GRAY_M,
+            animation: "loadingCircle 3s infinite linear",
+          }}
+        />
+      </Tooltip>
+    );
   }
-
-  return (
-    <Tooltip title={"When code started running"}>
-      <TimeAgo date={new Date(start)} />
-    </Tooltip>
-  );
 }


### PR DESCRIPTION
# Description

This avoid briefly flashing this time ago string. Instead, it shows a gray dot like the one to indicate it queued to run, and moves that time ago info in the tooltip.

![Screenshot from 2024-06-05 16-36-08](https://github.com/sagemathinc/cocalc/assets/207405/886dc4c1-92b3-4ac7-a74e-3cd1806404ee)

now

![Screenshot from 2024-06-05 20-30-37](https://github.com/sagemathinc/cocalc/assets/207405/34361386-0f9f-4d0b-a6fe-cb9fd38595ef)



## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
