### PR TITLE
on-prem: software environment selector more similar to jupyter hub

### DIFF
--- a/src/packages/frontend/project/settings/compute-image-selector.tsx
+++ b/src/packages/frontend/project/settings/compute-image-selector.tsx
@@ -7,6 +7,7 @@
 
 import { DownOutlined } from "@ant-design/icons";
 import { Button, Col, Dropdown, MenuProps, Row } from "antd";
+import { SizeType } from "antd/es/config-provider/SizeContext";
 import { fromJS } from "immutable";
 
 import { useTypedRedux } from "@cocalc/frontend/app-framework";
@@ -43,12 +44,21 @@ interface ComputeImageSelectorProps {
   onFocus?: () => void;
   onSelect: (e) => void;
   disabled?: boolean;
+  size?: SizeType;
 }
 
 export const ComputeImageSelector: React.FC<ComputeImageSelectorProps> = (
   props: ComputeImageSelectorProps,
 ) => {
-  const { selected_image, onFocus, onBlur, onSelect, layout, disabled } = props;
+  const {
+    selected_image,
+    onFocus,
+    onBlur,
+    onSelect,
+    layout,
+    disabled,
+    size = "small",
+  } = props;
 
   const software_envs: SoftwareEnvironments | null = useTypedRedux(
     "customize",
@@ -131,7 +141,7 @@ export const ComputeImageSelector: React.FC<ComputeImageSelectorProps> = (
         <Button
           onBlur={onBlur}
           onFocus={onFocus}
-          size="small"
+          size={size}
           disabled={disabled}
         >
           {selected_title} <DownOutlined />

--- a/src/packages/server/software-envs.ts
+++ b/src/packages/server/software-envs.ts
@@ -5,17 +5,18 @@
 
 // This is used by the hub to adjust the "customization" variable for the user visible site, and also by manage in on-prem, to actually get the associated configuration
 
+import { constants } from "node:fs";
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
 import getLogger from "@cocalc/backend/logger";
 import {
   Purpose,
   sanitizeSoftwareEnv,
   SoftwareEnvConfig,
 } from "@cocalc/util/sanitize-software-envs";
-import { constants } from "fs";
-import { access, readFile } from "fs/promises";
-import { join } from "path";
 
-const logger = getLogger("hub:webapp-config");
+const logger = getLogger("hub:software-envs");
 const L = logger.debug;
 const W = logger.warn;
 
@@ -28,7 +29,7 @@ const cache: { [key in Purpose]: SoftwareEnvConfig | false | null } = {
  * A configuration for available software environments could be stored at the location of $COCALC_SOFTWARE_ENVIRONMENTS.
  */
 export async function getSoftwareEnvironments(
-  purpose: Purpose
+  purpose: Purpose,
 ): Promise<SoftwareEnvConfig | null> {
   if (cache[purpose] === null) {
     cache[purpose] = (await readConfig(purpose)) ?? false;
@@ -46,14 +47,14 @@ async function readConfig(purpose: Purpose): Promise<SoftwareEnvConfig | null> {
 
   if (!(await isReadable(softwareFn))) {
     W(
-      `WARNING: $COCALC_SOFTWARE_ENVIRONMENTS is defined but ${softwareFn} does not exist`
+      `WARNING: $COCALC_SOFTWARE_ENVIRONMENTS is defined but ${softwareFn} does not exist`,
     );
     return null;
   }
 
   if (!(await isReadable(registryFn))) {
     W(
-      `WARNING: $COCALC_SOFTWARE_ENVIRONMENTS is defined but ${registryFn} does not exist`
+      `WARNING: $COCALC_SOFTWARE_ENVIRONMENTS is defined but ${registryFn} does not exist`,
     );
     return null;
   }

--- a/src/packages/util/sanitize-software-envs.ts
+++ b/src/packages/util/sanitize-software-envs.ts
@@ -3,8 +3,9 @@
  *  License: AGPLv3 s.t. "Commons Clause" – see LICENSE.md for details
  */
 
-import { ComputeImage } from "@cocalc/util/compute-images";
 import { isEmpty, isObject, pick } from "lodash";
+
+import { ComputeImage } from "@cocalc/util/compute-images";
 import { DEFAULT_COMPUTE_IMAGE } from "./db-schema/defaults";
 
 // This sanitization routine checks if the "software environment" information
@@ -54,7 +55,7 @@ interface Opts {
  */
 export function sanitizeSoftwareEnv(
   opts: Opts,
-  L: (...msg) => void
+  L: (...msg) => void,
 ): SoftwareEnvConfig | null {
   const { software, registry, purpose } = opts;
 


### PR DESCRIPTION
# Description

this is just a small UX change for on-prem, to match a bit more closely how this works with jupyter hub 

![Screenshot from 2024-06-12 18-48-05](https://github.com/sagemathinc/cocalc/assets/207405/f5c20f08-b265-45b2-a780-20554ef38a51)


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
