### PR TITLE
API: create account tweaks for onprem

### DIFF
--- a/src/packages/database/index.ts
+++ b/src/packages/database/index.ts
@@ -13,6 +13,8 @@ COPYRIGHT : (c) 2021 SageMath, Inc.
 
 import { setupRecordConnectErrors } from "./postgres/record-connect-error";
 
+import { PostgreSQL } from "./postgres/types";
+
 const base = require("./postgres-base");
 
 export const {
@@ -29,8 +31,9 @@ export const {
 // Each of the following calls composes the PostgreSQL class with further important functionality.
 // Order matters.
 
-let theDB: any = undefined;
-export function db(opts = {}) {
+let theDB: PostgreSQL | undefined = undefined;
+
+export function db(opts = {}): PostgreSQL {
   if (theDB === undefined) {
     let PostgreSQL = base.PostgreSQL;
 
@@ -45,13 +48,17 @@ export function db(opts = {}) {
         PostgreSQL,
       );
     }
-    theDB = new PostgreSQL(opts);
-    setupRecordConnectErrors(theDB);
+    const theDBnew = new PostgreSQL(opts);
+    setupRecordConnectErrors(theDBnew);
+    theDB = theDBnew;
   }
 
+  if (theDB == null) {
+    throw new Error("Fatal error setting up PostgreSQL instance");
+  }
   return theDB;
 }
 
 import getPool from "./pool";
-export { getPool };
 export { stripNullFields } from "./postgres/util";
+export { getPool };

--- a/src/packages/database/postgres/account-queries.ts
+++ b/src/packages/database/postgres/account-queries.ts
@@ -19,12 +19,12 @@ import { PostgreSQL } from "./types";
 /* For now we define "paying customer" to mean they have a subscription.
   It's OK if it expired.  They at least bought one once.
   This is mainly used for anti-abuse purposes...
-  
+
   TODO: modernize this or don't use this at all...
 */
 export async function is_paying_customer(
   db: PostgreSQL,
-  account_id: string
+  account_id: string,
 ): Promise<boolean> {
   let x;
   try {
@@ -54,7 +54,7 @@ interface SetAccountFields {
 
 // this is like set_account_info_if_different, but only sets the fields if they're not set
 export async function set_account_info_if_not_set(
-  opts: SetAccountFields
+  opts: SetAccountFields,
 ): Promise<void> {
   return await set_account_info_if_different(opts, false);
 }
@@ -62,12 +62,16 @@ export async function set_account_info_if_not_set(
 // This sets the given fields of an account, if it is different from the current value  – except for the email address, which we only set but not change
 export async function set_account_info_if_different(
   opts: SetAccountFields,
-  overwrite = true
+  overwrite = true,
 ): Promise<void> {
   const columns = ["email_address", "first_name", "last_name"];
 
   // this could throw an error for "no such account"
-  const account = await get_account(opts.db, opts.account_id, columns);
+  const account = await get_account<{
+    email_address: string;
+    first_name: string;
+    last_name: string;
+  }>(opts.db, opts.account_id, columns);
 
   const do_set: { [field: string]: string } = {};
   let do_email: string | undefined = undefined;
@@ -106,7 +110,7 @@ export async function set_account_info_if_different(
 export async function set_account(
   db: PostgreSQL,
   account_id: string,
-  set: { [field: string]: any }
+  set: { [field: string]: any },
 ): Promise<void> {
   await db.async_query({
     query: "UPDATE accounts",
@@ -115,11 +119,12 @@ export async function set_account(
   });
 }
 
-export async function get_account(
+// TODO typing: pick the column fields from the actual account type stored in the database
+export async function get_account<T>(
   db: PostgreSQL,
   account_id: string,
-  columns: string[]
-): Promise<void> {
+  columns: string[],
+): Promise<T> {
   return await callback2(db.get_account.bind(db), {
     account_id,
     columns,
@@ -133,7 +138,7 @@ interface SetEmailAddressVerifiedOpts {
 }
 
 export async function set_email_address_verified(
-  opts: SetEmailAddressVerifiedOpts
+  opts: SetEmailAddressVerifiedOpts,
 ): Promise<void> {
   const { db, account_id, email_address } = opts;
   assert_valid_account_id(account_id);
@@ -143,4 +148,14 @@ export async function set_email_address_verified(
     jsonb_set: { email_address_verified: { [email_address]: new Date() } },
     where: { "account_id = $::UUID": account_id },
   });
+}
+
+export async function is_admin(
+  db: PostgreSQL,
+  account_id: string,
+): Promise<boolean> {
+  const { groups } = await get_account<{ groups?: string[] }>(db, account_id, [
+    "groups",
+  ]);
+  return Array.isArray(groups) && groups.includes("admin");
 }

--- a/src/packages/database/postgres/types.ts
+++ b/src/packages/database/postgres/types.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from "events";
 import { Client } from "pg";
 
 import { PassportStrategyDB } from "@cocalc/database/settings/auth-sso-types";
+import { ProjectState, ProjectStatus } from "@cocalc/util/db-schema/projects";
 import {
   CB,
   CBDB,
@@ -49,6 +50,17 @@ export interface QueryOptions<T = UntypedQueryResult> {
 
 export interface AsyncQueryOptions<T = UntypedQueryResult>
   extends Omit<QueryOptions<T>, "cb"> {}
+
+export interface UserQueryOptions {
+  client_id?: string; // if given, uses to control number of queries at once by one client.
+  priority?: number; // (NOT IMPLEMENTED) priority for this query (an integer [-10,...,19] like in UNIX)
+  account_id?: string;
+  project_id?: string;
+  query?: object;
+  options?: object[];
+  changes?: undefined; // id of change feed
+  cb?: CB<{ action?: "close" }>;
+}
 
 export interface ChangefeedOptions {
   table: string; // Name of the table
@@ -100,6 +112,8 @@ export interface PostgreSQL extends EventEmitter {
   _stop_listening(table: string, select: QuerySelect, watch: string[]);
 
   _query(opts: QueryOptions): void;
+
+  user_query(opts: UserQueryOptions): void;
 
   _client(): Client | undefined;
   _clients: Client[] | undefined;
@@ -294,7 +308,7 @@ export interface PostgreSQL extends EventEmitter {
     order_by?: any;
     where_function?: Function;
     idle_timeout_s?: number;
-    cb: CB;
+    cb?: CB;
   });
 
   projects_that_need_to_be_started(): Promise<string[]>;
@@ -308,4 +322,38 @@ export interface PostgreSQL extends EventEmitter {
       email_address: string;
     }>;
   }): Promise<void>;
+
+  user_query_cancel_changefeed(opts: { id: any; cb?: CB }): void;
+
+  save_blob(opts: {
+    uuid: string;
+    blob?: Buffer;
+    ttl?: number;
+    project_id?: string;
+    cb: CB;
+  }): void;
+
+  syncdoc_history_async(string_id: string, patches?: boolean): void;
+
+  set_project_state(opts: {
+    project_id: string;
+    state: ProjectState;
+    time?: Date;
+    error?: any;
+    ip?: string;
+    cb: CB;
+  }): void;
+
+  set_project_status(opts: { project_id: string; status: ProjectStatus }): void;
+
+  touch(opts: { project_id: string; account_id: string; cb: CB });
+
+  get_project_extra_env(opts: { project_id: string; cb: CB }): void;
+
+  projectControl?: (project_id: string) => Project;
+
+  ensure_connection_to_project?: (project_id: string, cb?: CB) => Promise<void>;
 }
+
+// This is an extension of BaseProject in projects/control/base.ts
+type Project = EventEmitter & {};

--- a/src/packages/next/lib/api/assert-trusted.ts
+++ b/src/packages/next/lib/api/assert-trusted.ts
@@ -1,11 +1,29 @@
+import { db } from "@cocalc/database";
+import { is_admin } from "@cocalc/database/postgres/account-queries";
+import { getServerSettings } from "@cocalc/database/settings";
 import getMinBalance from "@cocalc/server/purchases/get-min-balance";
+import { KUCALC_COCALC_COM } from "@cocalc/util/db-schema/site-defaults";
 import { currency } from "@cocalc/util/misc";
 
 const THRESH = -100;
-export const TRUST_ERROR_MESSAGE = `Please contact support and request a minimum balance that is under ${currency(THRESH)} to access this API endpoint.`;
+export const TRUST_ERROR_MESSAGE = `Please contact support and request a minimum balance that is under ${currency(
+  THRESH,
+)} to access this API endpoint.`;
 
 export default async function assertTrusted(account_id: string): Promise<void> {
-  if ((await getMinBalance(account_id)) > THRESH) {
-    throw Error(TRUST_ERROR_MESSAGE);
+  const { kucalc } = await getServerSettings();
+
+  if (kucalc === KUCALC_COCALC_COM) {
+    // on cocalc.com, we check if users have gained trust by giving them a lower min balance
+    if ((await getMinBalance(account_id)) > THRESH) {
+      throw new Error(TRUST_ERROR_MESSAGE);
+    }
+  } else {
+    // for on-prem instances, only admins are allowed to create accounts
+    if (!(await is_admin(db(), account_id))) {
+      throw new Error(
+        "Only users in the group 'admin' are allowed to create new users.",
+      );
+    }
   }
 }

--- a/src/packages/next/lib/api/schema/accounts/sign-up.ts
+++ b/src/packages/next/lib/api/schema/accounts/sign-up.ts
@@ -1,0 +1,66 @@
+import { SignUpIssues } from "lib/types/sign-up";
+import { z } from "../../framework";
+
+import { FailedAPIOperationSchema } from "../common";
+
+import { AccountIdSchema } from "./common";
+
+// OpenAPI spec
+//
+export const SignUpInputSchema = z
+  .object({
+    email: z
+      .string()
+      .email()
+      .describe(
+        "Email address of new user. TIP: If you want to pass in an email like jd+1@example.com, use '%2B' in place of '+'",
+      ),
+    password: z.string().describe("Initial password of new user."),
+    firstName: z.string().describe("First name"),
+    lastName: z.string().describe("Last name"),
+    terms: z
+      .boolean()
+      .describe("Must be set to 'true' to indicate acceptance of ToS."),
+    registrationToken: z
+      .string()
+      .optional()
+      .describe("If required, enter a currently valid registration token."),
+    tags: z.array(z.string()).optional().describe("Tag users"),
+    publicPathId: z
+      .string()
+      .optional()
+      .describe("ID of published document, used to get a license ID"),
+    signupReason: z.string().optional(),
+  })
+  .describe(
+    "Create a new account. In production, this is not available for all users and requires additional trust! For on-premises, this functionality is only available for administrators.",
+  );
+
+const IssuesSchema = z.object({
+  terms: z.string().optional().describe("Problem with ToS"),
+  email: z.string().optional().describe("Problem with the email address"),
+  password: z.string().optional().describe("Problem with the password"),
+  api: z.string().optional().describe("Problem with the API"),
+});
+
+export const SignUpOutputSchema = z.union([
+  z.union([
+    z.object({
+      account_id: AccountIdSchema.describe("Account ID"),
+    }),
+    z
+      .object({
+        issues: IssuesSchema,
+      })
+      .describe("Reporting back possible issues creating a new account."),
+  ]),
+  FailedAPIOperationSchema,
+]);
+
+export type SignUpInput = z.infer<typeof SignUpInputSchema>;
+export type SignUpOutput = z.infer<typeof SignUpOutputSchema>;
+
+// consistency check
+export const _1: Required<SignUpIssues> = {} as Required<
+  z.infer<typeof IssuesSchema>
+>;

--- a/src/packages/next/lib/types/sign-up.ts
+++ b/src/packages/next/lib/types/sign-up.ts
@@ -1,0 +1,6 @@
+export interface SignUpIssues {
+    terms?: string;
+    email?: string;
+    password?: string;
+    api?: string;
+  }

--- a/src/packages/next/pages/api/v2/auth/sign-up.ts
+++ b/src/packages/next/pages/api/v2/auth/sign-up.ts
@@ -30,25 +30,26 @@ curl -u sk_abcdefQWERTY090900000000: \
 TIP: If you want to pass in an email like jd+1@example.com, use '%2B' in place of '+'.
 */
 
-import { v4 } from "uuid";
 import { Request, Response } from "express";
-import {
-  len,
-  is_valid_email_address as isValidEmailAddress,
-} from "@cocalc/util/misc";
+import { v4 } from "uuid";
+
+import { getServerSettings } from "@cocalc/database/settings/server-settings";
+import createAccount from "@cocalc/server/accounts/create-account";
 import isAccountAvailable from "@cocalc/server/auth/is-account-available";
 import isDomainExclusiveSSO from "@cocalc/server/auth/is-domain-exclusive-sso";
-import createAccount from "@cocalc/server/accounts/create-account";
-import { getAccount, signUserIn } from "./sign-in";
-import sendWelcomeEmail from "@cocalc/server/email/welcome-email";
-import redeemRegistrationToken from "@cocalc/server/auth/tokens/redeem";
-import { getServerSettings } from "@cocalc/database/settings/server-settings";
-import getParams from "lib/api/get-params";
-import reCaptcha from "@cocalc/server/auth/recaptcha";
-import getSiteLicenseId from "@cocalc/server/public-paths/site-license-id";
 import passwordStrength from "@cocalc/server/auth/password-strength";
-import assertTrusted from "lib/api/assert-trusted";
+import reCaptcha from "@cocalc/server/auth/recaptcha";
+import redeemRegistrationToken from "@cocalc/server/auth/tokens/redeem";
+import sendWelcomeEmail from "@cocalc/server/email/welcome-email";
+import getSiteLicenseId from "@cocalc/server/public-paths/site-license-id";
+import {
+  is_valid_email_address as isValidEmailAddress,
+  len,
+} from "@cocalc/util/misc";
 import getAccountId from "lib/account/get-account";
+import assertTrusted from "lib/api/assert-trusted";
+import getParams from "lib/api/get-params";
+import { getAccount, signUserIn } from "./sign-in";
 
 interface Issues {
   terms?: string;

--- a/src/packages/server/accounts/create-account.ts
+++ b/src/packages/server/accounts/create-account.ts
@@ -11,6 +11,7 @@ import accountCreationActions, {
 } from "./account-creation-actions";
 import { getLogger } from "@cocalc/backend/logger";
 import { getServerSettings } from "@cocalc/database/settings/server-settings";
+
 const log = getLogger("server:accounts:create");
 
 interface Params {

--- a/src/packages/server/projects/control/kucalc.ts
+++ b/src/packages/server/projects/control/kucalc.ts
@@ -187,7 +187,7 @@ class Project extends BaseProject {
     }
   }
 
-  private getProjectSynctable(): any {
+  private getProjectSynctable() {
     // this is all in coffeescript, hence the any type above.
     return db().synctable({
       table: "projects",

--- a/src/packages/server/projects/control/util.ts
+++ b/src/packages/server/projects/control/util.ts
@@ -199,28 +199,30 @@ export async function deleteUser(project_id: string): Promise<void> {
   }
 }
 
+const ENV_VARS_DELETE = [
+  "PGDATA",
+  "PGHOST",
+  "PGUSER",
+  "PGDATABASE",
+  "PROJECTS",
+  "BASE_PATH",
+  "PORT",
+  "DATA",
+  "LOGS",
+  "PWD",
+  "LINES",
+  "COLUMNS",
+  "LS_COLORS",
+  "INIT_CWD",
+  "DEBUG_FILE",
+] as const;
+
 export function sanitizedEnv(env: { [key: string]: string | undefined }): {
   [key: string]: string;
 } {
   const env2 = { ...env };
   // Remove some potentially confusing env variables
-  for (const key of [
-    "PGDATA",
-    "PGHOST",
-    "PGUSER",
-    "PGDATABASE",
-    "PROJECTS",
-    "BASE_PATH",
-    "PORT",
-    "DATA",
-    "LOGS",
-    "PWD",
-    "LINES",
-    "COLUMNS",
-    "LS_COLORS",
-    "INIT_CWD",
-    "DEBUG_FILE",
-  ]) {
+  for (const key of ENV_VARS_DELETE) {
     delete env2[key];
   }
   // Comment about stripping things starting with /root:


### PR DESCRIPTION
* follow up of 433f4b3bcb56688c3edd9271c12f9cbb4c11c753: for onprem, require admin group:
  * When a regular user wants to create a user: `{'issues': {'api': "Error: Only users in the group 'admin' are allowed to create new users."}}`
  * When an admin wants to create a user, works fine (account_id returned)
* I also typed that db database object, and had to deal with the fallout. No change in functionality, just many small typing details.
* OpenAPI spec, also documenting that issues object upon failure.

![Screenshot from 2024-11-01 14-16-57](https://github.com/user-attachments/assets/3cb71e40-dcc3-4eba-a6bc-291e35b664d6)
