### PR TITLE
server_settings: don't do anything if there are no variables

### DIFF
--- a/src/packages/database/settings/server-settings.ts
+++ b/src/packages/database/settings/server-settings.ts
@@ -90,6 +90,12 @@ export async function load_server_settings_from_env(
   db: PostgreSQL,
 ): Promise<void> {
   const PREFIX = SERVER_SETTINGS_ENV_PREFIX;
+
+  // if none of the envvars starts with the prefix, then we don't do anything
+  if (!Object.keys(process.env).some((k) => k.startsWith(PREFIX))) {
+    return;
+  }
+
   L.debug("load_server_settings_from_env variables prefixed by ", PREFIX);
   // reset all readonly values
   await db.async_query({


### PR DESCRIPTION
this is pretty trivial. if none of the environment variables starts with the $PREFIX, do not set any server settings. This avoids one hub resetting all envvars to readonly=false, just because that pod didn't get all variables. also, if no variables are set, this just skips this feature.