### PR TITLE
conat/server: add prometheus metrics

### DIFF
--- a/src/packages/conat/core/server.ts
+++ b/src/packages/conat/core/server.ts
@@ -74,6 +74,7 @@ import { type SysConatServer, sysApiSubject, sysApi } from "./sys";
 import { forkedConatServer } from "./start-server";
 import { stickyChoice } from "./sticky";
 import { EventEmitter } from "events";
+import { Metrics } from "../types";
 
 const logger = getLogger("conat:core:server");
 
@@ -308,6 +309,10 @@ export class ConatServer extends EventEmitter {
       resource: RESOURCE,
       log: (...args) => this.log("usage", ...args),
     });
+  };
+
+  public getUsage = (): Metrics => {
+    return this.usage.getMetrics();
   };
 
   // this is for the Kubernetes health check -- I haven't
@@ -602,7 +607,9 @@ export class ConatServer extends EventEmitter {
       return;
     }
     if (!(await this.isAllowed({ user, subject, type: "sub" }))) {
-      const message = `permission denied subscribing to '${subject}' from ${JSON.stringify(user)}`;
+      const message = `permission denied subscribing to '${subject}' from ${JSON.stringify(
+        user,
+      )}`;
       this.log(message);
       throw new ConatError(message, {
         code: 403,
@@ -706,7 +713,9 @@ export class ConatServer extends EventEmitter {
     }
 
     if (!(await this.isAllowed({ user: from, subject, type: "pub" }))) {
-      const message = `permission denied publishing to '${subject}' from ${JSON.stringify(from)}`;
+      const message = `permission denied publishing to '${subject}' from ${JSON.stringify(
+        from,
+      )}`;
       this.log(message);
       throw new ConatError(message, {
         // this is the http code for permission denied, and having this
@@ -950,7 +959,9 @@ export class ConatServer extends EventEmitter {
           return;
         }
         if (!(await this.isAllowed({ user, subject, type: "pub" }))) {
-          const message = `permission denied waiting for interest in '${subject}' from ${JSON.stringify(user)}`;
+          const message = `permission denied waiting for interest in '${subject}' from ${JSON.stringify(
+            user,
+          )}`;
           this.log(message);
           respond({ error: message, code: 403 });
         }
@@ -1791,7 +1802,9 @@ export function updateSticky(update: StickyUpdate, sticky: Sticky): boolean {
 function getServerAddress(options: Options) {
   const port = options.port;
   const path = options.path?.slice(0, -"/conat".length) ?? "";
-  return `http${options.ssl || port == 443 ? "s" : ""}://${options.clusterIpAddress ?? "localhost"}:${port}${path}`;
+  return `http${options.ssl || port == 443 ? "s" : ""}://${
+    options.clusterIpAddress ?? "localhost"
+  }:${port}${path}`;
 }
 
 /*

--- a/src/packages/conat/types.ts
+++ b/src/packages/conat/types.ts
@@ -9,3 +9,8 @@ export interface Location {
 
   path?: string;
 }
+
+type EventType = "total" | "add" | "delete" | "deny";
+type ValueType = "count" | "limit";
+type MetricKey = `${EventType}:${ValueType}`;
+export type Metrics = { [K in MetricKey]?: number };

--- a/src/packages/server/conat/socketio/health.ts
+++ b/src/packages/server/conat/socketio/health.ts
@@ -3,27 +3,23 @@ Health check for use in Kubernetes.
 */
 
 import type { ConatServer } from "@cocalc/conat/core/server";
-import { conatClusterHealthPort } from "@cocalc/backend/data";
-import { createServer } from "http";
+import type { IncomingMessage, ServerResponse } from "http";
 import { getLogger } from "@cocalc/backend/logger";
 
 const logger = getLogger("conat:socketio:health");
 
-export async function health(server: ConatServer) {
-  logger.debug(
-    `starting /health socketio server on port ${conatClusterHealthPort}`,
-  );
-  const healthServer = createServer();
-  healthServer.listen(conatClusterHealthPort);
-  healthServer.on("request", (req, res) => {
-    if (req.method === "GET") {
-      if (server.isHealthy()) {
-        res.statusCode = 200;
-        res.end("healthy");
-      } else {
-        res.statusCode = 500;
-        res.end("Unhealthy");
-      }
-    }
-  });
+export function handleHealth(
+  server: ConatServer,
+  _req: IncomingMessage,
+  res: ServerResponse,
+) {
+  const healthy = server.isHealthy();
+  logger.debug("/health reporting conat is healthy=${healthy}");
+  if (healthy) {
+    res.statusCode = 200;
+    res.end("healthy");
+  } else {
+    res.statusCode = 500;
+    res.end("Unhealthy");
+  }
 }

--- a/src/packages/server/conat/socketio/metrics.ts
+++ b/src/packages/server/conat/socketio/metrics.ts
@@ -1,0 +1,58 @@
+/*
+Metrics endpoint for use in Kubernetes.
+*/
+
+import { delay } from "awaiting";
+import type { IncomingMessage, ServerResponse } from "http";
+import { Gauge, register } from "prom-client";
+
+import { getLogger } from "@cocalc/backend/logger";
+import type { ConatServer } from "@cocalc/conat/core/server";
+import { Metrics } from "@cocalc/conat/types";
+
+const logger = getLogger("conat:socketio:metrics");
+
+const DELAY_MS = 10_000;
+
+const usageMetric = new Gauge({
+  name: "cocalc_conat_usage",
+  help: "Conat server usage metrics",
+  labelNames: ["event", "value"],
+});
+
+// periodically grab the metrics and set the Gauge, avoids an event emitter callback memory leak
+export async function initMetrics(server: ConatServer) {
+  logger.debug("metrics endpoint initialized");
+
+  await delay(DELAY_MS);
+  while (server.state != "closed") {
+    try {
+      const usage: Metrics = server.getUsage();
+      if (usage) {
+        for (const [key, val] of Object.entries(usage)) {
+          const [event, value] = key.split(":");
+          usageMetric.set({ event, value }, val);
+        }
+      }
+    } catch (err) {
+      logger.debug(`WARNING: error retrieving metrics -- ${err}`);
+    }
+    await delay(DELAY_MS);
+  }
+}
+
+export async function handleMetrics(
+  _req: IncomingMessage,
+  res: ServerResponse,
+) {
+  try {
+    const metricsData = await register.metrics();
+    res.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+    res.statusCode = 200;
+    res.end(metricsData);
+  } catch (error) {
+    logger.error("Error getting metrics:", error);
+    res.statusCode = 500;
+    res.end("Internal server error");
+  }
+}


### PR DESCRIPTION
Ok, well, I'm not sure how to test this or what metrics to even expose. The idea is to start very simple:

1. a "vitals" http server is created in the "server.ts" and then metrics and health return their data if path and method match.
2. on conat's side, some metrics are stored in a map "metrics" to avoid a dependency on prometheus (it needs node.js).
3. periodically, that values are grabbed by the server and exposed in prometheus.