### PR TITLE
database: if all clients fail to connect, emit "disconnect" event

### DIFF
--- a/src/packages/database/postgres-base.coffee
+++ b/src/packages/database/postgres-base.coffee
@@ -44,6 +44,7 @@ winston      = require('@cocalc/backend/logger').getLogger('postgres')
 misc_node = require('@cocalc/backend/misc_node')
 { sslConfigToPsqlEnv, pghost, pgdatabase, pguser, pgssl } = require("@cocalc/backend/data")
 
+{ recordConnected, recordDisconnected } = require("./postgres/record-connect-error")
 
 {defaults} = misc = require('@cocalc/util/misc')
 required = defaults.required
@@ -191,6 +192,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                 if not err
                     @_state = 'connected'
                     @emit('connect')
+                    recordConnected()
 
     disconnect: () =>
         if @_clients?
@@ -280,6 +282,7 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                             # already started connecting
                             return
                         @emit('disconnect')
+                        recordDisconnected()
                         dbg("error -- #{err}")
                         @disconnect()
                         @connect()  # start trying to reconnect
@@ -355,6 +358,10 @@ class exports.PostgreSQL extends EventEmitter    # emits a 'connect' event whene
                 mesg = "Failed to connect to database -- #{err}"
                 dbg(mesg)
                 console.warn(mesg)  # make it clear for interactive users with debugging off -- common mistake with env not setup right.
+                # If we're unable to connect (or all clients fail), we are disconnected. This tells postgres/record-connect-error.ts about this problem.
+                # See https://github.com/sagemathinc/cocalc/issues/5997 for some logs related to that.
+                @emit('disconnect')
+                recordDisconnected()
                 cb?(err)
             else
                 @_clients = locals.clients

--- a/src/packages/database/postgres/record-connect-error.ts
+++ b/src/packages/database/postgres/record-connect-error.ts
@@ -22,7 +22,8 @@ const L = getLogger("db:record-connect-error");
 // a "connect" event will reset this to null
 let lastDisconnected: number | null = null;
 
-function recordDisconnected() {
+// ATTN: do not move/rename this function, since it is referenced in postgres-base.coffee
+export function recordDisconnected() {
   L.debug("disconnected");
   const now = Date.now();
   try {
@@ -35,7 +36,8 @@ function recordDisconnected() {
   }
 }
 
-function recordConnected() {
+// ATTN: do not move/rename this function, since it is referenced in postgres-base.coffee
+export function recordConnected() {
   L.debug("connected");
   try {
     getStatusGauge().labels("connected").set(Date.now());
@@ -45,9 +47,12 @@ function recordConnected() {
   lastDisconnected = null;
 }
 
-export function setupRecordConnectErrors(db: PostgreSQL) {
-  db.on("connect", () => recordConnected());
-  db.on("disconnect", () => recordDisconnected());
+export function setupRecordConnectErrors(_db: PostgreSQL) {
+  // These event listeners are not robust. Somehow, a "removeAllListeners" or similar must trimp them up
+  // The problem arises when the database connection is dropped, reconnected, and dropped again:
+  // After the 2nd connection drop, the "disconnect" event is attempted to emit, but never appears here.
+  //db.on("connect", () => recordConnected());
+  //db.on("disconnect", () => recordDisconnected());
 }
 
 export function howLongDisconnectedMins(): number | undefined {


### PR DESCRIPTION
This is related to https://github.com/sagemathinc/cocalc/issues/5997 … i.e. this records the case where there is no connection to the database, to eventually cause the health check to fail. This is more general than the "forgot the database password"-problem, because it should cause a health check failure in all cases, when it is not possible to establish a connection to the database.

test: I haven't tested this, but I think it should be fine. In the end, the `misc.retry_until_success` will call this `@_connect` again and again and the health checks last disconnect timestamp will be set once and kept at the point in time when this failure happened for the first time. 

---

This really needed more work. The weird part is, when there is a "disconnect" event, it should be emitted and received by that record-connect-error, but the second time around (connect-disconnect-connect-disconnect), it no longer receives the event. Somewhere, everyone who listens to the event emitter is removed, or just the "disconnect" event, and never re-establishes the connection.  I saw there is code in the syncstrings part, which could be relevant – not sure.

In any case, my fix is to call the register connect/disconnect functions directly. A disconnect happens either when the database client is disconnected or if the attempt to connect fails. 

My test in my local dev environment was to start/stop the database and check what the health check has to say, i.e.

```
$ curl http://localhost:5000/healthcheck
healthchecks:
concurrent 0 < undefined – OK
uptime 1m40s – draining in 24m49s – terminating in 25m49s – OK
DB problems for 0.14 < 5 mins – OK

vs.

$ curl http://localhost:5000/healthcheck
healthchecks:
concurrent 0 < undefined – OK
uptime 1m41s – draining in 24m48s – terminating in 25m48s – OK
no DB connection problems – OK
```

flipping back and forth when starting/stopping my local db.

