### PR TITLE
frontend/latex: fix parsing file names with brackets like "file.tex [42]"

### DIFF
--- a/src/packages/frontend/misc/latex-log-parser.test.ts
+++ b/src/packages/frontend/misc/latex-log-parser.test.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import { LatexParser } from "@cocalc/frontend/frame-editors/latex-editor/latex-log-parser";
+
+describe("latex-log-parser", () => {
+  test("log1", () => {
+    const log1 = fs.readFileSync("./misc/latex-logs/log1.txt", "utf-8");
+    const parsed1 = new LatexParser(log1, {
+      ignoreDuplicates: true,
+    }).parse();
+    const err0 = parsed1.errors[0];
+    expect(err0.line).toBe(1);
+    expect(err0.file).toEqual("subfile.tex");
+    expect(parsed1.deps[0]).toEqual("master.tex");
+    expect(parsed1.deps[1]).toEqual("subfile.tex");
+  });
+
+  // This is an abbrivated log of https://github.com/sagemathinc/cocalc/issues/8089
+  test("log2", () => {
+    const log2 = fs.readFileSync("./misc/latex-logs/log2.txt", "utf-8");
+    const parsed2 = new LatexParser(log2, {
+      ignoreDuplicates: true,
+    }).parse();
+    const err0 = parsed2.all[0];
+    expect(err0.file).toEqual("ch_Euclidean.tex");
+    expect(err0.message).toEqual("Marginpar on page 1 moved.");
+    expect(parsed2.deps).toEqual(["01.tex", "02.5.tex"]);
+    expect(parsed2.files).toEqual(["livre1.tex", "ch_Euclidean.tex"]);
+  });
+});

