### PR TITLE
Frontend: processes vertical size

### DIFF
--- a/src/packages/frontend/cspell.json
+++ b/src/packages/frontend/cspell.json
@@ -70,7 +70,11 @@
     "flyouts",
     "buttonbar",
     "noconf",
-    "flyoutdragbar"
+    "flyoutdragbar",
+    "ptree",
+    "pchildren",
+    "nprocs",
+    "pids"
   ],
   "flagWords": [],
   "ignorePaths": ["node_modules/**", "dist/**", "dist-ts/**", "build/**"],

--- a/src/packages/frontend/project/context.tsx
+++ b/src/packages/frontend/project/context.tsx
@@ -32,6 +32,7 @@ export interface ProjectContextState {
   actions?: ProjectActions;
   active_project_tab?: string;
   compute_image: string | undefined;
+  contentSize: { width: number; height: number };
   enabledLLMs: LLMServicesAvailable;
   flipTabs: [number, React.Dispatch<React.SetStateAction<number>>];
   group?: UserGroup;
@@ -47,22 +48,15 @@ export interface ProjectContextState {
   onCoCalcDocker: boolean;
   project_id: string;
   project?: Project;
+  setContentSize: (size: { width: number; height: number }) => void;
   status: ProjectStatus;
 }
 
 export const emptyProjectContext = {
   actions: undefined,
   active_project_tab: undefined,
-  group: undefined,
-  project: undefined,
-  is_active: false,
-  project_id: "",
-  isRunning: undefined,
-  status: INIT_PROJECT_STATE,
-  hasInternet: undefined,
-  flipTabs: [0, () => {}],
-  onCoCalcCom: true,
-  onCoCalcDocker: false,
+  compute_image: undefined,
+  contentSize: { width: 0, height: 0 },
   enabledLLMs: {
     openai: false,
     google: false,
@@ -72,12 +66,22 @@ export const emptyProjectContext = {
     custom_openai: false,
     user: false,
   },
+  flipTabs: [0, () => {}],
+  group: undefined,
+  hasInternet: undefined,
+  is_active: false,
+  isRunning: undefined,
   mainWidthPx: 0,
   manageStarredFiles: {
     starred: [],
     setStarredPath: () => {},
   },
-  compute_image: undefined,
+  onCoCalcCom: true,
+  onCoCalcDocker: false,
+  project: undefined,
+  project_id: "",
+  setContentSize: () => {},
+  status: INIT_PROJECT_STATE,
 } as ProjectContextState;
 
 export const ProjectContext: Context<ProjectContextState> =
@@ -141,10 +145,13 @@ export function useProjectContextProvider({
     userDefinedLLM,
   ]);
 
+  const [contentSize, setContentSize] = useState({ width: 0, height: 0 });
+
   return {
     actions,
     active_project_tab,
     compute_image,
+    contentSize,
     enabledLLMs,
     flipTabs,
     group,
@@ -157,6 +164,7 @@ export function useProjectContextProvider({
     onCoCalcDocker,
     project_id,
     project,
+    setContentSize,
     status,
   };
 }

--- a/src/packages/frontend/project/info/project-info.tsx
+++ b/src/packages/frontend/project/info/project-info.tsx
@@ -3,6 +3,8 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
+// cSpell:ignore chldsum
+
 import { Alert } from "antd";
 
 import { cgroup_stats } from "@cocalc/comm/project-status/utils";
@@ -132,7 +134,7 @@ export const ProjectInfo: React.FC<Props> = React.memo(
           set_have_children(pchildren);
           break;
         case "flyout":
-          // flyout does not nest children, not enogh space
+          // flyout does not nest children, not enough space
           set_ptree(linearList(info.processes));
           break;
         default:


### PR DESCRIPTION
Dynamically compute the height/width of the process tree in the "full" processes table.

To do this, this PR adds a "contentSize" to the ProjectContext. This could be useful in other situations as well!

<img width="1380" height="1086" alt="Screenshot from 2025-08-18 11-41-24" src="https://github.com/user-attachments/assets/3ffac4fe-4fc4-4a42-b5a9-8782a1ef602b" />
