### PR TITLE
LLM housekeeping

### DIFF
--- a/src/cocalc.code-workspace
+++ b/src/cocalc.code-workspace
@@ -1,70 +1,8 @@
 {
   "folders": [
     {
-      "name": "util",
-      "path": "packages/util"
-    },
-    {
-      "name": "sync",
-      "path": "packages/sync"
-    },
-    {
-      "name": "static",
-      "path": "packages/static"
-    },
-    {
-      "name": "project",
-      "path": "packages/project"
-    },
-    {
-      "name": "server",
-      "path": "packages/server"
-    },
-    {
-      "name": "next",
-      "path": "packages/next"
-    },
-    {
-      "name": "frontend",
-      "path": "packages/frontend"
-    },
-    {
-      "name": "hub",
-      "path": "packages/hub"
-    },
-    {
-      "name": "database",
-      "path": "packages/database"
-    },
-    {
-      "name": "cdn",
-      "path": "packages/cdn"
-    },
-    {
-      "name": "backend",
-      "path": "packages/backend"
-    },
-    {
-      "name": "assets",
-      "path": "packages/assets"
-    },
-    {
-      "path": "packages/sync-client"
-    },
-    {
-      "path": "packages/jupyter"
-    },
-    {
-      "path": "packages/compute"
-    },
-    {
-      "path": "packages/terminal"
-    },
-    {
-      "path": "packages/comm"
-    },
-    {
-      "path": "packages/api-client"
+      "name": "cocalc",
+      "path": "."
     }
   ],
   "settings": {
@@ -78,7 +16,18 @@
     "jest.autoRun": "off",
     "files.exclude": {
       "dist": true,
-      "node_modules": true
+      "node_modules": true,
+      "compute": true,
+      "data": true,
+      "dev": true,
+      "examples": true,
+      "node_modules": true,
+      "requirements.txt": true,
+      "scripts": true,
+      "smc_pyutil": true,
+      "smc_sagews": true,
+      ".mypy_cache": true,
+      "pnpm-lock.yaml": true
     },
     "prettier.trailingComma": "all"
   }

--- a/src/packages/frontend/account/user-defined-llm.tsx
+++ b/src/packages/frontend/account/user-defined-llm.tsx
@@ -42,6 +42,8 @@ import {
 } from "@cocalc/util/db-schema/llm-utils";
 import { trunc, unreachable } from "@cocalc/util/misc";
 
+// @cspell:ignore mixtral userdefined
+
 interface Props {
   on_change: (name: string, value: any) => void;
 }
@@ -403,7 +405,7 @@ export function UserDefinedLLMComponent({ on_change }: Props) {
 
 function TestCustomLLM({ llm }: { llm: UserDefinedLLM }) {
   const [querying, setQuerying] = useState<boolean>(false);
-  const [prompt, setPrompt] = useState<string>("Capital of Australia?");
+  const [prompt, setPrompt] = useState<string>("Capital city of Australia?");
   const [reply, setReply] = useState<string>("");
   const [error, setError] = useState<string>("");
 

--- a/src/packages/frontend/cspell.json
+++ b/src/packages/frontend/cspell.json
@@ -57,5 +57,8 @@
   "ignorePaths": ["node_modules/**", "dist/**", "dist-ts/**", "build/**"],
   "allowCompoundWords": false,
   "ignoreRegExpList": ["/import\\s+.*?\\s+from\\s+['\"].*?['\"]/g"],
-  "import": ["@cspell/dict-typescript/cspell-ext.json"]
+  "import": [
+    "@cspell/dict-typescript/cspell-ext.json",
+    "./node_modules/@cspell/dict-typescript/cspell-ext.json"
+  ]
 }

--- a/src/packages/frontend/cspell.json
+++ b/src/packages/frontend/cspell.json
@@ -51,7 +51,8 @@
     "MDLG",
     "isdir",
     "mintime",
-    "PoweroffOutlined"
+    "PoweroffOutlined",
+    "immutablejs"
   ],
   "flagWords": [],
   "ignorePaths": ["node_modules/**", "dist/**", "dist-ts/**", "build/**"],

--- a/src/packages/package.json
+++ b/src/packages/package.json
@@ -22,7 +22,7 @@
       "undici@<5.28.3": "^5.28.4",
       "postcss@<8.4.31": "^8.4.31",
       "retry-request@<7.0.1": "^7.0.2",
-      "@langchain/core": "^0.3.41",
+      "@langchain/core": "^0.3.46",
       "langchain": "^0.3.11",
       "katex@<0.16.9": "^0.16.10",
       "nanoid@<3.3.8": "^3.3.8",

--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   undici@<5.28.3: ^5.28.4
   postcss@<8.4.31: ^8.4.31
   retry-request@<7.0.1: ^7.0.2
-  '@langchain/core': ^0.3.41
+  '@langchain/core': ^0.3.46
   langchain: ^0.3.11
   katex@<0.16.9: ^0.16.10
   nanoid@<3.3.8: ^3.3.8
@@ -32,13 +32,13 @@ importers:
         version: 5.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.81)
+        version: 29.7.0(@types/node@18.19.86)
       ts-jest:
         specifier: ^29.2.3
-        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.81))(typescript@5.7.3)
+        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.86))(typescript@5.8.2)
       typescript:
         specifier: ^5.7.3
-        version: 5.7.3
+        version: 5.8.2
 
   api-client:
     dependencies:
@@ -51,7 +51,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
 
   assets:
     dependencies:
@@ -103,7 +103,7 @@ importers:
         version: 4.4.0(supports-color@9.4.0)
       fs-extra:
         specifier: ^11.2.0
-        version: 11.2.0
+        version: 11.3.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -143,7 +143,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
       expect:
         specifier: ^26.6.2
         version: 26.6.2
@@ -174,7 +174,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
 
   database:
     dependencies:
@@ -244,7 +244,7 @@ importers:
         version: 4.17.9
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.81
+        version: 18.19.86
       '@types/pg':
         specifier: ^8.6.1
         version: 8.11.11
@@ -972,7 +972,7 @@ importers:
         version: 2.26.1
       ws:
         specifier: ^8.18.0
-        version: 8.18.0
+        version: 8.18.1
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -982,7 +982,7 @@ importers:
         version: 1.17.16
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.81
+        version: 18.19.86
       '@types/passport':
         specifier: ^1.0.9
         version: 1.0.17
@@ -1094,7 +1094,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
 
   nats:
     dependencies:
@@ -1146,7 +1146,7 @@ importers:
         version: 4.17.9
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.76
+        version: 18.19.86
 
   next:
     dependencies:
@@ -1288,10 +1288,10 @@ importers:
         version: 4.17.21
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.81
+        version: 18.19.86
       node-mocks-http:
         specifier: ^1.14.1
-        version: 1.16.2(@types/express@4.17.21)(@types/node@18.19.81)
+        version: 1.16.2(@types/express@4.17.21)(@types/node@18.19.86)
       react-test-renderer:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
@@ -1438,7 +1438,7 @@ importers:
         version: 2.0.2
       ws:
         specifier: ^8.18.0
-        version: 8.18.0
+        version: 8.18.1
       zeromq:
         specifier: ^5.2.8
         version: 5.3.1
@@ -1457,7 +1457,7 @@ importers:
         version: 4.17.9
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
       '@types/primus':
         specifier: ^7.3.9
         version: 7.3.9
@@ -1511,22 +1511,22 @@ importers:
         version: 1.4.1
       '@langchain/anthropic':
         specifier: ^0.3.18
-        version: 0.3.18(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)
-      '@langchain/community':
-        specifier: ^0.3.41
-        version: 0.3.41(eb9ba273cb8cbdf2c37321ea60fe93aa)
+        version: 0.3.18(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)
       '@langchain/core':
-        specifier: ^0.3.41
-        version: 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
+        specifier: ^0.3.46
+        version: 0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
       '@langchain/google-genai':
         specifier: ^0.2.4
-        version: 0.2.4(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(zod@3.24.2)
+        version: 0.2.4(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(zod@3.24.2)
       '@langchain/mistralai':
         specifier: ^0.2.0
-        version: 0.2.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))
+        version: 0.2.0(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))
+      '@langchain/ollama':
+        specifier: ^0.2.0
+        version: 0.2.0(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))
       '@langchain/openai':
         specifier: ^0.5.5
-        version: 0.5.6(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)(ws@8.18.1)
+        version: 0.5.6(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)(ws@8.18.1)
       '@nats-io/jetstream':
         specifier: 3.0.0
         version: 3.0.0
@@ -1580,7 +1580,7 @@ importers:
         version: 3.0.0
       axios:
         specifier: ^1.7.5
