### PR TITLE
compute env: remove Ubuntu 18.04

### DIFF
--- a/src/packages/next/lib/landing/landing.test.ts
+++ b/src/packages/next/lib/landing/landing.test.ts
@@ -10,7 +10,7 @@ import { SOFTWARE_FALLBACK, SOFTWARE_URLS } from "./software-data";
 import { EnvData } from "./types";
 
 test("3 known software environments", () => {
-  expect(SOFTWARE_ENV_NAMES.length).toBe(4);
+  expect(SOFTWARE_ENV_NAMES.length).toBe(3);
 });
 
 describe("Download URLs", () => {

--- a/src/packages/next/lib/landing/software-data.ts
+++ b/src/packages/next/lib/landing/software-data.ts
@@ -13,7 +13,6 @@ import {
 } from "@cocalc/util/consts/software-envs";
 import { EnvData } from "./types";
 
-import SOFTWARE_1804 from "software-inventory/18.04.json";
 import SOFTWARE_2004 from "software-inventory/20.04.json";
 import SOFTWARE_2204 from "software-inventory/22.04.json";
 import SOFTWARE_2404 from "software-inventory/24.04.json";
@@ -28,7 +27,6 @@ export const SOFTWARE_URLS: { [key in SoftwareEnvNames]: string } = fromPairs(
 
 // Note: we need to be explicit with these rougher types, because TS can't infer them from the JSON files since they're too large.
 export const SOFTWARE_FALLBACK: { [key in SoftwareEnvNames]: EnvData } = {
-  "18.04": SOFTWARE_1804 as EnvData,
   "20.04": SOFTWARE_2004 as EnvData,
   "22.04": SOFTWARE_2204 as EnvData,
   "24.04": SOFTWARE_2404 as EnvData,

--- a/src/packages/next/pages/software/index.tsx
+++ b/src/packages/next/pages/software/index.tsx
@@ -3,7 +3,7 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
-import { Button, Layout } from "antd";
+import { Button, Layout, Space } from "antd";
 
 import {
   LanguageName,
@@ -56,23 +56,24 @@ const LINKS: { [lang in LanguageName | "executables"]: string } = {
 function renderSoftwareEnvLinks(lang: LanguageName | "executables") {
   return (
     <Paragraph>
-      {SOFTWARE_ENV_NAMES.map((name) => {
-        const type = SOFTWARE_ENV_DEFAULT === name ? "primary" : undefined;
-        const style =
-          SOFTWARE_ENV_DEFAULT === name ? { color: "white" } : undefined;
-        // toLowerCase is necessary for R → r
-        const href = `/software/${lang.toLowerCase()}/${name}`;
-        return (
-          <Button
-            size="small"
-            type={type}
-            style={{ ...style, marginRight: "10px" }}
-            href={href}
-          >
-            {name}
-          </Button>
-        );
-      })}
+      <Space>
+        {SOFTWARE_ENV_NAMES.map((name) => {
+          const type = SOFTWARE_ENV_DEFAULT === name ? "primary" : undefined;
+          const style = type === "primary" ? { fontWeight: "bold" } : {};
+          // toLowerCase is necessary for R → r
+          const href = `/software/${lang.toLowerCase()}/${name}`;
+          return (
+            <Button
+              size="small"
+              type={type}
+              href={href}
+              style={{ ...style, padding: "5px" }}
+            >
+              {name}
+            </Button>
+          );
+        })}
+      </Space>
     </Paragraph>
   );
 }

--- a/src/packages/next/software-inventory/setup.sh
+++ b/src/packages/next/software-inventory/setup.sh
@@ -25,7 +25,7 @@ download_and_copy() {
 pids=()
 
 # Start downloads in parallel
-for name in "18.04" "20.04" "22.04" "24.04"; do
+for name in "20.04" "22.04" "24.04"; do
     download_and_copy "$name" &
     pids+=($!)
 done

--- a/src/packages/util/compute-images.ts
+++ b/src/packages/util/compute-images.ts
@@ -97,6 +97,7 @@ const COMPUTE_IMAGES: { [key: string]: ComputeImageProd } = {
     short: "Ubuntu 18.04 (EndOfLife)",
     descr: "Reached end of life in August 2020",
     group: "Main",
+    hidden: true,
   },
   [DISMISS_IMG_2004]: {
     order: 1,

--- a/src/packages/util/consts/software-envs.ts
+++ b/src/packages/util/consts/software-envs.ts
@@ -15,6 +15,6 @@ export type LanguageName = (typeof LANGUAGE_NAMES)[number];
 
 // sort this starting from the newest to the oldest – appears in the UI, e.g. on that /software/index page
 // TODO: after https://github.com/sagemathinc/cocalc/pull/6284 has been merged, make 22.04 the first entry in that list
-export const SOFTWARE_ENV_NAMES = ["24.04", "22.04", "20.04", "18.04"] as const;
+export const SOFTWARE_ENV_NAMES = ["24.04", "22.04", "20.04"] as const;
 export type SoftwareEnvNames = (typeof SOFTWARE_ENV_NAMES)[number];
 export const SOFTWARE_ENV_DEFAULT: SoftwareEnvNames = "22.04";


### PR DESCRIPTION
The frontend relevant change is already in master. This is for removing the related next packages. No need to deploy any of that with urgency, there are already fallbacks in place.

regarding #8266:

![Screenshot from 2025-04-14 12-36-54](https://github.com/user-attachments/assets/31b1983e-4fad-4d82-bd01-73ee7c1f0fee)

Although, there might be similar issues with other elements.