### PR TITLE
frontend/latex/pdf-watcher: wrong directory fallback for $HOME

### DIFF
--- a/src/packages/frontend/frame-editors/latex-editor/pdf-watcher.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/pdf-watcher.ts
@@ -32,7 +32,7 @@ export class PDFWatcher {
     this.on_change = on_change;
 
     const { head: directory, tail: pdfFilename } = path_split(this.pdf_path);
-    this.watch_dir = directory || ".";
+    this.watch_dir = directory ?? "";
     this.pdf_filename = pdfFilename;
   }
 


### PR DESCRIPTION
silly bug, assumes it resolves relative linux directories