-        version: 1.8.4(debug@4.4.0)
+        version: 1.8.4
       base62:
         specifier: ^2.0.1
         version: 2.0.2
@@ -1734,7 +1734,7 @@ importers:
         version: 0.7.31
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.81
+        version: 18.19.86
       '@types/node-zendesk':
         specifier: ^2.0.15
         version: 2.0.15
@@ -1786,7 +1786,7 @@ importers:
         version: 3.5.30
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.81
+        version: 18.19.86
       '@types/react':
         specifier: ^18.3.10
         version: 18.3.10
@@ -1939,7 +1939,7 @@ importers:
         version: 1.6.7
       ts-jest:
         specifier: ^29.2.3
-        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.81))(typescript@5.8.2)
+        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.86))(typescript@5.8.2)
       tsd:
         specifier: ^0.22.0
         version: 0.22.0
@@ -1997,10 +1997,10 @@ importers:
         version: 4.17.9
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
       ts-jest:
         specifier: ^29.2.3
-        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.50))(typescript@5.8.2)
+        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.86))(typescript@5.8.2)
 
   sync-client:
     dependencies:
@@ -2033,7 +2033,7 @@ importers:
         version: 8.0.9
       ws:
         specifier: ^8.18.0
-        version: 8.18.0
+        version: 8.18.1
     devDependencies:
       '@types/cookie':
         specifier: ^0.6.0
@@ -2043,7 +2043,7 @@ importers:
         version: 4.1.12
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.81
+        version: 18.19.86
       '@types/primus':
         specifier: ^7.3.9
         version: 7.3.9
@@ -2086,7 +2086,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
 
   terminal:
     dependencies:
@@ -2129,7 +2129,7 @@ importers:
         version: 4.17.9
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
       '@types/primus':
         specifier: ^7.3.9
         version: 7.3.9
@@ -2226,7 +2226,7 @@ importers:
         version: 4.17.9
       '@types/node':
         specifier: ^18.16.14
-        version: 18.19.50
+        version: 18.19.86
       '@types/seedrandom':
         specifier: ^3.0.8
         version: 3.0.8
@@ -2333,9 +2333,6 @@ packages:
 
   '@antfu/utils@8.1.1':
     resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
-
-  '@anthropic-ai/sdk@0.27.3':
-    resolution: {integrity: sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==}
 
   '@anthropic-ai/sdk@0.37.0':
     resolution: {integrity: sha512-tHjX2YbkUBwEgg0JZU3EFSSAQPoK4qQR/NFYa8Vtzd5UAyXzZksCw2In69Rml4R/TyHPBfRYaLK35XiOe33pjw==}
