### PR TITLE
show email address when adding students by email

### DIFF
--- a/src/packages/frontend/course/students/students-panel.tsx
+++ b/src/packages/frontend/course/students/students-panel.tsx
@@ -424,9 +424,10 @@ export const StudentsPanel: React.FC<StudentsPanelReactProps> = React.memo(
           x.account_id != null
             ? x.first_name + " " + x.last_name
             : x.email_address;
+        const email = !include_name_search && (x.account_id != null) && x.email_address ? " (" + x.email_address + ")": "";
         v.push(
-          <option key={key} value={key} label={student_name}>
-            {student_name}
+          <option key={key} value={key} label={student_name + email}>
+            {student_name + email}
           </option>,
         );
       }


### PR DESCRIPTION
# Description
Fixes #7843 
Shows email address in parenthesis alongside the name when adding students by email. If there's no name, in which case the email address is already shown, we don't show it. 
![Screenshot from 2024-09-14 13-31-04](https://github.com/user-attachments/assets/ff2867a5-f037-4c24-b802-417278240c7c)




## [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Testing instructions are provided, if not obvious
- [ ] Release instructions are provided, if not obvious
