### PR TITLE
frontend/share: fix share dialog restriction

### DIFF
--- a/src/packages/frontend/cspell.json
+++ b/src/packages/frontend/cspell.json
@@ -46,7 +46,10 @@
     "vertexai",
     "vfill",
     "xsmall",
-    "MDLG"
+    "MDLG",
+    "isdir",
+    "mintime",
+    "PoweroffOutlined"
   ],
   "flagWords": [],
   "ignorePaths": ["node_modules/**", "dist/**", "dist-ts/**", "build/**"],

--- a/src/packages/frontend/project/explorer/action-box.tsx
+++ b/src/packages/frontend/project/explorer/action-box.tsx
@@ -20,6 +20,7 @@ import { useRedux, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { Icon, Loading, LoginLink } from "@cocalc/frontend/components";
 import SelectServer from "@cocalc/frontend/compute/select-server";
 import ComputeServerTag from "@cocalc/frontend/compute/server-tag";
+import { useRunQuota } from "@cocalc/frontend/project/settings/run-quota/hooks";
 import { file_actions, ProjectActions } from "@cocalc/frontend/project_store";
 import { SelectProject } from "@cocalc/frontend/projects/select-project";
 import ConfigureShare from "@cocalc/frontend/share/config";
@@ -60,14 +61,9 @@ interface ReactProps {
 export function ActionBox(props: ReactProps) {
   const intl = useIntl();
   const { project_id } = useProjectContext();
+  const runQuota = useRunQuota(project_id, null);
   const get_user_type: () => string = useRedux("account", "get_user_type");
   const compute_server_id = useTypedRedux({ project_id }, "compute_server_id");
-  const get_total_project_quotas: (
-    project_id: string,
-  ) => { network: boolean } | undefined = useRedux([
-    "projects",
-    "get_total_project_quotas",
-  ]);
 
   const [copy_destination_directory, set_copy_destination_directory] =
     useState<string>("");
@@ -550,9 +546,6 @@ export function ActionBox(props: ReactProps) {
       // directory listing not loaded yet... (will get re-rendered when loaded)
       return <Loading />;
     }
-    const total_quotas = get_total_project_quotas(props.project_id) || {
-      network: undefined,
-    };
     return (
       <ConfigureShare
         project_id={props.project_id}
@@ -566,7 +559,7 @@ export function ActionBox(props: ReactProps) {
         close={cancel_action}
         action_key={action_key}
         set_public_path={(opts) => props.actions.set_public_path(path, opts)}
-        has_network_access={total_quotas.network}
+        has_network_access={!!runQuota.network}
       />
     );
   }

--- a/src/packages/frontend/project/settings/run-quota/hooks.tsx
+++ b/src/packages/frontend/project/settings/run-quota/hooks.tsx
@@ -3,6 +3,8 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
+// cSpell: ignore dval
+
 import { List, Map } from "immutable";
 import { fromPairs, isEqual } from "lodash";
 
@@ -143,7 +145,7 @@ export function useCurrentUsage({
 
   function memory(usage) {
     if (runQuota == null) return;
-    // this also displays the "dedicated memory" amount, past of entire limite
+    // this also displays the "dedicated memory" amount, past of entire limit
     const mem_req = runQuota.get("memory_request"); // mb
     const mem_limit = runQuota.get("memory_limit"); // mb
     const { mem_rss } = usage;
@@ -180,7 +182,7 @@ export function useCurrentUsage({
     return;
   }
 
-  function whenWillProjectStopp() {
+  function whenWillProjectStop() {
     if (last_edited == null) return;
     const always_running = runQuota?.get("always_running") ?? false;
     if (always_running) return; // not applicable
@@ -222,7 +224,7 @@ export function useCurrentUsage({
           const key = upgrade2quota_key(name);
           switch (name) {
             case "mintime":
-              return [key, whenWillProjectStopp()];
+              return [key, whenWillProjectStop()];
             case "disk_quota":
               return [key, disk(usage)];
             case "memory_request":

--- a/src/packages/frontend/project/settings/run-quota/run-quota.tsx
+++ b/src/packages/frontend/project/settings/run-quota/run-quota.tsx
@@ -3,6 +3,8 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
+// cSpell: ignore dedi
+
 import { PoweroffOutlined } from "@ant-design/icons";
 import { Table, Typography } from "antd";
 

--- a/src/packages/frontend/project/settings/upgrade-usage.tsx
+++ b/src/packages/frontend/project/settings/upgrade-usage.tsx
@@ -330,7 +330,7 @@ export const UpgradeUsage: React.FC<Props> = React.memo(
       if (gpu == null || gpu === false) return;
       const info = process_gpu_quota({ gpu });
       const nodes = info.nodeSelector
-        ? ` on nodes labaled: ${Object.entries(info.nodeSelector)
+        ? ` on nodes labeled: ${Object.entries(info.nodeSelector)
             .map(([key, value]) => `${key}=${value}`)
             .join(", ")}`
         : "";

--- a/src/packages/frontend/share/config.tsx
+++ b/src/packages/frontend/share/config.tsx
@@ -106,7 +106,7 @@ interface Props {
 
 // ensures the custom font sizes in the text of the first row is consistent
 const FONTSIZE_TOP = "12pt";
-const ACCESS_LEVEL_OPTION_SYLE: CSS = { fontSize: FONTSIZE_TOP };
+const ACCESS_LEVEL_OPTION_STYLE: CSS = { fontSize: FONTSIZE_TOP };
 
 const STATES = {
   private: "Private",
@@ -294,7 +294,7 @@ export default function Configure(props: Props) {
                       name="sharing_options"
                       value="public_listed"
                       disabled={!props.has_network_access}
-                      style={ACCESS_LEVEL_OPTION_SYLE}
+                      style={ACCESS_LEVEL_OPTION_STYLE}
                     >
                       <Icon name="eye" style={{ marginRight: "5px" }} />
                       <SC>{STATES.public_listed}</SC> - on the{" "}
@@ -311,7 +311,7 @@ export default function Configure(props: Props) {
                     <Radio
                       name="sharing_options"
                       value="public_unlisted"
-                      style={ACCESS_LEVEL_OPTION_SYLE}
+                      style={ACCESS_LEVEL_OPTION_STYLE}
                     >
                       <Icon name="eye-slash" style={{ marginRight: "5px" }} />
                       <SC>{STATES.public_unlisted}</SC> - only people with the
@@ -323,7 +323,7 @@ export default function Configure(props: Props) {
                         <Radio
                           name="sharing_options"
                           value="authenticated"
-                          style={ACCESS_LEVEL_OPTION_SYLE}
+                          style={ACCESS_LEVEL_OPTION_STYLE}
                         >
                           <Icon
                             name={SHARE_AUTHENTICATED_ICON}
@@ -338,7 +338,7 @@ export default function Configure(props: Props) {
                     <Radio
                       name="sharing_options"
                       value="private"
-                      style={ACCESS_LEVEL_OPTION_SYLE}
+                      style={ACCESS_LEVEL_OPTION_STYLE}
                     >
                       <Icon name="lock" style={{ marginRight: "5px" }} />
                       <SC>{STATES.private}</SC> - only collaborators on this


### PR DESCRIPTION
see #8170

Uses (maybe stale) run_quota information to determine if project has the internet upgrade

Below are two situations for kucalc=yes - either no license and no internet, hence banner and no sharing – or a license, upgrades are there, no upgrade banner, and user can share. The root bug for this is assuming the basis-license has no upgrades at all, which is not necessarily true. 

## no license

![Screenshot from 2025-01-31 16-59-34](https://github.com/user-attachments/assets/f3b45bdb-3eb1-4f56-8938-4cdd340bbc4c)

## with an active license

![Screenshot from 2025-01-31 17-00-54](https://github.com/user-attachments/assets/836aa600-cdbf-4882-9e51-07051e3fc319)



