### PR TITLE
jupyter: ignore non-standard messages from Colab kernel 

### DIFF
--- a/src/packages/jupyter/execute/output-handler.ts
+++ b/src/packages/jupyter/execute/output-handler.ts
@@ -182,6 +182,9 @@ export class OutputHandler extends EventEmitter {
     delete mesg.code;
     delete mesg.status;
     delete mesg.source;
+    // Colab sends non-standard messages like {"request":{"delayMillis":500}}
+    // Let's ignore them https://github.com/sagemathinc/cocalc/issues/8460
+    delete mesg.request;
     for (const k in mesg) {
       const v = mesg[k];
       if (is_object(v) && len(v) === 0) {


### PR DESCRIPTION
this fixes #8460 by just dropping that type of non-standard message