### PR TITLE
frontend/frame-editor: add typing info to instantiated FrameTreeLeaf

### DIFF
--- a/src/packages/frontend/account/editor-settings/color-schemes.tsx
+++ b/src/packages/frontend/account/editor-settings/color-schemes.tsx
@@ -4,13 +4,14 @@
  */
 
 import { useIntl } from "react-intl";
-import { Map } from "immutable";
-import { LabeledRow, SelectorInput } from "@cocalc/frontend/components";
-import { CodeMirrorStatic } from "@cocalc/frontend/jupyter/codemirror-static";
-import { cm_options } from "@cocalc/frontend/frame-editors/codemirror/cm-options";
+
 import { Button } from "@cocalc/frontend/antd-bootstrap";
+import { LabeledRow, SelectorInput } from "@cocalc/frontend/components";
+import { cm_options } from "@cocalc/frontend/frame-editors/codemirror/cm-options";
+import { CodeMirrorStatic } from "@cocalc/frontend/jupyter/codemirror-static";
 import { AsyncComponent } from "@cocalc/frontend/misc/async-component";
 import { EDITOR_COLOR_SCHEMES } from "@cocalc/util/db-schema/accounts";
+import { AccountState } from "../types";
 
 interface Props {
   theme: string;
@@ -71,7 +72,10 @@ def is_prime_lucas_lehmer(p):
 // bundle.  This probably doesn't work so well yet though.
 const CodeMirrorPreview = AsyncComponent(async () => {
   await import("@cocalc/frontend/codemirror/init");
-  return (props: { editor_settings: Map<string, any>; font_size?: number }) => {
+  return (props: {
+    editor_settings: AccountState["editor_settings"];
+    font_size?: number;
+  }) => {
     // Ensure that we load all the codemirror plugins, modes, etc., so that
     // we can show the codemirror preview of the current theme, fonts, etc.
     import("@cocalc/frontend/codemirror/init");

--- a/src/packages/frontend/account/types.ts
+++ b/src/packages/frontend/account/types.ts
@@ -36,6 +36,9 @@ export interface AccountState {
   editor_settings: TypedMap<{
     jupyter_classic?: boolean;
     jupyter?: { kernel: string };
+    theme?: string;
+    physical_keyboard?: string;
+    keyboard_variant?: string;
   }>;
   font_size: number;
   other_settings: TypedMap<{

--- a/src/packages/frontend/chat/chatroom.tsx
+++ b/src/packages/frontend/chat/chatroom.tsx
@@ -20,7 +20,7 @@ import { Icon, Loading } from "@cocalc/frontend/components";
 import StaticMarkdown from "@cocalc/frontend/editors/slate/static-markdown";
 import { FrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 import { hoursToTimeIntervalHuman } from "@cocalc/util/misc";
-import type { ChatActions } from "./actions";
+import { EditorComponentProps } from "../frame-editors/frame-tree/types";
 import { ChatLog } from "./chat-log";
 import Filter from "./filter";
 import { FoldAllThreads } from "./fold-threads";
@@ -65,15 +65,6 @@ const CHAT_LOG_STYLE: React.CSSProperties = {
   position: "relative",
 } as const;
 
-interface Props {
-  actions: ChatActions;
-  project_id: string;
-  path: string;
-  is_visible?: boolean;
-  font_size: number;
-  desc?;
-}
-
 export function ChatRoom({
   actions,
   project_id,
@@ -81,7 +72,7 @@ export function ChatRoom({
   is_visible,
   font_size,
   desc,
-}: Props) {
+}: EditorComponentProps) {
   const useEditor = useEditorRedux<ChatState>({ project_id, path });
   const [input, setInput] = useState("");
   const search = desc?.get("data-search") ?? "";

--- a/src/packages/frontend/chat/side-chat.tsx
+++ b/src/packages/frontend/chat/side-chat.tsx
@@ -1,7 +1,8 @@
 import { Button, Flex, Space, Tooltip } from "antd";
-import { CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
+  CSS,
   redux,
   useActions,
   useRedux,
@@ -26,7 +27,7 @@ import VideoChatButton from "./video/launch-button";
 interface Props {
   project_id: string;
   path: string;
-  style?: CSSProperties;
+  style?: CSS;
   fontSize?: number;
   actions?: ChatActions;
   desc?;

--- a/src/packages/frontend/frame-editors/chat-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/chat-editor/editor.ts
@@ -11,7 +11,7 @@ import { createElement } from "react";
 
 import { ChatRoom } from "@cocalc/frontend/chat/chatroom";
 import { createEditor } from "@cocalc/frontend/frame-editors/frame-tree/editor";
-import type { EditorDescription } from "@cocalc/frontend/frame-editors/frame-tree/types";
+import type { EditorComponentProps, EditorDescription } from "@cocalc/frontend/frame-editors/frame-tree/types";
 import { terminal } from "@cocalc/frontend/frame-editors/terminal-editor/editor";
 import { time_travel } from "@cocalc/frontend/frame-editors/time-travel-editor/editor";
 import { set } from "@cocalc/util/misc";
@@ -22,7 +22,7 @@ const chatroom: EditorDescription = {
   short: "Chatroom",
   name: "Chatroom",
   icon: "comment",
-  component: (props) => {
+  component: (props: EditorComponentProps) => {
     const actions = props.actions.getChatActions(props.id);
     return createElement(ChatRoom, {
       ...props,

--- a/src/packages/frontend/frame-editors/codemirror/cm-options.ts
+++ b/src/packages/frontend/frame-editors/codemirror/cm-options.ts
@@ -8,18 +8,18 @@ Compute the codemirror options for file with given name,
 using the given editor settings.
 */
 
-import * as CodeMirror from "codemirror";
-import { file_associations } from "../../file-associations";
-import * as feature from "../../feature";
-import { path_split } from "@cocalc/util/misc";
-import { get_editor_settings } from "../generic/client";
 import { EDITOR_COLOR_SCHEMES } from "@cocalc/util/db-schema/accounts";
+import { path_split } from "@cocalc/util/misc";
+import * as CodeMirror from "codemirror";
+import * as feature from "../../feature";
+import { file_associations } from "../../file-associations";
+import { get_editor_settings } from "../generic/client";
 
-import { filename_extension_notilde, defaults } from "@cocalc/util/misc";
+import { defaults, filename_extension_notilde } from "@cocalc/util/misc";
 
 import { extra_alt_keys } from "./mobile";
-import { Map } from "immutable";
 
+import { AccountState } from "../../account/types";
 import { valid_indent } from "./util";
 
 function save(cm) {
@@ -36,17 +36,17 @@ export function default_opts(filename) {
 
 export function cm_options(
   filename: string, // extension determines editor mode
-  editor_settings: Map<string, any>,
+  editor_settings: AccountState["editor_settings"],
   gutters: string[] = [], // array of extra gutters
   editor_actions: any = undefined,
   frame_tree_actions: any = undefined,
-  frame_id: string = ""
+  frame_id: string = "",
 ) {
-  let theme = editor_settings.get("theme");
+  let theme = editor_settings?.get("theme");
   // if we do not know the theme, fallback to default
-  if (EDITOR_COLOR_SCHEMES[theme] == null) {
+  if (!theme || EDITOR_COLOR_SCHEMES[theme] == null) {
     console.warn(
-      `codemirror theme '${theme}' not known -- fallback to 'Default'`
+      `codemirror theme '${theme}' not known -- fallback to 'Default'`,
     );
     theme = "default";
   }
@@ -57,7 +57,7 @@ export function cm_options(
     mode: "txt",
     show_trailing_whitespace: editor_settings.get(
       "show_trailing_whitespace",
-      true
+      true,
     ),
     allow_javascript_eval: true, // if false, the one use of eval isn't allowed.
     line_numbers: editor_settings.get("line_numbers", true),
@@ -132,7 +132,7 @@ export function cm_options(
       } else {
         if (get_editor_settings().get("show_exec_warning")) {
           frame_tree_actions.set_error(
-            "You can evaluate code in a file with the extension 'sagews' or 'ipynb'.   Please create a Sage Worksheet or Jupyter notebook instead."
+            "You can evaluate code in a file with the extension 'sagews' or 'ipynb'.   Please create a Sage Worksheet or Jupyter notebook instead.",
           );
         }
       }

--- a/src/packages/frontend/frame-editors/course-editor/course-panel-wrapper.tsx
+++ b/src/packages/frontend/frame-editors/course-editor/course-panel-wrapper.tsx
@@ -8,36 +8,37 @@ This is some slightly complicated code to avoid needless duplication.
 
 It's a bit more complicated than you might expect partly due to the fact
 we have to insert these course tab components as frame in a frame tree,
-so there is no commoon containing react component that we control...
+so there is no common containing react component that we control...
 */
 
+import { Map } from "immutable";
+
 import {
+  AppRedux,
   React,
   Rendered,
   redux,
-  AppRedux,
   useEditorRedux,
   useRedux,
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
-import { Loading, ActivityDisplay } from "@cocalc/frontend/components";
+import { ActivityDisplay, Loading } from "@cocalc/frontend/components";
 import ShowError from "@cocalc/frontend/components/error";
+import Modals from "@cocalc/frontend/course/modals";
+import { PayBanner } from "@cocalc/frontend/course/pay-banner";
 import {
   AssignmentsMap,
   CourseSettingsRecord,
-  StudentsMap,
+  CourseStore,
   HandoutsMap,
+  StudentsMap,
 } from "@cocalc/frontend/course/store";
-import { Map } from "immutable";
-import { ProjectMap, UserMap } from "../../todo-types";
-import { CourseActions, course_redux_name } from "./course-actions";
-import { values } from "@cocalc/util/misc";
-import { CourseTabBar } from "./course-tab-bar";
-import type { CourseEditorActions, CourseEditorState } from "./actions";
-import { CourseStore } from "@cocalc/frontend/course/store";
-import { PayBanner } from "@cocalc/frontend/course/pay-banner";
-import Modals from "@cocalc/frontend/course/modals";
 import { getScale } from "@cocalc/frontend/frame-editors/frame-tree/hooks";
+import { ProjectMap, UserMap } from "@cocalc/frontend/todo-types";
+import { values } from "@cocalc/util/misc";
+import type { CourseEditorActions, CourseEditorState } from "./actions";
+import { CourseActions, course_redux_name } from "./course-actions";
+import { CourseTabBar } from "./course-tab-bar";
 
 export interface FrameProps {
   id: string;

--- a/src/packages/frontend/frame-editors/course-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/course-editor/editor.ts
@@ -7,15 +7,18 @@
 Spec for editing courses via a frame tree.
 */
 
+import React from "react";
+
 import { COMMANDS } from "@cocalc/frontend/course/commands";
 import { addEditorMenus } from "@cocalc/frontend/frame-editors/frame-tree/commands";
-import { menu } from "@cocalc/frontend/i18n";
-import { course, labels } from "@cocalc/frontend/i18n";
+import { course, labels, menu } from "@cocalc/frontend/i18n";
 import { set } from "@cocalc/util/misc";
+
 import { createEditor } from "../frame-tree/editor";
 import { EditorDescription } from "../frame-tree/types";
 import { terminal } from "../terminal-editor/editor";
 import { time_travel } from "../time-travel-editor/editor";
+import { FrameProps } from "./course-panel-wrapper";
 import {
   Actions,
   Assignments,
@@ -108,7 +111,11 @@ function initMenus() {
 
 initMenus();
 
-const course_students: EditorDescription = {
+type CourseEditorDescription = Omit<EditorDescription, "component"> & {
+  component: React.FC<FrameProps>;
+};
+
+const course_students: CourseEditorDescription = {
   type: "course-students",
   short: course.students,
   name: course.students,
@@ -118,7 +125,7 @@ const course_students: EditorDescription = {
   buttons,
 } as const;
 
-const course_assignments: EditorDescription = {
+const course_assignments: CourseEditorDescription = {
   type: "course-assignments",
   short: course.assignments,
   name: course.assignments,
@@ -128,7 +135,7 @@ const course_assignments: EditorDescription = {
   buttons,
 } as const;
 
-const course_handouts: EditorDescription = {
+const course_handouts: CourseEditorDescription = {
   type: "course-handouts",
   short: course.handouts,
   name: course.handouts,
@@ -138,7 +145,7 @@ const course_handouts: EditorDescription = {
   buttons,
 } as const;
 
-const course_configuration: EditorDescription = {
+const course_configuration: CourseEditorDescription = {
   type: "course-configuration",
   short: labels.configuration_short,
   name: labels.configuration,
@@ -148,7 +155,7 @@ const course_configuration: EditorDescription = {
   buttons,
 } as const;
 
-const course_actions: EditorDescription = {
+const course_actions: CourseEditorDescription = {
   type: "course-actions",
   short: course.actions,
   name: course.actions,
@@ -158,7 +165,7 @@ const course_actions: EditorDescription = {
   buttons,
 } as const;
 
-const course_shared_project: EditorDescription = {
+const course_shared_project: CourseEditorDescription = {
   type: "course-shared_project",
   short: labels.shared,
   name: course.shared_project,

--- a/src/packages/frontend/frame-editors/csv-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/csv-editor/editor.ts
@@ -13,9 +13,11 @@ import { createEditor } from "../frame-tree/editor";
 import { EditorDescription } from "../frame-tree/types";
 import { terminal } from "../terminal-editor/editor";
 import { time_travel } from "../time-travel-editor/editor";
-import Grid from "./grid";
+import Grid, { GridProps } from "./grid";
 
-const grid: EditorDescription = {
+const grid: Omit<EditorDescription, "component"> & {
+  component: React.FC<GridProps>;
+} = {
   type: "csv-grid",
   short: "Grid",
   name: "Grid",

--- a/src/packages/frontend/frame-editors/csv-editor/grid.tsx
+++ b/src/packages/frontend/frame-editors/csv-editor/grid.tsx
@@ -1,7 +1,11 @@
 import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 import CSV from "@cocalc/frontend/components/data-grid/csv";
 
-export default function Grid({ value }) {
+export interface GridProps {
+  value: string;
+}
+
+export default function Grid({ value }: GridProps) {
   const { actions, desc } = useFrameContext();
   return (
     <div

--- a/src/packages/frontend/frame-editors/frame-tree/editor.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/editor.tsx
@@ -214,11 +214,11 @@ const FrameTreeEditor: React.FC<FrameTreeEditorProps> = React.memo(
   shouldMemoize,
 );
 
-interface Options {
+interface Options<T = EditorSpec> {
   display_name: string;
   format_bar?: boolean;
   format_bar_exclude?: SetMap;
-  editor_spec: EditorSpec;
+  editor_spec: T;
 }
 
 export interface EditorProps {
@@ -231,7 +231,9 @@ export interface EditorProps {
 
 // this returns a function that creates a FrameTreeEditor for given Options.
 // memoization happens in FrameTreeEditor
-export function createEditor(opts: Options): React.FC<EditorProps> {
+export function createEditor<T = EditorSpec>(
+  opts: Options<T>,
+): React.FC<EditorProps> {
   const Editor = (props: EditorProps) => {
     const { actions, name, path, project_id, is_visible } = props;
     return (

--- a/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/frame-tree.tsx
@@ -28,18 +28,20 @@ or
     deletable : bool
 */
 
-import { copy, hidden_meta_file, is_different } from "@cocalc/util/misc";
 import { delay } from "awaiting";
 import { Map, Set } from "immutable";
 import React from "react";
+
+import { AccountState } from "@cocalc/frontend/account/types";
 import {
   redux,
   Rendered,
-  useState,
   useEffect,
+  useState,
 } from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
 import { AvailableFeatures } from "@cocalc/frontend/project_configuration";
+import { copy, hidden_meta_file, is_different } from "@cocalc/util/misc";
 import { Actions } from "../code-editor/actions";
 import { cm as cm_spec } from "../code-editor/editor";
 import { TimeTravelActions } from "../time-travel-editor/actions";
@@ -50,7 +52,6 @@ import { get_file_editor } from "./register";
 import { FrameTitleBar } from "./title-bar";
 import * as tree_ops from "./tree-ops";
 import { EditorDescription, EditorSpec, EditorState, NodeDesc } from "./types";
-import { AccountState } from "@cocalc/frontend/account/types";
 
 interface FrameTreeProps {
   actions: Actions;
@@ -59,7 +60,7 @@ interface FrameTreeProps {
   complete: Map<string, any>;
   cursors: Map<string, any>;
   derived_file_types: Set<string>;
-  editor_settings?: AccountState["editor_settings"];
+  editor_settings: AccountState["editor_settings"];
   editor_spec: EditorSpec;
   editor_state: EditorState; // IMPORTANT: change does NOT cause re-render (uncontrolled); only used for full initial render, on purpose, i.e., setting scroll positions.
   font_size: number;
@@ -377,7 +378,9 @@ export const FrameTree: React.FC<FrameTreeProps> = React.memo(
         component = spec != null ? spec.component : undefined;
         if (component == null) {
           throw Error(
-            `unknown type '${type}'. Known types for this editor: ${JSON.stringify(Object.keys(editor_spec))}`,
+            `unknown type '${type}'. Known types for this editor: ${JSON.stringify(
+              Object.keys(editor_spec),
+            )}`,
           );
         }
       } catch (err) {

--- a/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/leaf.tsx
@@ -3,6 +3,8 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
+import { Map, Set } from "immutable";
+
 import {
   CSS,
   React,
@@ -12,10 +14,14 @@ import {
 } from "@cocalc/frontend/app-framework";
 import { ErrorDisplay, Loading } from "@cocalc/frontend/components";
 import { AvailableFeatures } from "@cocalc/frontend/project_configuration";
-import { Map, Set } from "immutable";
 import { AccountState } from "@cocalc/frontend/account/types";
 import { Actions } from "../code-editor/actions";
-import { EditorDescription, EditorState, NodeDesc } from "./types";
+import {
+  EditorComponentProps,
+  EditorDescription,
+  EditorState,
+  NodeDesc,
+} from "./types";
 import DeletedFile from "@cocalc/frontend/project/deleted-file";
 
 const ERROR_STYLE: CSS = {
@@ -35,7 +41,7 @@ interface Props {
   derived_file_types: Set<string>;
   desc: NodeDesc;
   editor_actions: Actions;
-  editor_settings?: AccountState["editor_settings"];
+  editor_settings: AccountState["editor_settings"];
   editor_state: EditorState;
   font_size: number;
   is_fullscreen: boolean;
@@ -52,7 +58,7 @@ interface Props {
   terminal?: Map<string, any>;
   // is_visible: true if the entire frame tree is visible (i.e., the tab is shown);
   // knowing this can be critical for rendering certain types of editors, e.g.,
-  // see https://github.com/sagemathinc/cocalc/issues/5133 where xterm.js would get
+  // se https://github.com/sagemathinc/cocalc/issues/5133 where xterm.js would get
   // randomly rendered wrong if it was initialized when the div was in the DOM,
   // but hidden.
   is_visible: boolean;
@@ -137,46 +143,47 @@ export const FrameTreeLeaf: React.FC<Props> = React.memo(
     function render_leaf(): Rendered {
       if (!is_loaded) return <Loading theme="medium" />;
       if (TheComponent == null) throw Error("component must not be null");
-      return (
-        <TheComponent
-          id={desc.get("id")}
-          name={props.name}
-          actions={actions}
-          editor_actions={editor_actions}
-          mode={spec.mode}
-          read_only={desc.get("read_only", read_only || is_public)}
-          is_public={is_public}
-          font_size={desc.get("font_size", font_size)}
-          path={path}
-          fullscreen_style={spec.fullscreen_style}
-          project_id={project_id}
-          editor_state={editor_state.get(desc.get("id"), Map())}
-          is_current={desc.get("id") === active_id}
-          cursors={cursors}
-          value={value}
-          misspelled_words={misspelled_words}
-          is_fullscreen={is_fullscreen}
-          reload={reload}
-          resize={resize}
-          reload_images={!!spec.reload_images}
-          gutters={spec.gutters != null ? spec.gutters : []}
-          gutter_markers={gutter_markers}
-          editor_settings={editor_settings}
-          terminal={terminal}
-          settings={settings}
-          status={status}
-          complete={complete && complete.get(desc.get("id"))}
-          derived_file_types={derived_file_types}
-          local_view_state={local_view_state}
-          desc={desc}
-          available_features={available_features}
-          is_subframe={is_subframe}
-          is_visible={is_visible}
-          tab_is_visible={tab_is_visible}
-          placeholder={placeholder}
-          onFocus={() => actions.set_active_id(desc.get("id"), true)}
-        />
-      );
+
+      const componentProps: EditorComponentProps = {
+        id: desc.get("id"),
+        actions,
+        available_features,
+        complete: complete && complete.get(desc.get("id")),
+        cursors,
+        derived_file_types: derived_file_types,
+        desc,
+        editor_actions,
+        editor_settings,
+        editor_state: editor_state.get(desc.get("id"), Map()),
+        font_size: desc.get("font_size", font_size),
+        fullscreen_style: spec.fullscreen_style,
+        gutter_markers,
+        gutters: spec.gutters != null ? spec.gutters : [],
+        is_current: desc.get("id") === active_id,
+        is_fullscreen,
+        is_public,
+        is_subframe,
+        is_visible,
+        local_view_state,
+        misspelled_words,
+        mode: spec.mode,
+        name: props.name,
+        onFocus: () => actions.set_active_id(desc.get("id"), true),
+        path,
+        placeholder,
+        project_id,
+        read_only: desc.get("read_only", read_only || is_public),
+        reload_images: !!spec.reload_images,
+        reload,
+        resize,
+        settings,
+        status,
+        tab_is_visible,
+        terminal,
+        value,
+      };
+
+      return <TheComponent {...componentProps} />;
     }
 
     function render_error(): Rendered {

--- a/src/packages/frontend/frame-editors/frame-tree/types.ts
+++ b/src/packages/frontend/frame-editors/frame-tree/types.ts
@@ -3,10 +3,14 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
-import { Map } from "immutable";
+import { Map, Set } from "immutable";
+import { ReactNode } from "react";
 
+import { AccountState } from "@cocalc/frontend/account/types";
 import { IconName } from "@cocalc/frontend/components/icon";
 import { IntlMessage } from "@cocalc/frontend/i18n";
+import type { AvailableFeatures } from "@cocalc/frontend/project_configuration";
+
 import type { Command } from "./commands";
 
 export type FrameDirection = "row" | "col";
@@ -103,7 +107,7 @@ export interface EditorDescription {
   short: string | IntlMessage; // short description of the editor
   name: string | IntlMessage; // slightly longer description
   icon: IconName;
-  component: any; // React component
+  component: (props: EditorComponentProps) => ReactNode;
 
   // commands that will be displayed in the menu (if they exist)
   commands?: { [commandName: string]: boolean };
@@ -138,3 +142,42 @@ export interface EditorSpec {
 }
 
 export type EditorState = Map<string, any>; // TODO: use TypeMap and do this right.
+
+export interface EditorComponentProps {
+  id: string;
+  actions;
+  available_features: AvailableFeatures;
+  complete;
+  cursors?: Map<string, any>;
+  derived_file_types: Set<string>;
+  desc: NodeDesc;
+  editor_actions;
+  editor_settings: AccountState["editor_settings"];
+  editor_state: Map<string, any>;
+  font_size: number;
+  fullscreen_style: EditorDescription["fullscreen_style"];
+  gutter_markers?: Map<string, any>;
+  gutters?: EditorDescription["gutters"];
+  is_current: boolean;
+  is_fullscreen: boolean;
+  is_public: boolean;
+  is_subframe: boolean;
+  is_visible: boolean;
+  local_view_state: Map<string, any>;
+  misspelled_words?: Set<string> | string;
+  mode: EditorDescription["mode"];
+  name: string;
+  onFocus: () => void;
+  path: string;
+  placeholder?: string;
+  project_id: string;
+  read_only: boolean;
+  reload_images: boolean;
+  reload?: number;
+  resize: number;
+  settings: Map<string, any>;
+  status: string;
+  tab_is_visible: boolean;
+  terminal?: Map<string, any>;
+  value?: string;
+}

--- a/src/packages/frontend/frame-editors/generic/chat.tsx
+++ b/src/packages/frontend/frame-editors/generic/chat.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useEffect, useState } from "react";
+
 import { redux } from "@cocalc/frontend/app-framework";
 import type { ChatActions } from "@cocalc/frontend/chat/actions";
 import { initChat } from "@cocalc/frontend/chat/register";
@@ -11,17 +12,13 @@ import SideChat from "@cocalc/frontend/chat/side-chat";
 import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 import { labels } from "@cocalc/frontend/i18n";
 import { hidden_meta_file, set } from "@cocalc/util/misc";
-import { EditorDescription } from "../frame-tree/types";
+import { EditorComponentProps, EditorDescription } from "../frame-tree/types";
 
 export function chatFile(path: string): string {
   return hidden_meta_file(path, "sage-chat");
 }
-interface Props {
-  font_size: number;
-  desc;
-}
 
-function Chat({ font_size, desc }: Props) {
+function Chat({ font_size, desc }: EditorComponentProps) {
   const { project_id, path: path0, actions, id: frameId } = useFrameContext();
   const path = chatFile(path0);
   const [sideChatActions, setSideChatActions] = useState<ChatActions | null>(

--- a/src/packages/frontend/frame-editors/html-editor/iframe-html.tsx
+++ b/src/packages/frontend/frame-editors/html-editor/iframe-html.tsx
@@ -15,28 +15,31 @@ Component that shows rendered HTML in an iFrame, so safe and no mangling needed.
 // Some day in the future this might no longer be necessary ... (react 16.13.1)
 
 import $ from "jquery";
-import { Set } from "immutable";
+
+import { Spin, Switch, Tooltip } from "antd";
 import { delay } from "awaiting";
+import { Set } from "immutable";
+import { debounce } from "lodash";
+import { join } from "path";
+import { useEffect, useRef, useState } from "react";
+
 import {
   change_filename_extension,
   is_different,
   list_alternatives,
   path_split,
 } from "@cocalc/util/misc";
-import { debounce } from "lodash";
-import { React, ReactDOM, Rendered, CSS } from "../../app-framework";
+
+import { CSS, React, ReactDOM, Rendered } from "@cocalc/frontend/app-framework";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import {
+  delete_local_storage,
+  get_local_storage,
+  set_local_storage,
+} from "@cocalc/frontend/misc/local-storage";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { use_font_size_scaling } from "../frame-tree/hooks";
 import { EditorState } from "../frame-tree/types";
-import { useEffect, useRef, useState } from "react";
-import { webapp_client } from "@cocalc/frontend/webapp-client";
-import { Switch, Spin, Tooltip } from "antd";
-import {
-  set_local_storage,
-  get_local_storage,
-  delete_local_storage,
-} from "@cocalc/frontend/misc/local-storage";
-import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
-import { join } from "path";
 
 interface Props {
   id: string;
@@ -46,7 +49,7 @@ interface Props {
   fullscreen_style?: any;
   project_id: string;
   path: string;
-  reload: number;
+  reload?: number;
   font_size: number;
   tab_is_visible: boolean;
   mode: "rmd" | undefined;
@@ -266,7 +269,7 @@ export const IFrameHTML: React.FC<Props> = React.memo((props: Props) => {
     return (
       <iframe
         ref={iframe}
-        srcDoc={!trust && mode != "rmd" ? value : (srcDoc ?? "")}
+        srcDoc={!trust && mode != "rmd" ? value : srcDoc ?? ""}
         width={"100%"}
         height={"100%"}
         style={{ border: 0, ...style }}

--- a/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/cell-notebook.tsx
+++ b/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/cell-notebook.tsx
@@ -8,10 +8,11 @@ Frame that display a Jupyter notebook in the traditional way with input and outp
 */
 
 import { Map } from "immutable";
-import { Component, Rendered } from "@cocalc/frontend/app-framework";
+
+import { Rendered } from "@cocalc/frontend/app-framework";
+import { EditorState } from "@cocalc/frontend/frame-editors/frame-tree/types";
 import { JupyterActions } from "@cocalc/frontend/jupyter/browser-actions";
 import { JupyterEditor } from "@cocalc/frontend/jupyter/main";
-import { EditorState } from "../../frame-tree/types";
 import { JupyterEditorActions } from "../actions";
 
 interface Props {
@@ -28,32 +29,31 @@ interface Props {
   desc: Map<string, any>;
 }
 
-export class CellNotebook extends Component<Props, {}> {
-  private data(key: string, def?: any): any {
-    return this.props.desc.get("data-" + key, def);
+export function CellNotebook(props: Props): Rendered {
+  function data(key: string, def?: any): any {
+    return props.desc.get("data-" + key, def);
   }
 
-  render(): Rendered {
-    // Actions for the underlying Jupyter notebook state, kernel state, etc.
-    const jupyter_actions: JupyterActions = this.props.actions.jupyter_actions;
-    return (
-      <JupyterEditor
-        actions={jupyter_actions}
-        editor_actions={this.props.actions}
-        name={jupyter_actions.name}
-        is_focused={this.props.is_current}
-        is_visible={this.props.is_visible}
-        is_fullscreen={this.props.is_fullscreen}
-        font_size={this.props.font_size}
-        mode={this.data("mode", "escape")}
-        cur_id={this.data("cur_id")}
-        sel_ids={this.data("sel_ids")}
-        md_edit_ids={this.data("md_edit_ids")}
-        scroll={this.data("scroll")}
-        scroll_seq={this.data("scroll_seq")}
-        scrollTop={this.data("scrollTop")}
-        hook_offset={this.data("hook_offset")}
-      />
-    );
-  }
+  // Actions for the underlying Jupyter notebook state, kernel state, etc.
+  const jupyter_actions: JupyterActions = props.actions.jupyter_actions;
+
+  return (
+    <JupyterEditor
+      actions={jupyter_actions}
+      editor_actions={props.actions}
+      name={jupyter_actions.name}
+      is_focused={props.is_current}
+      is_visible={props.is_visible}
+      is_fullscreen={props.is_fullscreen}
+      font_size={props.font_size}
+      mode={data("mode", "escape")}
+      cur_id={data("cur_id")}
+      sel_ids={data("sel_ids")}
+      md_edit_ids={data("md_edit_ids")}
+      scroll={data("scroll")}
+      scroll_seq={data("scroll_seq")}
+      scrollTop={data("scrollTop")}
+      hook_offset={data("hook_offset")}
+    />
+  );
 }

--- a/src/packages/frontend/frame-editors/jupyter-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/editor.ts
@@ -102,7 +102,7 @@ const jupyter_slideshow_revealjs: EditorDescription = {
   short: "Slideshow",
   name: "Slideshow (Reveal.js)",
   icon: "slides",
-  component: Slideshow,
+  component: Slideshow as any, // TODO: rclass wrapper is incompatible with this type → rewrite Slideshow to be a React.FC
   commands: set(["build"]),
 } as const;
 

--- a/src/packages/frontend/frame-editors/jupyter-editor/raw-ipynb.tsx
+++ b/src/packages/frontend/frame-editors/jupyter-editor/raw-ipynb.tsx
@@ -7,19 +7,19 @@
 Frame that displays the raw JSON for a Jupyter Notebook
 */
 
+import { fromJS } from "immutable";
 
+import { AccountState } from "@cocalc/frontend/account/types";
+import { RawEditor } from "@cocalc/frontend/jupyter/raw-editor";
 
-import { RawEditor } from "../../jupyter/raw-editor";
+import { cm_options } from "../codemirror/cm-options";
 
 import { JupyterEditorActions } from "./actions";
-
-import { Map, fromJS } from "immutable";
-import { cm_options } from "../codemirror/cm-options";
 
 interface Props {
   actions: JupyterEditorActions;
   font_size: number;
-  editor_settings: Map<string, any>;
+  editor_settings: AccountState["editor_settings"];
   project_id: string;
 }
 

--- a/src/packages/frontend/frame-editors/jupyter-editor/slideshow-revealjs/slideshow.tsx
+++ b/src/packages/frontend/frame-editors/jupyter-editor/slideshow-revealjs/slideshow.tsx
@@ -20,9 +20,9 @@ TODO:
 
 import { delay } from "awaiting";
 
-import { Rendered, Component, rclass, rtypes } from "../../../app-framework";
+import { Rendered, Component, rclass, rtypes } from "@cocalc/frontend/app-framework";
 
-import { Loading } from "../../../components";
+import { Loading } from "@cocalc/frontend/components";
 
 import { Map } from "immutable";
 

--- a/src/packages/frontend/frame-editors/jupyter-editor/snippets/main.tsx
+++ b/src/packages/frontend/frame-editors/jupyter-editor/snippets/main.tsx
@@ -13,6 +13,7 @@ declare var require: {
   ) => void;
 };
 
+import { Map } from "immutable";
 import {
   CaretRightOutlined,
   LeftSquareOutlined,
@@ -257,8 +258,8 @@ export const JupyterSnippets: React.FC<Props> = React.memo((props: Props) => {
       doc[0] === ""
         ? undefined
         : typeof doc[0] === "string"
-          ? [doc[0]]
-          : doc[0];
+        ? [doc[0]]
+        : doc[0];
     if (code != null && insertSetup) {
       const setup = generateSetupCode({ code, data });
       if (setup != "") code.unshift(setup);

--- a/src/packages/frontend/frame-editors/latex-editor/errors-and-warnings.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/errors-and-warnings.tsx
@@ -190,7 +190,7 @@ interface ErrorsAndWarningsProps {
   is_fullscreen: boolean;
   project_id: string;
   path: string;
-  reload: number;
+  reload?: number;
   font_size: number;
 }
 

--- a/src/packages/frontend/frame-editors/latex-editor/pdfjs.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/pdfjs.tsx
@@ -40,7 +40,7 @@ interface PDFJSProps {
   is_fullscreen: boolean;
   project_id: string;
   path: string;
-  reload: number;
+  reload?: number;
   font_size: number;
   is_current: boolean;
   is_visible: boolean;
@@ -82,7 +82,7 @@ export function PDFJS({
   usePinchToZoom({ target: divRef });
 
   useEffect(() => {
-    loadDoc(reload);
+    loadDoc(reload ?? 0);
   }, [reload]);
 
   useEffect(() => {
@@ -152,7 +152,7 @@ export function PDFJS({
     }
     if (evt.key == "ArrowUp") {
       if (evt.ctrlKey || evt.metaKey) {
-        // begining of document
+        // beginning of document
         virtuosoRef.current?.scrollTo({ top: 0 });
       } else {
         virtuosoRef.current?.scrollBy({

--- a/src/packages/frontend/frame-editors/lean-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/lean-editor/editor.ts
@@ -48,7 +48,7 @@ const lean_info: EditorDescription = {
   short: "Info",
   name: "Info at Cursor", // more focused -- usually used in "tactic mode"
   icon: "info-circle",
-  component: LeanInfo,
+  component: LeanInfo as any, // TODO: rclass wrapper does not fit the EditorDescription type
   commands: set(["decrease_font_size", "increase_font_size"]),
 } as const;
 
@@ -57,7 +57,7 @@ const lean_messages: EditorDescription = {
   short: "Mesages",
   name: "All Messages" /* less focused -- usually used in "term mode" */,
   icon: "eye",
-  component: LeanMessages,
+  component: LeanMessages as any, // TODO: rclass wrapper does not fit the EditorDescription type
   commands: set(["decrease_font_size", "increase_font_size"]),
 } as const;
 
@@ -66,7 +66,7 @@ const lean_help: EditorDescription = {
   short: "Help",
   name: "Help at Cursor",
   icon: "question-circle",
-  component: LeanHelp,
+  component: LeanHelp as any, // TODO: rclass wrapper does not fit the EditorDescription type
   commands: set(["decrease_font_size", "increase_font_size"]),
 } as const;
 

--- a/src/packages/frontend/frame-editors/markdown-editor/rendered-markdown.tsx
+++ b/src/packages/frontend/frame-editors/markdown-editor/rendered-markdown.tsx
@@ -30,7 +30,7 @@ interface Props {
   project_id: string;
   font_size: number;
   read_only: boolean;
-  value: string;
+  value?: string;
   editor_state: EditorState;
   reload_images: boolean;
   is_current: boolean;
@@ -56,7 +56,7 @@ export const RenderedMarkdown: React.FC<Props> = React.memo((props: Props) => {
     path,
     project_id,
     font_size,
-    value,
+    value = "",
     editor_state,
     reload_images,
     is_current,

--- a/src/packages/frontend/frame-editors/sagews-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/sagews-editor/editor.ts
@@ -47,7 +47,7 @@ const cells: EditorDescription = {
   short: "Cells",
   name: "Cell Worksheet",
   icon: "minus-square",
-  component: CellWorksheet,
+  component: CellWorksheet as any, // TODO: rclass wrapper does not fit the EditorDescription type
   commands: worksheetCommands,
 } as const;
 
@@ -56,7 +56,7 @@ const document: EditorDescription = {
   short: "Document",
   name: "Document Worksheet",
   icon: "file-alt",
-  component: DocumentWorksheet,
+  component: DocumentWorksheet as any, // TODO: rclass wrapper does not fit the EditorDescription type
   commands: worksheetCommands,
 } as const;
 

--- a/src/packages/frontend/frame-editors/settings/editor.tsx
+++ b/src/packages/frontend/frame-editors/settings/editor.tsx
@@ -99,6 +99,6 @@ export const SETTINGS_SPEC: EditorDescription = {
   name: editor.editor_settings,
   icon: "wrench",
   commands: {},
-  component: Settings,
+  component: Settings as any, // TODO: Component incompatible with type, rewrite to React.FC
   hide_public: true,
 } as const;

--- a/src/packages/frontend/frame-editors/terminal-editor/terminal.tsx
+++ b/src/packages/frontend/frame-editors/terminal-editor/terminal.tsx
@@ -32,7 +32,7 @@ interface Props {
   font_size: number;
   editor_state: any;
   is_current: boolean;
-  terminal: Map<string, any>;
+  terminal?: Map<string, any>;
   desc: Map<string, any>;
   resize: number;
   is_visible: boolean;
@@ -185,7 +185,7 @@ export const TerminalFrame: React.FC<Props> = React.memo((props: Props) => {
     );
   }
 
-  const backgroundColor = background_color(props.terminal.get("color_scheme"));
+  const backgroundColor = background_color(props.terminal?.get("color_scheme"));
   /* 4px padding is consistent with CodeMirror */
 
   return (
@@ -201,7 +201,7 @@ export const TerminalFrame: React.FC<Props> = React.memo((props: Props) => {
         className={"smc-vfill"}
         style={{ backgroundColor, padding: "0 0 0 4px" }}
         onClick={() => {
-          // Focus on click, since otherwise, clicking right outside term defocuses,
+          // Focus on click, since otherwise, clicking right outside term de-focusses,
           // which is confusing.
           terminalRef.current?.focus();
         }}

--- a/src/packages/frontend/frame-editors/time-travel-editor/diff.tsx
+++ b/src/packages/frontend/frame-editors/time-travel-editor/diff.tsx
@@ -14,10 +14,11 @@ and it uses tables)  Codemirror automatically supports large documents, editor t
 so we build something on Codemirror instead
 */
 
-import { useEffect, useRef, MutableRefObject } from "react";
-import { debounce } from "lodash";
 import * as CodeMirror from "codemirror";
-import { Map } from "immutable";
+import { debounce } from "lodash";
+import { MutableRefObject, useEffect, useRef } from "react";
+
+import { AccountState } from "@cocalc/frontend/account/types";
 import { cm_options } from "../codemirror/cm-options";
 import { init_style_hacks } from "../codemirror/util";
 import { set_cm_line_diff } from "./diff-util";
@@ -26,7 +27,7 @@ interface Props {
   v0: string;
   v1: string;
   path: string; // filename of doc, which determines what sort of syntax highlighting to use.
-  editor_settings: Map<string, any>;
+  editor_settings: AccountState["editor_settings"];
   font_size: number;
   use_json: boolean;
 }

--- a/src/packages/frontend/frame-editors/time-travel-editor/sagews-diff.tsx
+++ b/src/packages/frontend/frame-editors/time-travel-editor/sagews-diff.tsx
@@ -4,18 +4,20 @@
  */
 
 /*
-This is just going to be a horible wrapper around the ancient complicated
+This is just going to be a horrible wrapper around the ancient complicated
 code to get this done for now.
 */
 
-import { debounce } from "lodash";
 import * as CodeMirror from "codemirror";
-import { Map } from "immutable";
-import { useEffect, useRef, MutableRefObject } from "react";
+import { debounce } from "lodash";
+import { MutableRefObject, useEffect, useRef } from "react";
+
+import { AccountState } from "@cocalc/frontend/account/types";
+import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 import { set_cm_line_diff } from "./diff-util";
+
 const { codemirror_editor } = require("../../editor");
 const { SynchronizedWorksheet } = require("../../sagews/sagews");
-import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
 
 interface Props {
   v0: string;
@@ -23,7 +25,7 @@ interface Props {
   path: string;
   project_id: string;
   font_size: number;
-  editor_settings: Map<string, any>;
+  editor_settings: AccountState["editor_settings"];
 }
 
 export function SagewsDiff(props: Props) {

--- a/src/packages/frontend/frame-editors/time-travel-editor/time-travel.tsx
+++ b/src/packages/frontend/frame-editors/time-travel-editor/time-travel.tsx
@@ -5,38 +5,40 @@
 
 // Time travel editor react component
 
-import { useEffect, useMemo, useState } from "react";
 import { Button, Checkbox, Space, Tooltip } from "antd";
 import { Map } from "immutable";
+import { debounce } from "lodash";
+import { useEffect, useMemo, useState } from "react";
+
+import { AccountState } from "@cocalc/frontend/account/types";
 import {
   redux,
-  useTypedRedux,
   useAsyncEffect,
   useEditorRedux,
+  useTypedRedux,
 } from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
-import { TimeTravelActions, TimeTravelState } from "./actions";
-import { Diff } from "./diff";
-import { NavigationButtons } from "./navigation-buttons";
-import { NavigationSlider } from "./navigation-slider";
-import { RangeSlider } from "./range-slider";
-import { Version, VersionRange } from "./version";
-import { GitAuthors, TimeTravelAuthors } from "./authors";
-import { LoadMoreHistory } from "./load-more-history";
-import { OpenFile } from "./open-file";
-import { RevertFile } from "./revert-file";
-import { ChangesMode } from "./changes-mode";
-import { OpenSnapshots } from "./open-snapshots";
-import { Export } from "./export";
+import ShowError from "@cocalc/frontend/components/error";
+import RequireLicense from "@cocalc/frontend/site-licenses/require-license";
+import useLicenses from "@cocalc/frontend/site-licenses/use-licenses";
+import type { Document } from "@cocalc/sync/editor/generic/types";
 import json_stable from "json-stable-stringify";
 import { to_ipynb } from "../../jupyter/history-viewer";
+import { TimeTravelActions, TimeTravelState } from "./actions";
+import { GitAuthors, TimeTravelAuthors } from "./authors";
+import { ChangesMode } from "./changes-mode";
+import { Diff } from "./diff";
+import { Export } from "./export";
+import { LoadMoreHistory } from "./load-more-history";
+import { NavigationButtons } from "./navigation-buttons";
+import { NavigationSlider } from "./navigation-slider";
+import { OpenFile } from "./open-file";
+import { OpenSnapshots } from "./open-snapshots";
+import { RangeSlider } from "./range-slider";
+import { RevertFile } from "./revert-file";
 import { SagewsDiff } from "./sagews-diff";
+import { Version, VersionRange } from "./version";
 import { HAS_SPECIAL_VIEWER, Viewer } from "./viewer";
-import type { Document } from "@cocalc/sync/editor/generic/types";
-import useLicenses from "@cocalc/frontend/site-licenses/use-licenses";
-import RequireLicense from "@cocalc/frontend/site-licenses/require-license";
-import ShowError from "@cocalc/frontend/components/error";
-import { debounce } from "lodash";
 
 interface Props {
   actions: TimeTravelActions;
@@ -45,7 +47,7 @@ interface Props {
   project_id: string;
   desc: Map<string, any>;
   font_size: number;
-  editor_settings: Map<string, any>;
+  editor_settings: AccountState["editor_settings"];
   resize: number;
   is_current: boolean;
   is_subframe: boolean;

--- a/src/packages/frontend/frame-editors/whiteboard-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/whiteboard-editor/editor.ts
@@ -41,7 +41,11 @@ export const whiteboardCommands = set([
   "chatgpt",
 ]);
 
-const whiteboard: EditorDescription = {
+type WhiteboardEditorDescription = Omit<EditorDescription, "component"> & {
+  component: React.FC<{ presentation: boolean }>;
+};
+
+const whiteboard: WhiteboardEditorDescription = {
   type: "whiteboard",
   short: "Whiteboard",
   name: "Whiteboard",

--- a/src/packages/frontend/frame-editors/whiteboard-editor/whiteboard.tsx
+++ b/src/packages/frontend/frame-editors/whiteboard-editor/whiteboard.tsx
@@ -1,24 +1,25 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+
 import { useEditorRedux } from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
+import useAutoHide from "@cocalc/frontend/components/use-auto-hide";
 import { State, elementsList } from "./actions";
 import Canvas from "./canvas";
+import KernelPanel from "./elements/code/kernel";
+import { useFrameContext, usePageInfo } from "./hooks";
+import NewPage from "./new-page";
+import StartSlideshowButton from "./start-slideshow";
+import CodePanel from "./tools/code";
+import EdgePanel from "./tools/edge";
+import FramePanel from "./tools/frame";
+import IconPanel from "./tools/icon";
+import NavigationPanel from "./tools/navigation";
+import NotePanel from "./tools/note";
 import ToolPanel from "./tools/panel";
 import PenPanel from "./tools/pen";
-import NotePanel from "./tools/note";
 import TextPanel from "./tools/text";
-import CodePanel from "./tools/code";
-import IconPanel from "./tools/icon";
 import TimerPanel from "./tools/timer";
-import FramePanel from "./tools/frame";
-import EdgePanel from "./tools/edge";
-import NavigationPanel from "./tools/navigation";
-import { useFrameContext, usePageInfo } from "./hooks";
 import Upload from "./tools/upload";
-import KernelPanel from "./elements/code/kernel";
-import NewPage from "./new-page";
-import useAutoHide from "@cocalc/frontend/components/use-auto-hide";
-import StartSlideshowButton from "./start-slideshow";
 
 interface Props {
   presentation?: boolean;

--- a/src/packages/frontend/frame-editors/x11-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/actions.ts
@@ -632,7 +632,10 @@ export class Actions extends BaseActions<X11EditorState> {
     });
   }
 
-  set_physical_keyboard(layout: string, variant: string): void {
+  set_physical_keyboard(
+    layout: string | undefined,
+    variant: string | undefined,
+  ): void {
     if (this.client == null) {
       // better to ignore if client isn't configured yet.
       // I saw this once when testing. (TODO: could be more careful.)

--- a/src/packages/frontend/frame-editors/x11-editor/x11.tsx
+++ b/src/packages/frontend/frame-editors/x11-editor/x11.tsx
@@ -7,27 +7,29 @@
 X11 Window frame.
 */
 
-import { Map, Set } from "immutable";
 import { delay } from "awaiting";
+import { Map, Set } from "immutable";
+import { debounce } from "lodash";
+
+import { AccountState } from "@cocalc/frontend/account/types";
 import {
+  React,
   ReactDOM,
   Rendered,
-  React,
   useEffect,
   useIsMountedRef,
-  useRef,
-  useRedux,
-  useTypedRedux,
-  usePrevious,
   useMemo,
-} from "../../app-framework";
-import { debounce } from "lodash";
-import { cmp, is_different } from "@cocalc/util/misc";
-import { Actions } from "./actions";
-import { WindowTab } from "./window-tab";
-import { TAB_BAR_GREY } from "./theme";
+  usePrevious,
+  useRedux,
+  useRef,
+  useTypedRedux,
+} from "@cocalc/frontend/app-framework";
 import { Loading } from "@cocalc/frontend/components";
 import { retry_until_success } from "@cocalc/util/async-utils";
+import { cmp, is_different } from "@cocalc/util/misc";
+import { Actions } from "./actions";
+import { TAB_BAR_GREY } from "./theme";
+import { WindowTab } from "./window-tab";
 
 interface Props {
   actions: Actions;
@@ -36,8 +38,8 @@ interface Props {
   desc: Map<string, any>;
   is_current: boolean;
   font_size: number;
-  reload: string;
-  editor_settings: Map<string, any>;
+  reload?: number;
+  editor_settings: AccountState["editor_settings"];
   resize: number;
 }
 
@@ -93,7 +95,7 @@ export const X11: React.FC<Props> = React.memo((props: Props) => {
     // keyboard layout change
     actions.set_physical_keyboard(
       editor_settings.get("physical_keyboard"),
-      editor_settings.get("keyboard_variant")
+      editor_settings.get("keyboard_variant"),
     );
   }, [
     editor_settings.get("physical_keyboard"),
@@ -169,7 +171,7 @@ export const X11: React.FC<Props> = React.memo((props: Props) => {
     // set keyboard layout
     actions.set_physical_keyboard(
       editor_settings.get("physical_keyboard"),
-      editor_settings.get("keyboard_variant")
+      editor_settings.get("keyboard_variant"),
     );
 
     return () => {
@@ -206,7 +208,9 @@ export const X11: React.FC<Props> = React.memo((props: Props) => {
     }
     try {
       client.insert_window_in_dom(wid, node);
-      await insert_children_in_dom(windows.getIn([wid, "children"], Set()) as any);
+      await insert_children_in_dom(
+        windows.getIn([wid, "children"], Set()) as any,
+      );
     } catch (err) {
       // window not available right now.
       is_loaded.current = false;
@@ -277,7 +281,7 @@ export const X11: React.FC<Props> = React.memo((props: Props) => {
           is_current={wid === desc.get("wid")}
           info={windows.get(wid)}
           actions={actions}
-        />
+        />,
       );
     }
     return v;

--- a/src/packages/frontend/frame-editors/x11-editor/xpra-client.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/xpra-client.ts
@@ -530,7 +530,10 @@ export class XpraClient extends EventEmitter {
     return await this.server.exec(opts);
   }
 
-  public set_physical_keyboard(layout: string, variant: string): void {
+  public set_physical_keyboard(
+    layout: string | undefined,
+    variant: string | undefined,
+  ): void {
     this.client.set_physical_keyboard(layout, variant);
   }
 }

--- a/src/packages/frontend/frame-editors/x11-editor/xpra/client.ts
+++ b/src/packages/frontend/frame-editors/x11-editor/xpra/client.ts
@@ -21,22 +21,22 @@
  * CoCalc Xpra Client
  */
 
-import { Surface, MAX_WIDTH, MAX_HEIGHT } from "./surface";
 import { getCapabilities } from "./capabilities";
-import { Keyboard } from "./keyboard";
-import { Mouse } from "./mouse";
 import { Connection } from "./connection";
 import { PING_FREQUENCY } from "./constants";
+import { Keyboard } from "./keyboard";
+import { Mouse } from "./mouse";
+import { MAX_HEIGHT, MAX_WIDTH, Surface } from "./surface";
 import {
   arraybufferBase64,
-  hexUUID,
   calculateDPI,
+  hexUUID,
   keyboardLayout,
   timestamp,
 } from "./util";
 
-import { EventEmitter } from "events";
 import { close } from "@cocalc/util/misc";
+import { EventEmitter } from "events";
 
 function createConfiguration(defaults = {}, append = {}) {
   return Object.assign(
@@ -67,7 +67,7 @@ function createConfiguration(defaults = {}, append = {}) {
       lz4: true,
     },
     defaults,
-    append
+    append,
   );
 }
 
@@ -214,7 +214,10 @@ export class Client {
     this.connection.open(this.config);
   }
 
-  public set_physical_keyboard(layout: string, variant: string): void {
+  public set_physical_keyboard(
+    layout: string | undefined,
+    variant: string | undefined,
+  ): void {
     if (!layout || layout === "default") {
       layout = keyboardLayout(); // really dumb heuristic
     }
@@ -284,7 +287,7 @@ export class Client {
     data,
     sequence,
     rowstride,
-    options = {}
+    options = {},
   ): void {
     const found = this.findSurface(wid);
     if (found) {
@@ -304,7 +307,7 @@ export class Client {
           level,
           args.map((str) => {
             return unescape(encodeURIComponent(String(str)));
-          })
+          }),
         );
       } else {
         const f = console[name];
@@ -343,7 +346,7 @@ export class Client {
           surface.rescale(
             scale,
             Math.round(width * 0.85),
-            Math.round(height * 0.85)
+            Math.round(height * 0.85),
           );
         }
       }
@@ -363,7 +366,7 @@ export class Client {
     bus.on("ws:open", () => {
       this.clientCapabilities = getCapabilities(
         this.config,
-        this.audioCodecs.codecs
+        this.audioCodecs.codecs,
       );
 
       this.send("hello", this.clientCapabilities);
@@ -431,14 +434,13 @@ export class Client {
         w: number,
         h: number,
         metadata,
-        properties
+        properties,
       ) => {
         this.lastActiveWindow = 0;
 
         const props = Object.assign({}, properties || {}, {
-          "encodings.rgb_formats": this.clientCapabilities[
-            "encodings.rgb_formats"
-          ],
+          "encodings.rgb_formats":
+            this.clientCapabilities["encodings.rgb_formats"],
         });
 
         this.send("map-window", wid, x, y, w, h, props);
@@ -470,7 +472,7 @@ export class Client {
         this.surfaces[wid] = surface;
 
         bus.emit("window:create", surface);
-      }
+      },
     );
 
     bus.on(
@@ -482,7 +484,7 @@ export class Client {
         w: number,
         h: number,
         metadata,
-        properties
+        properties,
       ) => {
         let parentWid: number | undefined = metadata["transient-for"];
         if (parentWid === undefined) {
@@ -529,7 +531,7 @@ export class Client {
 
         bus.emit("overlay:create", surface);
         this.lastActiveWindow = parentWid;
-      }
+      },
     );
 
     bus.on("lost-window", (wid: number) => {
@@ -591,7 +593,7 @@ export class Client {
           console.log("x11: only png icons currently supported");
           // TODO!
         }
-      }
+      },
     );
 
     bus.on(
@@ -601,7 +603,7 @@ export class Client {
         // when a different user views it.  Obviously the move doesn't matter, but
         // the resize does.
         this.console.log("x11: TODO -- window-move-resize", wid, x, y, w, h);
-      }
+      },
     );
 
     bus.on("startup-complete", () => {
@@ -615,7 +617,7 @@ export class Client {
         this.send(
           "layout-changed",
           this.layout,
-          this.variant ? this.variant : ""
+          this.variant ? this.variant : "",
         );
         // console.log("x11 startup-complete layout-changed:", this.layout, this.variant);
       }
@@ -631,7 +633,7 @@ export class Client {
           if (this.surfaces[wid] === undefined) {
             this.bus.emit(
               "window:destroy",
-              this.surfaces_before_disconnect[wid]
+              this.surfaces_before_disconnect[wid],
             );
           }
         }
@@ -657,7 +659,7 @@ export class Client {
         expire_timeout,
         icon,
         actions,
-        hints
+        hints,
       ) => {
         bus.emit("notification:create", nid, {
           replaces_nid,
@@ -668,7 +670,7 @@ export class Client {
           actions,
           hints,
         });
-      }
+      },
     );
 
     bus.on("notify_close", (notificationId) => {
@@ -682,7 +684,7 @@ export class Client {
         mime: string,
         print: boolean,
         size: number,
-        data: string
+        data: string,
       ) => {
         if (data.length !== size) {
           console.warn("Invalid file", filename, mime, size);
@@ -694,7 +696,7 @@ export class Client {
         } else {
           bus.emit("system:upload", { filename, mime, size }, data);
         }
-      }
+      },
     );
 
     // TODO: figure out args, etc.


### PR DESCRIPTION
This is motivated by the "font_size" vs. "fontSize" props name mismatch.

The core of this is defining [EditorComponentProps](https://github.com/sagemathinc/cocalc/pull/8347/files#diff-4910ac700fd2ff06cad945fd01e249c9440aeb9715f0c37077fb4372833ee8cfR146) and then using that in the "leaf" [right here](https://github.com/sagemathinc/cocalc/pull/8347/files#diff-d59b38ddda77b8fc9cab9ccadc7405ffa7194fb2155363145caea57c92ad4ec8R147) and [here](https://github.com/sagemathinc/cocalc/pull/8347/files#diff-4910ac700fd2ff06cad945fd01e249c9440aeb9715f0c37077fb4372833ee8cfR110). There are also details like defining `editor_settings: AccountState["editor_settings"];`…

everything else is more or less a fallout of that …

## testing

I just checked that editors still open up and show their content

- [x] jupyter notebook + slideshow frame
- [x] latex
- [x] csv
- [x] timetravel
- [x] code editor for python
- [x] x11
- [x] whiteboard 
- [x] rmarkdown
- [x] html
- [x] courses
- [x] chat
- [x] sagews