### PR TITLE
OpenAPI doc: Completed first draft of Compute Server docs.

### DIFF
--- a/src/packages/next/lib/api/latex.ts
+++ b/src/packages/next/lib/api/latex.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_LATEX_COMMAND =
+  "latexmk -pdf -f -g -bibtex -deps -interaction=nonstopmode";

--- a/src/packages/next/lib/api/schema/accounts/common.ts
+++ b/src/packages/next/lib/api/schema/accounts/common.ts
@@ -1,0 +1,8 @@
+import { z } from "../../framework";
+
+export const AccountIdSchema = z
+  .string()
+  .uuid()
+  .describe("Account id.");
+
+export type AccountId = z.infer<typeof AccountIdSchema>;

--- a/src/packages/next/lib/api/schema/common.ts
+++ b/src/packages/next/lib/api/schema/common.ts
@@ -1,0 +1,21 @@
+import { z } from "../framework";
+
+export const SuccessfulAPIOperationSchema = z
+  .object({
+    status: z.enum(["ok"])
+      .describe(
+        `Indicates the status of this operation; if the operation was successful, the 
+        value of this field is always set to \`"ok"\`.`
+      )
+  });
+
+export const FailedAPIOperationSchema = z
+  .object({
+    error: z
+      .string()
+      .describe("Error message if something goes badly wrong."),
+  });
+
+
+export type FailedAPIOperation = z.infer<typeof FailedAPIOperationSchema>;
+export type SuccessfulAPIOperation = z.infer<typeof SuccessfulAPIOperationSchema>;

--- a/src/packages/next/lib/api/schema/compute/check-in.ts
+++ b/src/packages/next/lib/api/schema/compute/check-in.ts
@@ -1,0 +1,49 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+const VpnSha1Schema = z
+  .string()
+  .describe("SHA1 VPN hash")
+  .optional();
+
+const StorageSha1Schema = z
+  .string()
+  .describe("SHA-1 storage hash")
+  .optional();
+
+// OpenAPI spec
+//
+export const ComputeServerCheckInInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    vpn_sha1: VpnSha1Schema,
+    storage_sha1: StorageSha1Schema,
+  })
+  .describe(
+    `Used by compute servers to periodically checking in with CoCalc using a project api 
+    key.`,
+  );
+
+export const ComputeServerCheckInOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.object({
+    vpn: z
+      .object({
+        image: z
+          .string()
+          .describe("VPN image name and tag."),
+        nodes: z.array(z.object({
+        })),
+      }),
+    storage: z.array(z.object({
+    })),
+    vpn_sha1: VpnSha1Schema,
+    storage_sha1: StorageSha1Schema,
+  }),
+]);
+
+export type ComputeServerCheckInInput = z.infer<typeof ComputeServerCheckInInputSchema>;
+export type ComputeServerCheckInOutput = z.infer<typeof ComputeServerCheckInOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/common.ts
+++ b/src/packages/next/lib/api/schema/compute/common.ts
@@ -1,0 +1,159 @@
+import { z } from "../../framework";
+
+export const ComputeServerIdBodySchema = z
+  .number()
+  .int()
+  .min(0)
+  .describe("**Integer** compute server id.");
+
+export const ComputeServerIdQueryParamSchema = z
+  .string()
+  .describe("**String** compute server id.");
+
+export const ServerImageNoCacheQueryParamSchema = z
+  .object({
+    noCache: z
+      .string()
+      .describe("**Administrators only**. Disables database caching for this query.")
+      .optional(),
+  });
+
+export const ComputeServerStateSchema = z
+  .enum([
+    "deprovisioned",
+    "off",
+    "running",
+    "starting",
+    "stopping",
+    "suspended",
+    "suspending",
+    "unknown",
+  ])
+  .describe("The state of the compute server.");
+
+export const ComputeServerColorSchema = z
+  .string()
+  .describe(
+    `Compute server color in rgb(#,#,#) format. Used for color-coding compute servers in 
+    the CoCalc UI.`,
+  );
+
+export const ComputeServerTitleSchema = z
+  .string()
+  .describe(
+    `Title of this compute server. Used purely to make it easier for the user to keep 
+    track of it.`
+  );
+
+export const ComputeServerCloudSchema = z
+  .enum([
+    "google-cloud",
+    "hyperstack",
+    "onprem",
+  ])
+  .describe("The cloud provider used to run this compute server");
+
+export const ComputeServerImageProxySchema = z
+  .object({
+    path: z
+      .string(),
+    target: z
+      .string(),
+    ws: z
+      .boolean()
+      .optional(),
+    app: z
+      .string()
+      .optional(),
+    name: z
+      .string()
+      .optional(),
+  })
+
+export const GoogleCloudServerConfigurationSchema = z
+  .object({});
+
+export const HyperstackServerConfigurationSchema = z
+  .object({});
+
+export const ServerConfigurationSchema = z
+  .union([
+    GoogleCloudServerConfigurationSchema,
+    HyperstackServerConfigurationSchema,
+  ]);
+
+export const BaseServerConfigurationSchema = z
+  .object({
+    cloud: ComputeServerCloudSchema,
+    dns: z
+      .string()
+      .describe("DNS name"),
+    spot: z
+      .boolean()
+      .describe("If true, provision a spot instance."),
+    zone: z
+      .string()
+      .describe("Cloud provider zone to which this template defaults."),
+    image: z
+      .string()
+      .describe("Compute server template image name."),
+    region: z
+      .string()
+      .describe("Compute server template region name."),
+    ephemeral: z
+      .boolean()
+      .describe("Indicates whether the compute server is ephemeral.")
+      .optional(),
+    diskType: z
+      .string()
+      .describe("Compute server template disk type."),
+    diskSizeGb: z
+      .number()
+      .min(0)
+      .describe("Compute server template disk image size in GB."),
+    externalIp: z
+      .boolean()
+      .describe(
+        `When true, the compute server is configured with an external IP address.`
+      ),
+    tag_cocalc: z
+      .string()
+      .describe("CoCalc tag"),
+    machineType: z
+      .string()
+      .describe(
+        "Cloud-specific machine type for this template (e.g., `t2d-standard-1`)."
+      ),
+    excludeFromSync: z
+      .array(z.string())
+      .describe("Array of top level directories to exclude from sync."),
+    acceleratorType: z
+      .string()
+      .describe(
+        "Number of hardware accelerators to be provisioned to this server."
+      )
+      .optional(),
+    acceleratorCount: z
+      .number()
+      .int()
+      .min(0)
+      .describe(
+        "Number of hardware accelerators to be provisioned with this server."
+      )
+      .optional(),
+    proxy: ComputeServerImageProxySchema
+      .optional()
+  });
+
+export type BaseServerConfiguration = z.infer<typeof BaseServerConfigurationSchema>;
+export type ComputeServerBodyId = z.infer<typeof ComputeServerIdBodySchema>;
+export type ComputeServerCloud = z.infer<typeof ComputeServerCloudSchema>;
+export type ComputeServerColor = z.infer<typeof ComputeServerColorSchema>;
+export type ComputeServerImageProxy = z.infer<typeof ComputeServerImageProxySchema>;
+export type ComputeServerQueryParamId = z.infer<typeof ComputeServerIdBodySchema>;
+export type ComputeServerState = z.infer<typeof ComputeServerStateSchema>;
+export type ComputeServerTitle = z.infer<typeof ComputeServerTitleSchema>;
+export type GoogleCloudServerConfiguration = z.infer<typeof GoogleCloudServerConfigurationSchema>;
+export type HyperstackServerConfiguration = z.infer<typeof HyperstackServerConfigurationSchema>;
+export type ServerConfiguration = z.infer<typeof ServerConfigurationSchema>;
+export type ServerImageNoCache = z.infer<typeof ServerImageNoCacheQueryParamSchema>;

