### PR TITLE
project/metrics: remove space character

### DIFF
--- a/src/packages/project/kucalc.ts
+++ b/src/packages/project/kucalc.ts
@@ -262,7 +262,7 @@ export function prometheus_metrics(project_id): string {
       `# TYPE ${P}_running_processes_total gauge`,
       `${P}_running_processes_total{${labels}} ${cs.processes?.count ?? 0}`,
       `# HELP ${P}_oom_kills_total`,
-      `# TYPE ${P}_oom_kills_total counter `,
+      `# TYPE ${P}_oom_kills_total counter`,
       `${P}_oom_kills_total{${labels}} ${cs.oom_kills ?? 0}`,
     ].join("\n") + "\n" // makes sure the response ends with a newline!
   );


### PR DESCRIPTION
This removes a space character. Newer prometheus versions are more picky... 

… and no need to make an update just for that.