@@ -2669,18 +2666,6 @@ packages:
 
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
-
-  '@browserbasehq/sdk@2.5.0':
-    resolution: {integrity: sha512-bcnbYZvm5Ht1nrHUfWDK4crspiTy1ESJYMApsMiOTUnlKOan0ocRD6m7hZH34iSC2c2XWsoryR80cwsYgCBWzQ==}
-
-  '@browserbasehq/stagehand@1.14.0':
-    resolution: {integrity: sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==}
-    peerDependencies:
-      '@playwright/test': ^1.42.1
-      deepmerge: ^4.3.1
-      dotenv: ^16.4.5
-      openai: ^4.62.1
-      zod: ^3.23.8
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -3128,10 +3113,6 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@ibm-cloud/watsonx-ai@1.6.4':
-    resolution: {integrity: sha512-u0fmXagywjLAd3apZTV6kRQAHjWl3bNKv5422mQJsM/MZB5YPjx28tjEbpoORh15RuWjYyO/wHZACRWBBkNhbQ==}
-    engines: {node: '>=18.0.0'}
-
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -3314,418 +3295,35 @@ packages:
     resolution: {integrity: sha512-+2Pk9AFV4aBUOAqPT0VOaH6YbcVZ/xGoI6/dCW+W4svqcWwW7NExkAHdUAO9q+h2sUBbHs4j9bzLXlRQLvJ03A==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^0.3.41
+      '@langchain/core': ^0.3.46
 
-  '@langchain/community@0.3.41':
-    resolution: {integrity: sha512-i/DQ4bkKW+0W+zFy8ZrH7gRiag3KZuZU15pFXYom7wdZ8zcHJZZh2wi43hiBEWt8asx8Osyx4EhYO5SNp9ewkg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@arcjet/redact': ^v1.0.0-alpha.23
-      '@aws-crypto/sha256-js': ^5.0.0
-      '@aws-sdk/client-bedrock-agent-runtime': ^3.749.0
-      '@aws-sdk/client-bedrock-runtime': ^3.749.0
-      '@aws-sdk/client-dynamodb': ^3.749.0
-      '@aws-sdk/client-kendra': ^3.749.0
-      '@aws-sdk/client-lambda': ^3.749.0
-      '@aws-sdk/client-s3': ^3.749.0
-      '@aws-sdk/client-sagemaker-runtime': ^3.749.0
-      '@aws-sdk/client-sfn': ^3.749.0
-      '@aws-sdk/credential-provider-node': ^3.388.0
-      '@aws-sdk/dsql-signer': '*'
-      '@azure/search-documents': ^12.0.0
-      '@azure/storage-blob': ^12.15.0
-      '@browserbasehq/sdk': '*'
-      '@browserbasehq/stagehand': ^1.0.0
-      '@clickhouse/client': ^0.2.5
-      '@cloudflare/ai': '*'
-      '@datastax/astra-db-ts': ^1.0.0
-      '@elastic/elasticsearch': ^8.4.0
-      '@getmetal/metal-sdk': '*'
-      '@getzep/zep-cloud': ^1.0.6
-      '@getzep/zep-js': ^0.9.0
-      '@gomomento/sdk': ^1.51.1
-      '@gomomento/sdk-core': ^1.51.1
-      '@google-ai/generativelanguage': '*'
-      '@google-cloud/storage': ^6.10.1 || ^7.7.0
-      '@gradientai/nodejs-sdk': ^1.2.0
-      '@huggingface/inference': ^2.6.4
-      '@huggingface/transformers': ^3.2.3
-      '@ibm-cloud/watsonx-ai': '*'
-      '@lancedb/lancedb': ^0.12.0
-      '@langchain/core': ^0.3.41
-      '@layerup/layerup-security': ^1.5.12
-      '@libsql/client': ^0.14.0
-      '@mendable/firecrawl-js': ^1.4.3
-      '@mlc-ai/web-llm': '*'
-      '@mozilla/readability': '*'
-      '@neondatabase/serverless': '*'
-      '@notionhq/client': ^2.2.10
-      '@opensearch-project/opensearch': '*'
-      '@pinecone-database/pinecone': '*'
-      '@planetscale/database': ^1.8.0
-      '@premai/prem-sdk': ^0.3.25
-      '@qdrant/js-client-rest': ^1.8.2
-      '@raycast/api': ^1.55.2
-      '@rockset/client': ^0.9.1
-      '@smithy/eventstream-codec': ^2.0.5
-      '@smithy/protocol-http': ^3.0.6
-      '@smithy/signature-v4': ^2.0.10
-      '@smithy/util-utf8': ^2.0.0
-      '@spider-cloud/spider-client': ^0.0.21
-      '@supabase/supabase-js': ^2.45.0
-      '@tensorflow-models/universal-sentence-encoder': '*'
-      '@tensorflow/tfjs-converter': '*'
-      '@tensorflow/tfjs-core': '*'
-      '@upstash/ratelimit': ^1.1.3 || ^2.0.3
-      '@upstash/redis': ^1.20.6
-      '@upstash/vector': ^1.1.1
-      '@vercel/kv': '*'
-      '@vercel/postgres': '*'
-      '@writerai/writer-sdk': ^0.40.2
-      '@xata.io/client': ^0.28.0
-      '@zilliz/milvus2-sdk-node': '>=2.3.5'
-      apify-client: ^2.7.1
-      assemblyai: ^4.6.0
-      azion: ^1.11.1
-      better-sqlite3: '>=9.4.0 <12.0.0'
-      cassandra-driver: ^4.7.2
-      cborg: ^4.1.1
-      cheerio: ^1.0.0-rc.12
-      chromadb: '*'
-      closevector-common: 0.1.3
-      closevector-node: 0.1.6
-      closevector-web: 0.1.6
-      cohere-ai: '*'
-      convex: ^1.3.1
-      crypto-js: ^4.2.0
-      d3-dsv: ^2.0.0
-      discord.js: ^14.14.1
-      dria: ^0.0.3
-      duck-duck-scrape: ^2.2.5
-      epub2: ^3.0.1
-      fast-xml-parser: '*'
-      firebase-admin: ^11.9.0 || ^12.0.0
-      google-auth-library: '*'
-      googleapis: '*'
-      hnswlib-node: ^3.0.0
-      html-to-text: ^9.0.5
-      ibm-cloud-sdk-core: '*'
-      ignore: ^5.2.0
-      interface-datastore: ^8.2.11
-      ioredis: ^5.3.2
-      it-all: ^3.0.4
-      jsdom: '*'
-      jsonwebtoken: ^9.0.2
-      llmonitor: ^0.5.9
-      lodash: ^4.17.21
-      lunary: ^0.7.10
-      mammoth: ^1.6.0
-      mariadb: ^3.4.0
-      mem0ai: ^2.1.8
-      mongodb: '>=5.2.0'
-      mysql2: ^3.9.8
-      neo4j-driver: '*'
-      notion-to-md: ^3.1.0
-      officeparser: ^4.0.4
-      openai: '*'
-      pdf-parse: 1.1.1
-      pg: ^8.11.0
-      pg-copy-streams: ^6.0.5
-      pickleparser: ^0.2.1
-      playwright: ^1.32.1
-      portkey-ai: ^0.1.11
-      puppeteer: '*'
-      pyodide: '>=0.24.1 <0.27.0'
-      redis: '*'
-      replicate: '*'
-      sonix-speech-recognition: ^2.1.1
-      srt-parser-2: ^1.2.3
-      typeorm: ^0.3.20
-      typesense: ^1.5.3
-      usearch: ^1.1.1
-      voy-search: 0.6.2
-      weaviate-ts-client: '*'
-      web-auth-library: ^1.0.3
-      word-extractor: '*'
-      ws: ^8.14.2
-      youtubei.js: '*'
-    peerDependenciesMeta:
-      '@arcjet/redact':
-        optional: true
-      '@aws-crypto/sha256-js':
-        optional: true
-      '@aws-sdk/client-bedrock-agent-runtime':
-        optional: true
-      '@aws-sdk/client-bedrock-runtime':
-        optional: true
-      '@aws-sdk/client-dynamodb':
-        optional: true
-      '@aws-sdk/client-kendra':
-        optional: true
-      '@aws-sdk/client-lambda':
-        optional: true
-      '@aws-sdk/client-s3':
-        optional: true
-      '@aws-sdk/client-sagemaker-runtime':
-        optional: true
-      '@aws-sdk/client-sfn':
-        optional: true
-      '@aws-sdk/credential-provider-node':
-        optional: true
-      '@aws-sdk/dsql-signer':
-        optional: true
-      '@azure/search-documents':
-        optional: true
-      '@azure/storage-blob':
-        optional: true
-      '@browserbasehq/sdk':
-        optional: true
-      '@clickhouse/client':
-        optional: true
-      '@cloudflare/ai':
-        optional: true
-      '@datastax/astra-db-ts':
-        optional: true
-      '@elastic/elasticsearch':
-        optional: true
-      '@getmetal/metal-sdk':
-        optional: true
-      '@getzep/zep-cloud':
-        optional: true
-      '@getzep/zep-js':
-        optional: true
-      '@gomomento/sdk':
-        optional: true
-      '@gomomento/sdk-core':
-        optional: true
-      '@google-ai/generativelanguage':
-        optional: true
-      '@google-cloud/storage':
-        optional: true
-      '@gradientai/nodejs-sdk':
-        optional: true
-      '@huggingface/inference':
-        optional: true
-      '@huggingface/transformers':
-        optional: true
-      '@lancedb/lancedb':
-        optional: true
-      '@layerup/layerup-security':
-        optional: true
-      '@libsql/client':
-        optional: true
-      '@mendable/firecrawl-js':
-        optional: true
-      '@mlc-ai/web-llm':
-        optional: true
-      '@mozilla/readability':
-        optional: true
-      '@neondatabase/serverless':
-        optional: true
-      '@notionhq/client':
-        optional: true
-      '@opensearch-project/opensearch':
-        optional: true
-      '@pinecone-database/pinecone':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@premai/prem-sdk':
-        optional: true
-      '@qdrant/js-client-rest':
-        optional: true
-      '@raycast/api':
-        optional: true
-      '@rockset/client':
-        optional: true
-      '@smithy/eventstream-codec':
-        optional: true
-      '@smithy/protocol-http':
-        optional: true
-      '@smithy/signature-v4':
-        optional: true
-      '@smithy/util-utf8':
-        optional: true
-      '@spider-cloud/spider-client':
-        optional: true
-      '@supabase/supabase-js':
-        optional: true
-      '@tensorflow-models/universal-sentence-encoder':
-        optional: true
-      '@tensorflow/tfjs-converter':
-        optional: true
-      '@tensorflow/tfjs-core':
-        optional: true
-      '@upstash/ratelimit':
-        optional: true
-      '@upstash/redis':
-        optional: true
-      '@upstash/vector':
-        optional: true
-      '@vercel/kv':
-        optional: true
-      '@vercel/postgres':
-        optional: true
-      '@writerai/writer-sdk':
-        optional: true
-      '@xata.io/client':
-        optional: true
-      '@zilliz/milvus2-sdk-node':
-        optional: true
-      apify-client:
-        optional: true
-      assemblyai:
-        optional: true
-      azion:
-        optional: true
-      better-sqlite3:
-        optional: true
-      cassandra-driver:
-        optional: true
-      cborg:
-        optional: true
-      cheerio:
-        optional: true
-      chromadb:
-        optional: true
-      closevector-common:
-        optional: true
-      closevector-node:
-        optional: true
-      closevector-web:
-        optional: true
-      cohere-ai:
-        optional: true
-      convex:
-        optional: true
-      crypto-js:
-        optional: true
-      d3-dsv:
-        optional: true
-      discord.js:
-        optional: true
-      dria:
-        optional: true
-      duck-duck-scrape:
-        optional: true
-      epub2:
-        optional: true
-      fast-xml-parser:
-        optional: true
-      firebase-admin:
-        optional: true
-      google-auth-library:
-        optional: true
-      googleapis:
-        optional: true
-      hnswlib-node:
-        optional: true
-      html-to-text:
-        optional: true
-      ignore:
-        optional: true
-      interface-datastore:
-        optional: true
-      ioredis:
-        optional: true
-      it-all:
-        optional: true
-      jsdom:
-        optional: true
-      jsonwebtoken:
-        optional: true
-      llmonitor:
-        optional: true
-      lodash:
-        optional: true
-      lunary:
-        optional: true
-      mammoth:
-        optional: true
-      mariadb:
-        optional: true
-      mem0ai:
-        optional: true
-      mongodb:
-        optional: true
-      mysql2:
-        optional: true
-      neo4j-driver:
-        optional: true
-      notion-to-md:
-        optional: true
-      officeparser:
-        optional: true
-      pdf-parse:
-        optional: true
-      pg:
-        optional: true
-      pg-copy-streams:
-        optional: true
-      pickleparser:
-        optional: true
-      playwright:
-        optional: true
-      portkey-ai:
-        optional: true
-      puppeteer:
-        optional: true
-      pyodide:
-        optional: true
-      redis:
-        optional: true
-      replicate:
-        optional: true
-      sonix-speech-recognition:
-        optional: true
-      srt-parser-2:
-        optional: true
-      typeorm:
-        optional: true
-      typesense:
-        optional: true
-      usearch:
-        optional: true
-      voy-search:
-        optional: true
-      weaviate-ts-client:
-        optional: true
-      web-auth-library:
-        optional: true
-      word-extractor:
-        optional: true
-      ws:
-        optional: true
-      youtubei.js:
-        optional: true
-
-  '@langchain/core@0.3.44':
-    resolution: {integrity: sha512-3BsSFf7STvPPZyl2kMANgtVnCUvDdyP4k+koP+nY2Tczd5V+RFkuazIn/JOj/xxy/neZjr4PxFU4BFyF1aKXOA==}
+  '@langchain/core@0.3.46':
+    resolution: {integrity: sha512-uZ9iI8OIWjOoY/OBkNrjobYHPI/Ky/X4NllKLtkAaKt0aI02HAm2EmZnGrUd0oHjwlYLzjat0FE329ACqiXadw==}
     engines: {node: '>=18'}
 
   '@langchain/google-genai@0.2.4':
     resolution: {integrity: sha512-2w/QZMbSRpo6plKilqXXAmhdq5mB1gaDwOeN1tVpKBOwKtxsH9jOzxukKhs3QvXmfy/xod/WWLajBXxU+63/Dw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^0.3.41
+      '@langchain/core': ^0.3.46
 
   '@langchain/mistralai@0.2.0':
     resolution: {integrity: sha512-VdfbKZopAuSXf/vlXbriGWLK3c7j5s47DoB3S31xpprY2BMSKZZiX9vE9TsgxMfAPuIDPIYcfgU7p1upvTYt8g==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^0.3.41
+      '@langchain/core': ^0.3.46
+
+  '@langchain/ollama@0.2.0':
+    resolution: {integrity: sha512-jLlYFqt+nbhaJKLakk7lRTWHZJ7wHeJLM6yuv4jToQ8zPzpL//372+MjggDoW0mnw8ofysg1T2C6mEJspKJtiA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^0.3.46
 
   '@langchain/openai@0.5.6':
     resolution: {integrity: sha512-zN0iyJthPNmcefIBVybZwcTBgcqu/ElJFov42ZntxEncK4heOMAE9lkq9LQ5CaPU/SgrduibrM1oL57+tLUtaA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^0.3.41
-
-  '@langchain/textsplitters@0.1.0':
-    resolution: {integrity: sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@langchain/core': ^0.3.41
+      '@langchain/core': ^0.3.46
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -4912,15 +4510,6 @@ packages:
 
   '@types/node-zendesk@2.0.15':
     resolution: {integrity: sha512-8Kk7ceoSUiBst5+jX/121QBD8f69F5j9CqvLA1Ka+24vo+B6sPINnqPwfBJAs4/9jBpCLh7h2SH9hUbABiuZXg==}
-
-  '@types/node@18.19.50':
-    resolution: {integrity: sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==}
-
-  '@types/node@18.19.76':
-    resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
-
-  '@types/node@18.19.81':
-    resolution: {integrity: sha512-7KO9oZ2//ivtSsryp0LQUqq79zyGXzwq1WqfywpC9ucjY7YyltMMmxWgtRFRKCxwa7VPxVBVy4kHf5UC1E8Lug==}
 
   '@types/node@18.19.86':
     resolution: {integrity: sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==}
@@ -6872,10 +6461,6 @@ packages:
     resolution: {integrity: sha512-xHF8EP4XH/Ba9fvAF2LDd5O3IITVolerVV6xvkxoM8zlGEiCUrggpAnHyOoKJKCrhvPcGATFAUwIujj7bRG5UA==}
     hasBin: true
 
-  dotenv@16.5.0:
-    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
-    engines: {node: '>=12'}
-
   draw-svg-path@1.0.0:
     resolution: {integrity: sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==}
 
@@ -7247,9 +6832,6 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  expr-eval@2.0.2:
-    resolution: {integrity: sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==}
-
   express-rate-limit@7.4.0:
     resolution: {integrity: sha512-v1204w3cXu5gCDmAvgvzI6qjzZzoMWKnyVDk3ACgfswTQLYiGen+r8w0VnXnGMmzEN/g8fwIQ4JrFFd4ZP6ssg==}
     engines: {node: '>= 16'}
@@ -7371,10 +6953,6 @@ packages:
     resolution: {integrity: sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==}
     engines: {node: '>=18'}
 
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
-
   file-type@20.4.1:
     resolution: {integrity: sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==}
     engines: {node: '>=18'}
@@ -7463,10 +7041,6 @@ packages:
     resolution: {integrity: sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==}
     engines: {node: '>= 0.12'}
 
-  form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
-
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
@@ -7498,10 +7072,6 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
-  fs-extra@11.2.0:
-    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
-    engines: {node: '>=14.14'}
 
   fs-extra@11.3.0:
     resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
@@ -8070,10 +7640,6 @@ packages:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
 
-  ibm-cloud-sdk-core@5.3.2:
-    resolution: {integrity: sha512-YhtS+7hGNO61h/4jNShHxbbuJ1TnDqiFKQzfEaqePnonOvv8NnxWxOk92FlKKCCzZNOT34Gnd7WCLVJTntwEFQ==}
-    engines: {node: '>=18'}
-
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -8511,9 +8077,6 @@ packages:
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
-  isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
-
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -8938,78 +8501,12 @@ packages:
     resolution: {integrity: sha512-EJnr2MHCl5jsE53GtzpNdJ9WTf5g2y+6YKZiQ38txxQkgp1Ewjbg7mDiPUIhfSlDgLUbg3s3qtPpct04JA9yYg==}
     engines: {node: '>=18.0.0'}
 
-  langchain@0.3.21:
-    resolution: {integrity: sha512-fpor/V/xJRoLM7s1yQGlUE6aZIe6LLm7ciZcstNbBUYdFpCSigvADsW2cqlBCdbMXJxb5I/z9jznjGnmciJ+aw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@langchain/anthropic': '*'
-      '@langchain/aws': '*'
-      '@langchain/cerebras': '*'
-      '@langchain/cohere': '*'
-      '@langchain/core': ^0.3.41
-      '@langchain/deepseek': '*'
-      '@langchain/google-genai': '*'
-      '@langchain/google-vertexai': '*'
-      '@langchain/google-vertexai-web': '*'
-      '@langchain/groq': '*'
-      '@langchain/mistralai': '*'
-      '@langchain/ollama': '*'
-      '@langchain/xai': '*'
-      axios: '*'
-      cheerio: '*'
-      handlebars: ^4.7.8
-      peggy: ^3.0.2
-      typeorm: '*'
-    peerDependenciesMeta:
-      '@langchain/anthropic':
-        optional: true
-      '@langchain/aws':
-        optional: true
-      '@langchain/cerebras':
-        optional: true
-      '@langchain/cohere':
-        optional: true
-      '@langchain/deepseek':
-        optional: true
-      '@langchain/google-genai':
-        optional: true
-      '@langchain/google-vertexai':
-        optional: true
-      '@langchain/google-vertexai-web':
-        optional: true
-      '@langchain/groq':
-        optional: true
-      '@langchain/mistralai':
-        optional: true
-      '@langchain/ollama':
-        optional: true
-      '@langchain/xai':
-        optional: true
-      axios:
-        optional: true
-      cheerio:
-        optional: true
-      handlebars:
-        optional: true
-      peggy:
-        optional: true
-      typeorm:
-        optional: true
-
   langium@3.3.1:
     resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
     engines: {node: '>=16.0.0'}
 
   langs@2.0.0:
     resolution: {integrity: sha512-v4pxOBEQVN1WBTfB1crhTtxzNLZU9HPWgadlwzWKISJtt6Ku/CnpBrwVy+jFv8StjxsPfwPFzO0CMwdZLJ0/BA==}
-
-  langsmith@0.3.15:
-    resolution: {integrity: sha512-cv3ebg0Hh0gRbl72cv/uzaZ+KOdfa2mGF1s74vmB2vlNVO/Ap/O9RYaHV+tpR8nwhGZ50R3ILnTOwSwGP+XQxw==}
-    peerDependencies:
-      openai: '*'
-    peerDependenciesMeta:
-      openai:
-        optional: true
 
   langsmith@0.3.20:
     resolution: {integrity: sha512-zwVQos6tjcksCTfdM67QKq7yyED4GmQiZw/sJ6UCMYZxlvTMMg3PeQ9tOePXAWNWoJygOnH+EwGXr7gYOOETDg==}
@@ -9759,6 +9256,9 @@ packages:
   octicons@3.5.0:
     resolution: {integrity: sha512-jIjd+/oT46YgOK2SZbicD8vIGkinUwpx7HRm6okT3dU5fZQO/sEbMOKSfLxLhJIuI2KRlylN9nYfKiuM4uf+gA==}
 
+  ollama@0.5.15:
+    resolution: {integrity: sha512-TSaZSJyP7MQJFjSmmNsoJiriwa3U+/UJRw6+M8aucs5dTsaWNZsBIGpDb5rXnW6nXxJBB/z79gZY8IaiIQgelQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -9800,9 +9300,6 @@ packages:
         optional: true
       zod:
         optional: true
-
-  openapi-types@12.1.3:
-    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
@@ -10090,10 +9587,6 @@ packages:
   pdfjs-dist@4.10.38:
     resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
     engines: {node: '>=20'}
-
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
 
   peek-readable@7.0.0:
     resolution: {integrity: sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==}
@@ -10436,9 +9929,6 @@ packages:
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
-
-  psl@1.15.0:
-    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
@@ -10959,14 +10449,6 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  readable-stream@4.7.0:
-    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  readable-web-to-node-stream@3.0.4:
-    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
-    engines: {node: '>=8'}
-
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -11098,12 +10580,6 @@ packages:
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
-
-  retry-axios@2.6.0:
-    resolution: {integrity: sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==}
-    engines: {node: '>=10.7.0'}
-    peerDependencies:
-      axios: '*'
 
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
@@ -11651,10 +11127,6 @@ packages:
     resolution: {integrity: sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==}
     engines: {node: '>=18'}
 
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
-
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -11911,10 +11383,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
-
   token-types@6.0.0:
     resolution: {integrity: sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==}
     engines: {node: '>=14.16'}
@@ -11925,10 +11393,6 @@ packages:
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
-    engines: {node: '>=6'}
-
-  tough-cookie@4.1.4:
-    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
   tr46@0.0.3:
@@ -12082,11 +11546,6 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -12174,10 +11633,6 @@ packages:
 
   universal-cookie@4.0.4:
     resolution: {integrity: sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==}
-
-  universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
 
   universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
@@ -12518,6 +11973,9 @@ packages:
   webworkify@1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
 
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -12585,18 +12043,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -12868,18 +12314,6 @@ snapshots:
       tinyexec: 0.3.2
 
   '@antfu/utils@8.1.1': {}
-
-  '@anthropic-ai/sdk@0.27.3(encoding@0.1.13)':
-    dependencies:
-      '@types/node': 18.19.86
-      '@types/node-fetch': 2.6.12
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.6.7(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
 
   '@anthropic-ai/sdk@0.37.0(encoding@0.1.13)':
     dependencies:
@@ -13243,34 +12677,6 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.1': {}
 
-  '@browserbasehq/sdk@2.5.0(encoding@0.1.13)':
-    dependencies:
-      '@types/node': 18.19.86
-      '@types/node-fetch': 2.6.12
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.6.7(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-
-  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.51.1)(deepmerge@4.3.1)(dotenv@16.5.0)(encoding@0.1.13)(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(zod@3.24.2)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
-      '@browserbasehq/sdk': 2.5.0(encoding@0.1.13)
-      '@playwright/test': 1.51.1
-      deepmerge: 4.3.1
-      dotenv: 16.5.0
-      openai: 4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)
-      ws: 8.18.1
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.5(zod@3.24.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - utf-8-validate
-
   '@cfworker/json-schema@4.1.1': {}
 
   '@chevrotain/cst-dts-gen@11.0.3':
@@ -13299,7 +12705,7 @@ snapshots:
       awaiting: 3.0.0
       cheerio: 1.0.0-rc.12
       csv-parse: 5.6.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13751,16 +13157,6 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@ibm-cloud/watsonx-ai@1.6.4(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))':
-    dependencies:
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))
-      '@types/node': 18.19.86
-      extend: 3.0.2
-      ibm-cloud-sdk-core: 5.3.2
-    transitivePeerDependencies:
-      - '@langchain/core'
-      - supports-color
-
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@2.3.0':
@@ -13817,14 +13213,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.81)
+      jest-config: 29.7.0(@types/node@18.19.86)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13958,7 +13354,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -13967,7 +13363,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
@@ -14142,73 +13538,24 @@ snapshots:
       '@lumino/properties': 2.0.3
       '@lumino/signaling': 2.1.4
 
-  '@langchain/anthropic@0.3.18(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)':
+  '@langchain/anthropic@0.3.18(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)':
     dependencies:
       '@anthropic-ai/sdk': 0.37.0(encoding@0.1.13)
-      '@langchain/core': 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
+      '@langchain/core': 0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
       fast-xml-parser: 4.5.3
       zod: 3.24.2
       zod-to-json-schema: 3.24.5(zod@3.24.2)
     transitivePeerDependencies:
       - encoding
 
-  '@langchain/community@0.3.41(eb9ba273cb8cbdf2c37321ea60fe93aa)':
-    dependencies:
-      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.51.1)(deepmerge@4.3.1)(dotenv@16.5.0)(encoding@0.1.13)(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(zod@3.24.2)
-      '@ibm-cloud/watsonx-ai': 1.6.4(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))
-      '@langchain/core': 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
-      '@langchain/openai': 0.5.6(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)(ws@8.18.1)
-      binary-extensions: 2.2.0
-      expr-eval: 2.0.2
-      flat: 5.0.2
-      ibm-cloud-sdk-core: 5.3.2
-      js-yaml: 4.1.0
-      langchain: 0.3.21(@langchain/anthropic@0.3.18(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13))(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(@langchain/google-genai@0.2.4(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(zod@3.24.2))(@langchain/mistralai@0.2.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))))(axios@1.8.4)(encoding@0.1.13)(handlebars@4.7.8)(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(ws@8.18.1)
-      langsmith: 0.3.20(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
-      openai: 4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)
-      uuid: 10.0.0
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.5(zod@3.24.2)
-    optionalDependencies:
-      '@browserbasehq/sdk': 2.5.0(encoding@0.1.13)
-      '@google-ai/generativelanguage': 3.1.0
-      '@google-cloud/storage': 7.16.0(encoding@0.1.13)
-      better-sqlite3: 11.9.1
-      fast-xml-parser: 4.5.3
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis: 137.1.0(encoding@0.1.13)
-      ignore: 5.3.1
-      jsonwebtoken: 9.0.2
-      lodash: 4.17.21
-      pg: 8.14.1
-      playwright: 1.51.1
-      ws: 8.18.1
-    transitivePeerDependencies:
-      - '@langchain/anthropic'
-      - '@langchain/aws'
-      - '@langchain/cerebras'
-      - '@langchain/cohere'
-      - '@langchain/deepseek'
-      - '@langchain/google-genai'
-      - '@langchain/google-vertexai'
-      - '@langchain/google-vertexai-web'
-      - '@langchain/groq'
-      - '@langchain/mistralai'
-      - '@langchain/ollama'
-      - '@langchain/xai'
-      - axios
-      - encoding
-      - handlebars
-      - peggy
-
-  '@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))':
+  '@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.15(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
+      langsmith: 0.3.20(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -14218,26 +13565,34 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/google-genai@0.2.4(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(zod@3.24.2)':
+  '@langchain/google-genai@0.2.4(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(zod@3.24.2)':
     dependencies:
       '@google/generative-ai': 0.24.0
-      '@langchain/core': 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
+      '@langchain/core': 0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
       uuid: 11.1.0
       zod-to-json-schema: 3.24.5(zod@3.24.2)
     transitivePeerDependencies:
       - zod
 
-  '@langchain/mistralai@0.2.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))':
+  '@langchain/mistralai@0.2.0(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
+      '@langchain/core': 0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
       '@mistralai/mistralai': 1.5.2(zod@3.24.2)
       uuid: 10.0.0
       zod: 3.24.2
       zod-to-json-schema: 3.24.5(zod@3.24.2)
 
-  '@langchain/openai@0.5.6(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)(ws@8.18.1)':
+  '@langchain/ollama@0.2.0(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
+      '@langchain/core': 0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
+      ollama: 0.5.15
+      uuid: 10.0.0
+      zod: 3.24.2
+      zod-to-json-schema: 3.24.5(zod@3.24.2)
+
+  '@langchain/openai@0.5.6(@langchain/core@0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)(ws@8.18.1)':
+    dependencies:
+      '@langchain/core': 0.3.46(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
       js-tiktoken: 1.0.19
       openai: 4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)
       zod: 3.24.2
@@ -14245,11 +13600,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - ws
-
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))':
-    dependencies:
-      '@langchain/core': 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
-      js-tiktoken: 1.0.19
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -14634,7 +13984,7 @@ snapshots:
       '@types/xml2js': 0.4.14
       '@xmldom/is-dom-node': 1.0.1
       '@xmldom/xmldom': 0.8.10
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       xml-crypto: 6.1.0
       xml-encryption: 3.1.0
       xml2js: 0.6.2
@@ -14843,6 +14193,7 @@ snapshots:
   '@playwright/test@1.51.1':
     dependencies:
       playwright: 1.51.1
+    optional: true
 
   '@plotly/d3-sankey-circular@0.33.1':
     dependencies:
@@ -15132,7 +14483,7 @@ snapshots:
   '@sendgrid/client@8.1.5':
     dependencies:
       '@sendgrid/helpers': 8.0.0
-      axios: 1.8.4(debug@4.4.0)
+      axios: 1.8.4
     transitivePeerDependencies:
       - debug
 
@@ -15282,12 +14633,12 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/bonjour@3.5.13':
     dependencies:
@@ -15308,7 +14659,7 @@ snapshots:
 
   '@types/connect@3.4.35':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/cookie@0.3.3': {}
 
@@ -15458,7 +14809,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.0':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       '@types/qs': 6.9.17
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -15476,7 +14827,7 @@ snapshots:
 
   '@types/formidable@3.4.5':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/geojson-vt@3.2.5':
     dependencies:
@@ -15491,7 +14842,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/hast@2.3.10':
     dependencies:
@@ -15508,7 +14859,7 @@ snapshots:
 
   '@types/http-proxy@1.17.16':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -15595,19 +14946,7 @@ snapshots:
 
   '@types/node-zendesk@2.0.15':
     dependencies:
-      '@types/node': 18.19.81
-
-  '@types/node@18.19.50':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@18.19.76':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@18.19.81':
-    dependencies:
-      undici-types: 5.26.5
+      '@types/node': 18.19.86
 
   '@types/node@18.19.86':
     dependencies:
@@ -15617,7 +14956,7 @@ snapshots:
 
   '@types/nodemailer@6.4.17':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/normalize-package-data@2.4.1': {}
 
@@ -15652,7 +14991,7 @@ snapshots:
 
   '@types/pg@8.11.11':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       pg-protocol: 1.8.0
       pg-types: 4.0.2
 
@@ -15660,7 +14999,7 @@ snapshots:
 
   '@types/primus@7.3.9':
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/prismjs@1.26.5': {}
 
@@ -15721,7 +15060,7 @@ snapshots:
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       '@types/send': 0.17.4
 
   '@types/sizzle@2.3.3': {}
@@ -15758,7 +15097,7 @@ snapshots:
   '@types/watchpack@2.4.4':
     dependencies:
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   '@types/ws@8.18.1':
     dependencies:
@@ -16032,7 +15371,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16320,6 +15659,14 @@ snapshots:
       bl: 4.1.0
 
   awaiting@3.0.0: {}
+
+  axios@1.8.4:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axios@1.8.4(debug@4.4.0):
     dependencies:
@@ -17118,28 +16465,13 @@ snapshots:
     dependencies:
       capture-stack-trace: 1.0.2
 
-  create-jest@29.7.0(@types/node@18.19.50):
+  create-jest@29.7.0(@types/node@18.19.86):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.50)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@18.19.81):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.81)
+      jest-config: 29.7.0(@types/node@18.19.86)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -17604,6 +16936,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -17832,8 +17168,6 @@ snapshots:
     dependencies:
       commander: 6.2.1
       glob: 7.2.3
-
-  dotenv@16.5.0: {}
 
   draw-svg-path@1.0.0:
     dependencies:
@@ -18328,8 +17662,6 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expr-eval@2.0.2: {}
-
   express-rate-limit@7.4.0(express@4.21.2):
     dependencies:
       express: 4.21.2
@@ -18479,12 +17811,6 @@ snapshots:
     dependencies:
       flat-cache: 5.0.0
 
-  file-type@16.5.4:
-    dependencies:
-      readable-web-to-node-stream: 3.0.4
-      strtok3: 6.3.0
-      token-types: 4.2.1
-
   file-type@20.4.1:
     dependencies:
       '@tokenizer/inflate': 0.2.7
@@ -18559,6 +17885,8 @@ snapshots:
     dependencies:
       dtype: 2.0.0
 
+  follow-redirects@1.15.9: {}
+
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
       debug: 4.4.0(supports-color@8.1.1)
@@ -18589,12 +17917,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
       safe-buffer: 5.2.1
-
-  form-data@4.0.0:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
 
   form-data@4.0.2:
     dependencies:
@@ -18630,12 +17952,6 @@ snapshots:
       readable-stream: 2.3.8
 
   fs-constants@1.0.0: {}
-
-  fs-extra@11.2.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
 
   fs-extra@11.3.0:
     dependencies:
@@ -19405,7 +18721,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19439,14 +18755,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19461,26 +18777,6 @@ snapshots:
       ms: 2.1.2
 
   hyperdyperid@1.2.0: {}
-
-  ibm-cloud-sdk-core@5.3.2:
-    dependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 18.19.86
-      '@types/tough-cookie': 4.0.5
-      axios: 1.8.4(debug@4.4.0)
-      camelcase: 6.3.0
-      debug: 4.4.0(supports-color@8.1.1)
-      dotenv: 16.5.0
-      extend: 3.0.2
-      file-type: 16.5.4
-      form-data: 4.0.0
-      isstream: 0.1.2
-      jsonwebtoken: 9.0.2
-      mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.8.4)
-      tough-cookie: 4.1.4
-    transitivePeerDependencies:
-      - supports-color
 
   iconv-lite@0.4.24:
     dependencies:
@@ -19844,8 +19140,6 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
-  isstream@0.1.2: {}
-
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
@@ -19945,16 +19239,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.50):
+  jest-cli@29.7.0(@types/node@18.19.86):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.50)
+      create-jest: 29.7.0(@types/node@18.19.86)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@18.19.50)
+      jest-config: 29.7.0(@types/node@18.19.86)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -19964,26 +19258,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@18.19.81):
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.81)
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@18.19.81)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-config@29.7.0(@types/node@18.19.50):
+  jest-config@29.7.0(@types/node@18.19.86):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -20008,37 +19283,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.50
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@18.19.81):
-    dependencies:
-      '@babel/core': 7.26.9
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -20255,7 +19500,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -20294,24 +19539,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.50):
+  jest@29.7.0(@types/node@18.19.86):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@18.19.50)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@18.19.81):
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@18.19.81)
+      jest-cli: 29.7.0(@types/node@18.19.86)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -20545,32 +19778,6 @@ snapshots:
 
   lambda-cloud-node-api@1.0.1: {}
 