--- a/src/packages/next/lib/api/schema/compute/compute-server-action.ts
+++ b/src/packages/next/lib/api/schema/compute/compute-server-action.ts
@@ -1,0 +1,39 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const ComputeServerActionInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    action: z
+      .enum([
+        "start",
+        "stop",
+        "reboot",
+        "suspend",
+        "resume",
+        "deprovision",
+      ])
+      .describe("Action to be performed on the compute server."),
+  })
+  .describe(
+    "Perform various action on a specific compute server (e.g., power off, deprovision, etc.)."
+  );
+
+export const ComputeServerActionOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.object({
+    result: z
+      .array(z.string())
+      .describe(
+        "List of likely guesses for the type of code, from most likely to less likely.",
+      ),
+  }),
+]);
+
+export type ComputeServerActionInput = z.infer<typeof ComputeServerActionInputSchema>;
+export type ComputeServerActionOutput = z.infer<typeof ComputeServerActionOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/create-server.ts
+++ b/src/packages/next/lib/api/schema/compute/create-server.ts
@@ -1,0 +1,56 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ProjectIdSchema } from "../projects/common";
+
+import {
+  ComputeServerCloudSchema,
+  ComputeServerColorSchema,
+  ComputeServerIdBodySchema,
+  ComputeServerTitleSchema,
+  ServerConfigurationSchema
+} from "./common";
+
+// OpenAPI spec
+//
+export const CreateServerInputSchema = z
+  .object({
+    configuration: ServerConfigurationSchema,
+    title: ComputeServerTitleSchema,
+    color: ComputeServerColorSchema,
+    cloud: ComputeServerCloudSchema,
+    project_id: ProjectIdSchema
+      .describe(
+        "The project id that this compute server provides compute for."
+      ),
+    idle_timeout: z
+      .number()
+      .describe(
+        `The idle timeout in seconds of this compute server. If set to 0, the server will
+        never turn off automatically. The compute server idle timeouts if none of the tabs 
+        it is providing are actively touched through the web UI. _Not yet implemented._`
+      )
+      .optional(),
+    autorestart: z.boolean()
+      .describe(
+        `If true and the compute server stops for any reason, then it 
+        will be automatically started again. This is primarily useful for 
+        stopping instances.`
+      )
+      .optional(),
+    notes: z.string()
+      .describe("Open-ended text in markdown about this item.")
+      .optional(),
+  })
+  .describe(
+    "Create a new compute server with the provided configuration."
+  );
+
+export const CreateServerOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  ComputeServerIdBodySchema.describe("The id of the created compute server."),
+]);
+
+export type CreateServerInput = z.infer<typeof CreateServerInputSchema>;
+export type CreateServerOutput = z.infer<typeof CreateServerOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/delete-api-key.ts
+++ b/src/packages/next/lib/api/schema/compute/delete-api-key.ts
@@ -1,0 +1,23 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const DeleteComputeServerAPIKeyInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+  })
+  .describe(
+    "Deletes the project API key associated with a particular compute server."
+  );
+
+export const DeleteComputeServerAPIKeyOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type DeleteComputeServerAPIKeyInput = z.infer<typeof DeleteComputeServerAPIKeyInputSchema>;
+export type DeleteComputeServerAPIKeyOutput = z.infer<typeof DeleteComputeServerAPIKeyOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/delete-server.ts
+++ b/src/packages/next/lib/api/schema/compute/delete-server.ts
@@ -1,0 +1,23 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const DeleteComputeServerInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+  })
+  .describe(
+    "Deletes and deprovisions a compute server."
+  );
+
+export const DeleteComputeServerOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type DeleteComputeServerInput = z.infer<typeof DeleteComputeServerInputSchema>;
+export type DeleteComputeServerOutput = z.infer<typeof DeleteComputeServerOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-api-key.ts
+++ b/src/packages/next/lib/api/schema/compute/get-api-key.ts
@@ -1,0 +1,25 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerAPIKeyInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+  })
+  .describe(
+    `Gets the api key of the compute server. This operation always invalidates 
+    any existing key for this server and creates a new one. Only allowed for on-prem 
+    servers.`
+  );
+
+export const GetComputeServerAPIKeyOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.string().describe("API key for the compute server."),
+]);
+
+export type GetComputeServerAPIKeyInput = z.infer<typeof GetComputeServerAPIKeyInputSchema>;
+export type GetComputeServerAPIKeyOutput = z.infer<typeof GetComputeServerAPIKeyOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-detailed-state.ts
+++ b/src/packages/next/lib/api/schema/compute/get-detailed-state.ts
@@ -1,0 +1,41 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ProjectIdSchema } from "../projects/common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const GetDetailedServerStateInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    project_id: ProjectIdSchema,
+    name: z
+      .string()
+      .describe(
+        `Optional JSON path to select a particular property of the compute
+        server's detailed state.`
+      )
+      .optional(),
+  })
+  .describe(
+    `Returns a map from component name to something like \`{state:'running',time:Date.now()}\`.
+    This is used to provide users with insight into what's currently happening on their 
+    compute server. The response may optionally be filtered via a JSON path specified in 
+    the \`name\` attribute to obtain a particular (possibly nested) state property.`
+  );
+
+export const GetDetailedServerStateOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.string()
+    .describe(
+      `When the \`name\` field is not specified, the entire server state is returned as a
+      string; otherwise, only the subset of the server state corresponding to the JSON 
+      path specified in \`name\` is returned.`,
+    ),
+]);
+
+export type GetDetailedServerStateInput = z.infer<typeof GetDetailedServerStateInputSchema>;
+export type GetDetailedServerStateOutput = z.infer<typeof GetDetailedServerStateOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-images-google.ts
+++ b/src/packages/next/lib/api/schema/compute/get-images-google.ts
@@ -1,0 +1,54 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ServerImageNoCacheQueryParamSchema } from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerGoogleImagesInputSchema = ServerImageNoCacheQueryParamSchema
+  .describe(
+    "Used to get available compute server images for deployment to GCP."
+  );
+
+export const GetComputeServerGoogleImagesOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.record(
+    z.string().describe("Image name"),
+    z.object({
+      labels: z
+        .object({
+          image: z
+            .string()
+            .describe("CoCalc image name"),
+          tag: z
+            .string()
+            .describe("Image tag"),
+          arch: z
+            .enum([
+              "x86-64",
+              "arm64",
+            ])
+            .describe("Image architecture"),
+          tested: z
+            .string()
+            .describe("`true` if the image has been tested."),
+        })
+        .describe("Map of server image labels to values (e.g. architecture, etc.)"),
+      diskSizeGb: z
+        .number()
+        .min(0)
+        .describe("Disk size in GB"),
+      creationTimestamp: z
+        .string()
+        .describe("ISO 8601 timestamp indicating image creation time."),
+    })
+    .describe(
+      `Map of server image keys to detailed JSON information about the server image (e.g.,
+      image architecture, disk size, etc.`
+    ),
+  ),
+]);
+
+export type GetComputeServerGoogleImagesInput = z.infer<typeof GetComputeServerGoogleImagesInputSchema>;
+export type GetComputeServerGoogleImagesOutput = z.infer<typeof GetComputeServerGoogleImagesOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-images.ts
+++ b/src/packages/next/lib/api/schema/compute/get-images.ts
@@ -1,0 +1,122 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import {
+  ComputeServerImageProxySchema,
+  ServerImageNoCacheQueryParamSchema
+} from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerImagesInputSchema = ServerImageNoCacheQueryParamSchema
+  .describe(
+    "Used to get available compute server images."
+  );
+
+export const GetComputeServerImagesOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.record(
+    z.string(),
+    z.object({
+      system: z
+        .boolean()
+        .describe("")
+        .optional(),
+      priority: z
+        .number()
+        .min(0)
+        .describe("")
+        .optional(),
+      disabled: z
+        .boolean()
+        .describe("")
+        .optional(),
+      label: z
+        .string()
+        .describe("")
+        .optional(),
+      comment: z
+        .string()
+        .describe("")
+        .optional(),
+      package: z
+        .string()
+        .describe("")
+        .optional(),
+      package_arm64: z
+        .string()
+        .describe("")
+        .optional(),
+      minDiskSizeGb: z
+        .number()
+        .min(0)
+        .describe("")
+        .optional(),
+      dockerSizeGb: z
+        .number()
+        .min(0)
+        .describe("")
+        .optional(),
+      gpu: z
+        .boolean()
+        .describe("")
+        .optional(),
+      icon: z
+        .string()
+        .describe("")
+        .optional(),
+      url: z
+        .string()
+        .describe("")
+        .optional(),
+      source: z
+        .string()
+        .describe("")
+        .optional(),
+      description: z
+        .string()
+        .describe("")
+        .optional(),
+      versions: z
+        .array(
+          z.object({
+            tag: z
+              .string(),
+            tested: z
+              .boolean(),
+            version: z
+              .string()
+              .optional(),
+            label: z
+              .string()
+              .optional(),
+          })
+        )
+        .optional(),
+      videos: z
+        .array(z.string())
+        .optional(),
+      tutorials: z
+        .array(z.string())
+        .optional(),
+      jupyterKernels: z
+        .boolean()
+        .optional(),
+      requireDns: z
+        .boolean()
+        .optional(),
+      upstreamVersions: z
+        .string()
+        .optional(),
+      proxy: ComputeServerImageProxySchema
+        .optional(),
+    }))
+    .describe(
+      `Maps server image keys to detailed JSON information about the server image (e.g.,
+      download URL, descriptions, source files, etc.`
+    ),
+]);
+
+export type GetComputeServerImagesInput = z.infer<typeof GetComputeServerImagesInputSchema>;
+export type GetComputeServerImagesOutput = z.infer<typeof GetComputeServerImagesOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-log.ts
+++ b/src/packages/next/lib/api/schema/compute/get-log.ts
@@ -1,0 +1,64 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ProjectIdSchema } from "../projects/common";
+import { AccountIdSchema} from "../accounts/common";
+
+import {
+  ComputeServerIdBodySchema,
+  ComputeServerIdQueryParamSchema,
+} from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerLogInputSchema = z
+  .object({
+    id: ComputeServerIdQueryParamSchema,
+  })
+  .describe("Get event log for a particular compute server.");
+
+export const GetComputeServerLogOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.array(
+    z.object({
+      account_id: AccountIdSchema,
+      project_id: ProjectIdSchema,
+      id: z
+        .string()
+        .uuid()
+        .describe("Event id."),
+      time: z
+        .string()
+        .describe("ISO 8601 event timestamp."),
+      event: z
+        .object({
+          server_id: ComputeServerIdBodySchema,
+          event: z
+            .string()
+            .describe("Event name (e.g., `compute-server`"),
+          action: z
+            .string()
+            .describe("Event action (e.g., `configuration`"),
+          changes: z
+            .record(
+              z.string(),
+              z.object({
+                to: z
+                  .any()
+                  .describe("Previous state."),
+                from: z
+                  .any()
+                  .describe("New state."),
+              })
+            )
+            .describe("Changes made to the compute server.")
+        })
+        .describe("Detailed event data.")
+    })
+    .describe("A list of compute server events."),
+  ),
+]);
+
+export type GetComputeServerLogInput = z.infer<typeof GetComputeServerLogInputSchema>;
+export type GetComputeServerLogOutput = z.infer<typeof GetComputeServerLogOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-network-usage.ts
+++ b/src/packages/next/lib/api/schema/compute/get-network-usage.ts
@@ -1,0 +1,38 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerNetworkUsageInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    start: z
+      .string()
+      .describe("Time after which network usage is to be queried."),
+    end: z
+      .string()
+      .describe("Time before which network usage is to be queried."),
+  })
+  .describe(
+    "Get network usage by a specific server during a particular period of time."
+  );
+
+export const GetComputeServerNetworkUsageOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.object({
+    amount: z
+      .number()
+      .min(0)
+      .describe("Total amount of network usage."),
+    cost: z
+      .number()
+      .min(0)
+      .describe("Network usage cost.")
+  }),
+]);
+
+export type GetComputeServerNetworkUsageInput = z.infer<typeof GetComputeServerNetworkUsageInputSchema>;
+export type GetComputeServerNetworkUsageOutput = z.infer<typeof GetComputeServerNetworkUsageOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-serial-port-output.ts
+++ b/src/packages/next/lib/api/schema/compute/get-serial-port-output.ts
@@ -1,0 +1,23 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ComputeServerIdQueryParamSchema } from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerSerialPortOutputInputSchema = z
+  .object({
+    id: ComputeServerIdQueryParamSchema,
+  })
+  .describe(
+    "Get serial port output for a compute server."
+  );
+
+export const GetComputeServerSerialPortOutputOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.string().describe("Serial port output for the compute server."),
+]);
+
+export type GetComputeServerSerialPortOutputInput = z.infer<typeof GetComputeServerSerialPortOutputInputSchema>;
+export type GetComputeServerSerialPortOutputOutput = z.infer<typeof GetComputeServerSerialPortOutputOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-server-state.ts
+++ b/src/packages/next/lib/api/schema/compute/get-server-state.ts
@@ -1,0 +1,24 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import {
+  ComputeServerIdBodySchema,
+  ComputeServerStateSchema,
+} from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerStateInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+  })
+  .describe("Get server state from the cloud provider for a particular compute server.");
+
+export const GetComputeServerStateOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  ComputeServerStateSchema,
+]);
+
+export type GetComputeServerStateInput = z.infer<typeof GetComputeServerStateInputSchema>;
+export type GetComputeServerStateOutput = z.infer<typeof GetComputeServerStateOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-server-title.ts
+++ b/src/packages/next/lib/api/schema/compute/get-server-title.ts
@@ -1,0 +1,28 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import {
+  ComputeServerColorSchema,
+  ComputeServerIdQueryParamSchema,
+  ComputeServerTitleSchema,
+} from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServerTitleInputSchema = z
+  .object({
+    id: ComputeServerIdQueryParamSchema,
+  })
+  .describe("Get server state from the cloud provider for a particular compute server.");
+
+export const GetComputeServerTitleOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.object({
+    color: ComputeServerColorSchema,
+    title: ComputeServerTitleSchema,
+  }),
+]);
+
+export type GetComputeServerTitleInput = z.infer<typeof GetComputeServerTitleInputSchema>;
+export type GetComputeServerTitleOutput = z.infer<typeof GetComputeServerTitleOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-servers.ts
+++ b/src/packages/next/lib/api/schema/compute/get-servers.ts
@@ -1,0 +1,32 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ProjectIdSchema } from "../projects/common";
+
+import {
+  ComputeServerIdBodySchema,
+  ComputeServerIdQueryParamSchema,
+  ComputeServerTitleSchema,
+} from "./common";
+
+// OpenAPI spec
+//
+export const GetComputeServersInputSchema = z
+  .object({
+    id: ComputeServerIdQueryParamSchema.optional(),
+    project_id: ProjectIdSchema.optional(),
+  })
+  .describe("Parameters that restrict compute servers to get.");
+
+
+export const GetComputeServersOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.array(z.object({
+    id: ComputeServerIdBodySchema,
+    title: ComputeServerTitleSchema,
+  })),
+]);
+
+export type GetComputeServersInput = z.infer<typeof GetComputeServersInputSchema>;
+export type GetComputeServersOutput = z.infer<typeof GetComputeServersOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-template.ts
+++ b/src/packages/next/lib/api/schema/compute/get-template.ts
@@ -1,0 +1,83 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import {
+  BaseServerConfigurationSchema,
+  ComputeServerCloudSchema,
+  ComputeServerColorSchema,
+  ComputeServerIdBodySchema,
+  ComputeServerTitleSchema
+} from "./common";
+
+// OpenAPI spec
+//
+export const ComputeServerTemplateObjectSchema = z.object({
+  enabled: z
+    .boolean()
+    .describe("If true, this server template is to be shown in the CoCalc UI.")
+    .optional(),
+  priority: z
+    .number()
+    .describe("Semantic priority for this server template.")
+    .optional()
+})
+  .describe("Contains information about this template's priority and availability.");
+
+export const GetComputeServerTemplateSchema = z.object({
+  id: ComputeServerIdBodySchema
+    .describe("Compute server template id"),
+  title: ComputeServerTitleSchema,
+  color: ComputeServerColorSchema,
+  cloud: ComputeServerCloudSchema,
+  configuration: BaseServerConfigurationSchema
+    .describe(`Default cloud server configuration for this template. _The exact
+            structure of this object is still in development, and this schema should
+            be used accordingly.`,
+    ),
+  template: ComputeServerTemplateObjectSchema,
+  avatar_image_tiny: z
+    .union([
+      z.string()
+        .describe("Image URL"),
+      z.null(),
+    ])
+    .describe(
+      `tiny (32x32) visual image associated with the compute server. Suitable to 
+            include as part of changefeed`,
+    ),
+  position: z
+    .number()
+    .int()
+    .describe("Used for sorting a list of compute servers in the UI."),
+  cost_per_hour: z
+    .object({
+      running: z
+        .number()
+        .describe(
+          "Cost in (fractional) cents for the compute server when powered on."
+        ),
+      off: z
+        .number()
+        .describe(
+          "Cost in (fractional) cents for the compute server when powered off."
+        ),
+    })
+    .describe("Compute server template.")
+    .optional()
+});
+
+export const GetComputeServerTemplateInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema
+      .describe("Compute server template id.")
+  })
+  .describe("Get a specific compute server template by `id`.");
+
+export const GetComputeServerTemplateOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  GetComputeServerTemplateSchema,
+]);
+
+export type GetComputeServerTemplateInput = z.infer<typeof GetComputeServerTemplateInputSchema>;
+export type GetComputeServerTemplateOutput = z.infer<typeof GetComputeServerTemplateOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/get-templates.ts
+++ b/src/packages/next/lib/api/schema/compute/get-templates.ts
@@ -1,0 +1,17 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { GetComputeServerTemplateSchema } from "./get-template";
+
+// OpenAPI spec
+//
+export const GetComputeServerTemplatesOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.object({
+    templates: z.array(GetComputeServerTemplateSchema),
+  })
+    .describe("Default compute server templates."),
+]);
+
+export type GetComputeServerTemplatesOutput = z.infer<typeof GetComputeServerTemplatesOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/scripts.ts
+++ b/src/packages/next/lib/api/schema/compute/scripts.ts
@@ -1,0 +1,37 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const ComputeServerScriptsInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    api_key: z
+      .string()
+      .describe("Used to get the project associated with the compute server. "),
+    action: z
+      .enum([
+        "start",
+        "stop",
+        "deprovision",
+      ])
+      .describe("Determines which script is to be returned from this API call."),
+  })
+  .describe(
+    `Returns a bash script that when run as root starts a compute server and 
+    connects it to a project. This is meant to be used for on prem compute 
+    servers, hence it includes installing the \`/cocalc\` code and the 
+    \`user\` user.`
+  );
+
+export const ComputeServerScriptsOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.string()
+    .describe("The script of interest."),
+]);
+
+export type ComputeServerScriptsInput = z.infer<typeof ComputeServerScriptsInputSchema>;
+export type ComputeServerScriptsOutput = z.infer<typeof ComputeServerScriptsOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/set-detailed-state.ts
+++ b/src/packages/next/lib/api/schema/compute/set-detailed-state.ts
@@ -1,0 +1,57 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ProjectIdSchema } from "../projects/common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const SetDetailedServerStateInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    project_id: ProjectIdSchema,
+    name: z
+      .string()
+      .describe(
+        `Optional JSON path to select a particular property of the compute
+        server's detailed state.`
+      )
+      .optional(),
+    state: z
+      .string()
+      .describe(
+        `The value of the state field to be set. If this value is empty, the state variable
+        specified in the \`name\` field is removed.`
+      )
+      .optional(),
+    extra: z
+      .string()
+      .describe("State metadata.")
+      .optional(),
+    timeout: z
+      .number()
+      .min(0)
+      .describe("Specifies a duration for which this state variable is valid.")
+      .optional(),
+    progress: z
+      .number()
+      .optional(),
+  })
+  .describe(
+    `Set detailed state for a compute server; detailed state maps component name to
+    something like \`{state:'running',time:Date.now()}\` and is used to provide users with
+    insight into what's currently happening on their compute server. The \`name\`
+    must be provided to specify a particular (possibly nested) state property to be set.
+    _This is mainly used from the backend to convey information to user about what is 
+    going on in a compute server._`
+  );
+
+export const SetDetailedServerStateOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type SetDetailedServerStateInput = z.infer<typeof SetDetailedServerStateInputSchema>;
+export type SetDetailedServerStateOutput = z.infer<typeof SetDetailedServerStateOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/set-image-tested.ts
+++ b/src/packages/next/lib/api/schema/compute/set-image-tested.ts
@@ -1,0 +1,30 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const SetComputeServerImageTestedInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    tested: z
+      .boolean()
+      .describe(
+        "Indicates whether the server image specified in the `id` field has been tested."
+      ),
+  })
+  .describe(
+    `Set whether or not the image a compute server with given id is using has been tested.
+     This is used by admins when manually doing final integration testing for a new image
+     on some cloud provider.`
+  );
+
+export const SetComputeServerImageTestedOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type SetComputeServerImageTestedInput = z.infer<typeof SetComputeServerImageTestedInputSchema>;
+export type SetComputeServerImageTestedOutput = z.infer<typeof SetComputeServerImageTestedOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/set-server-cloud.ts
+++ b/src/packages/next/lib/api/schema/compute/set-server-cloud.ts
@@ -1,0 +1,26 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ComputeServerCloudSchema, ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const SetComputeServerCloudInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    cloud: ComputeServerCloudSchema,
+  })
+  .describe(
+    `Set the cloud of a compute server.  The owner is the only one allowed to do this.
+    Changing the cloud clears the configuration, since it is not meaningful between 
+    clouds.`
+  );
+
+export const SetComputeServerCloudOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type SetComputeServerCloudInput = z.infer<typeof SetComputeServerCloudInputSchema>;
+export type SetComputeServerCloudOutput = z.infer<typeof SetComputeServerCloudOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/set-server-color.ts
+++ b/src/packages/next/lib/api/schema/compute/set-server-color.ts
@@ -1,0 +1,25 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import {
+  ComputeServerColorSchema,
+  ComputeServerIdBodySchema
+} from "./common";
+
+// OpenAPI spec
+//
+export const SetComputeServerColorInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    color: ComputeServerColorSchema,
+  })
+  .describe("Set the color of a compute server.");
+
+export const SetComputeServerColorOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type SetComputeServerColorInput = z.infer<typeof SetComputeServerColorInputSchema>;
+export type SetComputeServerColorOutput = z.infer<typeof SetComputeServerColorOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/set-server-configuration.ts
+++ b/src/packages/next/lib/api/schema/compute/set-server-configuration.ts
@@ -1,0 +1,37 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import {
+  ComputeServerIdBodySchema,
+  GoogleCloudServerConfigurationSchema,
+  HyperstackServerConfigurationSchema,
+} from "./common";
+
+// OpenAPI spec
+//
+export const SetServerConfigurationInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    configuration: z
+      .union([
+        GoogleCloudServerConfigurationSchema.partial(),
+        HyperstackServerConfigurationSchema.partial(),
+      ])
+      .describe(
+        `Server configuration to change. Note that only a subset of the 
+        configuration is necessary so that configuration fields may be individually
+        changed.`
+      ),
+  })
+  .describe(
+    "Create a new compute server with the provided configuration."
+  );
+
+export const SetServerConfigurationOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type SetServerConfigurationInput = z.infer<typeof SetServerConfigurationInputSchema>;
+export type SetServerConfigurationOutput = z.infer<typeof SetServerConfigurationOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/set-server-title.ts
+++ b/src/packages/next/lib/api/schema/compute/set-server-title.ts
@@ -1,0 +1,24 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema, ComputeServerTitleSchema } from "./common";
+
+// OpenAPI spec
+//
+export const SetComputeServerTitleInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+    title: ComputeServerTitleSchema,
+  })
+  .describe(
+    "Set the title of a compute server.  The owner is the only one allowed to do this."
+  );
+
+export const SetComputeServerTitleOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type SetComputeServerTitleInput = z.infer<typeof SetComputeServerTitleInputSchema>;
+export type SetComputeServerTitleOutput = z.infer<typeof SetComputeServerTitleOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/set-template.ts
+++ b/src/packages/next/lib/api/schema/compute/set-template.ts
@@ -1,0 +1,24 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+import { ComputeServerTemplateObjectSchema } from "./get-template";
+
+// OpenAPI spec
+//
+export const SetComputeServerTemplateInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema
+      .describe("Compute server template id."),
+    template: ComputeServerTemplateObjectSchema,
+  })
+  .describe("**Administrators only**. Set a specific compute server template by `id`.");
+
+export const SetComputeServerTemplateOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type SetComputeServerTemplateInput = z.infer<typeof SetComputeServerTemplateInputSchema>;
+export type SetComputeServerTemplateOutput = z.infer<typeof SetComputeServerTemplateOutputSchema>;

