### PR TITLE
OOM banner links to deprecated boosters, suggest editing the license …

### DIFF
--- a/src/packages/frontend/project/warnings/oom.tsx
+++ b/src/packages/frontend/project/warnings/oom.tsx
@@ -126,17 +126,17 @@ export const OOMWarning: React.FC<{ project_id: string }> = ({
 
   function renderUpgrade() {
     if (hasLicenseUpgrades) {
-      const boostUrl = join(appBasePath, "/store/boost");
+      const boostUrl = join(appBasePath, "/settings/licenses");
       return (
         <A href={boostUrl} style={{ fontWeight: "bold" }}>
-          boost memory quota
+          edit your license to increase its memory quota
         </A>
       );
     } else {
       const slUrl = join(appBasePath, "/store/site-license");
       return (
         <A href={slUrl} style={{ fontWeight: "bold" }}>
-          upgrade memory quota
+          purchase a license with higher memory quota
         </A>
       );
     }


### PR DESCRIPTION
…instead

# Description

I did not test it in action since running OOM on the dev server shows the banner in the project that hosts it. But the logic seems correct.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