-  langchain@0.3.21(@langchain/anthropic@0.3.18(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13))(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(@langchain/google-genai@0.2.4(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(zod@3.24.2))(@langchain/mistralai@0.2.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))))(axios@1.8.4)(encoding@0.1.13)(handlebars@4.7.8)(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(ws@8.18.1):
-    dependencies:
-      '@langchain/core': 0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
-      '@langchain/openai': 0.5.6(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)(ws@8.18.1)
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))
-      js-tiktoken: 1.0.19
-      js-yaml: 4.1.0
-      jsonpointer: 5.0.1
-      langsmith: 0.3.20(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))
-      openapi-types: 12.1.3
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      yaml: 2.7.1
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.5(zod@3.24.2)
-    optionalDependencies:
-      '@langchain/anthropic': 0.3.18(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(encoding@0.1.13)
-      '@langchain/google-genai': 0.2.4(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(zod@3.24.2)
-      '@langchain/mistralai': 0.2.0(@langchain/core@0.3.44(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))
-      axios: 1.8.4(debug@4.4.0)
-      handlebars: 4.7.8
-    transitivePeerDependencies:
-      - encoding
-      - openai
-      - ws
-
   langium@3.3.1:
     dependencies:
       chevrotain: 11.0.3
@@ -20580,18 +19787,6 @@ snapshots:
       vscode-uri: 3.0.8
 
   langs@2.0.0: {}
-
-  langsmith@0.3.15(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)):
-    dependencies:
-      '@types/uuid': 10.0.0
-      chalk: 4.1.2
-      console-table-printer: 2.12.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      semver: 7.7.1
-      uuid: 10.0.0
-    optionalDependencies:
-      openai: 4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)
 
   langsmith@0.3.20(openai@4.95.1(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)):
     dependencies:
@@ -21332,7 +20527,7 @@ snapshots:
       process: 0.11.10
       uuid: 9.0.1
 
-  node-mocks-http@1.16.2(@types/express@4.17.21)(@types/node@18.19.81):
+  node-mocks-http@1.16.2(@types/express@4.17.21)(@types/node@18.19.86):
     dependencies:
       accepts: 1.3.8
       content-disposition: 0.5.4
@@ -21346,7 +20541,7 @@ snapshots:
       type-is: 1.6.18
     optionalDependencies:
       '@types/express': 4.17.21
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
 
   node-releases@2.0.19: {}
 
@@ -21455,6 +20650,10 @@ snapshots:
 
   octicons@3.5.0: {}
 
+  ollama@0.5.15:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -21500,8 +20699,6 @@ snapshots:
       zod: 3.24.2
     transitivePeerDependencies:
       - encoding
-
-  openapi-types@12.1.3: {}
 
   opener@1.5.2: {}
 
@@ -21825,8 +21022,6 @@ snapshots:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.69
 
-  peek-readable@4.1.0: {}
-
   peek-readable@7.0.0: {}
 
   pegjs@0.10.0: {}
@@ -21934,13 +21129,15 @@ snapshots:
 
   pkginfo@0.4.1: {}
 
-  playwright-core@1.51.1: {}
+  playwright-core@1.51.1:
+    optional: true
 
   playwright@1.51.1:
     dependencies:
       playwright-core: 1.51.1
     optionalDependencies:
       fsevents: 2.3.2
