### PR TITLE
hub/proxy: better fix for c64c203d29f5d061d5b

### DIFF
--- a/src/packages/hub/proxy/handle-upgrade.ts
+++ b/src/packages/hub/proxy/handle-upgrade.ts
@@ -3,6 +3,7 @@
 import { createProxyServer, type ProxyServer } from "http-proxy-3";
 import LRU from "lru-cache";
 import { getEventListeners } from "node:events";
+
 import getLogger from "@cocalc/hub/logger";
 import stripRememberMeCookie from "./strip-remember-me-cookie";
 import { getTarget } from "./target";
@@ -74,11 +75,14 @@ export default function init(
     if (internal_url != null) {
       req.url = internal_url;
     }
-    if (cache.has(target)) {
-      dbg("using cache");
-      const proxy = cache.get(target)!;
-      proxy.ws(req, socket, head);
-      return;
+
+    {
+      const proxy = cache.get(target);
+      if (proxy != null) {
+        dbg("using cache");
+        proxy.ws(req, socket, head);
+        return;
+      }
     }
 
     dbg("target", target);


### PR DESCRIPTION
This is a better fix than c64c203d29f5d061d5b because between checking if a cache holds a value and then accessing it, node could interrupt and remove that item. It's low chance, but possible.

This way here, the cache proxy is definitely an object.

It's wrapped in brackets, because later in that function here is another proxy variable, just to avoid a clash.