### PR TITLE
next/policies: revert dropping the VPAT policy date

### DIFF
--- a/src/packages/next/pages/policies/accessibility.tsx
+++ b/src/packages/next/pages/policies/accessibility.tsx
@@ -30,6 +30,7 @@ export default function AccessibilityPage({ customize }) {
               <h1 style={{ fontSize: "28pt" }}>
                 CoCalc Voluntary Product Accessibility Template (VPAT)
               </h1>
+              <h2>Last Updated: July 3, 2019</h2>
             </div>
             <div style={{ fontSize: "12pt", overflowX: "auto" }}>
               <Accessibility />


### PR DESCRIPTION
Reverts the change from commit 949b0c6b136061e29af6c22d5aeb66d6f9565378 that removed the "Last Updated" date from the VPAT page.

Fixes #8478
