### PR TITLE
project/info: cgroup v2 compatibility

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -20,6 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) and also Gemini CLI 
 - Some older code is JavaScript or CoffeeScript, which will be translated to TypeScript
 - Use ES modules (import/export) syntax, not CommonJS (require)
 - Organize the list of imports in such a way: installed npm packages are on top, newline, then are imports from @cocalc's code base. Sorted alphabetically.
+- **Backend Logging**: Use `getLogger` from `@cocalc/project/logger` for logging in backend code. Do NOT use `console.log`. Example: `const L = getLogger("module:name").debug;`
 
 ## Development Commands
 

--- a/src/packages/comm/project-status/utils.ts
+++ b/src/packages/comm/project-status/utils.ts
@@ -8,13 +8,28 @@ import type {
   DiskUsageInfo,
 } from "@cocalc/util/types/project-info/types";
 
-// DiskUsage for /tmp !
+/**
+ * Calculate resource usage statistics from cgroup data.
+ *
+ * This function processes cgroup resource information and calculates usage percentages
+ * for both memory and CPU. It works with both cgroup v1 and v2 data structures,
+ * handling the unified CGroup interface that abstracts the differences between versions.
+ */
 export function cgroup_stats(cg: CGroup, du?: DiskUsageInfo) {
-  // why? /tmp is a memory disk in kucalc
+  // DiskUsage for /tmp – add to memory usage since it's already been
+  // calculated appropriately by the backend based on whether /tmp is tmpfs
   const mem_rss = cg.mem_stat.total_rss + (du?.usage ?? 0);
   const mem_tot = cg.mem_stat.hierarchical_memory_limit;
-  const mem_pct = 100 * Math.min(1, mem_rss / mem_tot);
-  const cpu_pct = 100 * Math.min(1, cg.cpu_usage_rate / cg.cpu_cores_limit);
+
+  // Handle unlimited (-1) and zero memory limits to avoid division by zero
+  const mem_pct = mem_tot <= 0 ? 0 : 100 * Math.min(1, mem_rss / mem_tot);
+
+  // Handle unlimited (-1) and zero CPU limits to avoid division by zero
+  const cpu_pct =
+    cg.cpu_cores_limit <= 0
+      ? 0
+      : 100 * Math.min(1, cg.cpu_usage_rate / cg.cpu_cores_limit);
+
   const cpu_tot = cg.cpu_usage; // seconds
   return { mem_rss, mem_tot, mem_pct, cpu_pct, cpu_tot };
 }

--- a/src/packages/project/project-info/server.ts
+++ b/src/packages/project/project-info/server.ts
@@ -8,15 +8,21 @@ Project information server, doing the heavy lifting of telling the client
 about what's going on in a project.
 
 This is an event emitter that emits a ProjectInfo object periodically when running.
+
+One important aspect is that this avoids spawning subprocesses, which could be problematic
+if there is a limit on the number of processes that can be spawned, or memory pressure, etc.
 */
 
 import { delay } from "awaiting";
 import type { DiskUsage as DF_DiskUsage } from "diskusage";
 import { check as df } from "diskusage";
 import { EventEmitter } from "node:events";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
+
 import { ProcessStats } from "@cocalc/backend/process-stats";
 import { pidToPath as terminalPidToPath } from "@cocalc/project/conat/terminal/manager";
