### PR TITLE
frontend/compute-servers: filter out arm64 based on name

### DIFF
--- a/src/packages/util/db-schema/compute-servers.ts
+++ b/src/packages/util/db-schema/compute-servers.ts
@@ -251,6 +251,18 @@ for (const state of ORDERED_STATES) {
   n += 1;
 }
 
+// Helper function to determine the architecture of a machine type
+export function getMachineTypeArchitecture(machineType: string): Architecture {
+  const v = machineType.split("-");
+  if (v[0].endsWith("a")) {
+    // The known machines with ARM are: t2a-, c4a-
+    // Everything else ends with a number or d.
+    // Hopefully this pattern persists.
+    return "arm64";
+  }
+  return "x86_64";
+}
+
 export function getArchitecture(configuration: Configuration): Architecture {
   if (configuration.cloud == "onprem") {
     return configuration.arch ?? "x86_64";
@@ -260,14 +272,7 @@ export function getArchitecture(configuration: Configuration): Architecture {
     return "x86_64";
   }
   const { machineType } = configuration;
-  const v = machineType.split("-");
-  if (v[0].endsWith("a")) {
-    // The known machines with are are: t2a-, c4a-
-    // Everything else ends with a number or d.
-    // Hopefully this pattern persists.
-    return "arm64";
-  }
-  return "x86_64";
+  return getMachineTypeArchitecture(machineType);
 }
 
 function supportsSuspend(configuration: Configuration) {


### PR DESCRIPTION
fixes #8519

The idea is to extract the `getMachineTypeArchitecture` heuristic (something based on name) from the utils package → then use that check for filtering the `machineType` name (not the config)

screenshots or didn't happen:

## searching for t2a

arm has them

<img width="659" height="280" alt="Screenshot from 2025-08-20 15-42-31" src="https://github.com/user-attachments/assets/1a91a441-6f71-48a6-b0e6-e5e2881d21bf" />

but x84 don't

<img width="663" height="195" alt="Screenshot from 2025-08-20 15-42-17" src="https://github.com/user-attachments/assets/d5ca62a2-b911-4e3b-88bc-5988f6540584" />


