### PR TITLE
raise LLM quota limit

### DIFF
--- a/src/packages/frontend/cspell.json
+++ b/src/packages/frontend/cspell.json
@@ -52,7 +52,8 @@
     "isdir",
     "mintime",
     "PoweroffOutlined",
-    "immutablejs"
+    "immutablejs",
+    "reuseinflight"
   ],
   "flagWords": [],
   "ignorePaths": ["node_modules/**", "dist/**", "dist-ts/**", "build/**"],

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -177,6 +177,7 @@ export interface CustomizeState {
   selectable_llms: List<string>;
   default_llm?: string;
   user_defined_llm: boolean;
+  llm_default_quota?: number;
 
   insecure_test_mode?: boolean;
 
@@ -334,7 +335,7 @@ function process_customize(obj) {
   for (const k in site_settings_conf) {
     const v = site_settings_conf[k];
     obj[k] =
-      obj[k] != null ? obj[k] : (v.to_val?.(v.default, obj_orig) ?? v.default);
+      obj[k] != null ? obj[k] : v.to_val?.(v.default, obj_orig) ?? v.default;
   }
   // the llm markup special case
   obj.llm_markup = obj_orig._llm_markup ?? 30;

--- a/src/packages/frontend/purchases/all-quotas-config.tsx
+++ b/src/packages/frontend/purchases/all-quotas-config.tsx
@@ -23,11 +23,7 @@ import { Icon } from "@cocalc/frontend/components/icon";
 import { getServiceCosts } from "@cocalc/frontend/purchases/api";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { LLM_COST, service2model_core } from "@cocalc/util/db-schema/llm-utils";
-import {
-  DEFAULT_LLM_QUOTA,
-  QUOTA_SPEC,
-  Service,
-} from "@cocalc/util/db-schema/purchase-quotas";
+import { QUOTA_SPEC, Service } from "@cocalc/util/db-schema/purchase-quotas";
 import { currency } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import Cost from "./pay-as-you-go/cost";
@@ -57,6 +53,9 @@ export default function AllQuotasConfig() {
   const lastFetchedQuotasRef = useRef<ServiceQuota[] | null>(null);
   const [changed, setChanged] = useState<boolean>(false);
   const selectableLLMs = useTypedRedux("customize", "selectable_llms");
+  // The 10 is just for the initial rollout, the value is customizable
+  const llm_default_quota =
+    useTypedRedux("customize", "llm_default_quota") ?? 10;
 
   const getQuotas = async () => {
     let quotas, charges;
@@ -86,7 +85,7 @@ export default function AllQuotasConfig() {
           continue;
         }
       }
-      const defaultQuota = isLLM ? DEFAULT_LLM_QUOTA : 0;
+      const defaultQuota: number = isLLM ? llm_default_quota : 0;
       w[service] = {
         current: charges[service] ?? 0,
         service: service as Service,

--- a/src/packages/server/purchases/is-purchase-allowed.test.ts
+++ b/src/packages/server/purchases/is-purchase-allowed.test.ts
@@ -5,7 +5,6 @@
 
 import getPool, { initEphemeralDatabase } from "@cocalc/database/pool";
 import { getServerSettings } from "@cocalc/database/settings/server-settings";
-import { DEFAULT_LLM_QUOTA } from "@cocalc/util/db-schema/purchase-quotas";
 import { MAX_COST } from "@cocalc/util/db-schema/purchases";
 import { uuid } from "@cocalc/util/misc";
 import createAccount from "../accounts/create-account";
@@ -231,6 +230,7 @@ describe("test checking whether or not purchase is allowed under various conditi
 
   it("default quota for LLMs is about 10", async () => {
     const minBalance = await getPurchaseQuota(account_id, "openai-o1");
-    expect(minBalance).toBe(DEFAULT_LLM_QUOTA);
+    const { llm_default_quota } = await getServerSettings();
+    expect(minBalance).toBe(llm_default_quota);
   });
 });

--- a/src/packages/server/purchases/is-purchase-allowed.ts
+++ b/src/packages/server/purchases/is-purchase-allowed.ts
@@ -1,5 +1,6 @@
 import type { PoolClient } from "@cocalc/database/pool";
 import { getServerSettings } from "@cocalc/database/settings/server-settings";
+import isBanned from "@cocalc/server/accounts/is-banned";
 import isValidAccount from "@cocalc/server/accounts/is-valid-account";
 import {
   getMaxCost,
@@ -8,17 +9,17 @@ import {
   service2model,
 } from "@cocalc/util/db-schema/llm-utils";
 import {
+  DEFAULT_LLM_QUOTA,
   QUOTA_SPEC,
   Service,
   isPaygService,
 } from "@cocalc/util/db-schema/purchase-quotas";
 import { MAX_COST } from "@cocalc/util/db-schema/purchases";
-import { currency, round2up, round2down } from "@cocalc/util/misc";
+import { currency, round2down, round2up } from "@cocalc/util/misc";
+import { decimalSubtract } from "@cocalc/util/stripe/calc";
 import getBalance from "./get-balance";
 import { getTotalChargesThisMonth } from "./get-charges";
 import { getPurchaseQuotas } from "./purchase-quotas";
-import isBanned from "@cocalc/server/accounts/is-banned";
-import { decimalSubtract } from "@cocalc/util/stripe/calc";
 import { ALLOWED_SLACK } from "./shopping-cart-checkout";
 
 // Throws an exception if purchase is not allowed.  Code should

--- a/src/packages/server/purchases/is-purchase-allowed.ts
+++ b/src/packages/server/purchases/is-purchase-allowed.ts
@@ -9,7 +9,6 @@ import {
   service2model,
 } from "@cocalc/util/db-schema/llm-utils";
 import {
-  DEFAULT_LLM_QUOTA,
   QUOTA_SPEC,
   Service,
   isPaygService,
@@ -115,7 +114,8 @@ export async function isPurchaseAllowed({
     return { allowed: false, reason: `cost must be positive` };
   }
   const { services, minBalance } = await getPurchaseQuotas(account_id, client);
-  const { pay_as_you_go_min_payment } = await getServerSettings();
+  const { pay_as_you_go_min_payment, llm_default_quota } =
+    await getServerSettings();
 
   if (!isPaygService(service)) {
     // for non-PAYG, we only allow credit toward a purchase if your balance is positive.
@@ -177,7 +177,7 @@ export async function isPurchaseAllowed({
   // explicitly authorized.
   if (!QUOTA_SPEC[service]?.noSet) {
     const isLLM = QUOTA_SPEC[service]?.category === "ai";
-    const defaultQuota = isLLM ? DEFAULT_LLM_QUOTA : 0;
+    const defaultQuota = isLLM ? llm_default_quota : 0;
     const quotaForService = (services[service] ?? defaultQuota) + margin;
     if (quotaForService <= 0) {
       return {

--- a/src/packages/server/purchases/is-purchase-allowed.ts
+++ b/src/packages/server/purchases/is-purchase-allowed.ts
@@ -128,7 +128,9 @@ export async function isPurchaseAllowed({
       chargeAmount,
       reason:
         required < chargeAmount
-          ? `The minimum payment is ${currency(pay_as_you_go_min_payment)}, so a payment of ${currency(required)} is not allowed.`
+          ? `The minimum payment is ${currency(
+              pay_as_you_go_min_payment,
+            )}, so a payment of ${currency(required)} is not allowed.`
           : `Please pay ${currency(chargeAmount)}.`,
     };
   }
@@ -160,7 +162,9 @@ export async function isPurchaseAllowed({
     return {
       allowed: false,
       chargeAmount,
-      reason: `Please pay ${currency(round2up(chargeAmount))}${v.length > 0 ? ": " : ""} ${v.join(", ")}`,
+      reason: `Please pay ${currency(round2up(chargeAmount))}${
+        v.length > 0 ? ": " : ""
+      } ${v.join(", ")}`,
     };
   }
 
@@ -171,7 +175,9 @@ export async function isPurchaseAllowed({
   // This is a self-imposed limit by the user to control what they
   // explicitly authorized.
   if (!QUOTA_SPEC[service]?.noSet) {
-    const quotaForService = (services[service] ?? 0) + margin;
+    const isLLM = QUOTA_SPEC[service]?.category === "ai";
+    const defaultQuota = isLLM ? DEFAULT_LLM_QUOTA : 0;
+    const quotaForService = (services[service] ?? defaultQuota) + margin;
     if (quotaForService <= 0) {
       return {
         allowed: true,
@@ -194,7 +200,9 @@ export async function isPurchaseAllowed({
       return {
         allowed: true,
         discouraged: true,
-        reason: `This purchase may exceed your personal monthly spending budget of ${currency(quotaForService)} for "${
+        reason: `This purchase may exceed your personal monthly spending budget of ${currency(
+          quotaForService,
+        )} for "${
           QUOTA_SPEC[service]?.display ?? service
         }".  This month you have spent ${currency(chargesForService)} on ${
           QUOTA_SPEC[service]?.display ?? service

--- a/src/packages/util/db-schema/purchase-quotas.ts
+++ b/src/packages/util/db-schema/purchase-quotas.ts
@@ -37,9 +37,6 @@ export function isPaygService(service: Service): boolean {
   return IS_PAYG[category ?? ""] ?? false;
 }
 
-// if not set, we default to $10 instead of $0 for LLMs
-export const DEFAULT_LLM_QUOTA = 10
-
 const GPT_TURBO_128k: Spec = {
   display: "OpenAI GPT-4 Turbo 128k",
   color: "#10a37f",

--- a/src/packages/util/db-schema/purchase-quotas.ts
+++ b/src/packages/util/db-schema/purchase-quotas.ts
@@ -37,6 +37,9 @@ export function isPaygService(service: Service): boolean {
   return IS_PAYG[category ?? ""] ?? false;
 }
 
+// if not set, we default to $10 instead of $0 for LLMs
+export const DEFAULT_LLM_QUOTA = 10
+
 const GPT_TURBO_128k: Spec = {
   display: "OpenAI GPT-4 Turbo 128k",
   color: "#10a37f",

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -71,6 +71,7 @@ export type SiteSettingsKeys =
   | "selectable_llms"
   | "default_llm"
   | "user_defined_llm"
+  | "llm_default_quota"
   | "neural_search_enabled"
   | "jupyter_api_enabled"
   | "organization_name"
@@ -862,6 +863,15 @@ export const site_settings_conf: SiteSettings = {
     default: "no",
     to_val: to_bool,
     valid: only_booleans,
+    tags: ["AI LLM"],
+  },
+  llm_default_quota: {
+    name: "Default Quota for LLMs",
+    desc: "We do not want to send users messages about LLM usage, if they didn't bother to set their quotas to >0. This is the default quota for LLMs. Integer val >=0",
+    default: "10",
+    to_val: to_int,
+    valid: only_nonneg_int,
+    show: only_commercial,
     tags: ["AI LLM"],
   },
   neural_search_enabled: {


### PR DESCRIPTION
I think this works, although I'm not 100% what to test and if there are negative side effects. So, a bit of caution …

For my local status see  the screenshot below. It shows the DB table for the quotas and how it looks in the UI. I can use the language models and do not get any warning messages. Except for Mistral Large, because there I set the quota to 0. "Budget Alert: Mistral AI Large"

My only remaining concern is to break quotas for other services.

This PR also switches a test, to use "compute-server" and not a language model … and adds a bit related to the default quota.

Finally, this also adds a `llm_default_quota` server settings with default 10.

![Screenshot from 2025-04-22 18-16-31](https://github.com/user-attachments/assets/0df7beb3-59c7-47a8-b91a-09178a64224e)