+import { getLogger } from "@cocalc/project/logger";
+import { get_path_for_pid as x11_pid2path } from "@cocalc/project/x11/server";
 import type {
   CGroup,
   CoCalcInfo,
@@ -25,12 +31,42 @@ import type {
   Processes,
   ProjectInfo,
 } from "@cocalc/util/types/project-info/types";
-import { get_path_for_pid as x11_pid2path } from "../x11/server";
-import { getLogger } from "../logger";
 
 const L = getLogger("project-info:server").debug;
 
 const bytes2MiB = (bytes) => bytes / (1024 * 1024);
+
+/**
+ * Detect if /tmp is mounted as tmpfs (memory-based filesystem) by reading /proc/mounts.
+ * Returns true if /tmp is tmpfs, false otherwise.
+ */
+async function isTmpMemoryBased(): Promise<boolean> {
+  try {
+    const mounts = await readFile("/proc/mounts", "utf8");
+    // Look for lines like: "tmpfs /tmp tmpfs rw,nosuid,nodev,noexec,relatime,size=1024000k 0 0"
+    const tmpfsPattern = /^\S+\s+\/tmp\s+tmpfs\s/m;
+    return tmpfsPattern.test(mounts);
+  } catch (error) {
+    L("Failed to read /proc/mounts, assuming /tmp is disk-based:", error);
+    return false; // Default to safer assumption for development environments
+  }
+}
+
+/**
+ * Safely read a file, returning null if the file doesn't exist.
+ * Throws for other errors.
+ */
+async function safeReadFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error: any) {
+    if (error.code === "ENOENT") {
+      console.warn(`safeReadFile: ${path} not found, skipping`);
+      return null;
+    }
+    throw error;
+  }
+}
 
 export class ProjectInfoServer extends EventEmitter {
   private last?: ProjectInfo = undefined;
@@ -38,14 +74,18 @@ export class ProjectInfoServer extends EventEmitter {
   private running = false;
   private readonly testing: boolean;
   private delay_s: number;
+  private tmpIsMemoryBased?: boolean;
   private cgroupFilesAreMissing: boolean = false;
   private processStats: ProcessStats;
+  private cgroupVersion: "v1" | "v2" | "unknown" | null;
 
   constructor(testing = false) {
     super();
     this.delay_s = 2;
     this.testing = testing;
     this.dbg = L;
+    // cgroup version will be detected lazily
+    this.cgroupVersion = null;
   }
 
   private async processes(timestamp: number) {
@@ -107,12 +147,66 @@ export class ProjectInfoServer extends EventEmitter {
     }
   }
 
-  // this is specific to running a project in a CGroup container
-  // Harald: however, even without a container this shouldn't fail … just tells
-  // you what the whole system is doing, all your processes.
-  // William: it's constantly failing in cocalc-docker every second, so to avoid
-  // clogging logs and wasting CPU, if the files are missing once, it stops updating.
+  /**
+   * Detect cgroup version lazily.
+   * Fine to run once, since the cgroup version won't change during the process lifetime.
+   */
+  private async detectCGroupVersion(): Promise<"v1" | "v2" | "unknown" | null> {
+    if (this.cgroupVersion !== null) {
+      return this.cgroupVersion;
+    }
+
+    try {
+      // Check for v2-specific file
+      await access("/sys/fs/cgroup/cgroup.controllers");
+      this.cgroupVersion = "v2";
+    } catch (error: any) {
+      if (error.code === "ENOENT") {
+        // File doesn't exist, so likely v1
+        this.cgroupVersion = "v1";
+      } else {
+        // Other errors (e.g., permissions): treat as unknown
+        console.error("Error detecting cgroup version:", error);
+        this.cgroupVersion = "unknown";
+      }
+    }
+
+    L(`detected cgroup version: ${this.cgroupVersion}`);
+    return this.cgroupVersion;
+  }
+
+  /**
+   * Collect cgroup resource usage information.
+   * This is specific to running a project in a CGroup container.
+   * Harald: however, even without a container this shouldn't fail … just tells
+   * you what the whole system is doing, all your processes.
+   * William: it's constantly failing in cocalc-docker every second, so to avoid
+   * clogging logs and wasting CPU, if the files are missing once, it stops updating.
+   */
   private async cgroup({ timestamp }): Promise<CGroup | undefined> {
+    const version = await this.detectCGroupVersion();
+    switch (version) {
+      case "v1":
+        return this.cgroupV1({ timestamp });
+      case "v2":
+        return this.cgroupV2({ timestamp });
+      default:
+        this.dbg("cgroup: unknown version, skipping");
+        return undefined;
+    }
+  }
+
+  /**
+   * Collect cgroup v1 resource usage information.
+   *
+   * cgroup v1 uses separate hierarchies for different resource controllers:
+   * - /sys/fs/cgroup/memory/memory.stat - memory statistics
+   * - /sys/fs/cgroup/cpu,cpuacct/cpuacct.usage - CPU usage in nanoseconds
+   * - /sys/fs/cgroup/memory/memory.oom_control - OOM kill information
+   * - /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us - CPU quota
+   * - /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us - CPU period
+   */
+  private async cgroupV1({ timestamp }): Promise<CGroup | undefined> {
     if (this.cgroupFilesAreMissing) {
       return;
     }
@@ -152,15 +246,19 @@ export class ProjectInfoServer extends EventEmitter {
         .split("\n")
         .filter((val) => val.startsWith("oom_kill "))
         .map((val) => parseInt(val.slice("oom_kill ".length)))[0];
+
+      // Handle unlimited CPU quota (-1) correctly
+      const cpu_cores_limit = cfs_quota === -1 ? -1 : cfs_quota / cfs_period;
+
       return {
         mem_stat,
         cpu_usage,
         cpu_usage_rate,
-        cpu_cores_limit: cfs_quota / cfs_period,
+        cpu_cores_limit,
         oom_kills,
       };
     } catch (err) {
-      this.dbg("cgroup: error", err);
+      this.dbg("cgroup v1: error", err);
       if (err.code == "ENOENT") {
         // TODO: instead of shutting this down, we could maybe do a better job
         // figuring out what the correct cgroups files are on a given system.
@@ -168,7 +266,223 @@ export class ProjectInfoServer extends EventEmitter {
         // but I do have /sys/fs/cgroup/memory.stat
         this.cgroupFilesAreMissing = true;
         this.dbg(
-          "cgroup: files are missing so cgroups info will no longer be updated",
+          "cgroup v1: files are missing so cgroups info will no longer be updated",
+        );
+      }
+      return undefined;
+    }
+  }
+
+  /**
+   * Get the current process's cgroup path for v2.
+   */
+  private async getCgroupV2Path(): Promise<string> {
+    try {
+      const cgroupData = await readFile("/proc/self/cgroup", "utf8");
+      // v2 format: "0::/path/to/cgroup"
+      const match = cgroupData.match(/^0::(.+)$/m);
+      if (match) {
+        return `/sys/fs/cgroup${match[1]}`;
+      }
+    } catch (error) {
+      console.warn("Failed to read /proc/self/cgroup, using root cgroup");
+    }
+    return "/sys/fs/cgroup";
+  }
+
+  /**
+   * Get system total memory from /proc/meminfo as fallback.
+   */
+  private async getSystemTotalMemory(): Promise<number> {
+    try {
+      const meminfo = await safeReadFile("/proc/meminfo");
+      if (meminfo) {
+        const match = meminfo.match(/^MemTotal:\s+(\d+)\s+kB$/m);
+        if (match) {
+          return parseInt(match[1]) / 1024; // Convert kB to MiB
+        }
+      }
+    } catch (error) {
+      console.warn("Failed to read system memory info:", error);
+    }
+    return -1; // Fallback to unlimited if can't read
+  }
+
+  /**
+   * Get system CPU core count from /proc/cpuinfo as fallback.
+   */
+  private async getSystemCpuCores(): Promise<number> {
+    try {
+      const cpuinfo = await safeReadFile("/proc/cpuinfo");
+      if (cpuinfo) {
+        const processors = cpuinfo.match(/^processor\s*:/gm);
+        return processors ? processors.length : -1;
+      }
+    } catch (error) {
+      console.warn("Failed to read system CPU info:", error);
+    }
+    return -1; // Fallback to unlimited if can't read
+  }
+
+  /**
+   * Collect cgroup v2 resource usage information.
+   *
+   * cgroup v2 uses a unified hierarchy with process-specific paths:
+   * - {cgroup_path}/memory.stat - comprehensive memory statistics
+   * - {cgroup_path}/cpu.stat - CPU usage statistics in microseconds
+   * - {cgroup_path}/memory.events - memory events including OOM kills
+   * - {cgroup_path}/cpu.max - CPU limits in "quota period" format
+   * - {cgroup_path}/memory.max - memory limit in bytes or "max"
+   *
+   * Memory stat mapping from v2 to v1 equivalent:
+   * - anon: Anonymous memory (private memory, roughly equivalent to v1 total_rss)
+   * - file: Page cache memory (file-backed memory)
+   * - kernel: Kernel memory usage
+   * - slab: Kernel slab memory (reclaimable + unreclaimable)
+   * - total_cache equivalent: file + slab (approximates v1 cached memory)
+   *
+   * ## Testing different cgroup environments
+   *
+   * ### Container with limits (CoCalc production scenario):
+   * ```bash
+   * # Test memory and CPU limits
+   * docker run --rm --memory=512m --cpus=0.5 ubuntu:24.04 sh -c "
+   *   cat /proc/self/cgroup                 # Shows: 0::/
+   *   cat /sys/fs/cgroup/memory.max         # Shows: 536870912 (512MB in bytes)
+   *   cat /sys/fs/cgroup/cpu.max            # Shows: 50000 100000 (0.5 cores)
+   *   cat /sys/fs/cgroup/memory.events      # Shows: low 0, high 0, max 0, oom 0, oom_kill 0, oom_group_kill 0
+   * "
+   * ```
+   *
+   * ### Container without limits:
+   * ```bash
+   * docker run --rm ubuntu:24.04 sh -c "
+   *   cat /proc/self/cgroup                 # Shows: 0::/
+   *   cat /sys/fs/cgroup/memory.max         # Shows: max
+   *   cat /sys/fs/cgroup/cpu.max            # Shows: max 100000
+   * "
+   * ```
+   *
+   * ### Host system (development environment):
+   * ```bash
+   * cat /proc/self/cgroup                   # Shows: 0::/user.slice/user-1000.slice/...
+   * # Files exist in /sys/fs/cgroup/user.slice/... but typically show unlimited values
+   * # System fallback examples:
+   * cat /proc/meminfo | head -1             # MemTotal: 32585044 kB
+   * grep -c "^processor" /proc/cpuinfo      # 8 (CPU cores)
+   * ```
+   *
+   * Expected file formats:
+   * - memory.max: "536870912" (bytes) or "max" (unlimited)
+   * - cpu.max: "50000 100000" (quota period) or "max 100000" (unlimited)
+   * - memory.events: "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0"
+   * - cpu.stat: "usage_usec 1234567\n..." (usage in microseconds)
+   * - memory.stat: "anon 12345\nfile 67890\nkernel 111\nslab 222\n..." (values in bytes)
+   */
+  private async cgroupV2({ timestamp }): Promise<CGroup | undefined> {
+    if (this.cgroupFilesAreMissing) {
+      return;
+    }
+    try {
+      const cgroupPath = await this.getCgroupV2Path();
+
+      const [
+        mem_stat_raw,
+        cpu_stat_raw,
+        mem_events_raw,
+        cpu_max_raw,
+        mem_max_raw,
+      ] = await Promise.all([
+        safeReadFile(`${cgroupPath}/memory.stat`),
+        safeReadFile(`${cgroupPath}/cpu.stat`),
+        safeReadFile(`${cgroupPath}/memory.events`),
+        safeReadFile(`${cgroupPath}/cpu.max`),
+        safeReadFile(`${cgroupPath}/memory.max`),
+      ]);
+
+      // Parse memory.stat - extract key memory statistics
+      // These keys provide the most relevant memory usage information
+      const mem_stat_keys = ["anon", "file", "kernel", "slab"];
+      const mem_stat = mem_stat_raw
+        ? mem_stat_raw
+            .split("\n")
+            .map((line) => line.split(" "))
+            .filter(([k, _]) => mem_stat_keys.includes(k))
+            .reduce((stat, [key, val]) => {
+              stat[key] = bytes2MiB(parseInt(val));
+              return stat;
+            }, {})
+        : {};
+
+      // For compatibility with v1 interface, map v2 stats to v1 equivalents:
+      // - total_rss: Anonymous memory (private/process memory)
+      mem_stat["total_rss"] = mem_stat["anon"] || 0;
+      // - total_cache: File cache + kernel slab memory (shared/cached memory)
+      mem_stat["total_cache"] =
+        (mem_stat["file"] || 0) + (mem_stat["slab"] || 0);
+
+      // - hierarchical_memory_limit: Memory limit from memory.max, with system fallback
+      const mem_max_value = mem_max_raw?.trim();
+      if (mem_max_value === "max" || !mem_max_value) {
+        // Use system total memory as fallback when cgroup limit is unlimited
+        mem_stat["hierarchical_memory_limit"] =
+          await this.getSystemTotalMemory();
+      } else {
+        mem_stat["hierarchical_memory_limit"] = bytes2MiB(
+          parseInt(mem_max_value),
+        );
+      }
+
+      // Parse cpu.stat - extract CPU usage in microseconds, convert to seconds
+      // v2 provides usage_usec (microseconds) vs v1 which provides nanoseconds
+      const cpu_usage_match = cpu_stat_raw?.match(/usage_usec (\d+)/);
+      const cpu_usage = cpu_usage_match
+        ? parseFloat(cpu_usage_match[1]) / 1000000
+        : 0;
+
+      // Calculate CPU usage rate
+      const dt = this.dt(timestamp);
+      const cpu_usage_rate =
+        this.last?.cgroup != null
+          ? (cpu_usage - this.last.cgroup.cpu_usage) / dt
+          : 0;
+
+      // Parse memory.events for OOM kills
+      const oom_kill_match = mem_events_raw?.match(/oom_kill (\d+)/);
+      const oom_kills = oom_kill_match ? parseInt(oom_kill_match[1]) : 0;
+
+      // Parse cpu.max for CPU limit, with system fallback
+      // v2 format: "quota period" (e.g., "50000 100000" = 0.5 cores) or "max" for unlimited
+      // v1 uses separate files: cpu.cfs_quota_us and cpu.cfs_period_us
+      const cpu_max_parts = cpu_max_raw?.trim().split(" ");
+      let cpu_cores_limit = -1; // -1 indicates unlimited
+      if (
+        cpu_max_parts &&
+        cpu_max_parts[0] !== "max" &&
+        cpu_max_parts.length >= 2
+      ) {
+        const quota = parseInt(cpu_max_parts[0]);
+        const period = parseInt(cpu_max_parts[1]);
+        cpu_cores_limit = quota / period;
+      } else {
+        // Use system CPU core count as fallback when cgroup limit is unlimited
+        cpu_cores_limit = await this.getSystemCpuCores();
+      }
+
+      return {
+        mem_stat,
+        cpu_usage,
+        cpu_usage_rate,
+        cpu_cores_limit,
+        oom_kills,
+      };
+    } catch (err) {
+      this.dbg("cgroupV2: error", err);
+      if (err.code == "ENOENT") {
+        // Mark files as missing to avoid repeated failed attempts
+        this.cgroupFilesAreMissing = true;
+        this.dbg(
+          "cgroupV2: files are missing so cgroups info will no longer be updated",
         );
       }
       return undefined;
@@ -191,7 +505,16 @@ export class ProjectInfoServer extends EventEmitter {
       df("/tmp"),
       df(process.env.HOME ?? "/home/user"),
     ]);
-    return { tmp: convert(tmp), project: convert(project) };
+
+    const tmpData = convert(tmp);
+
+    // If /tmp is not tmpfs (memory-based), don't count its disk usage toward memory
+    // since cgroup_stats adds disk_usage.tmp.usage to memory calculations
+    if (this.tmpIsMemoryBased === false) {
+      tmpData.usage = 0;
+    }
+
+    return { tmp: tmpData, project: convert(project) };
   }
 
   // orchestrating where all the information is bundled up for an update
@@ -240,6 +563,9 @@ export class ProjectInfoServer extends EventEmitter {
     if (this.running) {
       throw Error("Cannot start ProjectInfoServer twice");
     }
+
+    // Initialize tmpfs detection once at startup
+    this.tmpIsMemoryBased = await isTmpMemoryBased();
     this.running = true;
     this.processStats = new ProcessStats({
       testing: this.testing,

--- a/src/packages/project/project-status/server.ts
+++ b/src/packages/project/project-status/server.ts
@@ -15,14 +15,10 @@ status updates.
 Hence in particular, information like cpu, memory and disk are smoothed out and throttled.
 */
 
-import { getLogger } from "@cocalc/project/logger";
-import { how_long_ago_m, round1 } from "@cocalc/util/misc";
-import { version as smcVersion } from "@cocalc/util/smc-version";
 import { delay } from "awaiting";
 import { EventEmitter } from "events";
 import { isEqual } from "lodash";
-import { get_ProjectInfoServer, ProjectInfoServer } from "../project-info";
-import { ProjectInfo } from "@cocalc/util/types/project-info/types";
+
 import {
   ALERT_DISK_FREE,
   ALERT_HIGH_PCT /* ALERT_MEDIUM_PCT */,
@@ -38,6 +34,11 @@ import {
 import { cgroup_stats } from "@cocalc/comm/project-status/utils";
 import { createPublisher } from "@cocalc/conat/project/project-status";
 import { compute_server_id, project_id } from "@cocalc/project/data";
+import { getLogger } from "@cocalc/project/logger";
+import { how_long_ago_m, round1 } from "@cocalc/util/misc";
+import { version as smcVersion } from "@cocalc/util/smc-version";
+import { ProjectInfo } from "@cocalc/util/types/project-info/types";
+import { get_ProjectInfoServer, ProjectInfoServer } from "../project-info";
 
 // TODO: only return the "next" value, if it is significantly different from "prev"
 //function threshold(prev?: number, next?: number): number | undefined {


### PR DESCRIPTION
## Add cgroup v2 compatibility to project monitoring

### Summary
This PR implements comprehensive cgroup v2 support for CoCalc project monitoring, ensuring accurate resource usage reporting across different deployment environments (containers vs development setups).

### Key Changes

#### 🔧 **Core cgroup v2 Implementation** (`src/packages/project/project-info/server.ts`)
- **Added cgroup v2 detection and parsing** with automatic fallback to v1, by checking if a file for v2 exists
- **Process-specific cgroup path resolution** via `/proc/self/cgroup` parsing to handle systemd user slices. This is relevant, if a the project runs as sub-process, with a slice of resources of the parent cgroup (or something like that, I'm not 100% sure)
   - e.g.  if I run the cocalc project server via `systemd-run --uid=$USER --unit=cocalc --scope -p MemoryMax=10G -p CPUQuota=200%`, the cgroup slice has a path: `0::/system.slice/cocalc.scope`, and quotas are specific to this group. e.g. `/sys/fs/cgroup/system.slice/cocalc.scope/memory.max` → `10737418240`
- **System resource fallbacks** when cgroup limits are unlimited (reads `/proc/meminfo` and `/proc/cpuinfo`). This will show the total memory and cpu cores, essentially only relevant for local dev or un-containerized deployments.
- **tmpfs detection** for `/tmp` filesystem to correctly handle memory vs disk usage calculations. This is relevant, if `/tmp` is not mapped in memory, but on a regular disk.

#### 🐛 **Critical Bug Fixes**
- **Fixed ENOENT errors** when reading cgroup files by using process-specific paths instead of hardcoded root paths
- **Fixed memory calculation overflow**
- **Cross-environment compatibility** between development (host) and production (container) environments
- **Comprehensive error handling** with graceful degradation when cgroup files are missing

#### 🧹 **Code Quality ** 
- **Added comprehensive JSDoc documentation** with Docker testing examples

### Impact
- Eliminates memory reporting showing 100% usage incorrectly
- Provides accurate resource monitoring for project management
- Ensures compatibility with future Kubernetes cgroup v2 migration
- Maintains backward compatibility with existing cgroup v1 systems

## Testing

I was only able to test this for v2 cgroups, and without cgroups. However, since there is a detection for v1, which will work in kucalc, and almost no changes to the v1 processing, it should be fine. This ran in one of my projects in kucalc:

```
> try { await fs.access("/sys/fs/cgroup/cgroup.controllers") } catch (e) { console.log(e.code === "ENOENT") }
true
```

## Deployment