+    optional: true
 
   plotly.js@2.35.3(@rspack/core@1.3.4(@swc/helpers@0.5.5))(mapbox-gl@1.13.3)(webpack@5.99.5):
     dependencies:
@@ -22240,10 +21437,6 @@ snapshots:
 
   prr@1.0.1:
     optional: true
-
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
 
   pump@3.0.2:
     dependencies:
@@ -22904,18 +22097,6 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readable-stream@4.7.0:
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
-
-  readable-web-to-node-stream@3.0.4:
-    dependencies:
-      readable-stream: 4.7.0
-
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -23108,10 +22289,6 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-
-  retry-axios@2.6.0(axios@1.8.4):
-    dependencies:
-      axios: 1.8.4(debug@4.4.0)
 
   retry-request@7.0.2(encoding@0.1.13):
     dependencies:
@@ -23745,7 +22922,7 @@ snapshots:
 
   stripe@17.7.0:
     dependencies:
-      '@types/node': 18.19.81
+      '@types/node': 18.19.86
       qs: 6.13.0
 
   strnum@1.1.2: {}
@@ -23756,11 +22933,6 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
       peek-readable: 7.0.0
-
-  strtok3@6.3.0:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
 
   stubs@3.0.0: {}
 
@@ -24044,11 +23216,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  token-types@4.2.1:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
-
   token-types@6.0.0:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -24059,13 +23226,6 @@ snapshots:
       commander: 2.20.3
 
   totalist@3.0.1: {}