--- a/src/packages/next/lib/api/schema/compute/undelete-server.ts
+++ b/src/packages/next/lib/api/schema/compute/undelete-server.ts
@@ -1,0 +1,21 @@
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema, SuccessfulAPIOperationSchema } from "../common";
+
+import { ComputeServerIdBodySchema } from "./common";
+
+// OpenAPI spec
+//
+export const UndeleteComputeServerInputSchema = z
+  .object({
+    id: ComputeServerIdBodySchema,
+  })
+  .describe("Undelete a compute server.");
+
+export const UndeleteComputeServerOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  SuccessfulAPIOperationSchema,
+]);
+
+export type UndeleteComputeServerInput = z.infer<typeof UndeleteComputeServerInputSchema>;
+export type UndeleteComputeServerOutput = z.infer<typeof UndeleteComputeServerOutputSchema>;

--- a/src/packages/next/lib/api/schema/guesslang.ts
+++ b/src/packages/next/lib/api/schema/guesslang.ts
@@ -1,0 +1,35 @@
+import { z } from "../framework";
+
+import { FailedAPIOperationSchema } from "./common";
+
+// OpenAPI spec
+//
+export const GuesslangInputSchema = z
+  .object({
+    code: z.string().describe("A snippet of code."),
+    cutoff: z
+      .number()
+      .positive()
+      .default(5)
+      .describe("Maximum number of results to return."),
+  })
+  .describe(
+    `Use a sophisticated machine learning model (see 
+    \`@vscode/vscode-languagedetection\`) to guess the language of a snippet of 
+    code.`,
+  );
+
+export const GuesslangOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.object({
+    result: z
+      .array(z.string())
+      .describe(
+        `List of likely guesses for the type of code, from most likely to least 
+        likely.`,
+      ),
+  }),
+]);
+
+export type GuesslangInput = z.infer<typeof GuesslangInputSchema>;
+export type GuesslangOutput = z.infer<typeof GuesslangOutputSchema>;

