### PR TITLE
frontend/quota: change presets to a dropdown and special-case for LLM models

### DIFF
--- a/src/packages/frontend/client/purchases.ts
+++ b/src/packages/frontend/client/purchases.ts
@@ -1,7 +1,7 @@
 /*
 Functions for interfacing with the purchases functionality.
 
-TODO/DEPRECATE: this module is mostly pointess since I moved essentially
+TODO/DEPRECATE: this module is mostly pointless since I moved essentially
 all of this code to @cocalc/frontend/purchases/api, which is much better
 since it can also be used directly by our nextjs app, and also is
 scoped better.  That said quotaModal is here.

--- a/src/packages/frontend/project/explorer/action-box.tsx
+++ b/src/packages/frontend/project/explorer/action-box.tsx
@@ -3,6 +3,8 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
+// cSpell: ignore isdir
+
 import { Button as AntdButton, Radio, Space } from "antd";
 import * as immutable from "immutable";
 import { useState } from "react";

--- a/src/packages/frontend/purchases/quota-config.tsx
+++ b/src/packages/frontend/purchases/quota-config.tsx
@@ -4,6 +4,9 @@ in a modal on demand when you try to use a specific service and don't
 have sufficient quota.
 */
 
+import { Alert, Button, Card, InputNumber, Space, Spin } from "antd";
+import { useEffect, useState } from "react";
+
 import { SettingBox } from "@cocalc/frontend/components";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import {
@@ -12,10 +15,9 @@ import {
   serviceToDisplay,
 } from "@cocalc/util/db-schema/purchase-quotas";
 import getChargeAmount from "@cocalc/util/purchases/charge-amount";
-import { Alert, Button, Card, InputNumber, Space, Spin } from "antd";
-import { useEffect, useState } from "react";
 import Quotas, {
   PRESETS,
+  PRESETS_LLM,
   Preset,
   QUOTA_LIMIT_ICON_NAME,
   STEP,
@@ -81,6 +83,8 @@ export default function QuotaConfig({
     saveRef.current = saveServiceQuota;
   }
 
+  const presets = QUOTA_SPEC[service]?.category === "ai" ? PRESETS_LLM : PRESETS;
+
   return (
     <div>
       {!QUOTA_SPEC[service]?.noSet && (
@@ -118,16 +122,18 @@ export default function QuotaConfig({
                 Save{savedValue == inputValue ? "d" : ""}
               </Button>
               <div style={{ marginLeft: "15px" }}>
-                {PRESETS.filter((amount) => amount > 0).map((amount) => (
-                  <Preset
-                    key={amount}
-                    index={0}
-                    amount={amount}
-                    handleQuotaChange={(_, amount) => {
-                      setInputValue(amount);
-                    }}
-                  />
-                ))}
+                {presets
+                  .filter((amount) => amount > 0)
+                  .map((amount) => (
+                    <Preset
+                      key={amount}
+                      index={0}
+                      amount={amount}
+                      handleQuotaChange={(_, amount) => {
+                        setInputValue(amount);
+                      }}
+                    />
+                  ))}
               </div>
             </Space>
           )}


### PR DESCRIPTION
* lower preset values for LLMs
* instead of showing the preset tags everywhere, this is now a dropdown selector. editing the value works just like before.
* I also attempted to change this for the modal, but I couldn't figure out how to show the modal. I'm somehow assuming that modal is deprecated.

![Screenshot from 2025-02-04 11-43-43](https://github.com/user-attachments/assets/518ae3b8-ab03-4bae-a4b5-9ad4a59a1e5c)

![Screenshot from 2025-02-04 11-42-15](https://github.com/user-attachments/assets/ad62a662-3439-4970-a6ca-b9bd55db42a8)

