### PR TITLE
add a version number to the cost parameters for licenses

### DIFF
--- a/src/packages/frontend/purchases/edit-license.tsx
+++ b/src/packages/frontend/purchases/edit-license.tsx
@@ -23,6 +23,7 @@ import type { Changes } from "@cocalc/util/purchases/cost-to-edit-license";
 import { isEqual } from "lodash";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
+import { CURRENT_VERSION } from "@cocalc/util/licenses/purchase/consts";
 
 interface Props {
   license_id: string;
@@ -112,6 +113,7 @@ export default function EditLicense({ license_id, refresh }: Props) {
         }
         subInfo.start = null;
         subInfo.end = null;
+        subInfo.version = CURRENT_VERSION;
         setModifiedSubscriptionCost(compute_cost(subInfo).cost);
       }
     } catch (err) {
@@ -258,7 +260,7 @@ export default function EditLicense({ license_id, refresh }: Props) {
                     modifiedSubscriptionCost != null &&
                     modifiedSubscriptionCost != subscription.cost && (
                       <>
-                        cost:{" "}
+                        cost at current rates:{" "}
                         <b>
                           {currency(modifiedSubscriptionCost)}/
                           {subscription.interval}
@@ -270,8 +272,8 @@ export default function EditLicense({ license_id, refresh }: Props) {
                   {subscription?.cost != null && (
                     <div>
                       {" "}
-                      Current cost: {currency(subscription?.cost)}/
-                      {subscription.interval}.
+                      What you currently pay: {currency(subscription?.cost)}/
+                      {subscription.interval}
                     </div>
                   )}
                   {subscription != null &&
@@ -279,8 +281,9 @@ export default function EditLicense({ license_id, refresh }: Props) {
                     modifiedSubscriptionCost != subscription.cost && (
                       <div>
                         <b>
-                          New cost: {currency(modifiedSubscriptionCost)}/
-                          {subscription.interval}.
+                          New cost after changes:{" "}
+                          {currency(modifiedSubscriptionCost)}/
+                          {subscription.interval}
                         </b>
                       </div>
                     )}

--- a/src/packages/frontend/site-licenses/purchase/purchase.tsx
+++ b/src/packages/frontend/site-licenses/purchase/purchase.tsx
@@ -42,9 +42,9 @@ import {
   discount_yearly_pct,
 } from "@cocalc/util/licenses/purchase/consts";
 import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
-import {
+import type {
   Cost,
-  PurchaseInfoQuota,
+  PurchaseInfo,
   Subscription,
   Upgrade,
   User,
@@ -71,6 +71,7 @@ import { create_quote_support_ticket } from "./get-a-quote";
 import { PurchaseMethod } from "./purchase-method";
 import { QuotaEditor } from "./quota-editor";
 import { RadioGroup } from "./radio-group";
+import { CURRENT_VERSION } from "@cocalc/util/licenses/purchase/consts";
 
 const { RangePicker } = DatePicker;
 
@@ -173,6 +174,7 @@ export const PurchaseOneLicense: React.FC<Props> = React.memo(({ onClose }) => {
       return undefined;
     }
     return compute_cost({
+      version: CURRENT_VERSION,
       type: "quota",
       quantity,
       user,
@@ -589,7 +591,8 @@ export const PurchaseOneLicense: React.FC<Props> = React.memo(({ onClose }) => {
       quote == null
     )
       return;
-    const info: PurchaseInfoQuota = {
+    const info: PurchaseInfo = {
+      version: CURRENT_VERSION,
       type: "quota",
       quantity,
       user,

--- a/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
+++ b/src/packages/frontend/site-licenses/purchase/quota-editor.tsx
@@ -47,7 +47,6 @@ import { KUCALC_ON_PREMISES } from "@cocalc/util/db-schema/site-defaults";
 import {
   COSTS,
   CostMap,
-  GCE_COSTS,
 } from "@cocalc/util/licenses/purchase/consts";
 import { User } from "@cocalc/util/licenses/purchase/types";
 import { money } from "@cocalc/util/licenses/purchase/utils";
@@ -112,7 +111,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
     return (
       (quota.member ? COSTS.custom_cost.member : 1) *
       (quota.always_running ? COSTS.custom_cost.always_running : 1) *
-      (quota.member && quota.always_running ? GCE_COSTS.non_pre_factor : 1)
+      (quota.member && quota.always_running ? COSTS.gce.non_pre_factor : 1)
     );
   }, [quota]);
 
@@ -724,7 +723,7 @@ export const QuotaEditor: React.FC<Props> = (props: Props) => {
           <>
             <b>
               longer idle time increases price by up to{" "}
-              {COSTS.custom_cost.always_running * GCE_COSTS.non_pre_factor}{" "}
+              {COSTS.custom_cost.always_running * COSTS.gce.non_pre_factor}{" "}
               times
             </b>{" "}
             {render_explanation(`If you leave your project alone, it will be shut down the latest

--- a/src/packages/frontend/site-licenses/site-license-public-info.tsx
+++ b/src/packages/frontend/site-licenses/site-license-public-info.tsx
@@ -342,7 +342,7 @@ export const SiteLicensePublicInfoTable: React.FC<PropsTable> = (
       if (rec.expired) {
         return (
           <>
-            Expired {when}.{delimiter}Could update {runLimit} running{" "}
+            Expired {when}.{delimiter}Could upgrade {runLimit} running{" "}
             {plural(runLimit, "project")}.
           </>
         );

--- a/src/packages/next/components/store/quota-config-presets.tsx
+++ b/src/packages/next/components/store/quota-config-presets.tsx
@@ -47,7 +47,7 @@ type PresetEntries = {
 
 // some constants to keep text and preset in sync
 const STANDARD_CPU = 1;
-const STANDARD_RAM = 3;
+const STANDARD_RAM = 4;
 const LARGE_RAM = 8;
 const STANDARD_DISK = 3;
 

--- a/src/packages/next/pages/pricing/subscriptions.tsx
+++ b/src/packages/next/pages/pricing/subscriptions.tsx
@@ -32,6 +32,7 @@ import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
 import { Paragraph, Title } from "components/misc";
 import dayjs from "dayjs";
+import { CURRENT_VERSION } from "@cocalc/util/licenses/purchase/consts";
 
 function addMonth(date: Date): Date {
   return dayjs(date).add(30, "days").add(12, "hours").toDate();
@@ -64,6 +65,7 @@ const hobby: Item = (() => {
   } as const;
 
   const info: PurchaseInfo = {
+    version: CURRENT_VERSION,
     type: "quota",
     user: conf.user,
     upgrade: "custom",
@@ -109,6 +111,7 @@ const academic: Item = (() => {
   } as const;
 
   const info: PurchaseInfo = {
+    version: CURRENT_VERSION,
     type: "quota",
     user: conf.user,
     upgrade: "custom",
@@ -155,6 +158,7 @@ const business: Item = (() => {
   } as const;
 
   const info: PurchaseInfo = {
+    version: CURRENT_VERSION,
     type: "quota",
     user: conf.user,
     upgrade: "custom",

--- a/src/packages/server/prices.test.ts
+++ b/src/packages/server/prices.test.ts
@@ -6,10 +6,7 @@
 // test product ID and pricing
 
 import { ONE_DAY_MS } from "@cocalc/util/consts/billing";
-import type {
-  PurchaseInfo,
-  PurchaseInfoQuota,
-} from "@cocalc/util/licenses/purchase/types";
+import type { PurchaseInfo } from "@cocalc/util/licenses/purchase/types";
 import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
 import { round2 } from "@cocalc/util/misc";
 import {
@@ -31,7 +28,8 @@ describe("product id and compute cost", () => {
   // (since it isn't!) we set it back to run this test.
   // @ts-ignore
   COSTS.online_discount = 0.75;
-  const info1: Omit<PurchaseInfoQuota, "quantity"> = {
+  const info1 = {
+    version: "1",
     type: "quota",
     user: "academic",
     upgrade: "custom",
@@ -75,6 +73,7 @@ describe("product id and compute cost", () => {
         new Date((info1.start as Date).getTime() + days * ONE_DAY_MS),
       ),
     };
+    // @ts-ignore
     info2.cost = compute_cost(info2);
     // console.log(days, info2, Math.round(info2.cost.cost_per_unit * 10000));
     const unit_amount = unitAmount(info2);
@@ -89,6 +88,7 @@ describe("product id and compute cost", () => {
       start: new Date("2022-04-28T10:08:10.072Z"),
       end: new Date("2022-05-05T10:08:10.072Z"),
     };
+    // @ts-ignore
     info2.cost = compute_cost(info2);
     expect(unitAmount(info2)).toEqual(111);
   });
@@ -152,6 +152,7 @@ describe("dedicated disk", () => {
   it("calculates subscription price of one disk", () => {
     const start = startOfDay(new Date());
     const purchaseInfo: PurchaseInfo = {
+      version: "1",
       type: "disk",
       start,
       end: dayjs(start).add(30, "days").add(12, "hours").toDate(), // adding exact amount of time to make test well defined

--- a/src/packages/server/purchases/purchase-shopping-cart-item.test.ts
+++ b/src/packages/server/purchases/purchase-shopping-cart-item.test.ts
@@ -136,7 +136,7 @@ describe("create a subscription license and edit it and confirm the subscription
         member: true,
         period: "yearly",
         uptime: "short",
-        run_limit: 500,
+        run_limit: 200,
       },
       cost: {} as any,
     };

--- a/src/packages/server/vouchers/charge-for-unpaid-vouchers.ts
+++ b/src/packages/server/vouchers/charge-for-unpaid-vouchers.ts
@@ -20,6 +20,7 @@ import { getLogger } from "@cocalc/backend/logger";
 import { chargeUser } from "@cocalc/server/licenses/purchase/charge";
 import { StripeClient } from "@cocalc/server/stripe/client";
 import type { PurchaseInfo } from "@cocalc/util/db-schema/vouchers";
+import { CURRENT_VERSION } from "@cocalc/util/licenses/purchase/consts";
 
 const log = getLogger("charge-for-unpaid-vouchers");
 
@@ -34,7 +35,7 @@ export default async function chargeForUnpaidVouchers(): Promise<Result> {
 
   const pool = getPool();
   const { rows } = await pool.query(
-    "SELECT id, cost, tax, created_by, title FROM vouchers WHERE purchased is NULL AND when_pay='invoice' AND expire < NOW()"
+    "SELECT id, cost, tax, created_by, title FROM vouchers WHERE purchased is NULL AND when_pay='invoice' AND expire < NOW()",
   );
   const result: Result = {};
   for (const row of rows) {
@@ -67,7 +68,7 @@ async function chargeForUnpaidVoucher({
   const pool = getPool();
   const { rows } = await pool.query(
     "SELECT COUNT(*) AS quantity FROM voucher_codes WHERE id=$1 AND when_redeemed IS NOT NULL AND canceled IS NULL",
-    [id]
+    [id],
   );
   const quantity = rows[0].quantity;
   let purchased: PurchaseInfo;
@@ -76,6 +77,8 @@ async function chargeForUnpaidVoucher({
   } else {
     const stripe = new StripeClient({ account_id: created_by });
     const info = {
+      // version doesn't really matter since the cost is already explicitly given below
+      version: CURRENT_VERSION,
       type: "vouchers",
       quantity,
       cost,

--- a/src/packages/util/licenses/purchase/compute-cost.ts
+++ b/src/packages/util/licenses/purchase/compute-cost.ts
@@ -8,7 +8,7 @@ import {
   LicenseIdleTimeouts,
   requiresMemberhosting,
 } from "@cocalc/util/consts/site-license";
-import { BASIC, COSTS, GCE_COSTS, MAX, STANDARD } from "./consts";
+import { BASIC, getCosts, MAX, STANDARD } from "./consts";
 import { dedicatedPrice } from "./dedicated-price";
 import { Cost, PurchaseInfo } from "./types";
 
@@ -22,6 +22,7 @@ export function compute_cost(info: PurchaseInfo): Cost {
   }
 
   let {
+    version,
     quantity,
     user,
     upgrade,
@@ -35,8 +36,6 @@ export function compute_cost(info: PurchaseInfo): Cost {
     custom_uptime,
   } = info;
 
-  // at this point, we assume the start/end dates are already
-  // set to the start/end time of a day in the user's timezone.
   const start = info.start ? new Date(info.start) : undefined;
   const end = info.end ? new Date(info.end) : undefined;
 
@@ -45,7 +44,7 @@ export function compute_cost(info: PurchaseInfo): Cost {
     throw new Error(`unknown user ${user}`);
   }
 
-  // this is set in the next if/else block
+  // custom_always_running is set in the next if/else block
   let custom_always_running = false;
   if (upgrade == "standard") {
     // set custom_* to what they would be:
@@ -77,6 +76,8 @@ export function compute_cost(info: PurchaseInfo): Cost {
     custom_member = true;
   }
 
+  const COSTS = getCosts(version);
+
   // We compute the cost for one project for one month.
   // First we add the cost for RAM and CPU.
   let cost_per_project_per_month =
@@ -93,7 +94,7 @@ export function compute_cost(info: PurchaseInfo): Cost {
       // always on non-member means it gets restarted whenever the
       // pre-empt gets killed, which is still potentially very useful
       // for long-running computations that can be checkpointed and started.
-      cost_per_project_per_month *= GCE_COSTS.non_pre_factor;
+      cost_per_project_per_month *= COSTS.gce.non_pre_factor;
     }
   } else {
     // multiply by the idle_timeout factor

--- a/src/packages/util/licenses/purchase/compute-cost.ts
+++ b/src/packages/util/licenses/purchase/compute-cost.ts
@@ -10,8 +10,23 @@ import {
 } from "@cocalc/util/consts/site-license";
 import { BASIC, getCosts, MAX, STANDARD } from "./consts";
 import { dedicatedPrice } from "./dedicated-price";
-import { Cost, PurchaseInfo } from "./types";
+import type { Cost, PurchaseInfo } from "./types";
 
+// NOTE: the PurchaseInfo object optionally has a "version" field in it.
+// If the version is not specified, then it defaults to "1", which is the version
+// when we started versioning prices.  If it is something else, then different
+// cost parameters may be used in the algorithm below -- that's what's currently
+// implemented.  However... maybe we want a new cost function entirely?  That's
+// possible too:
+//    - just call a new function for your new version below (that's the easy part), and
+//    - there is frontend and other UI code that depends on the structure exported
+//      by contst.ts, and anything that uses that MUST be updated accordingly.  E.g.,
+//      there are tables with example costs for various scenarios, stuff about academic
+//      discounts, etc., and a completely different cost function would need to explain
+//      all that differently to users.
+// OBVIOUSLY: NEVER EVER CHANGE the code or parameters that compute the value of
+// a specific version of a license!  If you make any change, then you must assign a
+// new version number and also keep the old version around.
 export function compute_cost(info: PurchaseInfo): Cost {
   if (info.type === "disk" || info.type === "vm") {
     return compute_cost_dedicated(info);

--- a/src/packages/util/licenses/purchase/consts.ts
+++ b/src/packages/util/licenses/purchase/consts.ts
@@ -11,7 +11,7 @@ import costVersions from "./cost-versions";
 // is used when the version is not defined.
 const FALLBACK_VERSION = "1";
 
-const CURRENT_VERSION = "1";
+export const CURRENT_VERSION = "1";
 
 // Another gamble implicit in this is that pre's are available.  When they
 // aren't, cocalc.com switches to uses MUCH more expensive non-preemptibles.

--- a/src/packages/util/licenses/purchase/consts.ts
+++ b/src/packages/util/licenses/purchase/consts.ts
@@ -5,49 +5,13 @@
 
 import { CustomUpgrades, Subscription, User } from "./types";
 
-// discount is the number we multiply the price by:
+import costVersions from "./cost-versions";
 
-// TODO: move the actual **data** that defines this cost map to the database
-// and admin site settings.  It must be something that we can change at any time,
-// and that somebody else selling cocalc would set differently.
+// version for licenses before we were using versioning; this is what
+// is used when the version is not defined.
+const FALLBACK_VERSION = "1";
 
-// See https://cloud.google.com/compute/vm-instance-pricing#e2_custommachinetypepricing
-// for the monthly GCE prices
-export const GCE_COSTS = {
-  ram: 0.67, // for pre-emptibles
-  cpu: 5, // for pre-emptibles
-  disk: 0.04, // per GB/month
-  non_pre_factor: 3.5, // Roughly Google's factor for non-preemptible's
-} as const;
-
-// Our price = GCE price times this.  We charge LESS than Google VM's, due to our gamble
-// on having multiple users on a node at once.
-// 2022-06: price increase "version 2", from 0.75 → 0.8 to compensate for 15% higher GCE prices
-//          and there is also a minimum of 3gb storage (the free base quota) now.
-const COST_MULTIPLIER = 0.8;
-// We gamble that projects are packed at least twice as densely on non-member
-// nodes (it's often worse).
-const NONMEMBER_DENSITY = 2;
-// Changing this doesn't change the actual academic prices --
-// it just changes the *business* prices.
-const ACADEMIC_DISCOUNT = 0.6;
-// Disk factor is based on how many copies of user data we have, plus guesses about
-// bandwidth to transfer data around (to/from cloud storage, backblaze, etc.).
-// 10 since we have about that many copies of user data, plus snapshots, and
-// we store their data long after they stop paying...
-const DISK_FACTOR = 10;
-
-// These are based on what we observe in practice, what works well,
-// and what is configured in our backend autoscalers.  This only
-// impacts the cost of dedicated cpu and RAM.
-const RAM_OVERCOMMIT = 5;
-const CPU_OVERCOMMIT = 10;
-
-// Extra charge if project will always be on. Really we are gambling that
-// projects that are not always on, are off much of the time (at least 50%).
-// We use this factor since a 50-simultaneous active projects license could
-// easily be used about half of the time during a week in a large class.
-const ALWAYS_RUNNING_FACTOR = 2;
+const CURRENT_VERSION = "1";
 
 // Another gamble implicit in this is that pre's are available.  When they
 // aren't, cocalc.com switches to uses MUCH more expensive non-preemptibles.
@@ -62,23 +26,8 @@ export interface CostMap {
   member: number;
 }
 
-export const CUSTOM_COST: CostMap = {
-  ram:
-    (COST_MULTIPLIER * GCE_COSTS.ram) / ACADEMIC_DISCOUNT / NONMEMBER_DENSITY,
-  dedicated_ram:
-    (RAM_OVERCOMMIT * (COST_MULTIPLIER * GCE_COSTS.ram)) /
-    ACADEMIC_DISCOUNT /
-    NONMEMBER_DENSITY,
-  cpu:
-    (COST_MULTIPLIER * GCE_COSTS.cpu) / ACADEMIC_DISCOUNT / NONMEMBER_DENSITY,
-  dedicated_cpu:
-    (CPU_OVERCOMMIT * (COST_MULTIPLIER * GCE_COSTS.cpu)) /
-    ACADEMIC_DISCOUNT /
-    NONMEMBER_DENSITY,
-  disk: (DISK_FACTOR * COST_MULTIPLIER * GCE_COSTS.disk) / ACADEMIC_DISCOUNT,
-  always_running: ALWAYS_RUNNING_FACTOR,
-  member: NONMEMBER_DENSITY,
-} as const;
+// BASIC, STANDARD and MAX have nothing to do with defining pricing.  They
+// are just some presets that might have been used at some point (?).
 
 export const BASIC: CostMap = {
   ram: 1,
@@ -112,36 +61,88 @@ export const MAX: CostMap = {
 
 export const MIN_QUOTE = 100;
 
+interface GoogleComputeEngine {
+  ram: number;
+  cpu: number;
+  disk: number;
+  non_pre_factor: number;
+}
+
 interface CostsStructure {
+  version: string;
+
+  // these are critical to defining and computing the cost of a license
   user_discount: { [user in User]: number };
   sub_discount: { [sub in Subscription]: number };
-  min_quote: number;
   custom_cost: { [key in CustomUpgrades]: number };
   custom_max: { [key in CustomUpgrades]: number };
+  gce: GoogleComputeEngine;
+
+  // not even sure if any of this is ever used anymore -- it's generic.
+  min_quote: number;
   basic: { [key in CustomUpgrades]: number };
   standard: { [key in CustomUpgrades]: number };
   max: { [key in CustomUpgrades]: number };
 }
 
-export const COSTS: CostsStructure = {
-  user_discount: { academic: ACADEMIC_DISCOUNT, business: 1 },
-  sub_discount: { no: 1, monthly: 0.9, yearly: 0.85 },
-  min_quote: MIN_QUOTE,
-  custom_cost: CUSTOM_COST,
-  custom_max: MAX,
-  basic: BASIC,
-  standard: STANDARD,
-  max: MAX,
-} as const;
+export function getCosts(version = FALLBACK_VERSION): CostsStructure {
+  const {
+    SUB_DISCOUNT,
+    GCE_COSTS,
+    COST_MULTIPLIER,
+    NONMEMBER_DENSITY,
+    ACADEMIC_DISCOUNT,
+    DISK_FACTOR,
+    RAM_OVERCOMMIT,
+    CPU_OVERCOMMIT,
+    ALWAYS_RUNNING_FACTOR,
+  } = costVersions[version];
+
+  const CUSTOM_COST: CostMap = {
+    ram:
+      (COST_MULTIPLIER * GCE_COSTS.ram) / ACADEMIC_DISCOUNT / NONMEMBER_DENSITY,
+    dedicated_ram:
+      (RAM_OVERCOMMIT * (COST_MULTIPLIER * GCE_COSTS.ram)) /
+      ACADEMIC_DISCOUNT /
+      NONMEMBER_DENSITY,
+    cpu:
+      (COST_MULTIPLIER * GCE_COSTS.cpu) / ACADEMIC_DISCOUNT / NONMEMBER_DENSITY,
+    dedicated_cpu:
+      (CPU_OVERCOMMIT * (COST_MULTIPLIER * GCE_COSTS.cpu)) /
+      ACADEMIC_DISCOUNT /
+      NONMEMBER_DENSITY,
+    disk: (DISK_FACTOR * COST_MULTIPLIER * GCE_COSTS.disk) / ACADEMIC_DISCOUNT,
+    always_running: ALWAYS_RUNNING_FACTOR,
+    member: NONMEMBER_DENSITY,
+  } as const;
+
+  return {
+    version,
+
+    user_discount: { academic: ACADEMIC_DISCOUNT, business: 1 },
+    sub_discount: SUB_DISCOUNT,
+    custom_cost: CUSTOM_COST,
+    custom_max: MAX,
+    gce: GCE_COSTS,
+
+    min_quote: MIN_QUOTE,
+    basic: BASIC,
+    standard: STANDARD,
+    max: MAX,
+  } as const;
+}
+
+const COSTS = getCosts(CURRENT_VERSION);
+export { COSTS };
 
 export const discount_pct = Math.round(
-  (1 - COSTS.user_discount["academic"]) * 100
+  (1 - COSTS.user_discount["academic"]) * 100,
 );
 
 export const discount_monthly_pct = Math.round(
-  (1 - COSTS.sub_discount["monthly"]) * 100
+  (1 - COSTS.sub_discount["monthly"]) * 100,
 );
 
 export const discount_yearly_pct = Math.round(
-  (1 - COSTS.sub_discount["yearly"]) * 100
+  (1 - COSTS.sub_discount["yearly"]) * 100,
 );

--- a/src/packages/util/licenses/purchase/cost-versions.ts
+++ b/src/packages/util/licenses/purchase/cost-versions.ts
@@ -51,17 +51,17 @@ const COST = {
   },
 
   2: {
-    SUB_DISCOUNT: { no: 1, monthly: 0.85, yearly: 0.8 },
+    SUB_DISCOUNT: { no: 1, monthly: 0.85, yearly: 0.75 },
     GCE_COSTS: {
-      ram: 0.67,
+      ram: 0.7,
       cpu: 5,
-      disk: 0.05,
+      disk: 0.1,
       non_pre_factor: 3.5,
     },
-    COST_MULTIPLIER: 1.2,
+    COST_MULTIPLIER: 1,
     NONMEMBER_DENSITY: 2,
     ACADEMIC_DISCOUNT: 0.6,
-    DISK_FACTOR: 20,
+    DISK_FACTOR: 10,
     RAM_OVERCOMMIT: 5,
     CPU_OVERCOMMIT: 10,
     ALWAYS_RUNNING_FACTOR: 2,

--- a/src/packages/util/licenses/purchase/cost-versions.ts
+++ b/src/packages/util/licenses/purchase/cost-versions.ts
@@ -50,6 +50,23 @@ const COST = {
     ALWAYS_RUNNING_FACTOR: 2,
   },
 
+  2: {
+    SUB_DISCOUNT: { no: 1, monthly: 0.85, yearly: 0.8 },
+    GCE_COSTS: {
+      ram: 0.67,
+      cpu: 5,
+      disk: 0.05,
+      non_pre_factor: 3.5,
+    },
+    COST_MULTIPLIER: 1.2,
+    NONMEMBER_DENSITY: 2,
+    ACADEMIC_DISCOUNT: 0.6,
+    DISK_FACTOR: 20,
+    RAM_OVERCOMMIT: 5,
+    CPU_OVERCOMMIT: 10,
+    ALWAYS_RUNNING_FACTOR: 2,
+  },
+
   // this version is PURELY for testing purposes
   test_1: {
     SUB_DISCOUNT: { no: 1, monthly: 0.9, yearly: 0.85 },

--- a/src/packages/util/licenses/purchase/cost-versions.ts
+++ b/src/packages/util/licenses/purchase/cost-versions.ts
@@ -3,6 +3,10 @@
 // the value of any existing licenses.  For pay-as-you-go, on the other hand, the charges
 // are always short live and ephemeral, and the parameters for them are in the database.
 
+// OBVIOUSLY: NEVER EVER CHANGE the existing parameters that define the value of
+// a specific released version of a license!  If you make any change, then you must assign a
+// new version number and also keep the old version around!!!!
+
 const COST = {
   1: {
     // Subscription discount
@@ -43,6 +47,24 @@ const COST = {
     // projects that are not always on, are off much of the time (at least 50%).
     // We use this factor since a 50-simultaneous active projects license could
     // easily be used about half of the time during a week in a large class.
+    ALWAYS_RUNNING_FACTOR: 2,
+  },
+
+  // this version is PURELY for testing purposes
+  test_1: {
+    SUB_DISCOUNT: { no: 1, monthly: 0.9, yearly: 0.85 },
+    GCE_COSTS: {
+      ram: 0.67,
+      cpu: 5,
+      disk: 0.04,
+      non_pre_factor: 3.5,
+    },
+    COST_MULTIPLIER: 1.6, // double version 1
+    NONMEMBER_DENSITY: 2,
+    ACADEMIC_DISCOUNT: 0.6,
+    DISK_FACTOR: 10,
+    RAM_OVERCOMMIT: 5,
+    CPU_OVERCOMMIT: 10,
     ALWAYS_RUNNING_FACTOR: 2,
   },
 } as const;

--- a/src/packages/util/licenses/purchase/cost-versions.ts
+++ b/src/packages/util/licenses/purchase/cost-versions.ts
@@ -1,0 +1,50 @@
+// We hard code the prices for licenses (and all versions of them) because they must
+// remain with the system forever, since we always want to be able to easily compute
+// the value of any existing licenses.  For pay-as-you-go, on the other hand, the charges
+// are always short live and ephemeral, and the parameters for them are in the database.
+
+const COST = {
+  1: {
+    // Subscription discount
+    SUB_DISCOUNT: { no: 1, monthly: 0.9, yearly: 0.85 },
+    // See https://cloud.google.com/compute/vm-instance-pricing#e2_custommachinetypepricing
+    // for the monthly GCE prices
+    GCE_COSTS: {
+      ram: 0.67, // for pre-emptibles
+      cpu: 5, // for pre-emptibles
+      disk: 0.04, // per GB/month
+      non_pre_factor: 3.5, // Roughly Google's factor for non-preemptible's
+    },
+
+    // Our price = GCE price times this.  We charge LESS than Google VM's, due to our gamble
+    // on having multiple users on a node at once.
+    // 2022-06: price increase "version 2", from 0.75 → 0.8 to compensate for 15% higher GCE prices
+    //          and there is also a minimum of 3gb storage (the free base quota) now.
+    COST_MULTIPLIER: 0.8,
+    // We gamble that projects are packed at least twice as densely on non-member
+    // nodes (it's often worse).
+    NONMEMBER_DENSITY: 2,
+    // Changing this doesn't change the actual academic prices --
+    // it just changes the *business* prices.
+    ACADEMIC_DISCOUNT: 0.6,
+    // Disk factor is based on how many copies of user data we have, plus guesses about
+    // bandwidth to transfer data around (to/from cloud storage, backblaze, etc.).
+    // 10 since we have about that many copies of user data, plus snapshots, and
+    // we store their data long after they stop paying...
+    DISK_FACTOR: 10,
+
+    // These are based on what we observe in practice, what works well,
+    // and what is configured in our backend autoscalers.  This only
+    // impacts the cost of dedicated cpu and RAM.
+    RAM_OVERCOMMIT: 5,
+    CPU_OVERCOMMIT: 10,
+
+    // Extra charge if project will always be on. Really we are gambling that
+    // projects that are not always on, are off much of the time (at least 50%).
+    // We use this factor since a 50-simultaneous active projects license could
+    // easily be used about half of the time during a week in a large class.
+    ALWAYS_RUNNING_FACTOR: 2,
+  },
+} as const;
+
+export default COST;

--- a/src/packages/util/licenses/purchase/cost-versions.ts
+++ b/src/packages/util/licenses/purchase/cost-versions.ts
@@ -58,7 +58,7 @@ const COST = {
       disk: 0.1,
       non_pre_factor: 3.5,
     },
-    COST_MULTIPLIER: 1,
+    COST_MULTIPLIER: 0.9,
     NONMEMBER_DENSITY: 2,
     ACADEMIC_DISCOUNT: 0.6,
     DISK_FACTOR: 10,

--- a/src/packages/util/licenses/purchase/purchase-info.ts
+++ b/src/packages/util/licenses/purchase/purchase-info.ts
@@ -3,6 +3,7 @@ import type {
   SiteLicenseDescriptionDB,
 } from "@cocalc/util/upgrades/shopping";
 import type { PurchaseInfo, StartEndDates, Subscription } from "./types";
+import { CURRENT_VERSION } from "./consts";
 import type { Date0 } from "@cocalc/util/types/store";
 import dayjs from "dayjs";
 
@@ -28,6 +29,7 @@ export default function getPurchaseInfo(
         boost = false,
       } = conf;
       return {
+        version: CURRENT_VERSION,
         type, // "quota"
         user,
         upgrade: "custom" as "custom",
@@ -48,6 +50,7 @@ export default function getPurchaseInfo(
 
     case "vm":
       return {
+        version: CURRENT_VERSION,
         type: "vm",
         quantity: 1,
         dedicated_vm: conf.dedicated_vm,
@@ -59,6 +62,7 @@ export default function getPurchaseInfo(
 
     case "disk":
       return {
+        version: CURRENT_VERSION,
         type: "disk",
         quantity: 1,
         dedicated_disk: conf.dedicated_disk,

--- a/src/packages/util/licenses/purchase/purchase-info.ts
+++ b/src/packages/util/licenses/purchase/purchase-info.ts
@@ -7,6 +7,7 @@ import { CURRENT_VERSION } from "./consts";
 import type { Date0 } from "@cocalc/util/types/store";
 import dayjs from "dayjs";
 
+// this ALWAYS returns purchaseInfo that is the *current* version.
 export default function getPurchaseInfo(
   conf: SiteLicenseDescriptionDB,
 ): PurchaseInfo {

--- a/src/packages/util/licenses/purchase/types.ts
+++ b/src/packages/util/licenses/purchase/types.ts
@@ -54,6 +54,10 @@ import type { Uptime } from "@cocalc/util/consts/site-license";
 import type { DedicatedDisk, DedicatedVM } from "@cocalc/util/types/dedicated";
 import type { CustomDescription, Period } from "../../upgrades/shopping";
 
+interface Version {
+  version?: string; // it's just a string with no special interpretation.
+}
+
 interface PurchaseInfoQuota0 {
   type: "quota";
   user: User;
@@ -77,7 +81,8 @@ interface PurchaseInfoQuota0 {
   run_limit?: number;
 }
 
-export type PurchaseInfoQuota = PurchaseInfoQuota0 &
+export type PurchaseInfoQuota = Version &
+  PurchaseInfoQuota0 &
   CustomDescription &
   StartEndDates;
 

--- a/src/packages/util/licenses/purchase/types.ts
+++ b/src/packages/util/licenses/purchase/types.ts
@@ -55,7 +55,7 @@ import type { DedicatedDisk, DedicatedVM } from "@cocalc/util/types/dedicated";
 import type { CustomDescription, Period } from "../../upgrades/shopping";
 
 interface Version {
-  version?: string; // it's just a string with no special interpretation.
+  version: string; // it's just a string with no special interpretation.
 }
 
 interface PurchaseInfoQuota0 {
@@ -81,8 +81,7 @@ interface PurchaseInfoQuota0 {
   run_limit?: number;
 }
 
-export type PurchaseInfoQuota = Version &
-  PurchaseInfoQuota0 &
+export type PurchaseInfoQuota = PurchaseInfoQuota0 &
   CustomDescription &
   StartEndDates;
 
@@ -113,11 +112,13 @@ export type PurchaseInfoDisk = {
   payment_method?: string;
 };
 
-export type PurchaseInfo =
-  | PurchaseInfoQuota
-  | (PurchaseInfoVoucher & CustomDescription)
-  | (PurchaseInfoVM & StartEndDates & CustomDescription)
-  | (PurchaseInfoDisk & StartEndDates & CustomDescription);
+export type PurchaseInfo = Version &
+  (
+    | PurchaseInfoQuota
+    | (PurchaseInfoVoucher & CustomDescription)
+    | (PurchaseInfoVM & StartEndDates & CustomDescription)
+    | (PurchaseInfoDisk & StartEndDates & CustomDescription)
+  );
 
 // stripe's metadata can only handle string or number values.
 export type ProductMetadataQuota = Record<

--- a/src/packages/util/licenses/store/compute-cost.ts
+++ b/src/packages/util/licenses/store/compute-cost.ts
@@ -16,6 +16,7 @@ import { fixRange } from "@cocalc/util/licenses/purchase/purchase-info";
 import { getDays } from "@cocalc/util/stripe/timecalcs";
 import { PRICES } from "@cocalc/util/upgrades/dedicated";
 import type { ComputeCostProps } from "@cocalc/util/upgrades/shopping";
+import { CURRENT_VERSION } from "@cocalc/util/licenses/purchase/consts";
 
 function computeDedicatedDiskCost(
   props: ComputeCostProps,
@@ -138,6 +139,7 @@ export function computeCost(
       }
 
       const input: PurchaseInfo = {
+        version: CURRENT_VERSION,
         type: "quota",
         user,
         upgrade: "custom" as "custom",

--- a/src/packages/util/purchases/cost-to-edit-license.ts
+++ b/src/packages/util/purchases/cost-to-edit-license.ts
@@ -9,6 +9,7 @@ import { LicenseIdleTimeouts } from "@cocalc/util/consts/site-license";
 import type { Uptime } from "@cocalc/util/consts/site-license";
 import { MAX } from "@cocalc/util/licenses/purchase/consts";
 import { round2up } from "../misc";
+import { CURRENT_VERSION } from "@cocalc/util/licenses/purchase/consts";
 
 export interface Changes {
   end?: Date;
@@ -104,7 +105,9 @@ export default function costToEditLicense(
   log("editLicense with start date updated:", { origInfo });
 
   // Make copy of data with modified params.
-  const modifiedInfo = cloneDeep(origInfo);
+  // modifiedInfo uses the current default pricing algorithm, since that the cost today
+  // to make this purchase, hence changing version below.
+  const modifiedInfo = { ...cloneDeep(origInfo), version: CURRENT_VERSION };
   if (changes.start != null) {
     modifiedInfo.start = changes.start;
   }
@@ -222,6 +225,8 @@ export default function costToEditLicense(
   log({ modifiedInfo });
 
   // Determine price for the change
+
+  // the value of the license the user currently owned.  The pricing algorithm version is important here.
   const currentValue = currentLicenseValue(origInfo);
 
   if (numChanges > 0 && modifiedInfo.type == "quota") {
@@ -234,6 +239,9 @@ export default function costToEditLicense(
     delete modifiedInfo.cost_per_hour;
   }
 
+  // Determine price for the modified license they would like to switch to.
+  // modifiedInfo uses the current default pricing algorithm, since that the cost today
+  // to make this purchase, hence changing version below.
   const modifiedValue = currentLicenseValue(modifiedInfo);
   // cost can be negative, when we give user a refund.
   // **We round away from zero!**  The reason is because
@@ -288,17 +296,17 @@ function currentLicenseValue(info: PurchaseInfo): number {
   // Perhaps we won't raise rates before switching to a full
   // pay as you go model....
 
-//   if (info.cost_per_hour) {
-//     // if this is set, we use it to compute the value
-//     // The value is cost_per_hour times the number of hours left until info.end.
-//     const end = dayjs(info.end);
-//     const start = dayjs(info.start);
-//     const hoursRemaining = end.diff(start, "hours", true);
-//     // the hoursRemaining can easily be *negative* if info.end is
-//     // in the past.
-//     // However the value of a license is never negative, so we max with 0.
-//     return Math.max(0, hoursRemaining * info.cost_per_hour);
-//   }
+  //   if (info.cost_per_hour) {
+  //     // if this is set, we use it to compute the value
+  //     // The value is cost_per_hour times the number of hours left until info.end.
+  //     const end = dayjs(info.end);
+  //     const start = dayjs(info.start);
+  //     const hoursRemaining = end.diff(start, "hours", true);
+  //     // the hoursRemaining can easily be *negative* if info.end is
+  //     // in the past.
+  //     // However the value of a license is never negative, so we max with 0.
+  //     return Math.max(0, hoursRemaining * info.cost_per_hour);
+  //   }
 
   // Compute value using the current rate.
   // As mentioned above, we can keep old rates if/when we change the rate,


### PR DESCRIPTION
- this is just the first step in util; to really use this, we need to also make it so the version number is encoded in PurchaseInfo when the purchase is made.
- need to write some unit tests -- this is exactly the sort of thing where they are easy and useful

@haraldschilly I bet if you glance at [src/packages/util/licenses/purchase/cost-versions.ts](https://github.com/sagemathinc/cocalc/pull/7675/files#diff-59a01e8b2aab719f945c91b357cdf18af457ef18f590a1a601fba2d991bd69c3) you'll have ideas about how we might want to update those parameters for a new v2 pricing, which we could switch to.