### PR TITLE
next/share: insert noindex and nofollow meta tags for github, gist and unlisted pages

### DIFF
--- a/src/packages/next/lib/share/proxy/get-public-path.ts
+++ b/src/packages/next/lib/share/proxy/get-public-path.ts
@@ -115,8 +115,8 @@ export default async function getProxyPublicPath({
 
   const now = new Date();
   await pool.query(
-    "INSERT INTO public_paths (id, url, project_id, path, description, last_edited, last_saved, created) VALUES($1, $2, $3, $4, $5, $6, $7, $8)",
-    [id, publicPathUrl, project_id, path, description, now, now, now],
+    "INSERT INTO public_paths (id, url, project_id, path, description, last_edited, last_saved, created, unlisted) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+    [id, publicPathUrl, project_id, path, description, now, now, now, true],
   );
   return {
     id,

--- a/src/packages/next/pages/share/public_paths/[...id].tsx
+++ b/src/packages/next/pages/share/public_paths/[...id].tsx
@@ -19,23 +19,30 @@ export default (props: PublicPathProps) => (
   <>
     <PublicPath {...props} />
     <NextHead>
-      <meta property="og:type" content="article"/>
-      <meta property="og:title" content={props.path}/>
+      <meta property="og:type" content="article" />
+      <meta property="og:title" content={props.path} />
 
       {props.description && (
-        <meta property="og:description" content={props.description}/>
+        <meta property="og:description" content={props.description} />
       )}
-      {props.ogUrl && (
-        <meta property="og:url" content={props.ogUrl}/>
-      )}
-      {props.ogImage && (
-        <meta property="og:image" content={props.ogImage}/>
-      )}
+      {props.ogUrl && <meta property="og:url" content={props.ogUrl} />}
+      {props.ogImage && <meta property="og:image" content={props.ogImage} />}
       {props.created && (
-        <meta property="article:published_time" content={props.created}/>
+        <meta property="article:published_time" content={props.created} />
       )}
       {props.last_edited && (
-        <meta property="article:modified_time" content={props.last_edited}/>
+        <meta property="article:modified_time" content={props.last_edited} />
+      )}
+
+      {/* Prevent search engine indexing of unlisted content or proxied content from external URLs */}
+      {(props.unlisted ||
+        (props.url &&
+          (props.url.startsWith("github/") ||
+            props.url.startsWith("gist/")))) && (
+        <>
+          <meta name="robots" content="noindex, nofollow" />
+          <meta name="googlebot" content="noindex, nofollow" />
+        </>
       )}
     </NextHead>
   </>
@@ -81,7 +88,8 @@ export async function getServerSideProps(context) {
 
       // Add image path for social media sharing
       //
-      customize.props.ogImage = customize.props.customize.logoSquareURL ||
+      customize.props.ogImage =
+        customize.props.customize.logoSquareURL ||
         `${customize.props.customize.siteURL}${ogShareLogo.src}`;
     }
 


### PR DESCRIPTION
* this should fix #8587
* my only issue is, when testing this locally I get a 404 page for github content. But from the prod database I do know, that these "url" start with github/ or gist/
* additionally, when the `getProxyPublicPath()` function creates an entry, it sets the "unlisted" parameter to true. In prod, that field is null.

