### PR TITLE
Fix Project Collaborator Permission Check

### DIFF
--- a/src/packages/next/pages/api/v2/projects/copy-path.ts
+++ b/src/packages/next/pages/api/v2/projects/copy-path.ts
@@ -40,7 +40,9 @@ export default async function handle(req, res) {
     if (!account_id) {
       throw Error("must be signed in");
     }
-    if (!isCollaborator({ account_id, project_id: target_project_id })) {
+    if (
+      !(await isCollaborator({ account_id, project_id: target_project_id }))
+    ) {
       throw Error("must be a collaborator on target project");
     }
     if (public_id) {
@@ -54,7 +56,7 @@ export default async function handle(req, res) {
       ) {
       }
     } else {
-      if (!isCollaborator({ account_id, project_id: src_project_id })) {
+      if (!(await isCollaborator({ account_id, project_id: src_project_id }))) {
         throw Error("must be a collaborator on source project");
       }
     }
@@ -90,7 +92,7 @@ async function isContainedInPublicPath({ id, project_id, path }) {
   const pool = getPool("long");
   const { rows } = await pool.query(
     "SELECT project_id, path FROM public_paths WHERE disabled IS NOT TRUE AND vhost IS NULL AND id=$1",
-    [id]
+    [id],
   );
   return (
     rows.length > 0 &&

--- a/src/packages/next/pages/api/v2/projects/copy-url.ts
+++ b/src/packages/next/pages/api/v2/projects/copy-url.ts
@@ -32,13 +32,13 @@ export default async function handle(req, res) {
     if (!account_id) {
       throw Error("must be signed in");
     }
-    if (!isCollaborator({ account_id, project_id })) {
+    if (!(await isCollaborator({ account_id, project_id }))) {
       throw Error("must be a collaborator on target project");
     }
     const info = await getProxiedPublicPathInfo(url);
     if (info.contents?.content == null) {
       throw Error(
-        "copying of directories (e.g., full GitHub repos) is not implemented; copy an individual file instead"
+        "copying of directories (e.g., full GitHub repos) is not implemented; copy an individual file instead",
       );
     }
     const i = url.lastIndexOf("/");

--- a/src/packages/next/pages/api/v2/projects/start.ts
+++ b/src/packages/next/pages/api/v2/projects/start.ts
@@ -27,7 +27,7 @@ async function handle(req, res) {
     if (!account_id) {
       throw Error("must be signed in");
     }
-    if (!isCollaborator({ account_id, project_id })) {
+    if (!(await isCollaborator({ account_id, project_id }))) {
       throw Error("must be a collaborator to start project");
     }
     const project = getProject(project_id);

--- a/src/packages/next/pages/api/v2/projects/stop.ts
+++ b/src/packages/next/pages/api/v2/projects/stop.ts
@@ -27,7 +27,7 @@ async function handle(req, res) {
     if (!account_id) {
       throw Error("must be signed in");
     }
-    if (!isCollaborator({ account_id, project_id })) {
+    if (!(await isCollaborator({ account_id, project_id }))) {
       throw Error("must be a collaborator to stop project");
     }
     const project = getProject(project_id);

--- a/src/packages/next/pages/api/v2/projects/touch.ts
+++ b/src/packages/next/pages/api/v2/projects/touch.ts
@@ -21,7 +21,7 @@ export default async function handle(req, res) {
     if (!account_id) {
       throw Error("must be signed in");
     }
-    if (!isCollaborator({ account_id, project_id })) {
+    if (!(await isCollaborator({ account_id, project_id }))) {
       throw Error("must be a collaborator to stop project");
     }
     const project = getProject(project_id);

--- a/src/packages/server/jupyter/execute.ts
+++ b/src/packages/server/jupyter/execute.ts
@@ -132,7 +132,7 @@ export async function execute({
         "account_id must be specified -- make sure you are signed in",
       );
     }
-    if (!isCollaborator({ project_id, account_id })) {
+    if (!(await isCollaborator({ project_id, account_id }))) {
       throw Error("permission denied -- user must be collaborator on project");
     }
     request_account_id = account_id;

--- a/src/packages/server/jupyter/kernels.ts
+++ b/src/packages/server/jupyter/kernels.ts
@@ -36,9 +36,11 @@ export default async function getKernels({
 }): Promise<object[]> {
   if (project_id != null) {
     if (account_id == null) {
-      throw Error("account_id must be specified -- make sure you are signed in");
+      throw Error(
+        "account_id must be specified -- make sure you are signed in",
+      );
     }
-    if (!isCollaborator({ project_id, account_id })) {
+    if (!(await isCollaborator({ project_id, account_id }))) {
       throw Error("permission denied -- user must be collaborator on project");
     }
   }


### PR DESCRIPTION
# Description

Added `await` call to enforce collaborator permissions check for {copy-path,copy-url,start,stop,touch} project operations.