### PR TITLE
hub/startup: set support account to first admin account

### DIFF
--- a/src/packages/database/postgres/admins.ts
+++ b/src/packages/database/postgres/admins.ts
@@ -3,7 +3,7 @@ import getPool from "@cocalc/database/pool";
 // get account_id's of all admins -- "long" cache
 // *Always sorted by account_id lexicographically.*
 
-export default async function admins(): Promise<string[]> {
+export async function getAdmins(): Promise<string[]> {
   const pool = getPool("long");
   const { rows } = await pool.query(
     "SELECT account_id FROM accounts where 'admin' = ANY(groups) AND coalesce(deleted,false) = false",

--- a/src/packages/hub/hub.ts
+++ b/src/packages/hub/hub.ts
@@ -12,6 +12,7 @@ import { callback } from "awaiting";
 import blocked from "blocked";
 import { spawn } from "child_process";
 import { program as commander, Option } from "commander";
+
 import basePath from "@cocalc/backend/base-path";
 import {
   pghost as DEFAULT_DB_HOST,
@@ -23,7 +24,10 @@ import port from "@cocalc/backend/port";
 import { init_start_always_running_projects } from "@cocalc/database/postgres/always-running";
 import { load_server_settings_from_env } from "@cocalc/database/settings/server-settings";
 import { init_passport } from "@cocalc/server/hub/auth";
-import { initialOnPremSetup } from "@cocalc/server/initial-onprem-setup";
+import {
+  initialOnPremSetup,
+  setupOnPremSupportAccount,
+} from "@cocalc/server/initial-onprem-setup";
 import initHandleMentions from "@cocalc/server/mentions/handle";
 import initMessageMaintenance from "@cocalc/server/messages/maintenance";
 import initProjectControl, {
@@ -150,6 +154,7 @@ async function startServer(): Promise<void> {
 
   // set server settings based on environment variables
   await load_server_settings_from_env(database);
+  await setupOnPremSupportAccount(database);
 
   if (program.agentPort) {
     logger.info("Configure agent port");

--- a/src/packages/server/messages/admin-alert.ts
+++ b/src/packages/server/messages/admin-alert.ts
@@ -17,11 +17,11 @@ is broken.
 
 */
 
-import { getServerSettings } from "@cocalc/database/settings/server-settings";
-import send from "./send";
-import getAdmins from "@cocalc/server/accounts/admins";
 import { getLogger } from "@cocalc/backend/logger";
 import { db } from "@cocalc/database";
+import { getAdmins } from "@cocalc/database/postgres/admins";
+import { getServerSettings } from "@cocalc/database/settings/server-settings";
+import send from "./send";
 
 const logger = getLogger("server:messages:admin");
 


### PR DESCRIPTION
if `support_account_id` isn't set for onprem, set it to the first admin account. This makes it clear for admins who will be the sender of these messages.