### PR TITLE
frontend/projects: fix icon of starred or recent directories

### DIFF
--- a/src/packages/frontend/projects/util.tsx
+++ b/src/packages/frontend/projects/util.tsx
@@ -348,8 +348,10 @@ export function useFilesMenuItems(
 
     return files.map((file) => {
       const filename = typeof file === "string" ? file : file.filename;
-      const info = file_options(filename);
-      const icon: IconName = info?.icon ?? "file";
+      const isDirectory = filename.endsWith("/");
+      const icon: IconName = isDirectory
+        ? "folder-open"
+        : (file_options(filename)?.icon ?? "file");
 
       const label = labelStyle ? (
         <span style={labelStyle}>{trunc_middle(filename, truncLength)}</span>


### PR DESCRIPTION
This is just a trivial fix: directories had a (?) icon, but should have their folder icon.

<img width="846" height="556" alt="Screenshot from 2025-11-27 15-41-53" src="https://github.com/user-attachments/assets/e5860a4e-84d1-46c1-94c9-7a0e432a77e2" />
