### PR TITLE
Improve Admin Refunds

### DIFF
--- a/src/packages/database/postgres-base.coffee
+++ b/src/packages/database/postgres-base.coffee
@@ -1041,7 +1041,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
         if opts.table
             tables = [opts.table]
         else
-            tables = (k for k, v of SCHEMA when v.fields?.expire? and not v.virtual)
+            tables = (k for k, v of SCHEMA when v.fields?.expire?.type == 'timestamp' and not v.virtual)
         async.map(tables, f, opts.cb)
 
     # count number of entries in a table

--- a/src/packages/frontend/purchases/admin-refund.tsx
+++ b/src/packages/frontend/purchases/admin-refund.tsx
@@ -35,10 +35,12 @@ export default function AdminRefund({
   purchase_id,
   service,
   cost,
+  refresh,
 }: {
   purchase_id: number;
   service: Service;
   cost: number;
+  refresh?;
 }) {
   const [error, setError] = useState<string>("");
   const [refunding, setRefunding] = useState<boolean>(false);
@@ -56,6 +58,7 @@ export default function AdminRefund({
       setRefunding(true);
       await adminCreateRefund({ purchase_id, ...values });
       setIsModalVisible(false);
+      refresh?.();
     } catch (err) {
       setError(`${err}`);
     } finally {
@@ -93,7 +96,7 @@ export default function AdminRefund({
         )}
         {service == "license" && (
           <>
-            The license will have it expire time set to now, and the{" "}
+            The license will be immediately expired, and the{" "}
             <b>full amount {currency(amount, 2)} paid for this license</b> will
             be credited to the account as a new credit "Credit for Refunded
             Transaction {purchase_id}".

--- a/src/packages/frontend/purchases/purchases.tsx
+++ b/src/packages/frontend/purchases/purchases.tsx
@@ -1023,8 +1023,10 @@ function Description({ description, period_end, service }) {
         )}
       >
         Edit License: <License license_id={license_id} />
-        {describeQuotaFromInfo(description.modifiedInfo)}{" "}
-        <LicenseDates info={description.modifiedInfo} />
+        <div>
+          {describeQuotaFromInfo(description.modifiedInfo)}
+          <LicenseDates info={description.modifiedInfo} />
+        </div>
       </Popover>
     );
   }
@@ -1327,9 +1329,7 @@ function License({ license_id }) {
 
   return (
     <span>
-      <Button onClick={() => setOpen(!open)}>
-        {license_id}
-      </Button>
+      <Button onClick={() => setOpen(!open)}>{license_id}</Button>
       {open && (
         <div style={{ maxWidth: "100%", minWidth: "700px" }}>
           <SiteLicensePublicInfo license_id={license_id} />

--- a/src/packages/frontend/purchases/purchases.tsx
+++ b/src/packages/frontend/purchases/purchases.tsx
@@ -66,7 +66,7 @@ import {
   round4,
 } from "@cocalc/util/misc";
 import { decimalAdd } from "@cocalc/util/stripe/calc";
-import AdminRefund from "./admin-refund";
+import AdminRefund, { isRefundable } from "./admin-refund";
 import * as api from "./api";
 import EmailStatement from "./email-statement";
 import Export from "./export";
@@ -688,7 +688,6 @@ function DetailedPurchaseTable({
               render: (_, record) => (
                 <>
                   <Amount record={record} />
-                  <Pending record={record} />
                 </>
               ),
               sorter: (a, b) => (a.cost ?? 0) - (b.cost ?? 0),
@@ -735,6 +734,7 @@ function PurchaseDescription({
   period_end,
   service,
   admin,
+  cost,
 }) {
   return (
     <div>
@@ -763,9 +763,11 @@ function PurchaseDescription({
             style={{ marginBottom: "15px" }}
           />
         )}
+        {admin && id != null && isRefundable(service) && (
+          <AdminRefund purchase_id={id} service={service} cost={cost} />
+        )}
         {invoice_id && (
           <Space>
-            {admin && id != null && <AdminRefund purchase_id={id} />}
             {!admin && (
               <Button
                 size="small"
@@ -1180,28 +1182,6 @@ function Amount({ record }) {
     );
   }
   return <>-</>;
-}
-
-function Pending({ record }) {
-  if (!record.pending) return null;
-  return (
-    <div>
-      <Tooltip
-        title={
-          <>
-            The transaction has not yet completed and is{" "}
-            <b>thus not included in your running balance</b>. Ensure you have
-            automatic payments configured or add credit to your account to pay
-            this.
-          </>
-        }
-      >
-        <Tag style={{ marginRight: 0 }} color="red">
-          Pending
-        </Tag>
-      </Tooltip>
-    </div>
-  );
 }
 
 function Balance({ balance }) {

--- a/src/packages/frontend/purchases/purchases.tsx
+++ b/src/packages/frontend/purchases/purchases.tsx
@@ -763,12 +763,20 @@ function PurchaseDescription({
             style={{ marginBottom: "15px" }}
           />
         )}
-        {admin && id != null && isRefundable(service) && (
-          <AdminRefund purchase_id={id} service={service} cost={cost} />
+        {description.refund_purchase_id && (
+          <b style={{ marginLeft: "8px" }}>
+            REFUNDED: Transaction {description.refund_purchase_id}
+          </b>
         )}
+        {admin &&
+          description.refund_purchase_id == null &&
+          id != null &&
+          isRefundable(service, invoice_id) && (
+            <AdminRefund purchase_id={id} service={service} cost={cost} />
+          )}
         {invoice_id && (
           <Space>
-            {!admin && (
+            {!admin && !description.refund_purchase_id && (
               <Button
                 size="small"
                 type="link"

--- a/src/packages/frontend/purchases/purchases.tsx
+++ b/src/packages/frontend/purchases/purchases.tsx
@@ -37,7 +37,7 @@ import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
 import { load_target } from "@cocalc/frontend/history";
 import { open_new_tab } from "@cocalc/frontend/misc/open-browser-tab";
 import { ProjectTitle } from "@cocalc/frontend/projects/project-title";
-import { SiteLicensePublicInfo as License } from "@cocalc/frontend/site-licenses/site-license-public-info-component";
+import { SiteLicensePublicInfo } from "@cocalc/frontend/site-licenses/site-license-public-info-component";
 import getSupportURL from "@cocalc/frontend/support/url";
 import {
   ANTHROPIC_PREFIX,
@@ -913,35 +913,7 @@ function Description({ description, period_end, service }) {
   // <pre>{JSON.stringify(description, undefined, 2)}</pre>
   if (service === "license") {
     const { license_id } = description;
-    return (
-      <Popover
-        overlayStyle={{
-          maxHeight: "60vh",
-          overflow: "auto",
-          border: "1px solid #ccc",
-          borderRadius: "5px",
-          boxShadow: "4px 4px 2px #dfdfdf",
-        }}
-        title={
-          <>
-            Licenses:{" "}
-            {license_id && (
-              <Next href={`licenses/how-used?license_id=${license_id}`}>
-                {license_id}
-              </Next>
-            )}
-          </>
-        }
-        content={() => <>{license_id && <License license_id={license_id} />}</>}
-      >
-        License:{" "}
-        {license_id && (
-          <Next href={`licenses/how-used?license_id=${license_id}`}>
-            {license_id}
-          </Next>
-        )}
-      </Popover>
-    );
+    return <>License: {license_id && <License license_id={license_id} />}</>;
   }
   if (service === "credit") {
     return (
@@ -1030,10 +1002,7 @@ function Description({ description, period_end, service }) {
       <Popover
         title={
           <div style={{ fontSize: "13pt" }}>
-            <Icon name="pencil" /> Edited License:{" "}
-            <Next href={`licenses/how-used?license_id=${license_id}`}>
-              {license_id}
-            </Next>
+            <Icon name="pencil" /> Edited License
           </div>
         }
         content={() => (
@@ -1053,6 +1022,7 @@ function Description({ description, period_end, service }) {
           </div>
         )}
       >
+        Edit License: <License license_id={license_id} />
         {describeQuotaFromInfo(description.modifiedInfo)}{" "}
         <LicenseDates info={description.modifiedInfo} />
       </Popover>
@@ -1350,4 +1320,21 @@ function getFilter(purchase) {
     purchase.filter = JSON.stringify(purchase).toLowerCase();
   }
   return purchase.filter;
+}
+
+function License({ license_id }) {
+  const [open, setOpen] = useState<boolean>(false);
+
+  return (
+    <span>
+      <Button onClick={() => setOpen(!open)}>
+        {license_id}
+      </Button>
+      {open && (
+        <div style={{ maxWidth: "100%", minWidth: "700px" }}>
+          <SiteLicensePublicInfo license_id={license_id} />
+        </div>
+      )}
+    </span>
+  );
 }

--- a/src/packages/frontend/purchases/purchases.tsx
+++ b/src/packages/frontend/purchases/purchases.tsx
@@ -481,6 +481,7 @@ export function PurchasesTable({
           <DetailedPurchaseTable
             purchases={filteredPurchases}
             admin={!!account_id}
+            refresh={refreshRecords}
           />
         )}
       </div>
@@ -575,9 +576,11 @@ function GroupedPurchaseTable({ purchases }) {
 function DetailedPurchaseTable({
   purchases,
   admin,
+  refresh,
 }: {
   purchases: PurchaseItem[] | null;
   admin: boolean;
+  refresh?;
 }) {
   const [current, setCurrent] = useState<PurchaseItem | undefined>(undefined);
   const fragment = useTypedRedux("account", "fragment");
@@ -631,7 +634,11 @@ function DetailedPurchaseTable({
               key: "description",
               width: "35%",
               render: (_, purchase) => (
-                <PurchaseDescription {...(purchase as any)} admin={admin} />
+                <PurchaseDescription
+                  {...(purchase as any)}
+                  admin={admin}
+                  refresh={refresh}
+                />
               ),
             },
             {
@@ -735,6 +742,7 @@ function PurchaseDescription({
   service,
   admin,
   cost,
+  refresh,
 }) {
   return (
     <div>
@@ -772,7 +780,12 @@ function PurchaseDescription({
           description.refund_purchase_id == null &&
           id != null &&
           isRefundable(service, invoice_id) && (
-            <AdminRefund purchase_id={id} service={service} cost={cost} />
+            <AdminRefund
+              purchase_id={id}
+              service={service}
+              cost={cost}
+              refresh={refresh}
+            />
           )}
         {invoice_id && (
           <Space>
@@ -950,21 +963,18 @@ function Description({ description, period_end, service }) {
   if (service === "refund") {
     const { notes, reason, purchase_id } = description;
     return (
-      <Tooltip
-        title={
-          <div>
-            Reason: {capitalize(reason.replace(/_/g, " "))}
-            {!!notes && (
-              <>
-                <br />
-                Notes: {notes}
-              </>
-            )}
-          </div>
-        }
-      >
+      <div>
         Refund Transaction {purchase_id}
-      </Tooltip>
+        <div>
+          Reason: {capitalize(reason.replace(/_/g, " "))}
+          {!!notes && (
+            <>
+              <br />
+              Notes: {notes}
+            </>
+          )}
+        </div>
+      </div>
     );
   }
 

--- a/src/packages/frontend/site-licenses/site-license-public-info-component.tsx
+++ b/src/packages/frontend/site-licenses/site-license-public-info-component.tsx
@@ -231,14 +231,14 @@ export const SiteLicensePublicInfo: React.FC<Props> = (
       license_status != null
         ? license_status === "expired"
         : info?.expires != null
-        ? new Date() >= info.expires
-        : false;
+          ? new Date() >= info.expires
+          : false;
     if (!expired && info?.subscription_id) {
       // no need to say anything because it is not expired and
       // a subscription will extend it (unless it is canceled)
       return null;
     }
-    const word = expired ? "EXPIRED" : "Valid through";
+    const word = expired ? "EXPIRED" : "Fully prepaid through";
     const when =
       info?.expires != null ? (
         <TimeAgo date={info.expires} />
@@ -253,14 +253,9 @@ export const SiteLicensePublicInfo: React.FC<Props> = (
       <li
         style={expired ? { fontSize: "110%", fontWeight: "bold" } : undefined}
       >
-        {word} {when}
-        {!!info?.expires && !expired && (
-          <>
-            {info?.subscription_id
-              ? " depending on subscription status."
-              : " unless it is edited."}
-          </>
-        )}
+        <b>
+          {word} {when}.
+        </b>
       </li>
     );
   }
@@ -664,13 +659,14 @@ export const SiteLicensePublicInfo: React.FC<Props> = (
       if (!info?.is_manager) return;
       return (
         <Button
-          style={{ marginBottom: "5px" }}
+          type="link"
+          style={{ marginBottom: "5px", marginLeft: "-15px" }}
           onClick={() => {
             set_is_editing_title(true);
             set_title(info?.title);
           }}
         >
-          Set title...
+          Title...
         </Button>
       );
     }
@@ -730,12 +726,14 @@ export const SiteLicensePublicInfo: React.FC<Props> = (
       if (!info?.is_manager) return;
       return (
         <Button
+          type="link"
+          style={{ marginLeft: "-15px" }}
           onClick={() => {
             set_is_editing_description(true);
             set_description(info?.description);
           }}
         >
-          Set description...
+          Description...
         </Button>
       );
     }

--- a/src/packages/server/billing/get-invoices-and-receipts.ts
+++ b/src/packages/server/billing/get-invoices-and-receipts.ts
@@ -46,7 +46,6 @@ export async function getInvoiceUrl(
     const charges = await stripe.charges.list({
       payment_intent: invoice_id,
     });
-    console.log(charges);
     return charges.data?.[0]?.receipt_url;
   }
   const invoice = await stripe.invoices.retrieve(invoice_id);

--- a/src/packages/server/compute/maintenance/purchases/low-balance.ts
+++ b/src/packages/server/compute/maintenance/purchases/low-balance.ts
@@ -114,7 +114,7 @@ async function checkAllowed(service, server) {
     });
   } else {
     action = "Computer Server Turned Off";
-    callToAction = `Add credit to your account, so your compute server isn't deleted.`;
+    callToAction = `[Add credit to your account or enable automatic deposits, so your compute server isn't deleted.](${await siteURL()}/settings/payg)`;
     adminAlert({
       subject: "WARNING -- low balance situation",
       body: `
@@ -179,17 +179,11 @@ Hello ${name},
 Your Compute Server '${server.title}' (Id: ${server.project_specific_id}) is
 hitting your ${service} quota, or you are very low on funds.
 
-Action Taken: ${action}
+- Action Taken: ${action}
 
-${callToAction}
+- ${callToAction}
 
-Add credit to your account and see all of your purchases:
-
-${await siteURL()}/settings/purchases
-
-Compute Servers in your project ${projectTitle}
-
-${await siteURL()}/projects/${server.project_id}/servers
+- [Compute Servers in your project "${projectTitle}"](${await siteURL()}/projects/${server.project_id}/servers)
 
 ${await support()}
 `;

--- a/src/packages/server/messages/get.ts
+++ b/src/packages/server/messages/get.ts
@@ -77,7 +77,6 @@ export default async function get({
   }
 
   const pool = getPool();
-  console.log(query, params);
   const { rows } = await pool.query(query, params);
 
   return rows as unknown as MessageMe[];

--- a/src/packages/server/messages/maintenance.ts
+++ b/src/packages/server/messages/maintenance.ts
@@ -184,7 +184,6 @@ export async function sendEmailSummary({
     });
 
     log.debug(`sendEmailSummary: got ${messages.length} new messages`);
-    console.log(messages);
     if (messages.length == 0) {
       const pool = getPool();
       await pool.query(

--- a/src/packages/server/projects/control/kubernetes.ts
+++ b/src/packages/server/projects/control/kubernetes.ts
@@ -31,7 +31,7 @@ const winston = getLogger("project-control-kubernetes");
 
 class Project extends BaseProject {
   async state(): Promise<ProjectState> {
-    console.log("state");
+    winston.debug("state ", this.project_id);
     throw Error("implement me");
   }
 

--- a/src/packages/server/purchases/create-refund.ts
+++ b/src/packages/server/purchases/create-refund.ts
@@ -10,6 +10,7 @@ import createPurchase from "./create-purchase";
 import type { Reason, Refund } from "@cocalc/util/db-schema/purchases";
 import { currency } from "@cocalc/util/misc";
 import send, { support, url } from "@cocalc/server/messages/send";
+import { changeLicense } from "./edit-license";
 
 const logger = getLogger("purchase:create-refund");
 
@@ -207,8 +208,8 @@ async function refundLicense(
   let refund_purchase_id;
   let action;
   try {
+    const { license_id } = description;
     if (service == "license") {
-      const { license_id } = description;
       // a purchase of a new license.  just set the expire to now, making this worthless
       action = `The license ${license_id} is now expired.`;
 
@@ -217,7 +218,7 @@ async function refundLicense(
       ]);
     } else if (service == "edit-license") {
       action = "The changes to the license have been reverted.";
-      throw Error("todo");
+      await changeLicense(license_id, description.origInfo, client);
     }
 
     refund_purchase_id = await createPurchase({

--- a/src/packages/server/purchases/create-refund.ts
+++ b/src/packages/server/purchases/create-refund.ts
@@ -34,33 +34,47 @@ export default async function createRefund(opts: {
   ) {
     // don't trust typescript, since used via api...
     throw Error(
-      `reason must be one of "duplicate", "fraudulent", "requested_by_customer" or "other"`,
+      `Reason must be one of "duplicate", "fraudulent", "requested_by_customer" or "other"`,
     );
   }
 
   logger.debug("get the purchase");
   const pool = getPool();
   const { rows: purchases } = await pool.query(
-    "SELECT account_id, invoice_id, service, cost FROM purchases WHERE id=$1",
+    "SELECT id, account_id, invoice_id, service, cost FROM purchases WHERE id=$1",
     [purchase_id],
   );
   if (purchases.length == 0) {
-    throw Error(`no purchase with id ${purchase_id}`);
+    throw Error(`No purchase with id ${purchase_id}`);
   }
+  const { service } = purchases[0];
   logger.debug("got ", purchases);
-  let {
-    invoice_id,
-    service,
-    cost,
-    account_id: customer_account_id,
-  } = purchases[0];
-  if (service != "credit") {
+  if (service == "credit" || service == "auto-credit") {
+    return await refundCredit(account_id, reason, notes, purchases[0]);
+  } else if (service == "license" || service == "edit-license") {
+    return await refundLicense(account_id, reason, notes, purchases[0]);
+  } else {
     throw Error(
-      `only credits can be refunded, but this purchase is of service type '${service}'`,
+      `Only credits and license purchases can be refunded, but this purchase is of service type '${service}'`,
     );
   }
+}
+
+async function refundCredit(
+  admin_account_id,
+  reason,
+  notes,
+  {
+    id: purchase_id,
+    invoice_id,
+    cost,
+    account_id,
+    description: orig_description,
+  },
+) {
+  logger.debug("refundCredit", purchase_id);
   if (!invoice_id) {
-    throw Error("only credits with an invoice_id can be refunded");
+    throw Error("Only credits with an invoice_id can be refunded");
   }
   const stripe = await getConn();
 
@@ -83,6 +97,7 @@ export default async function createRefund(opts: {
   }
 
   const client = await getTransactionClient();
+  let refund_purchase_id;
   try {
     const description = {
       type: "refund",
@@ -90,8 +105,8 @@ export default async function createRefund(opts: {
       notes,
       reason,
     } as Refund;
-    const id = await createPurchase({
-      account_id: customer_account_id,
+    refund_purchase_id = await createPurchase({
+      account_id,
       service: "refund",
       cost: -cost,
       description,
@@ -99,10 +114,9 @@ export default async function createRefund(opts: {
     });
     const refund = await stripe.refunds.create({
       charge,
-      metadata: { account_id, purchase_id, notes } as any,
+      metadata: { account_id: admin_account_id, purchase_id, notes } as any,
       reason: reason != "other" ? reason : undefined,
     });
-    await client.query("COMMIT");
 
     if (paymentIntentId) {
       await stripe.paymentIntents.update(paymentIntentId, {
@@ -118,21 +132,35 @@ export default async function createRefund(opts: {
     // It's fine doing this after the commit, since the refund.id
     // is not ever used; it just seems like a good idea to include
     // for our records, but we only know it *after* calling stripe.
-    description.refund_id = refund.id;
     await client.query("UPDATE purchases SET description=$2 WHERE id=$1", [
-      id,
-      description,
+      refund_purchase_id,
+      { ...description, refund_id: refund.id },
     ]);
-    // send confirmation message
-    try {
-      const { site_name: siteName } = await getServerSettings();
-      const subject = `${siteName} Refund of Transaction ${purchase_id} for ${currency(
-        Math.abs(cost),
-      )} + tax`;
-      const body = `
+    // we also set new purchase id
+    await client.query("UPDATE purchases SET description=$2 WHERE id=$1", [
+      purchase_id,
+      { ...orig_description, refund_purchase_id },
+    ]);
+
+    await client.query("COMMIT");
+  } catch (err) {
+    logger.debug("error creating refund", { account_id, invoice_id }, err);
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  // send confirmation message
+  try {
+    const { site_name: siteName } = await getServerSettings();
+    const subject = `${siteName} Refund of Transaction ${purchase_id} for ${currency(
+      Math.abs(cost),
+    )} + tax`;
+    const body = `
 ${siteName} has refunded your credit of ${currency(
-        Math.abs(cost),
-      )} + tax from transaction ${purchase_id}.
+      Math.abs(cost),
+    )} + tax from transaction ${purchase_id}.
 This refund will appear immediately in [your ${siteName} account](/settings/purchases),
 and should post on your credit card or bank statement within 5-10 days.
 
@@ -144,17 +172,28 @@ and should post on your credit card or bank statement within 5-10 days.
 
 ${await support()}
 `;
-      await send({ to_ids: [customer_account_id], subject, body });
-    } catch (err) {
-      logger.debug("WARNING -- issue sending email", err);
-    }
-
-    return id;
+    await send({ to_ids: [account_id], subject, body });
   } catch (err) {
-    logger.debug("error creating refund", { account_id, invoice_id }, err);
-    await client.query("ROLLBACK");
-    throw err;
-  } finally {
-    client.release();
+    logger.debug("WARNING -- issue sending email", err);
   }
+
+  return refund_purchase_id;
+}
+
+async function refundLicense(
+  admin_account_id,
+  reason,
+  notes,
+  { id: purchase_id, service, cost, account_id },
+) {
+  logger.debug("refundLicense", admin_account_id, {
+    notes,
+    reason,
+    purchase_id,
+    service,
+    cost,
+    account_id,
+  });
+  throw Error("todo");
+  return 0;
 }

--- a/src/packages/server/purchases/edit-license.ts
+++ b/src/packages/server/purchases/edit-license.ts
@@ -331,7 +331,7 @@ function requiresRestart(info: PurchaseInfo, changes: Changes): boolean {
   return false;
 }
 
-async function changeLicense(
+export async function changeLicense(
   license_id: string,
   info: PurchaseInfo,
   client: PoolClient,

--- a/src/packages/server/shopping/cart/get.ts
+++ b/src/packages/server/shopping/cart/get.ts
@@ -82,7 +82,6 @@ export default async function getCart({
     // for non-historical items we adjust the interval to be valid, e.g., can't buy license in the past
     await ensureValidLicenseIntervals(rows, pool);
   }
-  console.log({ query, rows });
   return rows as any as Item[];
 }
 


### PR DESCRIPTION
Make it so admins can fully refund any license edit (e.g., extending subscription by a month), and also credit card payment (both normal *AND* automatic balance increases) through the UI, and improve the UI regarding show what has happened:

<img width="1349" alt="image" src="https://github.com/user-attachments/assets/e050fd5a-d424-49bf-be92-bc7e754ffd90" />

and

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/0f64798d-b23f-45f6-99e0-a4d703b58fd4" />

Everything is already done EXCEPT the backend part of actually refunding the license creating/changes.