### PR TITLE
next/store: make all license presets selectable columns

### DIFF
--- a/src/packages/next/components/landing/pricing-item.tsx
+++ b/src/packages/next/components/landing/pricing-item.tsx
@@ -8,19 +8,44 @@ import { ReactNode } from "react";
 
 import { Icon, IconName } from "@cocalc/frontend/components/icon";
 import { COLORS } from "@cocalc/util/theme";
+import { CSS } from "components/misc";
+
+import styles from "./pricing.module.css";
 
 interface Props {
   children: ReactNode;
   icon: IconName;
   title: string;
+  style?: CSS;
+  active?: boolean;
+  onClick?: () => void;
 }
 
-export default function PricingItem({ icon, children, title }: Props) {
+const ACTIVE_STYLE: CSS = {
+  outline: `2px solid ${COLORS.BLUE_D}`,
+} as const;
+
+export default function PricingItem({
+  icon,
+  children,
+  title,
+  style,
+  active,
+  onClick,
+}: Props) {
+  const outerStyle: CSS = {
+    padding: 0,
+    ...style,
+  } as const;
+  const activeStyle: CSS = active === true ? ACTIVE_STYLE : {};
+  const innerStyle: CSS = { color: COLORS.GRAY_M, ...activeStyle };
+
   return (
-    <List.Item style={{ padding: 0 }}>
+    <List.Item style={outerStyle} onClick={onClick}>
       <Card
-        styles={{ header: { backgroundColor: "#d9edf7" } }}
-        style={{ color: COLORS.GRAY_M }}
+        className={onClick != null ? styles.item : undefined}
+        styles={{ header: { backgroundColor: COLORS.BLUE_LLLL } }}
+        style={innerStyle}
         type="inner"
         title={
           <span style={{ fontSize: "120%" }}>
@@ -44,10 +69,11 @@ const STYLE: React.CSSProperties = {
 interface Line {
   amount?: string | number | ReactNode;
   desc?: string | ReactNode;
+  indent?: boolean;
 }
 
 export function Line(props: Line) {
-  const { amount, desc } = props;
+  const { amount, desc, indent = true } = props;
   if (!amount)
     return (
       <div>
@@ -67,14 +93,13 @@ export function Line(props: Line) {
       unit = "x";
     }
   }
+
+  const indentStyle: CSS = indent ? { width: "3em", textAlign: "right" } : {};
+
   return (
     <div>
       <b style={STYLE}>
-        <div
-          style={{ display: "inline-block", width: "3em", textAlign: "right" }}
-        >
-          {amount}
-        </div>{" "}
+        <div style={{ display: "inline-block", ...indentStyle }}>{amount}</div>{" "}
         {unit}
       </b>{" "}
       {desc}

--- a/src/packages/next/components/landing/pricing.module.css
+++ b/src/packages/next/components/landing/pricing.module.css
@@ -1,0 +1,10 @@
+.item {
+  cursor: pointer;
+  position: relative;
+  transition: 0.1s;
+  top: 0;
+}
+
+.item:hover {
+  top: -5px;
+}

--- a/src/packages/next/components/store/quota-config-presets.tsx
+++ b/src/packages/next/components/store/quota-config-presets.tsx
@@ -5,10 +5,11 @@
 
 import { IconName } from "@cocalc/frontend/components/icon";
 import { Uptime } from "@cocalc/util/consts/site-license";
+import { Paragraph } from "components/misc";
 import A from "components/misc/A";
 import { ReactNode } from "react";
 
-export type Presets = "standard" | "instructor" | "research";
+export type Preset = "standard" | "instructor" | "research";
 
 // Fields to be used to match a configured license against a pre-existing preset.
 //
@@ -20,20 +21,22 @@ export const PRESET_MATCH_FIELDS: Record<string, string> = {
   member: "member hosting",
 };
 
-export interface Preset {
-  icon?: IconName;
+export interface PresetConfig {
+  icon: IconName;
   name: string;
   descr: ReactNode;
-  details?: ReactNode;
+  details: ReactNode;
   cpu: number;
   ram: number;
   disk: number;
   uptime: Uptime;
   member: boolean;
+  expect: string[];
+  note?: ReactNode;
 }
 
 type PresetEntries = {
-  [key in Presets]: Preset;
+  [key in Preset]: PresetConfig;
 };
 
 // some constants to keep text and preset in sync
@@ -41,11 +44,28 @@ const STANDARD_CPU = 1;
 const STANDARD_RAM = 4;
 const STANDARD_DISK = 3;
 
+const PRESET_STANDARD_NAME = "Standard";
+
 export const PRESETS: PresetEntries = {
   standard: {
     icon: "line-chart",
-    name: "Standard",
-    descr: "is a good choice for most users and students to get started",
+    name: PRESET_STANDARD_NAME,
+    descr:
+      "is a good choice for most users to get started and students in a course",
+    expect: [
+      "Run 2 or 3 Jupyter Notebooks at the same time,",
+      "Edit LaTeX, Markdown, and R Documents,",
+      `${STANDARD_DISK} GB disk space is sufficient to store many files and small datasets.`,
+    ],
+    note: (
+      <Paragraph type="secondary">
+        You can start small with just a "Run Limit" of one and small quotas.
+        Later, if your usage incrases, you can edit your license to change the
+        "Run Limit" and/or the quotas. Read more about{" "}
+        <A href={"https://doc.cocalc.com/licenses.html"}>Managing Licenses</A>{" "}
+        in our documentation.
+      </Paragraph>
+    ),
     details: (
       <>
         You can run two or three Jupyter Notebooks in the same project at the
@@ -64,8 +84,45 @@ export const PRESETS: PresetEntries = {
   instructor: {
     icon: "slides",
     name: "Instructor",
-    descr:
-      "is a good choice for the instructor's project when teaching a course",
+    descr: "for your instructor project when teaching a course",
+    expect: [
+      "Grade the work of students,",
+      "Run several Jupyter Notebooks at the same time¹,",
+      "Store the files of all students,",
+      "Make longer breaks without your project being shut down.",
+    ],
+    note: (
+      <>
+        <Paragraph type="secondary">
+          For your instructor project, you only need one such license with a
+          "Run Limit" of 1. Apply that license via the{" "}
+          <A href={"https://doc.cocalc.com/project-settings.html#licenses"}>
+            project settings
+          </A>
+          . For the students, select a "{PRESET_STANDARD_NAME}" license with a
+          "Run Limit" of the number of students and distribute it via the{" "}
+          <A
+            href={
+              "https://doc.cocalc.com/teaching-upgrade-course.html#teacher-or-institute-pays-for-upgrades"
+            }
+          >
+            course configuration
+          </A>
+          .
+        </Paragraph>
+        <Paragraph type="secondary">
+          ¹ Still, make sure to use the{" "}
+          <A
+            href={
+              "https://doc.cocalc.com/jupyter.html?highlight=halt%20button#use-the-halt-button-to-conserve-memory"
+            }
+          >
+            Halt button
+          </A>
+          .
+        </Paragraph>
+      </>
+    ),
     details: (
       <>
         The upgrade schema is suitable for grading the work of students: by
@@ -99,7 +156,29 @@ export const PRESETS: PresetEntries = {
   research: {
     icon: "users",
     name: "Researcher",
-    descr: "is a good choice for a research group",
+    descr: "is a good choice for intesse usage or a research group",
+    expect: [
+      "Run many Jupyter Notebooks at once,",
+      "Run memory-intensive computations,",
+      "1 day idle-timeout is sufficient to not interrupt your work,",
+      "and to execute long-running calculations.",
+      "More disk space also allows you to store larger datasets.",
+    ],
+    note: (
+      <>
+        <Paragraph type="secondary">
+          If you need <b>vastly more dedicated disk space, CPU or RAM</b>, you
+          should instead{" "}
+          <b>
+            rent a{" "}
+            <A href="https://doc.cocalc.com/compute_server.html">
+              compute server
+            </A>
+            .
+          </b>
+        </Paragraph>
+      </>
+    ),
     details: (
       <>
         This configuration allows the project to run many Jupyter Notebooks and

--- a/src/packages/next/components/store/site-license.tsx
+++ b/src/packages/next/components/store/site-license.tsx
@@ -9,6 +9,7 @@ Create a new site license.
 import { Form, Input } from "antd";
 import { isEmpty } from "lodash";
 import { useEffect, useRef, useState } from "react";
+
 import { Icon } from "@cocalc/frontend/components/icon";
 import { get_local_storage } from "@cocalc/frontend/misc/local-storage";
 import { CostInputPeriod } from "@cocalc/util/licenses/purchase/types";
@@ -26,7 +27,7 @@ import { ApplyLicenseToProject } from "./apply-license-to-project";
 import { InfoBar } from "./cost-info-bar";
 import { IdleTimeout } from "./member-idletime";
 import { QuotaConfig } from "./quota-config";
-import { PRESETS, PRESET_MATCH_FIELDS, Presets } from "./quota-config-presets";
+import { PRESETS, PRESET_MATCH_FIELDS, Preset } from "./quota-config-presets";
 import { decodeFormValues, encodeFormValues } from "./quota-query-params";
 import { Reset } from "./reset";
 import { RunLimit } from "./run-limit";
@@ -35,7 +36,7 @@ import { TitleDescription } from "./title-description";
 import { ToggleExplanations } from "./toggle-explanations";
 import { UsageAndDuration } from "./usage-and-duration";
 
-const DEFAULT_PRESET: Presets = "standard";
+const DEFAULT_PRESET: Preset = "standard";
 
 const STYLE: React.CSSProperties = {
   marginTop: "15px",
@@ -125,7 +126,7 @@ function CreateSiteLicense({ showInfoBar = false, noAccount = false }) {
   const [form] = Form.useForm();
   const router = useRouter();
 
-  const [preset, setPreset] = useState<Presets | null>(DEFAULT_PRESET);
+  const [preset, setPreset] = useState<Preset | null>(DEFAULT_PRESET);
   const [presetAdjusted, setPresetAdjusted] = useState<boolean>(false);
 
   /**
@@ -136,19 +137,20 @@ function CreateSiteLicense({ showInfoBar = false, noAccount = false }) {
     const currentConfiguration = form.getFieldsValue(
       Object.keys(PRESET_MATCH_FIELDS),
     );
-    let foundPreset: Presets | undefined;
+
+    let foundPreset: Preset | undefined;
 
     Object.keys(PRESETS).some((p) => {
-      const presetMismatch = Object.keys(PRESET_MATCH_FIELDS).some(
+      const presetMatches = Object.keys(PRESET_MATCH_FIELDS).every(
         (formField) =>
-          !(PRESETS[p][formField] === currentConfiguration[formField]),
+          PRESETS[p][formField] === currentConfiguration[formField],
       );
 
-      if (!presetMismatch) {
-        foundPreset = p as Presets;
+      if (presetMatches) {
+        foundPreset = p as Preset;
       }
 
-      return !presetMismatch;
+      return presetMatches;
     });
 
     return foundPreset;
@@ -244,8 +246,8 @@ function CreateSiteLicense({ showInfoBar = false, noAccount = false }) {
         form={form}
         style={STYLE}
         name="basic"
-        labelCol={{ span: 6 }}
-        wrapperCol={{ span: 18 }}
+        labelCol={{ span: 3 }}
+        wrapperCol={{ span: 21 }}
         autoComplete="off"
         onValuesChange={onLicenseChange}
       >
@@ -279,13 +281,13 @@ function CreateSiteLicense({ showInfoBar = false, noAccount = false }) {
           setPreset={setPreset}
           presetAdjusted={presetAdjusted}
         />
-        {configMode === "expert" && (
+        {configMode === "expert" ? (
           <IdleTimeout
             showExplanations={showExplanations}
             form={form}
             onChange={onLicenseChange}
           />
-        )}
+        ) : undefined}
         <TitleDescription showExplanations={showExplanations} form={form} />
         <Reset
           addBox={addBox}

--- a/src/packages/next/components/store/usage-and-duration.tsx
+++ b/src/packages/next/components/store/usage-and-duration.tsx
@@ -57,7 +57,7 @@ export function UsageAndDuration(props: Props) {
         initialValue={
           isAcademic(profile?.email_address) ? "academic" : "business"
         }
-        label={"Type of Usage"}
+        label={"Usage"}
         extra={
           showExplanations ? (
             <>

--- a/src/packages/next/lib/api/schema/licenses/common.ts
+++ b/src/packages/next/lib/api/schema/licenses/common.ts
@@ -16,8 +16,8 @@ export const SiteLicenseIdleTimeoutSchema = z
 export const SiteLicenseUptimeSchema = z
   .union([SiteLicenseIdleTimeoutSchema, z.literal("always_running")])
   .describe(
-    `Determines how long a project runs while not being used before being automatically 
-     stopped. A \`short\` value corresponds to a 30-minute timeout, and a \`medium\` value 
+    `Determines how long a project runs while not being used before being automatically
+     stopped. A \`short\` value corresponds to a 30-minute timeout, and a \`medium\` value
      to a 2-hour timeout.`,
   );
 
@@ -31,7 +31,7 @@ export const SiteLicenseQuotaSchema = z.object({
     .boolean()
     .nullish()
     .describe(
-      `Indicates whether the project(s) this license is applied to should be 
+      `Indicates whether the project(s) this license is applied to should be
        allowed to always be running.`,
     ),
   boost: z
@@ -39,26 +39,26 @@ export const SiteLicenseQuotaSchema = z.object({
     .nullish()
     .describe(
       `If \`true\`, this license is a boost license and allows for a project to
-       temporarily boost the amount of resources available to a project by the amount 
+       temporarily boost the amount of resources available to a project by the amount
        specified in the \`cpu\`, \`memory\`, and \`disk\` fields.`,
     ),
   cpu: z
     .number()
     .min(1)
     .describe("Limits the total number of vCPUs allocated to a project."),
-  dedicated_cpu: z.number().min(1),
-  dedicated_ram: z.number().min(1),
+  dedicated_cpu: z.number().min(1).nullish(),
+  dedicated_ram: z.number().min(1).nullish(),
   disk: z
     .number()
     .min(1)
     .describe(
-      `Disk size in GB to be allocated to the project to which this license is 
+      `Disk size in GB to be allocated to the project to which this license is
        applied.`,
     ),
-  idle_timeout: SiteLicenseIdleTimeoutSchema,
+  idle_timeout: SiteLicenseIdleTimeoutSchema.nullish(),
   member: z.boolean().describe(
-    `Member hosting significantly reduces competition for resources, and we 
-     prioritize support requests much higher. _Please be aware: licenses of 
+    `Member hosting significantly reduces competition for resources, and we
+     prioritize support requests much higher. _Please be aware: licenses of
      different member hosting service levels cannot be combined!_`,
   ),
   ram: z

--- a/src/packages/next/pages/pricing/subscriptions.tsx
+++ b/src/packages/next/pages/pricing/subscriptions.tsx
@@ -4,11 +4,13 @@
  */
 
 import { Alert, Layout, List } from "antd";
+import dayjs from "dayjs";
 
 import { Icon, IconName } from "@cocalc/frontend/components/icon";
 import { LicenseIdleTimeouts } from "@cocalc/util/consts/site-license";
 import { compute_cost } from "@cocalc/util/licenses/purchase/compute-cost";
 import {
+  CURRENT_VERSION,
   discount_monthly_pct,
   discount_yearly_pct,
   MIN_QUOTE,
@@ -20,6 +22,7 @@ import Footer from "components/landing/footer";
 import Head from "components/landing/head";
 import Header from "components/landing/header";
 import PricingItem, { Line } from "components/landing/pricing-item";
+import { Paragraph, Title } from "components/misc";
 import A from "components/misc/A";
 import {
   applyLicense,
@@ -30,9 +33,6 @@ import { LinkToStore, StoreConf } from "components/store/link";
 import { MAX_WIDTH } from "lib/config";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
-import { Paragraph, Title } from "components/misc";
-import dayjs from "dayjs";
-import { CURRENT_VERSION } from "@cocalc/util/licenses/purchase/consts";
 
 function addMonth(date: Date): Date {
   return dayjs(date).add(30, "days").add(12, "hours").toDate();
@@ -291,7 +291,7 @@ function Body(): JSX.Element {
             <Line amount={item.shared_cores} desc="Shared CPU per project" />
             <Line amount={item.disk} desc="Disk space per project" />
             <Line amount={item.uptime} desc="Idle timeout" />
-            <Line amount={"Unlimited"} desc="Collaborators" />
+            <Line amount={"∞"} desc="Collaborators" />
             {item.academic ? (
               <Line amount="40%" desc="Academic discount" />
             ) : (


### PR DESCRIPTION
This was more work than I thought – also, because I wanted to fix this for narrower mobile screens, because then the 3 columns are really bad.

**testing**:  :warning:  ~~I'm stuck with this, because~~ I can't add a selected license to the cart. It throws an API validation error. → I made a fix to the api definition. I know the checks can be disabled, but for dev at least something basic like adding a license to the cart should work. I wonder if this ever worked? The changes I made should just be cosmetic, no change to the actual query. Commit: 55b47c2ff41840d25e7a123a15c90e95b013a2de


## narrow

just a list of options with a description, and below is more info.

![Screenshot from 2024-10-16 15-34-32](https://github.com/user-attachments/assets/7e6a6674-5a74-450a-a861-99051943c9d5)


## normal usage

* description is a bit modified
* quotas are easier to compare
* the "expectations" are new. They're derived from the previous text that has been there. The more detailed note shows up when it is selected. In particular, this shows the explanation for instructors with links to the documentation.

[screencast-localhost_5000-2024_10_16-15_35_35.webm](https://github.com/user-attachments/assets/86d3acc8-e665-4c66-8b0d-60ef0758e645)

