### PR TITLE
frontend/file tabs: fix compact design

### DIFF
--- a/src/packages/frontend/project/page/file-tab.tsx
+++ b/src/packages/frontend/project/page/file-tab.tsx
@@ -208,10 +208,10 @@ export function FileTab(props: Readonly<Props>) {
   // alerts only work on non-docker projects (for now) -- #7077
   const status_alerts: string[] =
     !onCoCalcDocker && name === "info"
-      ? (project_status
+      ? project_status
           ?.get("alerts")
           ?.map((a) => a.get("type"))
-          .toJS() ?? [])
+          .toJS() ?? []
       : [];
 
   const other_settings = useTypedRedux("account", "other_settings");
@@ -294,8 +294,8 @@ export function FileTab(props: Readonly<Props>) {
       flyout === active_flyout
         ? COLORS.PROJECT.FIXED_LEFT_ACTIVE
         : active_flyout == null
-          ? COLORS.GRAY_L
-          : COLORS.GRAY_L0;
+        ? COLORS.GRAY_L
+        : COLORS.GRAY_L0;
     const bg = flyout === active_flyout ? COLORS.GRAY_L0 : undefined;
 
     return (
@@ -335,7 +335,6 @@ export function FileTab(props: Readonly<Props>) {
   // how to read: default color -> style for component -> override color if there is activity
   const icon_style: CSSProperties = {
     marginRight: "2px",
-    marginLeft: "-10px",
     color: COLORS.FILE_ICON,
     ...props.iconStyle,
     ...(has_activity ? { color: "orange" } : undefined),
@@ -356,7 +355,7 @@ export function FileTab(props: Readonly<Props>) {
 
   const icon =
     path != null
-      ? (file_options(path)?.icon ?? "code-o")
+      ? file_options(path)?.icon ?? "code-o"
       : FIXED_PROJECT_TABS[name!].icon;
 
   const tags =
@@ -413,7 +412,12 @@ export function FileTab(props: Readonly<Props>) {
     >
       <div
         className="cc-project-fixedtab"
-        style={{ textAlign: "center", width: "100%" }}
+        style={{
+          textAlign: "center",
+          width: "100%",
+          paddingLeft: "8px",
+          paddingRight: "8px",
+        }}
       >
         {btnLeft}
       </div>


### PR DESCRIPTION
Just as I suspected, a negative margin to is used as an offset on top of a padding. This halves the padding on the side from 16px to 8px and hence it works fine now.

## before/normal

![Screenshot from 2025-05-13 11-58-18](https://github.com/user-attachments/assets/d0b9a533-4091-4875-9942-4b7d14c084f2)


## after/normal

![Screenshot from 2025-05-13 11-54-02](https://github.com/user-attachments/assets/b5ceb5ba-415b-42a0-a042-4f3957473bb4)


## before/compact

![Screenshot from 2025-05-13 11-58-57](https://github.com/user-attachments/assets/c70bcec3-9d12-4d23-957d-5177bcf8cabc)


## after/compact

![Screenshot from 2025-05-13 11-54-31](https://github.com/user-attachments/assets/dfa193aa-4483-40bd-a11d-c6bfb6198579)