-
-  tough-cookie@4.1.4:
-    dependencies:
-      psl: 1.15.0
-      punycode: 2.3.1
-      universalify: 0.2.0
-      url-parse: 1.5.10
 
   tr46@0.0.3: {}
 
@@ -24085,50 +23245,12 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.50))(typescript@5.8.2):
+  ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.86))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.19.50)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.8.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.9
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
-
-  ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.81))(typescript@5.7.3):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.19.81)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.7.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.9
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
-
-  ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.19.81))(typescript@5.8.2):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.19.81)
+      jest: 29.7.0(@types/node@18.19.86)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -24236,8 +23358,6 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.7.3: {}
-
   typescript@5.8.2: {}
 
   uc.micro@1.0.6: {}
@@ -24328,8 +23448,6 @@ snapshots:
     dependencies:
       '@types/cookie': 0.3.3
       cookie: 0.4.2
-
-  universalify@0.2.0: {}
 
   universalify@2.0.0: {}
 
@@ -24747,6 +23865,8 @@ snapshots:
 
   webworkify@1.5.0: {}
 
+  whatwg-fetch@3.6.20: {}
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -24837,8 +23957,6 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@7.5.10: {}
-
-  ws@8.18.0: {}
 
   ws@8.18.1: {}
 

--- a/src/packages/server/llm/client.ts
+++ b/src/packages/server/llm/client.ts
@@ -4,8 +4,8 @@ Get the client for the given LanguageModel.
 You do not have to worry too much about throwing an exception, because they're caught in ./index::evaluate
 */
 
-import { Ollama } from "@langchain/community/llms/ollama";
-import { OpenAI as LCOpenAI } from "@langchain/openai";
+import { Ollama } from "@langchain/ollama";
+import { ChatOpenAI as ChatOpenAILC } from "@langchain/openai";
 import { omit } from "lodash";
 import OpenAI from "openai";
 
@@ -174,7 +174,7 @@ export async function getCustomOpenAI(model: string) {
   // extract all other properties from the config, except the url, model, keepAlive field and the "cocalc" field
   const other = omit(config, ["baseUrl", "model", "keepAlive", "cocalc"]);
   const customOpenAIConfig = {
-    configuration: { baseURL }, // https://js.langchain.com/v0.1/docs/integrations/llms/openai/
+    configuration: { baseURL }, // https://js.langchain.com/docs/integrations/chat/openai/#custom-urls
     model: config.model ?? model,
     ...other,
   };
@@ -184,7 +184,7 @@ export async function getCustomOpenAI(model: string) {
     omit(customOpenAIConfig, ["apiKey", "openAIApiKey", "azureOpenAIApiKey"]),
   );
 
-  // https://js.langchain.com/v0.1/docs/integrations/llms/openai/
-  const client = new LCOpenAI(customOpenAIConfig);
+  // https://js.langchain.com/docs/integrations/chat/openai/
+  const client = new ChatOpenAILC(customOpenAIConfig);
   return client;
 }

--- a/src/packages/server/llm/custom-openai.ts
+++ b/src/packages/server/llm/custom-openai.ts
@@ -1,15 +1,18 @@
-import {
-  ChatPromptTemplate,
-  MessagesPlaceholder,
-} from "@langchain/core/prompts";
-import { RunnableWithMessageHistory } from "@langchain/core/runnables";
-import { OpenAI as LCOpenAI, OpenAICallOptions } from "@langchain/openai";
 import getLogger from "@cocalc/backend/logger";
 import {
   fromCustomOpenAIModel,
   isCustomOpenAI,
 } from "@cocalc/util/db-schema/llm-utils";
 import type { ChatOutput, History, Stream } from "@cocalc/util/types/llm";
+import {
+  ChatPromptTemplate,
+  MessagesPlaceholder,
+} from "@langchain/core/prompts";
+import { RunnableWithMessageHistory } from "@langchain/core/runnables";
+import {
+  ChatOpenAI as ChatOpenAILC,
+  OpenAICallOptions,
+} from "@langchain/openai";
 import { transformHistoryToMessages } from "./chat-history";
 import { numTokens } from "./chatgpt-numtokens";
 import { getCustomOpenAI } from "./client";
