### PR TITLE
github: test newer node versions, remove pinned 18.17.1

### DIFF
--- a/.github/workflows/make-and-test.yml
+++ b/.github/workflows/make-and-test.yml
@@ -65,7 +65,8 @@ jobs:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version:
-          - "18.17.1"
+          - "18"
+          - "20"
         pg-version:
           - "13.12"
           - "16"


### PR DESCRIPTION
node 22: fail