--- a/src/packages/frontend/misc/latex-logs/log1.txt
+++ b/src/packages/frontend/misc/latex-logs/log1.txt
@@ -1,0 +1,127 @@
+Rc files read:
+/etc/LatexMk
+Latexmk: This is Latexmk, John Collins, 31 Jan. 2024. Version 4.83.
+Force everything to be remade.
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex': Reasons for rerun
+Category 'other':
+Rerun of 'pdflatex' forced or previously required:
+Reason or flag: 'go_mode'
+
+------------
+Run number 1 of rule 'pdflatex'
+------------
+------------
+Running 'pdflatex -synctex=1 -interaction=nonstopmode -recorder "master.tex"'
+------------
+This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023/Debian) (preloaded format=pdflatex)
+restricted \write18 enabled.
+entering extended mode
+(./master.tex
+LaTeX2e <2023-11-01> patch level 1
+L3 programming layer <2024-01-22>
+(/usr/share/texlive/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2023/05/17 v1.4n Standard LaTeX document class
+(/usr/share/texlive/texmf-dist/tex/latex/base/size10.clo))
+(/usr/share/texmf/tex/latex/lm/t1lmr.fd)
+(/usr/share/texlive/texmf-dist/tex/latex/l3backend/l3backend-pdftex.def)
+(./master.aux (./subfile.aux) (./subfile.aux) (./subfile.aux) (./subfile.aux))
+(./master.out) (./master.out) [1{/var/lib/texmf/fonts/map/pdftex/updmap/pdftex.
+map}{/usr/share/texmf/fonts/enc/dvips/lm/lm-ec.enc}] (./subfile.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [2] (./subfile2.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [3] (./subfile3.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [4] (./subfile4.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [5] (./master.aux (./subfile.aux) (./subfile2.aux) (./subfile3.aux)
+(./subfile4.aux)) )
+(see the transcript file for additional information)</usr/share/texmf/fonts/typ
+e1/public/lm/lmr10.pfb>
+Output written on master.pdf (5 pages, 26772 bytes).
+SyncTeX written on master.synctex.gz.
+Transcript written on master.log.
+Latexmk: Getting log file 'master.log'
+Latexmk: Examining 'master.fls'
+Latexmk: Examining 'master.log'
+Latexmk: Log file says output to 'master.pdf'
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex': Reasons for rerun
+Changed files or newly in use/created:
+master.aux
+subfile.aux
+subfile2.aux
+subfile3.aux
+subfile4.aux
+
+------------
+Run number 2 of rule 'pdflatex'
+------------
+------------
+Running 'pdflatex -synctex=1 -interaction=nonstopmode -recorder "master.tex"'
+------------
+This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023/Debian) (preloaded format=pdflatex)
+restricted \write18 enabled.
+entering extended mode
+(./master.tex
+LaTeX2e <2023-11-01> patch level 1
+L3 programming layer <2024-01-22>
+(/usr/share/texlive/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2023/05/17 v1.4n Standard LaTeX document class
+(/usr/share/texlive/texmf-dist/tex/latex/base/size10.clo))
+(/usr/share/texmf/tex/latex/lm/t1lmr.fd)
+(/usr/share/texlive/texmf-dist/tex/latex/l3backend/l3backend-pdftex.def)
+(./master.aux (./subfile.aux) (./subfile2.aux) (./subfile3.aux) (./subfile4.aux
+)) (./master.out) (./master.out) [1{/var/lib/texmf/fonts/map/pdftex/updmap/pdft
+ex.map}{/usr/share/texmf/fonts/enc/dvips/lm/lm-ec.enc}] (./subfile.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [2] (./subfile2.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [3] (./subfile3.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [4] (./subfile4.tex
+! Undefined control sequence.
+l.1 test \oiwjfe
+{}
+) [5] (./master.aux (./subfile.aux) (./subfile2.aux) (./subfile3.aux)
+(./subfile4.aux)) )
+(see the transcript file for additional information)</usr/share/texmf/fonts/typ
+e1/public/lm/lmr10.pfb>
+Output written on master.pdf (5 pages, 26772 bytes).
+SyncTeX written on master.synctex.gz.
+Transcript written on master.log.
+Latexmk: Getting log file 'master.log'
+Latexmk: Examining 'master.fls'
+Latexmk: Examining 'master.log'
+Latexmk: Log file says output to 'master.pdf'
+Latexmk: Errors, in force_mode: so I tried finishing targets
+#===Dependents, and related info, for master.tex:
+master.pdf :\
+/etc/texmf/web2c/texmf.cnf\
+/usr/share/texmf/web2c/texmf.cnf\
+/var/lib/texmf/fonts/map/pdftex/updmap/pdftex.map\
+/var/lib/texmf/web2c/pdftex/pdflatex.fmt\
+master.tex\
+subfile.tex\
+subfile2.tex\
+subfile3.tex\
+subfile4.tex
+#===End dependents for master.tex:
+Collected error summary (may duplicate other messages):
+pdflatex: Command for 'pdflatex' gave return code 1
+Refer to 'master.log' and/or above output for details

--- a/src/packages/frontend/misc/latex-logs/log2.txt
+++ b/src/packages/frontend/misc/latex-logs/log2.txt
@@ -1,0 +1,70 @@
+Latexmk: applying rule 'bibtex livre1'...
+This is BibTeX, Version 0.99d (TeX Live 2022/dev/Debian)
+The top-level auxiliary file: livre1.aux
+The style file: livre1.bst
+Database file #1: master.bib
+Latexmk: applying rule 'makeindex /tmp/8783dd204d3d37d431ff4cfcf210a1a75dccadff/livre1.idx'...
+Latexmk: Change directory to '/tmp/8783dd204d3d37d431ff4cfcf210a1a75dccadff/'.
+Latexmk: Change directory back to '/home/user/TopicsBook/Edition1'
+Latexmk: applying rule 'pdflatex'...
+This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2022/dev/Debian) (preloaded format=pdflatex)
+restricted \write18 enabled.
+entering extended mode
+(./livre1.tex
+LaTeX2e <2021-11-15> patch level 1
+L3 programming layer <2022-01-21> (./livre1.cls
+Document Class: livre1 2007/06/25 v5.4
+Springer Verlag global LaTeX document class for monographs
+(/usr/share/texlive/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2021/10/04 v1.4n Standard LaTeX document class
+
+LaTeX Font Warning: Font shape `OT1/cmr/bx/n' in size <16> not available
+(Font) size <17.28> substituted on input line 3.
+
+(/usr/share/texlive/texmf-dist/tex/latex/amsfonts/umsa.fd)
+(/usr/share/texlive/texmf-dist/tex/latex/amsfonts/umsb.fd)
+(/usr/share/texlive/texmf-dist/tex/latex/stmaryrd/Ustmry.fd)
+(/usr/share/texlive/texmf-dist/tex/latex/jknapltx/ursfs.fd)
+
+LaTeX Font Warning: Font shape `U/stmry/b/n' undefined
+(Font) using `U/stmry/m/n' instead on input line 3.
+
+
+LaTeX Font Warning: Font shape `OT1/cmtt/m/n' in size <8.5> not available
+(Font) size <8> substituted on input line 15.
+
+) [3]
+:<-
+[4] (/tmp/8783dd204d3d37d431ff4cfcf210a1a75dccadff/livre1.toc [5] [6] [7]
+[8]) [9]
+:<+ ch_Euclidean.tex
+(./ch_Euclidean.tex [0]
+Chapter 1.
+
+LaTeX Warning: Marginpar on page 1 moved.
+
+pdfTeX warning (ext4): destination with the same identifier (name{page.1}) has
+been already used, duplicate ignored
+<to be read again>
+\relax
+l.48 \end{equation}
+[1] [2] [3] [4] [5] [6] [7]
+
+
+Latexmk: Examining '/tmp/8783dd204d3d37d431ff4cfcf210a1a75dccadff/livre1.log'
+=== TeX engine is 'pdfTeX'
+Latexmk: Errors, in force_mode: so I tried finishing targets
+#===Dependents, and related info, for livre1.tex:
+/tmp/8783dd204d3d37d431ff4cfcf210a1a75dccadff/livre1.pdf :\
+./livre1.bst\
+/etc/texmf/web2c/texmf.cnf\
+/usr/share/texlive/texmf-dist/tex/latex/xcolor/xcolor.sty\
+/usr/share/texlive/texmf-dist/web2c/texmf.cnf\
+/usr/share/texmf/fonts/enc/dvips/cm-super/cm-super-ts1.enc\
+/usr/share/texmf/fonts/type1/public/cm-super/sfrm1000.pfb\
+/usr/share/texmf/web2c/texmf.cnf\
+/var/lib/texmf/fonts/map/pdftex/updmap/pdftex.map\
+/var/lib/texmf/web2c/pdftex/pdflatex.fmt\
+01.tex\
+02.5.tex
+#===End dependents for livre1.tex:


### PR DESCRIPTION
see #8089

this also adds tests for the latex parser