--- a/src/packages/next/lib/api/schema/latex.ts
+++ b/src/packages/next/lib/api/schema/latex.ts
@@ -1,0 +1,103 @@
+import { z } from "../framework";
+
+import { DEFAULT_LATEX_COMMAND } from "../latex";
+
+import { FailedAPIOperationSchema } from "./common";
+
+// OpenAPI spec
+//
+export const LatexInputSchema = z
+  .object({
+    path: z
+      .string()
+      .describe(
+        `Path to a .tex file. If the file doesn't exist, it is created with the
+        given content. Also, if the directory containing path doesn't exist, it
+        is created. If the path starts with \`/tmp\` (e.g., 
+        \`/tmp/foo/bar.tex\`), then we do always do \`rm /tmp/foo/bar.*\` to
+        clean up temporary files. We do _not_ do this unless the path starts
+        with \`/tmp\`.`,
+      ),
+    content: z
+      .string()
+      .optional()
+      .describe(
+        `Textual content of the .tex file on which you want to run LaTeX. If
+        not given, path must refer to an actual file already in the project.
+        Then the path \`.tex\` file is created and this content written to it.`,
+      ),
+    project_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe(
+        `The v4 uuid of a project you have access to. If not given, your most
+        recent project is used, or if you have no projects, one is created. The
+        project is started if it isn't already running. **WARNING:** if the
+        project isn't running you may get an error while it is starting; if you
+        retry in a few seconds then it works.`,
+      ),
+    command: z
+      .string()
+      .optional()
+      .describe(
+        `LaTeX build command. This will be run from the directory containing
+        path and should produce the output pdf file.  If not given, we use
+        \`${DEFAULT_LATEX_COMMAND} filename.tex\`.`,
+      ),
+    timeout: z
+      .number()
+      .gte(5)
+      .default(30)
+      .describe(
+        `If given, this is a timeout in seconds for how long the LaTeX build
+        command can run before it is killed. You should increase this from the
+        default if you're building large documents.  See also the 
+        \`only_read_pdf\` option.`,
+      ),
+    ttl: z
+      .number()
+      .gte(60)
+      .describe("Time in seconds for which generated PDF url is valid.")
+      .default(3600),
+    only_read_pdf: z
+      .boolean()
+      .optional()
+      .describe( `Instead of running LaTeX, we **only** try to grab the output pdf if it
+        exists. Currently, you must also specify the \`project_id\` if you use
+        this option, since we haven't implemented a way to know in which project
+        the latex command was run. When true, \`only_read_pdf\` is the same as
+        when it is false, except only the step involving reading the pdf
+        happens. Use this if compiling times out for some reason due to network
+        timeout requirements.  **NOTE:** \`only_read_pdf\` doesn't currently
+        get the compilation output log.`,
+      ),
+  })
+  .describe(
+    `Turn LaTeX .tex file contents into a pdf.  This run in a CoCalc project
+    with a configurable timeout and command, so can involve arbitrarily
+    sophisticated processing.`,
+  )
+
+export const LatexOutputSchema = z.union([
+  FailedAPIOperationSchema,
+  z.object({
+    compile: z.object({
+      stdout: z.string(),
+      stderr: z.string(),
+      exit_code: z.number(),
+    }),
+    url: z
+      .string()
+      .describe("URL where you can view the generated PDF file"),
+    pdf: z
+      .string()
+      .describe(
+        `Information about reading the PDF from disk, e.g., an error if the PDF
+         does not exist.`,
+      ),
+  }),
+]);
+
+export type LatexInput = z.infer<typeof LatexInputSchema>;
+export type LatexOutput = z.infer<typeof LatexOutputSchema>;

