### PR TITLE
Compute Server API: Server configuration field now passes through ext…

### DIFF
--- a/src/packages/next/lib/api/schema/compute/common.ts
+++ b/src/packages/next/lib/api/schema/compute/common.ts
@@ -41,9 +41,9 @@ export const ComputeServerImageProxySchema = z.object({
   name: z.string().optional(),
 });
 
-export const GoogleCloudServerConfigurationSchema = z.object({});
+export const GoogleCloudServerConfigurationSchema = z.object({}).passthrough();
 
-export const HyperstackServerConfigurationSchema = z.object({});
+export const HyperstackServerConfigurationSchema = z.object({}).passthrough();
 
 export const ServerConfigurationSchema = z.union([
   GoogleCloudServerConfigurationSchema,


### PR DESCRIPTION
…ra keys in the `configuration` field during schema validation.
