### PR TITLE
Tweak UI help text for creating Cloud Filesystems

### DIFF
--- a/src/packages/frontend/compute/cloud-filesystem/bucket.tsx
+++ b/src/packages/frontend/compute/cloud-filesystem/bucket.tsx
@@ -38,10 +38,11 @@ export function BucketStorageClass({ configuration, setConfiguration }) {
         style={{ margin: "10px" }}
         showIcon
         type="info"
-        message={`Recommendation: Use Autoclass`}
+        message={`Recommendation: Autoclass`}
         description={
           <>
-            Use{" "}
+            Unless you understand why a different choice is better for your
+            data, use{" "}
             <A href="https://cloud.google.com/storage/docs/autoclass">
               autoclass
             </A>
@@ -56,8 +57,8 @@ export function BucketStorageClass({ configuration, setConfiguration }) {
                 priceData,
               }),
             )}{" "}
-            per million blocks (there are 65,536 blocks of size 16 MB in a 1 TB
-            file).
+            per million blocks (there are 65,536 blocks of size 16 MB in 1 TB of
+            data).
           </>
         }
       />
@@ -67,7 +68,7 @@ export function BucketStorageClass({ configuration, setConfiguration }) {
           (bucket_storage_class) => {
             const { min, max } = getDataStoragePriceRange({
               ...configuration,
-              prices:priceData,
+              prices: priceData,
               bucket_storage_class,
             });
             return {
@@ -227,8 +228,8 @@ export function BucketLocation({ configuration, setConfiguration }) {
         </A>
       </b>
       {NO_CHANGE}
-      You can use your cloud file system from any compute server in the world, in
-      any cloud or on prem. However, data transfer and operations are{" "}
+      You can use your cloud file system from any compute server in the world,
+      in any cloud or on prem. However, data transfer and operations are{" "}
       <b>faster and cheaper</b> when the file system and compute server are in
       the same region. <br />
       <div style={{ display: "flex", margin: "10px 0" }}>

--- a/src/packages/frontend/compute/cloud-filesystem/create.tsx
+++ b/src/packages/frontend/compute/cloud-filesystem/create.tsx
@@ -411,7 +411,7 @@ function Compression({ configuration, setConfiguration }) {
         style={{ margin: "10px" }}
         showIcon
         type="info"
-        message={`Recommendation`}
+        message={`Recommendation: LZ4`}
         description={
           <>
             Do not enable compression if most of your data is already
@@ -444,20 +444,18 @@ function BlockSize({ configuration, setConfiguration }) {
       <b style={{ fontSize: "13pt", color: "#666" }}>Block Size</b>
       {NO_CHANGE}
       The block size, which is between {MIN_BLOCK_SIZE} MB and {MAX_BLOCK_SIZE}{" "}
-      MB, is an upper bound on the size of the objects that are storied in the
+      MB, is an upper bound on the size of the objects that are stored in the
       cloud storage bucket.
       <Alert
         style={{ margin: "10px" }}
         showIcon
         type="info"
-        message={`Recommendation: use ${RECOMMENDED_BLOCK_SIZE} MB`}
+        message={`Recommendation: ${RECOMMENDED_BLOCK_SIZE} MB`}
         description={
           <>
-            It can be better to use a large block size, since the number of PUT
-            and GET operations is reduced, and they each cost money. Also, if
-            you use an autoclass storage class, use at least{" "}
-            {RECOMMENDED_BLOCK_SIZE} MB since there is a monthly per-object
-            cost, and consider {MAX_BLOCK_SIZE} MB.
+            Larger block size reduces the number of PUT and GET operations, and
+            they each cost money. Also, if you use an autoclass storage class,
+            there is a monthly per-object cost.
           </>
         }
       />


### PR DESCRIPTION
# Description

Recommendations had inconsistent usage of "use": "use/Use/and nothing" - I made it uniform "Recommendation: Default"

The block size explanation is only about "the bigger the merrier" while the last sentence made sense in the code, with variables, but not rendered, where different variables had the same value. The meaning was still "the bigger the merrier", so I just deleted it. If somebody understands why smaller is better in a particular case, there is the flexibility to adjust it.


## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
