### PR TITLE
frontend/project: fix spacing between 'About' title and project title

### DIFF
--- a/src/packages/frontend/project/settings/about-box.tsx
+++ b/src/packages/frontend/project/settings/about-box.tsx
@@ -4,7 +4,7 @@
  */
 
 import ShowError from "@cocalc/frontend/components/error";
-import { Alert, Button, Col, Modal, Row, Typography } from "antd";
+import { Alert, Button, Col, Flex, Modal, Row, Typography } from "antd";
 import React, { useState } from "react";
 import { useIntl } from "react-intl";
 
@@ -363,14 +363,16 @@ export const AboutBox: React.FC<Props> = (props: Readonly<Props>) => {
     return (
       <SettingBox
         title={
-          <>
-            {intl.formatMessage(labels.about)}{" "}
-            <ProjectTitle
-              style={{ float: "right" }}
-              project_id={project_id}
-              noClick
-            />
-          </>
+          <Flex
+            justify="space-between"
+            align="center"
+            wrap
+            gap="10px"
+            style={{ width: "100%" }}
+          >
+            {intl.formatMessage(labels.about)}
+            <ProjectTitle project_id={project_id} noClick />
+          </Flex>
         }
         icon="file-alt"
       >


### PR DESCRIPTION
fixes #8638

core issue is this "float right". this is now flex layout with wrapping.

<img width="557" height="205" alt="Screenshot from 2025-10-27 11-35-56" src="https://github.com/user-attachments/assets/db8748d8-fcc2-4991-a082-f14c482ebf1a" />