--- a/src/packages/next/lib/api/schema/projects/common.ts
+++ b/src/packages/next/lib/api/schema/projects/common.ts
@@ -1,0 +1,8 @@
+import { z } from "../../framework";
+
+export const ProjectIdSchema = z
+  .string()
+  .uuid()
+  .describe("Project id.");
+
+export type ProjectId = z.infer<typeof ProjectIdSchema>;

--- a/src/packages/next/pages/api/v2/compute/check-in.ts
+++ b/src/packages/next/pages/api/v2/compute/check-in.ts
@@ -19,7 +19,14 @@ import getProjectOrAccountId from "lib/account/get-account";
 import getParams from "lib/api/get-params";
 import { checkIn } from "@cocalc/server/compute/check-in";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  ComputeServerCheckInInputSchema,
+  ComputeServerCheckInOutputSchema,
+} from "lib/api/schema/compute/check-in";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -42,3 +49,24 @@ async function get(req) {
     storage_sha1,
   });
 }
+
+export default apiRoute({
+  checkIn: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: ComputeServerCheckInInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: ComputeServerCheckInOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/compute-server-action.ts
+++ b/src/packages/next/pages/api/v2/compute/compute-server-action.ts
@@ -2,12 +2,19 @@
 Request to do an action (e.g., "start") with a compute server.
 You must be the owner of the compute server.
 */
+import computeServerAction from "@cocalc/server/compute/compute-server-action";
 
 import getAccountId from "lib/account/get-account";
-import computeServerAction from "@cocalc/server/compute/compute-server-action";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  ComputeServerActionInputSchema,
+  ComputeServerActionOutputSchema,
+} from "lib/api/schema/compute/compute-server-action";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -29,3 +36,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  serverAction: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: ComputeServerActionInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: ComputeServerActionOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/create-server.ts
+++ b/src/packages/next/pages/api/v2/compute/create-server.ts
@@ -6,6 +6,13 @@ import getAccountId from "lib/account/get-account";
 import createServer from "@cocalc/server/compute/create-server";
 import getParams from "lib/api/get-params";
 
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  CreateServerInputSchema,
+  CreateServerOutputSchema
+} from "lib/api/schema/compute/create-server";
+
+
 async function handle(req, res) {
   try {
     res.json(await get(req));
@@ -43,32 +50,22 @@ async function get(req) {
   });
 }
 
