### PR TITLE
next/share: embed PDF

### DIFF
--- a/src/packages/hub/hub.ts
+++ b/src/packages/hub/hub.ts
@@ -7,18 +7,23 @@
 // middle of the action, connected to potentially thousands of clients,
 // many Sage sessions, and PostgreSQL database.
 
+import TTLCache from "@isaacs/ttlcache";
 import { callback } from "awaiting";
 import blocked from "blocked";
 import { spawn } from "child_process";
 import { program as commander, Option } from "commander";
+
 import basePath from "@cocalc/backend/base-path";
 import {
   pghost as DEFAULT_DB_HOST,
   pgdatabase as DEFAULT_DB_NAME,
   pguser as DEFAULT_DB_USER,
 } from "@cocalc/backend/data";
+import { trimLogFileSize } from "@cocalc/backend/logger";
 import port from "@cocalc/backend/port";
 import { init_start_always_running_projects } from "@cocalc/database/postgres/always-running";
+import { load_server_settings_from_env } from "@cocalc/database/settings/server-settings";
+import { init_passport } from "@cocalc/server/hub/auth";
 import { initialOnPremSetup } from "@cocalc/server/initial-onprem-setup";
 import initHandleMentions from "@cocalc/server/mentions/handle";
 import initProjectControl, {
@@ -28,23 +33,20 @@ import initIdleTimeout from "@cocalc/server/projects/control/stop-idle-projects"
 import initNewProjectPoolMaintenanceLoop from "@cocalc/server/projects/pool/maintain";
 import initPurchasesMaintenanceLoop from "@cocalc/server/purchases/maintenance";
 import initSalesloftMaintenance from "@cocalc/server/salesloft/init";
-import { load_server_settings_from_env } from "@cocalc/database/settings/server-settings";
 import { stripe_sync } from "@cocalc/server/stripe/sync";
 import { callback2, retry_until_success } from "@cocalc/util/async-utils";
-import { init_passport } from "@cocalc/server/hub/auth";
 import { getClients } from "./clients";
 import { set_agent_endpoint } from "./health-checks";
 import { start as startHubRegister } from "./hub_register";
 import { getLogger } from "./logger";
-import { trimLogFileSize } from "@cocalc/backend/logger";
 import initDatabase, { database } from "./servers/database";
 import initExpressApp from "./servers/express-app";
 import initHttpRedirect from "./servers/http-redirect";
 import initPrimus from "./servers/primus";
 import initVersionServer from "./servers/version";
+
 const { COOKIE_OPTIONS } = require("./client"); // import { COOKIE_OPTIONS } from "./client";
 const MetricsRecorder = require("./metrics-recorder"); // import * as MetricsRecorder from "./metrics-recorder";
-import TTLCache from "@isaacs/ttlcache";
 
 // Logger tagged with 'hub' for this file.
 const winston = getLogger("hub");

--- a/src/packages/hub/servers/app/next.ts
+++ b/src/packages/hub/servers/app/next.ts
@@ -6,17 +6,20 @@
 - ... and more?!
 */
 
+import { Application, NextFunction, Request, Response } from "express";
 import { join } from "path";
-import { Application, Request, Response, NextFunction } from "express";
+
 // @ts-ignore -- TODO: typescript doesn't like @cocalc/next/init (it is a js file).
 import initNextServer from "@cocalc/next/init";
-import handleRaw from "@cocalc/next/lib/share/handle-raw";
-import { getLogger } from "@cocalc/hub/logger";
-import shareRedirect from "./share-redirect";
-import createLandingRedirect from "./landing-redirect";
+
 import basePath from "@cocalc/backend/base-path";
-import { database } from "../database";
+import { getLogger } from "@cocalc/hub/logger";
+import handleRaw from "@cocalc/next/lib/share/handle-raw";
 import { callback2 } from "@cocalc/util/async-utils";
+import { database } from "../database";
+import createLandingRedirect from "./landing-redirect";
+import shareRedirect from "./share-redirect";
+import { separate_file_extension } from "@cocalc/util/misc";
 
 export default async function init(app: Application) {
   const winston = getLogger("nextjs");
@@ -48,18 +51,22 @@ export default async function init(app: Application) {
     // etc. servers is definitely too much, so we just disable this.
     // For serving actual raw content, the solution will be to use
     // a vhost.
+
     // 1: The raw static server:
     const raw = join(shareBasePath, "raw");
     app.all(
       join(raw, "*"),
       (req: Request, res: Response, next: NextFunction) => {
+        // Embedding only enabled for PDF files -- see note above
+        const download =
+          separate_file_extension(req.path).ext.toLowerCase() !== "pdf";
         try {
           handleRaw({
             ...parseURL(req, raw),
             req,
             res,
             next,
-            download: true /* do not change this by default -- see above. */,
+            download,
           });
         } catch (_err) {
           res.status(404).end();

--- a/src/packages/hub/servers/express-app.ts
+++ b/src/packages/hub/servers/express-app.ts
@@ -2,36 +2,37 @@
 The main hub express app.
 */
 
-import { path as WEBAPP_PATH } from "@cocalc/assets";
-import basePath from "@cocalc/backend/base-path";
-import { path as CDN_PATH } from "@cocalc/cdn";
-import vhostShare from "@cocalc/next/lib/share/virtual-hosts";
-import { path as STATIC_PATH } from "@cocalc/static";
 import compression from "compression";
 import cookieParser from "cookie-parser";
 import express from "express";
 import ms from "ms";
 import { join } from "path";
 import { parse as parseURL } from "url";
+import webpackDevMiddleware from "webpack-dev-middleware";
+import webpackHotMiddleware from "webpack-hot-middleware";
+
+import { path as WEBAPP_PATH } from "@cocalc/assets";
+import basePath from "@cocalc/backend/base-path";
+import { path as CDN_PATH } from "@cocalc/cdn";
+import vhostShare from "@cocalc/next/lib/share/virtual-hosts";
+import { path as STATIC_PATH } from "@cocalc/static";
 import { initAnalytics } from "../analytics";
 import { setup_health_checks as setupHealthChecks } from "../health-checks";
 import { getLogger } from "../logger";
 import initProxy from "../proxy";
 import initAPI from "./app/api";
 import initAppRedirect from "./app/app-redirect";
-import initBlobs from "./app/blobs";
 import initBlobUpload from "./app/blob-upload";
-import initStripeWebhook from "./app/webhooks/stripe";
+import initBlobs from "./app/blobs";
 import initCustomize from "./app/customize";
-import { setupInstrumentation, initMetricsEndpoint } from "./app/metrics";
+import { initMetricsEndpoint, setupInstrumentation } from "./app/metrics";
 import initNext from "./app/next";
 import initSetCookies from "./app/set-cookies";
 import initStats from "./app/stats";
+import initStripeWebhook from "./app/webhooks/stripe";
 import { database } from "./database";
 import initHttpServer from "./http";
 import initRobots from "./robots";
-import webpackHotMiddleware from "webpack-hot-middleware";
-import webpackDevMiddleware from "webpack-dev-middleware";
 
 // Used for longterm caching of files. This should be in units of seconds.
 const MAX_AGE = Math.round(ms("10 days") / 1000);

--- a/src/packages/next/components/path/path.tsx
+++ b/src/packages/next/components/path/path.tsx
@@ -3,7 +3,6 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
-import { useEffect, useState } from "react";
 import {
   Alert,
   Avatar as AntdAvatar,
@@ -13,32 +12,34 @@ import {
   Tooltip,
 } from "antd";
 import Link from "next/link";
-import PathContents from "components/share/path-contents";
-import PathActions from "components/share/path-actions";
-import LinkedPath from "components/share/linked-path";
-import Loading from "components/share/loading";
-import License from "components/share/license";
-import ProjectLink from "components/share/project-link";
-import useCounter from "lib/share/counter";
-import { Layout } from "components/share/layout";
-import { Customize } from "lib/share/customize";
-import type { CustomizeType } from "lib/customize";
-import { getTitle } from "lib/share/util";
-import SanitizedMarkdown from "components/misc/sanitized-markdown";
-import Badge from "components/misc/badge";
+import { useRouter } from "next/router";
+import { join } from "path";
+import { useEffect, useState } from "react";
+
 import { Icon } from "@cocalc/frontend/components/icon";
 import {
-  SHARE_AUTHENTICATED_ICON,
   SHARE_AUTHENTICATED_EXPLANATION,
+  SHARE_AUTHENTICATED_ICON,
 } from "@cocalc/util/consts/ui";
-import apiPost from "lib/api/post";
 import InPlaceSignInOrUp from "components/auth/in-place-sign-in-or-up";
-import { useRouter } from "next/router";
-import type { PathContents as PathContentsType } from "lib/share/get-contents";
-import Avatar from "components/share/proxy/avatar";
-import A from "components/misc/A";
-import { join } from "path";
 import { Tagline } from "components/landing/tagline";
+import A from "components/misc/A";
+import Badge from "components/misc/badge";
+import SanitizedMarkdown from "components/misc/sanitized-markdown";
+import { Layout } from "components/share/layout";
+import License from "components/share/license";
+import LinkedPath from "components/share/linked-path";
+import Loading from "components/share/loading";
+import PathActions from "components/share/path-actions";
+import PathContents from "components/share/path-contents";
+import ProjectLink from "components/share/project-link";
+import Avatar from "components/share/proxy/avatar";
+import apiPost from "lib/api/post";
+import type { CustomizeType } from "lib/customize";
+import useCounter from "lib/share/counter";
+import { Customize } from "lib/share/customize";
+import type { PathContents as PathContentsType } from "lib/share/get-contents";
+import { getTitle } from "lib/share/util";
 
 import { SocialMediaShareLinks } from "components/landing/social-media-share-links";
 

--- a/src/packages/next/components/share/file-contents.tsx
+++ b/src/packages/next/components/share/file-contents.tsx
@@ -3,29 +3,28 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
-import { getExtension } from "lib/share/util";
+import Markdown from "@cocalc/frontend/editors/slate/static-markdown";
 import {
   isAudio,
   isCodemirror,
-  isImage,
   isHTML,
+  isImage,
   isMarkdown,
   isVideo,
 } from "@cocalc/frontend/file-extensions";
-import rawURL from "lib/share/raw-url";
+import Slides from "@cocalc/frontend/frame-editors/slides-editor/share";
+import Whiteboard from "@cocalc/frontend/frame-editors/whiteboard-editor/share/index";
+import JupyterNotebook from "@cocalc/frontend/jupyter/nbviewer/nbviewer";
+import { FileContext } from "@cocalc/frontend/lib/file-context";
+import A from "components/misc/A";
 import { isIOS, isSafari } from "lib/share/feature";
+import rawURL from "lib/share/raw-url";
+import getUrlTransform from "lib/share/url-transform";
+import { containingPath, getExtension } from "lib/share/util";
+import useCustomize from "lib/use-customize";
+import getAnchorTagComponent from "./anchor-tag-component";
 import CodeMirror from "./codemirror";
 import SageWorksheet from "./sage-worksheet";
-import JupyterNotebook from "@cocalc/frontend/jupyter/nbviewer/nbviewer";
-import Markdown from "@cocalc/frontend/editors/slate/static-markdown";
-import Whiteboard from "@cocalc/frontend/frame-editors/whiteboard-editor/share/index";
-import Slides from "@cocalc/frontend/frame-editors/slides-editor/share";
-import A from "components/misc/A";
-import { containingPath } from "lib/share/util";
-import getUrlTransform from "lib/share/url-transform";
-import getAnchorTagComponent from "./anchor-tag-component";
-import { FileContext } from "@cocalc/frontend/lib/file-context";
-import useCustomize from "lib/use-customize";
 
 interface Props {
   id: string;
@@ -74,7 +73,7 @@ export default function FileContents({
     );
   } else if (isAudio(ext)) {
     return <audio src={raw} autoPlay={true} controls={true} loop={false} />;
-  } else if (ext == "pdf") {
+  } else if (ext === "pdf") {
     // iOS and iPADOS does not have any way to embed PDF's in pages.
     // I think pretty much every other web browser does, though
     // strangely even desktop Safari seems often broken, so we also block that.

--- a/src/packages/next/components/share/path-contents.tsx
+++ b/src/packages/next/components/share/path-contents.tsx
@@ -3,9 +3,9 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
+import { FileInfo } from "lib/share/get-contents";
 import DirectoryListing from "./directory-listing";
 import FileContents from "./file-contents";
-import { FileInfo } from "lib/share/get-contents";
 import Loading from "./loading";
 
 interface Props {

--- a/src/packages/next/lib/share/virtual-hosts.ts
+++ b/src/packages/next/lib/share/virtual-hosts.ts
@@ -8,12 +8,13 @@ Support for virtual hosts.
 */
 
 import type { Request, Response } from "express";
+
+import basePath from "@cocalc/backend/base-path";
 import { getLogger } from "@cocalc/backend/logger";
-import pathToFiles from "./path-to-files";
 import isAuthenticated from "./authenticate";
 import getVirtualHostInfo from "./get-vhost-info";
 import { staticHandler } from "./handle-raw";
-import basePath from "@cocalc/backend/base-path";
+import pathToFiles from "./path-to-files";
 
 const logger = getLogger("virtual-hosts");
 
@@ -23,7 +24,7 @@ export default function virtualHostsMiddleware() {
   return async function (
     req: Request,
     res: Response,
-    next: Function
+    next: Function,
   ): Promise<void> {
     // For debugging in cc-in-cc dev, just manually set host to something
     // else and comment this out.  That's the only way, since dev is otherwise
@@ -69,7 +70,7 @@ export default function virtualHostsMiddleware() {
       logger.debug(
         "not authenticated -- denying vhost='%s', path='%s'",
         vhost,
-        path
+        path,
       );
       res.status(403).end();
       return;


### PR DESCRIPTION
# Description

This renders a PDF on the share server embedded in an iframe. This is fine, because PDFs are sandboxed and isolated by all browsers anyways.

This also fixes a slight issue with using a cache and organizes imports.

## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