@@ -28,7 +31,7 @@ interface CustomOpenAIOpts {
 
 export async function evaluateCustomOpenAI(
   opts: Readonly<CustomOpenAIOpts>,
-  client?: LCOpenAI<OpenAICallOptions>,
+  client?: ChatOpenAILC<OpenAICallOptions>,
 ): Promise<ChatOutput> {
   if (client == null && !isCustomOpenAI(opts.model)) {
     throw new Error(`model ${opts.model} not supported`);
@@ -74,8 +77,12 @@ export async function evaluateCustomOpenAI(
 
   let output = "";
   for await (const chunk of chunks) {
-    output += chunk;
-    opts.stream?.(chunk);
+    const { content } = chunk;
+    if (typeof content !== "string") {
+      break;
+    }
+    output += content;
+    opts.stream?.(content);
   }
 
   // and an empty call when done

--- a/src/packages/server/llm/index.ts
+++ b/src/packages/server/llm/index.ts
@@ -383,6 +383,10 @@ export function normalizeOpenAIModel(model): OpenAIModel {
     model = "o1-mini";
   } else if (model.startsWith("o1")) {
     model = "o1";
+  } else if (model.startsWith("gpt-4.1-mini")) {
+    model = "gpt-4.1-mini";
+  } else if (model.startsWith("gpt-4.1")) {
+    model = "gpt-4.1";
   }
   if (!isOpenAIModel(model)) {
     throw new Error(`Internal problem normalizing OpenAI model name: ${model}`);

--- a/src/packages/server/llm/ollama.ts
+++ b/src/packages/server/llm/ollama.ts
@@ -1,4 +1,4 @@
-import type { Ollama } from "@langchain/community/llms/ollama";
+import type { Ollama } from "@langchain/ollama";
 import {
   ChatPromptTemplate,
   MessagesPlaceholder,
@@ -60,8 +60,9 @@ export async function evaluateOllama(
     inputMessagesKey: "input",
     historyMessagesKey: "chat_history",
     getMessageHistory: async () => {
-      const { messageHistory, tokens } =
-        await transformHistoryToMessages(history);
+      const { messageHistory, tokens } = await transformHistoryToMessages(
+        history,
+      );
       historyTokens = tokens;
       return messageHistory;
     },

--- a/src/packages/server/llm/test/00.test.ts
+++ b/src/packages/server/llm/test/00.test.ts
@@ -86,6 +86,12 @@ test_llm("openai")("OpenAI", () => {
   test("gpt 4o mini works", async () => {
     llmOpenAI("gpt-4o-mini-8k");
   });
+  test("gpt 4.1 works", async () => {
+    llmOpenAI("gpt-4.1");
+  });
+  test("gpt 4.1 mini works", async () => {
+    llmOpenAI("gpt-4.1-mini");
+  });
 
   // test("gpt o1", async () => {
   //   llmOpenAI("o1-8k");

--- a/src/packages/server/llm/user-defined.ts
+++ b/src/packages/server/llm/user-defined.ts
@@ -1,5 +1,5 @@
-import { Ollama, OllamaInput } from "@langchain/community/llms/ollama";
-import { OpenAI as LCOpenAI } from "@langchain/openai";
+import { Ollama, OllamaInput } from "@langchain/ollama";
+import { ChatOpenAI as ChatOpenAILC } from "@langchain/openai";
 
 import getLogger from "@cocalc/backend/logger";
 import { db } from "@cocalc/database";
@@ -69,7 +69,7 @@ export async function evaluateUserDefinedLLM(
   switch (service) {
     case "custom_openai": {
       // https://js.langchain.com/v0.2/docs/integrations/llms/openai/
-      const oic: ConstructorParameters<typeof LCOpenAI>["0"] = {
+      const oic: ConstructorParameters<typeof ChatOpenAILC>["0"] = {
         model: conf.model,
       };
       if (endpoint) {
@@ -80,7 +80,7 @@ export async function evaluateUserDefinedLLM(
         oic.apiKey = apiKey;
         oic.openAIApiKey = apiKey;
       }
-      const client = new LCOpenAI(oic);
+      const client = new ChatOpenAILC(oic);
       return await evaluateCustomOpenAI(
         { ...opts, model: toCustomOpenAIModel(conf.model) },
         client,
@@ -92,9 +92,8 @@ export async function evaluateUserDefinedLLM(
         baseUrl: conf.endpoint,
       };
       if (conf.apiKey) {
-        oc.headers = {
-          Authorization: `Bearer ${conf.apiKey}`,
-        };
+        oc.headers = new Headers();
+        oc.headers.set("Authorization", `Bearer ${conf.apiKey}`);
       }
       const client = new Ollama(oc);
       return await evaluateOllama(

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -26,7 +26,10 @@
     "./settings": "./dist/settings/index.js",
     "./settings/*": "./dist/settings/*.js"
   },
-  "keywords": ["utilities", "cocalc"],
+  "keywords": [
+    "utilities",
+    "cocalc"
+  ],
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "clean": "rm -rf node_modules dist",
@@ -53,10 +56,10 @@
     "@google/generative-ai": "^0.14.0",
     "@isaacs/ttlcache": "^1.2.1",
     "@langchain/anthropic": "^0.3.18",
-    "@langchain/community": "^0.3.41",
     "@langchain/core": "^0.3.46",
     "@langchain/google-genai": "^0.2.4",
     "@langchain/mistralai": "^0.2.0",
+    "@langchain/ollama": "^0.2.0",
     "@langchain/openai": "^0.5.5",
     "@nats-io/jetstream": "3.0.0",
     "@nats-io/jwt": "0.0.10-5",

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -54,7 +54,7 @@
     "@isaacs/ttlcache": "^1.2.1",
     "@langchain/anthropic": "^0.3.18",
     "@langchain/community": "^0.3.41",
-    "@langchain/core": "^0.3.45",
+    "@langchain/core": "^0.3.46",
     "@langchain/google-genai": "^0.2.4",
     "@langchain/mistralai": "^0.2.0",
     "@langchain/openai": "^0.5.5",

--- a/src/packages/util/db-schema/llm-utils.ts
+++ b/src/packages/util/db-schema/llm-utils.ts
@@ -115,6 +115,8 @@ export const MODELS_OPENAI = [
   "gpt-4-turbo-8k", // Released 2024-04-11
   "gpt-4-turbo",
   "gpt-4",
+  "gpt-4.1",
+  "gpt-4.1-mini",
   "gpt-4-32k",
   "gpt-3.5-turbo-16k",
   "text-embedding-ada-002", // TODO: this is for embeddings, should be moved to a different place
@@ -233,7 +235,9 @@ export const USER_SELECTABLE_LLMS_BY_VENDOR: {
       m === "gpt-4" ||
       m === "gpt-4-turbo-preview-8k" ||
       m === "gpt-4o-8k" ||
-      m === "gpt-4o-mini-8k",
+      m === "gpt-4o-mini-8k" ||
+      m === "gpt-4.1" ||
+      m === "gpt-4.1-mini",
 
     // ATTN: there is code for o1 and o1-mini, but it does not work yet.
     // The API changed, there is no support for streaming, and it took
@@ -722,6 +726,8 @@ export const LLM_USERNAMES: LLM2String = {
   "gpt-4o-8k": "GPT-4o",
   "gpt-4o-mini": "GPT-4o Mini 128k",
   "gpt-4o-mini-8k": "GPT-4o Mini",
+  "gpt-4.1": "GPT-4.1",
+  "gpt-4.1-mini": "GPT-4.1 Mini",
   "o1-mini-8k": "OpenAI o1-mini",
   "o1-8k": "OpenAI o1",
   "o1-mini": "OpenAI o1-mini",
@@ -758,6 +764,8 @@ export const LLM_DESCR: LLM2String = {
     "Can follow complex instructions and solve difficult problems. (OpenAI, 8k token context)",
   "gpt-4":
     "Powerful OpenAI model. Can follow complex instructions and solve difficult problems. (OpenAI, 8k token context)",
+  "gpt-4.1":
+    "Powerful OpenAI model. Can follow complex instructions and solve difficult problems. (OpenAI, 8k token context)",
   "gpt-4-32k": "",
   "gpt-3.5-turbo": "Fast, great for everyday tasks. (OpenAI, 4k token context)",
   "gpt-3.5-turbo-16k": `Same as ${LLM_USERNAMES["gpt-3.5-turbo"]} but with larger 16k token context`,
@@ -772,6 +780,7 @@ export const LLM_DESCR: LLM2String = {
   "gpt-4o": "Most powerful fastest, and cheapest (OpenAI, 128k token context)",
   "gpt-4o-mini-8k":
     "Most cost-efficient small model (OpenAI, 8k token context)",
+  "gpt-4.1-mini": "Most cost-efficient small model (OpenAI, 8k token context)",
   "gpt-4o-mini": "Most cost-efficient small model (OpenAI, 128k token context)",
   "text-embedding-ada-002": "Text embedding Ada 002 by OpenAI", // TODO: this is for embeddings, should be moved to a different place
   "o1-8k": "Spends more time thinking (8k token context)",
@@ -936,6 +945,18 @@ export const LLM_COST: { [name in LanguageModelCore]: Cost } = {
     completion_tokens: usd1Mtokens(30), // $30.00 / 1M tokens
     max_tokens: 128000, // This is a lot: blows up the "max cost" calculation → requires raising the minimum balance and quota limit
     free: false,
+  },
+  "gpt-4.1": {
+    prompt_tokens: usd1Mtokens(2),
+    completion_tokens: usd1Mtokens(8),
+    max_tokens: 8192,
+    free: false,
+  },
+  "gpt-4.1-mini": {
+    prompt_tokens: usd1Mtokens(0.4),
+    completion_tokens: usd1Mtokens(1.6),
+    max_tokens: 8192,
+    free: true,
   },
   "gpt-4o-8k": {
     prompt_tokens: usd1Mtokens(2.5),

--- a/src/packages/util/db-schema/purchase-quotas.ts
+++ b/src/packages/util/db-schema/purchase-quotas.ts
@@ -69,6 +69,17 @@ const GPT_OMNI_MINI_8K: Spec = {
   display: "OpenAI GPT-4o Mini",
 } as const;
 
+const GPT_41_8K: Spec = {
+  display: "OpenAI GPT-4.1",
+  color: "#10a37f",
+  category: "ai",
+} as const;
+
+const GPT_41_MINI_8K: Spec = {
+  ...GPT_41_8K,
+  display: "OpenAI GPT-4.1 Mini",
+} as const;
+
 const GPT_O1_8K: Spec = {
   ...GPT_OMNI_128k,
   display: "OpenAI o1",
@@ -178,6 +189,8 @@ export const QUOTA_SPEC: QuotaSpec = {
   "openai-gpt-4o-8k": GPT_OMNI_8K,
   "openai-gpt-4o-mini": GPT_OMNI_MINI_128k,
   "openai-gpt-4o-mini-8k": GPT_OMNI_MINI_8K,
+  "openai-gpt-4.1": GPT_41_8K,
+  "openai-gpt-4.1-mini": GPT_41_MINI_8K,
   "openai-o1-mini-8k": GPT_O1_8K,
   "openai-o1-8k": GPT_O1_MINI_8K,
   "openai-o1-mini": GPT_O1_8K,


### PR DESCRIPTION
This continues to fix some of the small details I saw, more refactoring in the future in small steps.

However, what this does is adding openai **4.1** and **4.1 mini**. I suggest to set 4.1 mini as the default.

4.1 mini is a bit more expensive, but still fine to offer for free and tests put it above o1-mini. See https://openai.com/index/gpt-4-1/ (4.1 family intelligence graph in the middle)

Related, since the list is getting long, we could disable GPT-4 and -turbo … or I just get rid of them in a future PR.