-import { apiRoute, apiRouteOperation, z } from "lib/api";
-
 export default apiRoute({
-  computeCreateServer: apiRouteOperation({
+  createServer: apiRouteOperation({
     method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
   })
     .input({
       contentType: "application/json",
-      body: z
-        .object({
-          project_id: z.string(),
-          title: z.string(),
-          color: z.string(),
-          idle_timeout: z.number().optional(),
-          autorestart: z.boolean().optional(),
-          cloud: z.string(),
-          configuration: z.record(z.unknown()),
-          notes: z.string().optional(),
-        })
-        .describe("Parameters that define a compute server."),
+      body: CreateServerInputSchema,
     })
     .outputs([
       {
         status: 200,
         contentType: "application/json",
-        body: z.number().describe("The id of the compute server."),
+        body: CreateServerOutputSchema,
       },
     ])
     .handler(handle),

--- a/src/packages/next/pages/api/v2/compute/delete-api-key.ts
+++ b/src/packages/next/pages/api/v2/compute/delete-api-key.ts
@@ -7,7 +7,14 @@ import { getServer } from "@cocalc/server/compute/get-servers";
 import getParams from "lib/api/get-params";
 import { deleteProjectApiKey } from "@cocalc/server/compute/project-api-key";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation, } from "lib/api";
+import {
+  DeleteComputeServerAPIKeyInputSchema,
+  DeleteComputeServerAPIKeyOutputSchema
+} from "lib/api/schema/compute/delete-api-key";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -29,3 +36,24 @@ async function get(req) {
   await deleteProjectApiKey({ account_id, server });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  deleteServerAPIKey: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: DeleteComputeServerAPIKeyInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: DeleteComputeServerAPIKeyOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/delete-server.ts
+++ b/src/packages/next/pages/api/v2/compute/delete-server.ts
@@ -7,7 +7,14 @@ import getAccountId from "lib/account/get-account";
 import deleteServer from "@cocalc/server/compute/delete-server";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  DeleteComputeServerInputSchema,
+  DeleteComputeServerOutputSchema
+} from "lib/api/schema/compute/delete-server";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -28,3 +35,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  deleteServer: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: DeleteComputeServerInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: DeleteComputeServerOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-api-key.ts
+++ b/src/packages/next/pages/api/v2/compute/get-api-key.ts
@@ -15,7 +15,14 @@ import {
   deleteProjectApiKey,
 } from "@cocalc/server/compute/project-api-key";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerAPIKeyInputSchema,
+  GetComputeServerAPIKeyOutputSchema,
+} from "lib/api/schema/compute/get-api-key";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -40,3 +47,24 @@ async function get(req) {
   await deleteProjectApiKey({ account_id, server });
   return await setProjectApiKey({ account_id, server });
 }
+
+export default apiRoute({
+  getServerAPIKey: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: GetComputeServerAPIKeyInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerAPIKeyOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-detailed-state.ts
+++ b/src/packages/next/pages/api/v2/compute/get-detailed-state.ts
@@ -12,7 +12,14 @@ import { getDetailedState } from "@cocalc/server/compute/set-detailed-state";
 import getParams from "lib/api/get-params";
 import isCollaborator from "@cocalc/server/projects/is-collaborator";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetDetailedServerStateInputSchema,
+  GetDetailedServerStateOutputSchema,
+} from "lib/api/schema/compute/get-detailed-state";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -52,3 +59,24 @@ async function get(req) {
     name,
   });
 }
+
+export default apiRoute({
+  getDetailedServerState: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: GetDetailedServerStateInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "text/plain",
+        body: GetDetailedServerStateOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-images-google.ts
+++ b/src/packages/next/pages/api/v2/compute/get-images-google.ts
@@ -7,7 +7,14 @@ import { getAllImages } from "@cocalc/server/compute/cloud/google-cloud/images";
 import getParams from "lib/api/get-params";
 import userIsInGroup from "@cocalc/server/accounts/is-in-group";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerGoogleImagesInputSchema,
+  GetComputeServerGoogleImagesOutputSchema,
+} from "lib/api/schema/compute/get-images-google";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -32,3 +39,24 @@ async function get(req) {
   }
   return await getAllImages({ noCache: !!noCache });
 }
+
+export default apiRoute({
+  getImagesGoogle: apiRouteOperation({
+    method: "GET",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      query: GetComputeServerGoogleImagesInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerGoogleImagesOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-images.ts
+++ b/src/packages/next/pages/api/v2/compute/get-images.ts
@@ -7,7 +7,14 @@ import { getImages } from "@cocalc/server/compute/images";
 import getParams from "lib/api/get-params";
 import userIsInGroup from "@cocalc/server/accounts/is-in-group";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerImagesInputSchema,
+  GetComputeServerImagesOutputSchema,
+} from "lib/api/schema/compute/get-images";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -32,3 +39,24 @@ async function get(req) {
   }
   return await getImages({ noCache: !!noCache });
 }
+
+export default apiRoute({
+  getImages: apiRouteOperation({
+    method: "GET",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      query: GetComputeServerImagesInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerImagesOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-log.ts
+++ b/src/packages/next/pages/api/v2/compute/get-log.ts
@@ -6,7 +6,14 @@ import getAccountId from "lib/account/get-account";
 import { getEventLog } from "@cocalc/server/compute/event-log";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerLogInputSchema,
+  GetComputeServerLogOutputSchema,
+} from "lib/api/schema/compute/get-log";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -25,3 +32,24 @@ async function get(req) {
   });
   return await getEventLog({ id, account_id });
 }
+
+export default apiRoute({
+  getLog: apiRouteOperation({
+    method: "GET",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      query: GetComputeServerLogInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerLogOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-network-usage.ts
+++ b/src/packages/next/pages/api/v2/compute/get-network-usage.ts
@@ -7,7 +7,14 @@ import { getNetworkUsage } from "@cocalc/server/compute/control";
 import getParams from "lib/api/get-params";
 import { getServer } from "@cocalc/server/compute/get-servers";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerNetworkUsageInputSchema,
+  GetComputeServerNetworkUsageOutputSchema,
+} from "lib/api/schema/compute/get-network-usage";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -35,3 +42,24 @@ async function get(req) {
     end: new Date(end),
   });
 }
+
+export default apiRoute({
+  getNetworkUsage: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: GetComputeServerNetworkUsageInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerNetworkUsageOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-serial-port-output.ts
+++ b/src/packages/next/pages/api/v2/compute/get-serial-port-output.ts
@@ -10,7 +10,14 @@ import { getServerNoCheck } from "@cocalc/server/compute/get-servers";
 import getParams from "lib/api/get-params";
 import isCollaborator from "@cocalc/server/projects/is-collaborator";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerSerialPortOutputInputSchema,
+  GetComputeServerSerialPortOutputOutputSchema
+} from "lib/api/schema/compute/get-serial-port-output";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -44,3 +51,24 @@ async function get(req) {
     account_id: server.account_id, // actual compute server owner
   });
 }
+
+export default apiRoute({
+  getSerialPortOutput: apiRouteOperation({
+    method: "GET",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      query: GetComputeServerSerialPortOutputInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerSerialPortOutputOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-server-state.ts
+++ b/src/packages/next/pages/api/v2/compute/get-server-state.ts
@@ -6,7 +6,14 @@ import getAccountId from "lib/account/get-account";
 import { state } from "@cocalc/server/compute/control";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerStateInputSchema,
+  GetComputeServerStateOutputSchema
+} from "lib/api/schema/compute/get-server-state";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -26,3 +33,24 @@ async function get(req) {
     id,
   });
 }
+
+export default apiRoute({
+  getServerState: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: GetComputeServerStateInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerStateOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-server-title.ts
+++ b/src/packages/next/pages/api/v2/compute/get-server-title.ts
@@ -6,7 +6,14 @@ import getAccountId from "lib/account/get-account";
 import { getTitle } from "@cocalc/server/compute/get-servers";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerTitleInputSchema,
+  GetComputeServerTitleOutputSchema
+} from "lib/api/schema/compute/get-server-title";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -25,3 +32,24 @@ async function get(req) {
   });
   return await getTitle({ id, account_id });
 }
+
+export default apiRoute({
+  getServerTitle: apiRouteOperation({
+    method: "GET",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      query: GetComputeServerTitleInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerTitleOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-servers.ts
+++ b/src/packages/next/pages/api/v2/compute/get-servers.ts
@@ -6,6 +6,13 @@ import getAccountId from "lib/account/get-account";
 import getServers from "@cocalc/server/compute/get-servers";
 import getParams from "lib/api/get-params";
 
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServersInputSchema,
+  GetComputeServersOutputSchema
+} from "lib/api/schema/compute/get-servers";
+
+
 async function handle(req, res) {
   try {
     res.json(await get(req));
@@ -30,31 +37,22 @@ async function get(req) {
   });
 }
 
-import { apiRoute, apiRouteOperation, z } from "lib/api";
-
-const serversSchema = z.object({
-  id: z.number(),
-  title: z.string(),
-});
-
 export default apiRoute({
-  computeGetServers: apiRouteOperation({
+  getServers: apiRouteOperation({
     method: "GET",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
   })
     .input({
       contentType: "application/json",
-      body: z
-        .object({
-          project_id: z.string().optional(),
-          id: z.number().optional(),
-        })
-        .describe("Parameters that restrict compute servers to get."),
+      query: GetComputeServersInputSchema,
     })
     .outputs([
       {
         status: 200,
         contentType: "application/json",
-        body: z.array(serversSchema),
+        body: GetComputeServersOutputSchema,
       },
     ])
     .handler(handle),

--- a/src/packages/next/pages/api/v2/compute/get-template.ts
+++ b/src/packages/next/pages/api/v2/compute/get-template.ts
@@ -5,7 +5,14 @@ Get A Single Template
 import { getTemplate } from "@cocalc/server/compute/templates";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerTemplateInputSchema,
+  GetComputeServerTemplateOutputSchema,
+} from "lib/api/schema/compute/get-template";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -18,3 +25,24 @@ async function get(req) {
   const { id } = getParams(req);
   return await getTemplate(id);
 }
+
+export default apiRoute({
+  getTemplate: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: GetComputeServerTemplateInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerTemplateOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/get-templates.ts
+++ b/src/packages/next/pages/api/v2/compute/get-templates.ts
@@ -4,7 +4,13 @@ Get Templates
 
 import { getTemplates } from "@cocalc/server/compute/templates";
 
-export default async function handle(_req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GetComputeServerTemplatesOutputSchema
+} from "lib/api/schema/compute/get-templates";
+
+
+async function handle(_req, res) {
   try {
     res.json(await await getTemplates());
   } catch (err) {
@@ -12,3 +18,20 @@ export default async function handle(_req, res) {
     return;
   }
 }
+
+export default apiRoute({
+  getTemplates: apiRouteOperation({
+    method: "GET",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: GetComputeServerTemplatesOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/scripts.ts
+++ b/src/packages/next/pages/api/v2/compute/scripts.ts
@@ -11,11 +11,20 @@ import {
   getStopScript,
   getDeprovisionScript,
 } from "@cocalc/server/compute/control";
-import { getAccountWithApiKey as getProjectIdWithApiKey } from "@cocalc/server/api/manage";
+import {
+  getAccountWithApiKey as getProjectIdWithApiKey,
+} from "@cocalc/server/api/manage";
 import getParams from "lib/api/get-params";
 import getPool from "@cocalc/database/pool";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  ComputeServerScriptsInputSchema,
+  ComputeServerScriptsOutputSchema,
+} from "lib/api/schema/compute/scripts";
+
+
+async function handle(req, res) {
   try {
     res.send(await get(req));
   } catch (err) {
@@ -71,3 +80,24 @@ export async function getScript({
     throw Error(`unknown action=${action}`);
   }
 }
+
+export default apiRoute({
+  scripts: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: ComputeServerScriptsInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "text/plain",
+        body: ComputeServerScriptsOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/set-detailed-state.ts
+++ b/src/packages/next/pages/api/v2/compute/set-detailed-state.ts
@@ -12,7 +12,14 @@ import setDetailedState from "@cocalc/server/compute/set-detailed-state";
 import getParams from "lib/api/get-params";
 import isCollaborator from "@cocalc/server/projects/is-collaborator";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  SetDetailedServerStateInputSchema,
+  SetDetailedServerStateOutputSchema
+} from "lib/api/schema/compute/set-detailed-state";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -67,3 +74,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  setDetailedState: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: SetDetailedServerStateInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: SetDetailedServerStateOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/set-image-tested.ts
+++ b/src/packages/next/pages/api/v2/compute/set-image-tested.ts
@@ -9,7 +9,14 @@ import { setImageTested } from "@cocalc/server/compute/control";
 import getParams from "lib/api/get-params";
 import userIsInGroup from "@cocalc/server/accounts/is-in-group";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  SetComputeServerImageTestedInputSchema,
+  SetComputeServerImageTestedOutputSchema,
+} from "lib/api/schema/compute/set-image-tested";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -30,3 +37,24 @@ async function get(req) {
   await setImageTested({ id, account_id, tested });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  setImageTested: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: SetComputeServerImageTestedInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: SetComputeServerImageTestedOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/set-server-cloud.ts
+++ b/src/packages/next/pages/api/v2/compute/set-server-cloud.ts
@@ -8,7 +8,14 @@ import getAccountId from "lib/account/get-account";
 import setServerCloud from "@cocalc/server/compute/set-server-cloud";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  SetComputeServerCloudInputSchema,
+  SetComputeServerCloudOutputSchema,
+} from "lib/api/schema/compute/set-server-cloud";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -30,3 +37,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  setServerCloud: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: SetComputeServerCloudInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: SetComputeServerCloudOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/set-server-color.ts
+++ b/src/packages/next/pages/api/v2/compute/set-server-color.ts
@@ -6,7 +6,14 @@ import getAccountId from "lib/account/get-account";
 import setServerColor from "@cocalc/server/compute/set-server-color";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  SetComputeServerColorInputSchema,
+  SetComputeServerColorOutputSchema
+} from "lib/api/schema/compute/set-server-color";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -28,3 +35,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  setServerColor: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: SetComputeServerColorInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: SetComputeServerColorOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/set-server-configuration.ts
+++ b/src/packages/next/pages/api/v2/compute/set-server-configuration.ts
@@ -7,7 +7,14 @@ import getAccountId from "lib/account/get-account";
 import setServerConfiguration from "@cocalc/server/compute/set-server-configuration";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  SetServerConfigurationInputSchema,
+  SetServerConfigurationOutputSchema
+} from "lib/api/schema/compute/set-server-configuration";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -29,3 +36,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  setServerConfiguration: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: SetServerConfigurationInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: SetServerConfigurationOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/set-server-title.ts
+++ b/src/packages/next/pages/api/v2/compute/set-server-title.ts
@@ -7,7 +7,14 @@ import getAccountId from "lib/account/get-account";
 import setServerTitle from "@cocalc/server/compute/set-server-title";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  SetComputeServerTitleInputSchema,
+  SetComputeServerTitleOutputSchema,
+} from "lib/api/schema/compute/set-server-title";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -29,3 +36,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  setServerTitle: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: SetComputeServerTitleInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: SetComputeServerTitleOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/set-template.ts
+++ b/src/packages/next/pages/api/v2/compute/set-template.ts
@@ -1,7 +1,6 @@
 /*
-Set whether or not the image a compute server with given id is using has been tested.
-This is used by admins when manually doing final integration testing for a new image
-on some cloud provider.
+Set a specific compute server template by id. This operation is designed for
+administrators only.
 */
 
 import getAccountId from "lib/account/get-account";
@@ -9,7 +8,14 @@ import { setTemplate } from "@cocalc/server/compute/templates";
 import getParams from "lib/api/get-params";
 import userIsInGroup from "@cocalc/server/accounts/is-in-group";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  SetComputeServerTemplateInputSchema,
+  SetComputeServerTemplateOutputSchema,
+} from "lib/api/schema/compute/set-template";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -33,3 +39,24 @@ async function get(req) {
   await setTemplate({ account_id, id, template });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  setTemplate: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: SetComputeServerTemplateInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: SetComputeServerTemplateOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/compute/undelete-server.ts
+++ b/src/packages/next/pages/api/v2/compute/undelete-server.ts
@@ -1,12 +1,20 @@
 /*
-Undelete a compute server. 
+Undelete a compute server.
 */
 
 import getAccountId from "lib/account/get-account";
 import undeleteServer from "@cocalc/server/compute/undelete-server";
 import getParams from "lib/api/get-params";
 
-export default async function handle(req, res) {
+import { apiRoute, apiRouteOperation } from "lib/api";
+
+import {
+  UndeleteComputeServerInputSchema,
+  UndeleteComputeServerOutputSchema,
+} from "lib/api/schema/compute/undelete-server";
+
+
+async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
@@ -27,3 +35,24 @@ async function get(req) {
   });
   return { status: "ok" };
 }
+
+export default apiRoute({
+  undeleteServer: apiRouteOperation({
+    method: "POST",
+    openApiOperation: {
+      tags: ["Compute"]
+    },
+  })
+    .input({
+      contentType: "application/json",
+      body: UndeleteComputeServerInputSchema,
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: "application/json",
+        body: UndeleteComputeServerOutputSchema,
+      },
+    ])
+    .handler(handle),
+});

--- a/src/packages/next/pages/api/v2/guesslang.ts
+++ b/src/packages/next/pages/api/v2/guesslang.ts
@@ -1,6 +1,12 @@
 import { ModelOperations } from "@vscode/vscode-languagedetection";
 import getParams from "lib/api/get-params";
 
+import { apiRoute, apiRouteOperation } from "lib/api";
+import {
+  GuesslangInputSchema,
+  GuesslangOutputSchema
+} from "lib/api/schema/guesslang";
+
 const modelOperations = new ModelOperations();
 
 async function handle(req, res) {
@@ -15,47 +21,22 @@ async function handle(req, res) {
   }
 }
 
-//** OpenAPI below **
-
-import { z, apiRoute, apiRouteOperation } from "lib/api";
-
-const querySchema = z
-  .object({
-    code: z.string().describe("A snippet of code."),
-    cutoff: z
-      .number()
-      .positive()
-      .default(5)
-      .describe("Maximum number of results to return."),
-  })
-  .describe(
-    "Use a sophisticated machine learning model (see @vscode/vscode-languagedetection) to guess the language of a snippet of code.",
-  );
-
 export default apiRoute({
   guesslang: apiRouteOperation({
     method: "POST",
+    openApiOperation: {
+      tags: ["Utils"]
+    },
   })
-    .input({ contentType: "application/json", body: querySchema })
+    .input({
+      contentType: "application/json",
+      body: GuesslangInputSchema,
+    })
     .outputs([
       {
         status: 200,
         contentType: "application/json",
-        body: z.union([
-          z.object({
-            error: z
-              .string()
-              .optional()
-              .describe("Error message is something goes badly wrong."),
-          }),
-          z.object({
-            result: z
-              .array(z.string())
-              .describe(
-                "List of likely guesses for the type of code, from most likely to less likely.",
-              ),
-          }),
-        ]),
+        body: GuesslangOutputSchema,
       },
     ])
     .handler(handle),


### PR DESCRIPTION
# Description

Added first draft of OpenAPI docs for the Compute Server API.

This should be considered an incremental update, as some endpoints have not been fully E2E tested in accordance with the API docs. In addition, the following endpoints are still in progress (but are minimally documented now) due to their deeper object structure:

- `/api/v2/compute/get-images`
- `/api/v2/compute/get-images-google`
- `/api/v2/compute/check-in` (pending the current shared storage work for compute servers)
- `/api/v2/compute/get-template[s?]`
- `/api/v2/compute/set-server-configuration`
