### PR TITLE
frontend/registration tokens: improve exam mode

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -42,14 +42,24 @@ This file provides guidance to Claude Code (claude.ai/code) and also Gemini CLI 
 - `cd packages/[package] && pnpm build` - Build and compile a specific package
   - For packages/next and packages/static, run `cd packages/[package] && pnpm build-dev`
 - `cd packages/[package] && pnpm test` - Run tests for a specific package
-- To typecheck the frontend, it is best to run `cd packages/static && pnpm build` - this implicitly compiles the frontend and reports TypeScript errors
 - **IMPORTANT**: When modifying packages like `util` that other packages depend on, you must run `pnpm build` in the modified package before typechecking dependent packages
 
 ### Development
 
 - **IMPORTANT**: Always run `prettier -w [filename]` immediately after editing any .ts, .tsx, .md, or .json file to ensure consistent styling
-- After TypeScript or `*.tsx` changes, run `pnpm build` in the relevant package directory
-  - When editing the frontend, run `pnpm build-dev` in `packages/static` (this implicitly builds the frontend)
+
+#### When Working on Frontend Code
+
+After making changes to files in `packages/frontend`:
+
+1. **Typecheck**: Run `cd packages/frontend && pnpm tsc --noEmit` to check for TypeScript errors
+2. **Build**: Run `cd packages/static && pnpm build-dev` to compile the frontend for testing
+
+**DO NOT** run `pnpm build` in `packages/frontend` - it won't work as expected for frontend development.
+
+#### When Working on Other Packages
+
+- After TypeScript changes, run `pnpm build` in the relevant package directory
 
 ## Architecture Overview
 
@@ -155,11 +165,11 @@ CoCalc is organized as a monorepo with key packages:
 
 ### Development Workflow
 
-1. Changes to TypeScript require compilation (`pnpm build` in relevant package)
-2. Database must be running before starting hub
-3. Hub coordinates all services and should be restarted after changes
-4. Use `pnpm clean && pnpm build-dev` when switching branches or after major changes
-5. **IMPORTANT**: After any frontend code changes, run `pnpm build-dev` in the `packages/static` directory to compile the frontend
+1. **Frontend changes**: After editing `packages/frontend`, typecheck with `cd packages/frontend && pnpm tsc --noEmit`, then build with `cd packages/static && pnpm build-dev`
+2. **Other package changes**: After TypeScript changes, run `pnpm build` in the relevant package directory
+3. Database must be running before starting hub
+4. Hub coordinates all services and should be restarted after changes
+5. Use `pnpm clean && pnpm build-dev` when switching branches or after major changes
 
 # Workflow
 

--- a/src/packages/database/postgres/site-license/hook.ts
+++ b/src/packages/database/postgres/site-license/hook.ts
@@ -71,7 +71,7 @@ const LAST_USED: { [license_id: string]: number } = {};
 export async function site_license_hook(
   db: PostgreSQL,
   project_id: string,
-  paygoActive: boolean
+  paygoActive: boolean,
 ): Promise<void> {
   try {
     const slh = new SiteLicenseHook(db, project_id, paygoActive);
@@ -174,7 +174,7 @@ class SiteLicenseHook {
     if (!isEqual(this.projectSiteLicenses, this.nextSiteLicense)) {
       // Now set the site license since something changed.
       dbg.info(
-        `setup a modified site license=${JSON.stringify(this.nextSiteLicense)}`
+        `setup a modified site license=${JSON.stringify(this.nextSiteLicense)}`,
       );
       await query({
         db: this.db,
@@ -246,19 +246,19 @@ class SiteLicenseHook {
           const val = validLicenses.get(id).toJS();
           const key = licenseToGroupKey(val);
           return ORDERING_GROUP_KEYS.indexOf(key);
-        })
+        }),
       );
     }
 
     return orderedIds;
   }
 
-  private computeQuotas(licenses) {
+  private computeQuotas(licenses: SiteLicenses) {
     return compute_total_quota_with_reasons(
       this.project.settings,
       this.project.users,
       licenses,
-      this.site_settings
+      this.site_settings,
     );
   }
 
@@ -301,19 +301,19 @@ class SiteLicenseHook {
         this.dbg.silly(`run_quota=${JSON.stringify(run_quota)}`);
         this.dbg.silly(
           `run_quota_with_license=${JSON.stringify(
-            run_quota_with_license
-          )} | reason=${JSON.stringify(newReasons)}`
+            run_quota_with_license,
+          )} | reason=${JSON.stringify(newReasons)}`,
         );
         if (!isEqual(run_quota, run_quota_with_license)) {
           this.dbg.info(
             `License "${license_id}" provides an effective upgrade ${JSON.stringify(
-              upgrades
-            )}.`
+              upgrades,
+            )}.`,
           );
           nextLicense[license_id] = { ...upgrades, status: "active" };
         } else {
           this.dbg.info(
-            `Found a valid license "${license_id}", but it provides nothing new so not using it (reason: ${newReasons[license_id]})`
+            `Found a valid license "${license_id}", but it provides nothing new so not using it (reason: ${newReasons[license_id]})`,
           );
           nextLicense[license_id] = {
             status: "ineffective",
@@ -366,7 +366,7 @@ class SiteLicenseHook {
    */
   private async checkLicense({ license, license_id }): Promise<LicenseStatus> {
     this.dbg.info(
-      `considering license ${license_id}: ${JSON.stringify(license?.toJS())}`
+      `considering license ${license_id}: ${JSON.stringify(license?.toJS())}`,
     );
     if (license == null) {
       this.dbg.info(`License "${license_id}" does not exist.`);
@@ -380,12 +380,12 @@ class SiteLicenseHook {
         return "expired";
       } else if (activates == null || activates > new Date()) {
         this.dbg.info(
-          `License "${license_id}" has not been explicitly activated yet ${activates}.`
+          `License "${license_id}" has not been explicitly activated yet ${activates}.`,
         );
         return "future";
       } else if (await this.aboveRunLimit(run_limit, license_id)) {
         this.dbg.info(
-          `License "${license_id}" won't be applied since it would exceed the run limit ${run_limit}.`
+          `License "${license_id}" won't be applied since it would exceed the run limit ${run_limit}.`,
         );
         return "exhausted";
       } else {
@@ -420,7 +420,7 @@ class SiteLicenseHook {
     if (typeof run_limit !== "number") return false;
     const usage = await number_of_running_projects_using_license(
       this.db,
-      license_id
+      license_id,
     );
     this.dbg.verbose(`run_limit=${run_limit}  usage=${usage}`);
     return usage >= run_limit;

--- a/src/packages/frontend/admin/registration-token-dialog.tsx
+++ b/src/packages/frontend/admin/registration-token-dialog.tsx
@@ -40,6 +40,7 @@ interface RegistrationTokenDialogProps {
   form: any;
   newRandomToken: () => string;
   saving: boolean;
+  licenseInputKey: number;
 }
 
 export default function RegistrationTokenDialog({
@@ -53,6 +54,7 @@ export default function RegistrationTokenDialog({
   form,
   newRandomToken,
   saving,
+  licenseInputKey,
 }: RegistrationTokenDialogProps) {
   const onFinish = async (values) => {
     await onSave(values);
@@ -216,7 +218,8 @@ export default function RegistrationTokenDialog({
         extra="Optional: Apply a site license to projects created via this token"
       >
         <SiteLicenseInput
-          defaultLicenseId={editingToken?.customize?.license}
+          key={licenseInputKey}
+          defaultLicenseId={form.getFieldValue(["customize", "license"])}
           onChange={(licenseId) =>
             form.setFieldValue(["customize", "license"], licenseId)
           }

--- a/src/packages/frontend/admin/registration-token-dialog.tsx
+++ b/src/packages/frontend/admin/registration-token-dialog.tsx
@@ -18,6 +18,7 @@ import {
 import type { RadioChangeEvent } from "antd";
 
 import { CancelText } from "@cocalc/frontend/i18n/components";
+import { SiteLicenseInput } from "@cocalc/frontend/site-licenses/input";
 import {
   CUSTOM_PRESET_KEY,
   EPHEMERAL_PRESETS,
@@ -215,6 +216,18 @@ export default function RegistrationTokenDialog({
               <Checkbox>Disable internet access</Checkbox>
             </Form.Item>
           </Space>
+        </Form.Item>
+        <Form.Item
+          name={["customize", "license"]}
+          label="License"
+          extra="Optional: Apply a site license to projects created via this token"
+        >
+          <SiteLicenseInput
+            defaultLicenseId={editingToken?.customize?.license}
+            onChange={(licenseId) =>
+              form.setFieldValue(["customize", "license"], licenseId)
+            }
+          />
         </Form.Item>
         <Form.Item name="active" label="Active" valuePropName="checked">
           <Switch />

--- a/src/packages/frontend/admin/registration-token-dialog.tsx
+++ b/src/packages/frontend/admin/registration-token-dialog.tsx
@@ -4,6 +4,7 @@
  */
 
 import {
+  Alert,
   Button as AntdButton,
   Checkbox,
   DatePicker,
@@ -22,6 +23,7 @@ import { SiteLicenseInput } from "@cocalc/frontend/site-licenses/input";
 import {
   CUSTOM_PRESET_KEY,
   EPHEMERAL_PRESETS,
+  EPHEMERAL_OFF_KEY,
   HOUR_MS,
   msToHours,
   type Token,
@@ -34,6 +36,7 @@ interface RegistrationTokenDialogProps {
   onCancel: () => void;
   onSave: (values: Token) => Promise<void>;
   onReset: () => void;
+  error?: string;
   form: any;
   newRandomToken: () => string;
   saving: boolean;
@@ -46,6 +49,7 @@ export default function RegistrationTokenDialog({
   onCancel,
   onSave,
   onReset,
+  error,
   form,
   newRandomToken,
   saving,
@@ -57,34 +61,172 @@ export default function RegistrationTokenDialog({
   const onRandom = () => form.setFieldsValue({ token: newRandomToken() });
   const limitMin = editingToken != null ? (editingToken.counter ?? 0) : 0;
 
-  return (
-    <Modal
-      open={open}
-      title={isEdit ? "Edit Registration Token" : "Create Registration Token"}
-      width={800}
-      destroyOnHidden={true}
-      maskClosable={false}
-      onCancel={onCancel}
-      footer={[
-        <AntdButton key="random" onClick={onRandom}>
-          Randomize
-        </AntdButton>,
-        <AntdButton key="reset" onClick={onReset}>
-          Reset
-        </AntdButton>,
-        <AntdButton key="cancel" onClick={onCancel}>
-          <CancelText />
-        </AntdButton>,
-        <AntdButton
-          key="save"
-          type="primary"
-          onClick={() => form.submit()}
-          loading={saving}
+  function renderFooter() {
+    return [
+      <AntdButton key="random" onClick={onRandom}>
+        Randomize
+      </AntdButton>,
+      <AntdButton key="reset" onClick={onReset}>
+        Reset
+      </AntdButton>,
+      <AntdButton key="cancel" onClick={onCancel}>
+        <CancelText />
+      </AntdButton>,
+      <AntdButton
+        key="save"
+        type="primary"
+        onClick={() => form.submit()}
+        loading={saving}
+      >
+        Save
+      </AntdButton>,
+    ];
+  }
+
+  function renderError() {
+    if (!error) return null;
+    return (
+      <Alert type="error" showIcon style={{ marginTop: 12 }} message={error} />
+    );
+  }
+
+  function renderEphemeralControls() {
+    return (
+      <Form.Item label="Ephemeral lifetime">
+        <Form.Item
+          noStyle
+          shouldUpdate={(prev, curr) =>
+            prev.ephemeral !== curr.ephemeral ||
+            prev._ephemeralMode !== curr._ephemeralMode
+          }
         >
-          Save
-        </AntdButton>,
-      ]}
-    >
+          {(formInstance) => {
+            const ephemeral = formInstance.getFieldValue("ephemeral");
+            const mode = formInstance.getFieldValue("_ephemeralMode");
+            const customHours = msToHours(ephemeral);
+
+            const selection =
+              mode ??
+              (ephemeral != null ? CUSTOM_PRESET_KEY : EPHEMERAL_OFF_KEY);
+
+            const handleRadioChange = ({
+              target: { value },
+            }: RadioChangeEvent) => {
+              if (value === EPHEMERAL_OFF_KEY) {
+                formInstance.setFieldsValue({
+                  ephemeral: undefined,
+                  _ephemeralMode: EPHEMERAL_OFF_KEY,
+                });
+                return;
+              }
+              if (value === CUSTOM_PRESET_KEY) {
+                formInstance.setFieldsValue({
+                  ephemeral: ephemeral != null ? ephemeral : HOUR_MS,
+                  _ephemeralMode: CUSTOM_PRESET_KEY,
+                });
+                return;
+              }
+              const preset = EPHEMERAL_PRESETS.find(
+                (option) => option.key === value,
+              );
+              formInstance.setFieldsValue({
+                ephemeral: preset?.value,
+                _ephemeralMode: value,
+              });
+            };
+
+            const handleCustomHoursChange = (hours: number | string | null) => {
+              const numeric =
+                typeof hours === "string" ? parseFloat(hours) : hours;
+              if (typeof numeric === "number" && !isNaN(numeric)) {
+                formInstance.setFieldsValue({
+                  ephemeral: numeric >= 1 ? numeric * HOUR_MS : HOUR_MS,
+                });
+              } else {
+                formInstance.setFieldsValue({ ephemeral: HOUR_MS });
+              }
+            };
+
+            return (
+              <>
+                <Radio.Group value={selection} onChange={handleRadioChange}>
+                  <Radio value={EPHEMERAL_OFF_KEY}>Off</Radio>
+                  {EPHEMERAL_PRESETS.map(({ key, label }) => (
+                    <Radio key={key} value={key}>
+                      {label}
+                    </Radio>
+                  ))}
+                  <Radio value={CUSTOM_PRESET_KEY}>Custom</Radio>
+                </Radio.Group>
+                {selection === CUSTOM_PRESET_KEY && (
+                  <div style={{ marginTop: "10px" }}>
+                    <InputNumber
+                      min={1}
+                      step={1}
+                      value={customHours ?? 1}
+                      onChange={handleCustomHoursChange}
+                      placeholder="Enter hours"
+                    />{" "}
+                    hours
+                  </div>
+                )}
+              </>
+            );
+          }}
+        </Form.Item>
+      </Form.Item>
+    );
+  }
+
+  function renderRestrictions() {
+    return (
+      <Form.Item label="Restrictions">
+        <Space direction="vertical">
+          <Form.Item
+            name={["customize", "disableCollaborators"]}
+            valuePropName="checked"
+            noStyle
+          >
+            <Checkbox>Disable configuring collaborators</Checkbox>
+          </Form.Item>
+          <Form.Item
+            name={["customize", "disableAI"]}
+            valuePropName="checked"
+            noStyle
+          >
+            <Checkbox>Disable artificial intelligence</Checkbox>
+          </Form.Item>
+          <Form.Item
+            name={["customize", "disableInternet"]}
+            valuePropName="checked"
+            noStyle
+          >
+            <Checkbox>Disable internet access</Checkbox>
+          </Form.Item>
+        </Space>
+      </Form.Item>
+    );
+  }
+
+  function renderLicense() {
+    return (
+      <Form.Item
+        name={["customize", "license"]}
+        label="License"
+        extra="Optional: Apply a site license to projects created via this token"
+      >
+        <SiteLicenseInput
+          defaultLicenseId={editingToken?.customize?.license}
+          onChange={(licenseId) =>
+            form.setFieldValue(["customize", "license"], licenseId)
+          }
+        />
+      </Form.Item>
+    );
+  }
+
+  function renderForm() {
+    return (
       <Form
         form={form}
         labelCol={{ span: 6 }}
@@ -114,125 +256,28 @@ export default function RegistrationTokenDialog({
         <Form.Item name="_ephemeralMode" hidden>
           <Input />
         </Form.Item>
-        <Form.Item label="Ephemeral lifetime">
-          <Form.Item
-            noStyle
-            shouldUpdate={(prev, curr) =>
-              prev.ephemeral !== curr.ephemeral ||
-              prev._ephemeralMode !== curr._ephemeralMode
-            }
-          >
-            {(formInstance) => {
-              const ephemeral = formInstance.getFieldValue("ephemeral");
-              const mode = formInstance.getFieldValue("_ephemeralMode");
-              const customHours = msToHours(ephemeral);
-
-              // Use mode if set, otherwise determine from value
-              const selection =
-                mode || (ephemeral != null ? CUSTOM_PRESET_KEY : undefined);
-
-              const handleRadioChange = ({
-                target: { value },
-              }: RadioChangeEvent) => {
-                if (value === CUSTOM_PRESET_KEY) {
-                  // Set to 1 hour when switching to Custom
-                  formInstance.setFieldsValue({
-                    ephemeral: ephemeral != null ? ephemeral : HOUR_MS,
-                    _ephemeralMode: CUSTOM_PRESET_KEY,
-                  });
-                  return;
-                }
-                const preset = EPHEMERAL_PRESETS.find(
-                  (option) => option.key === value,
-                );
-                formInstance.setFieldsValue({
-                  ephemeral: preset?.value,
-                  _ephemeralMode: value,
-                });
-              };
-
-              const handleCustomHoursChange = (
-                hours: number | string | null,
-              ) => {
-                const numeric =
-                  typeof hours === "string" ? parseFloat(hours) : hours;
-                if (typeof numeric === "number" && !isNaN(numeric)) {
-                  formInstance.setFieldsValue({
-                    ephemeral: numeric >= 1 ? numeric * HOUR_MS : HOUR_MS,
-                  });
-                } else {
-                  formInstance.setFieldsValue({ ephemeral: HOUR_MS });
-                }
-              };
-
-              return (
-                <>
-                  <Radio.Group value={selection} onChange={handleRadioChange}>
-                    {EPHEMERAL_PRESETS.map(({ key, label }) => (
-                      <Radio key={key} value={key}>
-                        {label}
-                      </Radio>
-                    ))}
-                    <Radio value={CUSTOM_PRESET_KEY}>Custom</Radio>
-                  </Radio.Group>
-                  {selection === CUSTOM_PRESET_KEY && (
-                    <div style={{ marginTop: "10px" }}>
-                      <InputNumber
-                        min={1}
-                        step={1}
-                        value={customHours ?? 1}
-                        onChange={handleCustomHoursChange}
-                        placeholder="Enter hours"
-                      />{" "}
-                      hours
-                    </div>
-                  )}
-                </>
-              );
-            }}
-          </Form.Item>
-        </Form.Item>
-        <Form.Item label="Restrictions">
-          <Space direction="vertical">
-            <Form.Item
-              name={["customize", "disableCollaborators"]}
-              valuePropName="checked"
-              noStyle
-            >
-              <Checkbox>Disable configuring collaborators</Checkbox>
-            </Form.Item>
-            <Form.Item
-              name={["customize", "disableAI"]}
-              valuePropName="checked"
-              noStyle
-            >
-              <Checkbox>Disable artificial intelligence</Checkbox>
-            </Form.Item>
-            <Form.Item
-              name={["customize", "disableInternet"]}
-              valuePropName="checked"
-              noStyle
-            >
-              <Checkbox>Disable internet access</Checkbox>
-            </Form.Item>
-          </Space>
-        </Form.Item>
-        <Form.Item
-          name={["customize", "license"]}
-          label="License"
-          extra="Optional: Apply a site license to projects created via this token"
-        >
-          <SiteLicenseInput
-            defaultLicenseId={editingToken?.customize?.license}
-            onChange={(licenseId) =>
-              form.setFieldValue(["customize", "license"], licenseId)
-            }
-          />
-        </Form.Item>
+        {renderEphemeralControls()}
+        {renderRestrictions()}
+        {renderLicense()}
         <Form.Item name="active" label="Active" valuePropName="checked">
           <Switch />
         </Form.Item>
       </Form>
+    );
+  }
+
+  return (
+    <Modal
+      open={open}
+      title={isEdit ? "Edit Registration Token" : "Create Registration Token"}
+      width={800}
+      destroyOnHidden={true}
+      maskClosable={false}
+      onCancel={onCancel}
+      footer={renderFooter()}
+    >
+      {renderForm()}
+      {renderError()}
     </Modal>
   );
 }

--- a/src/packages/frontend/admin/registration-token-dialog.tsx
+++ b/src/packages/frontend/admin/registration-token-dialog.tsx
@@ -1,0 +1,225 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2025 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import {
+  Button as AntdButton,
+  Checkbox,
+  DatePicker,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Radio,
+  Space,
+  Switch,
+} from "antd";
+import type { RadioChangeEvent } from "antd";
+
+import { CancelText } from "@cocalc/frontend/i18n/components";
+import {
+  CUSTOM_PRESET_KEY,
+  EPHEMERAL_PRESETS,
+  HOUR_MS,
+  msToHours,
+  type Token,
+} from "./types";
+
+interface RegistrationTokenDialogProps {
+  open: boolean;
+  isEdit: boolean;
+  editingToken: Token | null;
+  onCancel: () => void;
+  onSave: (values: Token) => Promise<void>;
+  onReset: () => void;
+  form: any;
+  newRandomToken: () => string;
+  saving: boolean;
+}
+
+export default function RegistrationTokenDialog({
+  open,
+  isEdit,
+  editingToken,
+  onCancel,
+  onSave,
+  onReset,
+  form,
+  newRandomToken,
+  saving,
+}: RegistrationTokenDialogProps) {
+  const onFinish = async (values) => {
+    await onSave(values);
+  };
+
+  const onRandom = () => form.setFieldsValue({ token: newRandomToken() });
+  const limitMin = editingToken != null ? (editingToken.counter ?? 0) : 0;
+
+  return (
+    <Modal
+      open={open}
+      title={isEdit ? "Edit Registration Token" : "Create Registration Token"}
+      width={800}
+      destroyOnHidden={true}
+      maskClosable={false}
+      onCancel={onCancel}
+      footer={[
+        <AntdButton key="random" onClick={onRandom}>
+          Randomize
+        </AntdButton>,
+        <AntdButton key="reset" onClick={onReset}>
+          Reset
+        </AntdButton>,
+        <AntdButton key="cancel" onClick={onCancel}>
+          <CancelText />
+        </AntdButton>,
+        <AntdButton
+          key="save"
+          type="primary"
+          onClick={() => form.submit()}
+          loading={saving}
+        >
+          Save
+        </AntdButton>,
+      ]}
+    >
+      <Form
+        form={form}
+        labelCol={{ span: 6 }}
+        wrapperCol={{ span: 18 }}
+        size="middle"
+        onFinish={onFinish}
+      >
+        <Form.Item name="token" label="Token" rules={[{ required: true }]}>
+          <Input disabled={true} />
+        </Form.Item>
+        <Form.Item
+          name="descr"
+          label="Description"
+          rules={[{ required: false }]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item name="expires" label="Expires" rules={[{ required: false }]}>
+          <DatePicker />
+        </Form.Item>
+        <Form.Item name="limit" label="Limit" rules={[{ required: false }]}>
+          <InputNumber min={limitMin} step={1} />
+        </Form.Item>
+        <Form.Item name="ephemeral" hidden>
+          <InputNumber />
+        </Form.Item>
+        <Form.Item name="_ephemeralMode" hidden>
+          <Input />
+        </Form.Item>
+        <Form.Item label="Ephemeral lifetime">
+          <Form.Item
+            noStyle
+            shouldUpdate={(prev, curr) =>
+              prev.ephemeral !== curr.ephemeral ||
+              prev._ephemeralMode !== curr._ephemeralMode
+            }
+          >
+            {(formInstance) => {
+              const ephemeral = formInstance.getFieldValue("ephemeral");
+              const mode = formInstance.getFieldValue("_ephemeralMode");
+              const customHours = msToHours(ephemeral);
+
+              // Use mode if set, otherwise determine from value
+              const selection =
+                mode || (ephemeral != null ? CUSTOM_PRESET_KEY : undefined);
+
+              const handleRadioChange = ({
+                target: { value },
+              }: RadioChangeEvent) => {
+                if (value === CUSTOM_PRESET_KEY) {
+                  // Set to 1 hour when switching to Custom
+                  formInstance.setFieldsValue({
+                    ephemeral: ephemeral != null ? ephemeral : HOUR_MS,
+                    _ephemeralMode: CUSTOM_PRESET_KEY,
+                  });
+                  return;
+                }
+                const preset = EPHEMERAL_PRESETS.find(
+                  (option) => option.key === value,
+                );
+                formInstance.setFieldsValue({
+                  ephemeral: preset?.value,
+                  _ephemeralMode: value,
+                });
+              };
+
+              const handleCustomHoursChange = (
+                hours: number | string | null,
+              ) => {
+                const numeric =
+                  typeof hours === "string" ? parseFloat(hours) : hours;
+                if (typeof numeric === "number" && !isNaN(numeric)) {
+                  formInstance.setFieldsValue({
+                    ephemeral: numeric >= 1 ? numeric * HOUR_MS : HOUR_MS,
+                  });
+                } else {
+                  formInstance.setFieldsValue({ ephemeral: HOUR_MS });
+                }
+              };
+
+              return (
+                <>
+                  <Radio.Group value={selection} onChange={handleRadioChange}>
+                    {EPHEMERAL_PRESETS.map(({ key, label }) => (
+                      <Radio key={key} value={key}>
+                        {label}
+                      </Radio>
+                    ))}
+                    <Radio value={CUSTOM_PRESET_KEY}>Custom</Radio>
+                  </Radio.Group>
+                  {selection === CUSTOM_PRESET_KEY && (
+                    <div style={{ marginTop: "10px" }}>
+                      <InputNumber
+                        min={1}
+                        step={1}
+                        value={customHours ?? 1}
+                        onChange={handleCustomHoursChange}
+                        placeholder="Enter hours"
+                      />{" "}
+                      hours
+                    </div>
+                  )}
+                </>
+              );
+            }}
+          </Form.Item>
+        </Form.Item>
+        <Form.Item label="Restrictions">
+          <Space direction="vertical">
+            <Form.Item
+              name={["customize", "disableCollaborators"]}
+              valuePropName="checked"
+              noStyle
+            >
+              <Checkbox>Disable configuring collaborators</Checkbox>
+            </Form.Item>
+            <Form.Item
+              name={["customize", "disableAI"]}
+              valuePropName="checked"
+              noStyle
+            >
+              <Checkbox>Disable artificial intelligence</Checkbox>
+            </Form.Item>
+            <Form.Item
+              name={["customize", "disableInternet"]}
+              valuePropName="checked"
+              noStyle
+            >
+              <Checkbox>Disable internet access</Checkbox>
+            </Form.Item>
+          </Space>
+        </Form.Item>
+        <Form.Item name="active" label="Active" valuePropName="checked">
+          <Switch />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/src/packages/frontend/admin/registration-token-hook.tsx
+++ b/src/packages/frontend/admin/registration-token-hook.tsx
@@ -135,9 +135,9 @@ export function useRegistrationTokens() {
       (k: RegistrationTokenSetFields) => (val[k] = val[k] ?? undefined),
     );
     if (val.customize != null) {
-      const { disableCollaborators, disableAI, disableInternet } =
+      const { disableCollaborators, disableAI, disableInternet, license } =
         val.customize;
-      if (!disableCollaborators && !disableAI && !disableInternet) {
+      if (!disableCollaborators && !disableAI && !disableInternet && !license) {
         val.customize = undefined;
       }
     }

--- a/src/packages/frontend/admin/registration-token-hook.tsx
+++ b/src/packages/frontend/admin/registration-token-hook.tsx
@@ -1,0 +1,304 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020-2025 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+/*
+Custom hook for managing registration tokens.
+*/
+
+import { Form } from "antd";
+import dayjs from "dayjs";
+import { pick } from "lodash";
+import { useEffect, useState } from "react";
+
+import { query } from "@cocalc/frontend/frame-editors/generic/client";
+import { RegistrationTokenSetFields } from "@cocalc/util/db-schema/types";
+import { seconds2hms, secure_random_token } from "@cocalc/util/misc";
+
+import { CUSTOM_PRESET_KEY, findPresetKey, type Token } from "./types";
+
+export function formatEphemeralHours(value?: number): string {
+  if (value == null) return "";
+  const seconds = value / 1000;
+  return seconds2hms(seconds, false, false, false);
+}
+
+export function ephemeralSignupUrl(token?: string): string {
+  if (!token) return "";
+  if (typeof window === "undefined") {
+    return `/ephemeral?token=${token}`;
+  }
+  const { protocol, host } = window.location;
+  return `${protocol}//${host}/ephemeral?token=${token}`;
+}
+
+export function getEphemeralMode(ephemeral?: number): string | undefined {
+  const presetKey = findPresetKey(ephemeral);
+  return presetKey || (ephemeral != null ? CUSTOM_PRESET_KEY : undefined);
+}
+
+export function useRegistrationTokens() {
+  const [data, setData] = useState<{ [key: string]: Token }>({});
+  const [noOrAllInactive, setNoOrAllInactive] = useState<boolean>(false);
+  const [editing, setEditing] = useState<Token | null>(null);
+  const [modalVisible, setModalVisible] = useState<boolean>(false);
+  const [editingToken, setEditingToken] = useState<Token | null>(null);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [deleting, setDeleting] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [lastSaved, setLastSaved] = useState<Token | null>(null);
+  const [error, setError] = useState<string>("");
+  const [selRows, setSelRows] = useState<any>([]);
+
+  // Antd
+  const [form] = Form.useForm();
+
+  // we load the data in a map, indexed by the token
+  // dates are converted to dayjs on the fly
+  async function load() {
+    let result: any;
+    setLoading(true);
+    try {
+      // TODO query should be limited by disabled != true
+      result = await query({
+        query: {
+          registration_tokens: {
+            token: "*",
+            descr: null,
+            expires: null,
+            limit: null,
+            disabled: null,
+            ephemeral: null,
+            customize: null,
+          },
+        },
+      });
+      const data = {};
+      let warn_signup = true;
+      for (const x of result.query.registration_tokens) {
+        if (x.expires) x.expires = dayjs(x.expires);
+        x.active = !x.disabled;
+        data[x.token] = x;
+        // we have at least one active token → no need to warn user
+        if (x.active) warn_signup = false;
+      }
+      setNoOrAllInactive(warn_signup);
+      setError("");
+      setData(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // every time we show or hide, clear the selection
+    setSelRows([]);
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (editing != null) {
+      // antd's form want's something called "Store" – which is just this?
+      form.setFieldsValue(editing as any);
+    }
+    if (lastSaved != null) {
+      setLastSaved(null);
+    }
+  }, [editing]);
+
+  // saving a specific token value converts dayjs back to pure Date objects
+  // we also record the last saved token as a template for the next add operation
+  async function save(val): Promise<void> {
+    // antd wraps the time in a dayjs object
+    const val_orig: Token = { ...val };
+    if (editing != null) setEditing(null);
+
+    // data preparation
+    if (val.expires != null && dayjs.isDayjs(val.expires)) {
+      val.expires = dayjs(val.expires).toDate();
+    }
+    val.disabled = !val.active;
+    val = pick(val, [
+      "token",
+      "disabled",
+      "expires",
+      "limit",
+      "descr",
+      "ephemeral",
+      "customize",
+    ] as RegistrationTokenSetFields[]);
+    // set optional field to undefined (to get rid of it)
+    ["descr", "limit", "expires", "ephemeral"].forEach(
+      (k: RegistrationTokenSetFields) => (val[k] = val[k] ?? undefined),
+    );
+    if (val.customize != null) {
+      const { disableCollaborators, disableAI, disableInternet } =
+        val.customize;
+      if (!disableCollaborators && !disableAI && !disableInternet) {
+        val.customize = undefined;
+      }
+    }
+    try {
+      setSaving(true);
+      await query({
+        query: {
+          registration_tokens: val,
+        },
+      });
+      // we save the original one, with dayjs in it!
+      setLastSaved(val_orig);
+      setSaving(false);
+      await load();
+    } catch (err) {
+      // Error path - set error (handle non-Error values)
+      const errorMessage = err?.message ?? String(err);
+      setError(errorMessage);
+      // For modal: preserve editing token for caller to handle
+      // For checkbox: just show error
+      if (modalVisible) {
+        setEditing(val_orig);
+      }
+      throw err; // Re-throw so caller knows it failed
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteToken(
+    token: string | undefined,
+    single: boolean = false,
+  ) {
+    if (token == null) return;
+    if (single) setDeleting(true);
+
+    try {
+      await query({
+        query: {
+          registration_tokens: { token },
+        },
+        options: [{ delete: true }],
+      });
+      if (single) load();
+    } catch (err) {
+      if (single) {
+        setError(err);
+      } else {
+        throw err;
+      }
+    } finally {
+      if (single) setDeleting(false);
+    }
+  }
+
+  async function deleteTokens(): Promise<void> {
+    setDeleting(true);
+    try {
+      // it's not possible to delete several tokens at once
+      await selRows.map(async (token) => await deleteToken(token));
+      setSelRows([]);
+      load();
+    } catch (err) {
+      setError(err);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  // we generate a random token and make sure it doesn't exist
+  // TODO also let the user generate one with a validation check
+  function newRandomToken(): string {
+    return secure_random_token(16);
+  }
+
+  // Modal event handlers
+  function handleModalOpen(token?: Token): void {
+    // IMPORTANT: Reset form first to avoid leaking previous values
+    form.resetFields();
+
+    if (token) {
+      // Edit mode
+      const mode = getEphemeralMode(token.ephemeral);
+      form.setFieldsValue({ ...token, _ephemeralMode: mode });
+      setEditingToken(token);
+    } else {
+      // Add mode - use lastSaved as template
+      const newToken = {
+        ...lastSaved,
+        token: newRandomToken(),
+        active: true,
+      };
+      const mode = getEphemeralMode(newToken.ephemeral);
+      form.setFieldsValue({ ...newToken, _ephemeralMode: mode });
+      setEditingToken(null);
+    }
+    setModalVisible(true);
+    setLastSaved(null); // Clear last saved marker (mimics old useEffect)
+  }
+
+  function handleModalCancel(): void {
+    setModalVisible(false);
+    setEditingToken(null);
+    form.resetFields();
+  }
+
+  function handleModalReset(): void {
+    // Mimics old Reset button: regenerate token, keep lastSaved template
+    form.resetFields(); // Clear first to avoid stale values
+    const newToken = {
+      ...lastSaved,
+      token: newRandomToken(),
+      active: true,
+    };
+    const mode = getEphemeralMode(newToken.ephemeral);
+    form.setFieldsValue({ ...newToken, _ephemeralMode: mode });
+    setEditingToken(null);
+  }
+
+  async function handleModalSave(values: Token): Promise<void> {
+    const val_orig: Token = { ...values };
+
+    try {
+      // Call the existing save() function which handles all transformation and persistence
+      await save(values);
+
+      // Success - close modal
+      setModalVisible(false);
+      setEditingToken(null);
+    } catch (err) {
+      // Error - keep modal open and preserve user input
+      // save() already set the error state, we just need to prevent closing
+      setEditingToken(val_orig); // Preserve for limit validation
+      form.setFieldsValue(val_orig); // Restore form with user's values
+    }
+  }
+
+  return {
+    data,
+    form,
+    saving,
+    deleting,
+    deleteToken,
+    deleteTokens,
+    loading,
+    lastSaved,
+    error,
+    setError,
+    selRows,
+    setSelRows,
+    setDeleting,
+    newRandomToken,
+    save,
+    load,
+    noOrAllInactive,
+    // Modal-related
+    modalVisible,
+    editingToken,
+    handleModalOpen,
+    handleModalCancel,
+    handleModalReset,
+    handleModalSave,
+  };
+}

--- a/src/packages/frontend/admin/registration-token-license-summary.tsx
+++ b/src/packages/frontend/admin/registration-token-license-summary.tsx
@@ -1,0 +1,58 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020-2025 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import { useEffect, useState } from "react";
+
+import {
+  site_license_public_info,
+  trunc_license_id,
+} from "@cocalc/frontend/site-licenses/util";
+import { describe_quota } from "@cocalc/util/licenses/describe-quota";
+
+interface Props {
+  licenseId?: string;
+}
+
+export default function LicenseSummary({ licenseId }: Props) {
+  const [summary, setSummary] = useState<string>("None");
+
+  useEffect(() => {
+    let isMounted = true;
+    if (!licenseId) {
+      setSummary("None");
+      return;
+    }
+    setSummary("Loading...");
+    (async () => {
+      try {
+        const info = await site_license_public_info(licenseId);
+        if (!isMounted) return;
+        if (!info) {
+          setSummary(`${trunc_license_id(licenseId)} (not found)`);
+          return;
+        }
+        const parts: string[] = [];
+        if (info.title) parts.push(info.title);
+        if (info.description) parts.push(info.description);
+        if (info.quota) {
+          const quotaDesc = describe_quota(info.quota);
+          if (quotaDesc) parts.push(quotaDesc);
+        }
+        const text = parts.filter(Boolean).join(" — ");
+        setSummary(text || trunc_license_id(licenseId));
+      } catch (err) {
+        if (isMounted) {
+          setSummary(`${trunc_license_id(licenseId)} (error loading)`);
+        }
+      }
+    })();
+    return () => {
+      isMounted = false;
+    };
+  }, [licenseId]);
+
+  if (!licenseId) return <span>None</span>;
+  return <span title={licenseId}>{summary}</span>;
+}

--- a/src/packages/frontend/admin/registration-token.tsx
+++ b/src/packages/frontend/admin/registration-token.tsx
@@ -16,9 +16,9 @@ import {
   Table,
 } from "antd";
 import type { DescriptionsProps } from "antd";
+import dayjs from "dayjs";
 import { List } from "immutable";
 import { sortBy } from "lodash";
-import dayjs from "dayjs";
 
 import { CopyOutlined, DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import { Alert } from "@cocalc/frontend/antd-bootstrap";
@@ -48,6 +48,7 @@ import {
   formatEphemeralHours,
   useRegistrationTokens,
 } from "./registration-token-hook";
+import LicenseSummary from "./registration-token-license-summary";
 import { type Token } from "./types";
 
 export function RegistrationToken() {
@@ -72,6 +73,7 @@ export function RegistrationToken() {
     // Modal-related
     modalVisible,
     editingToken,
+    modalError,
     handleModalOpen,
     handleModalCancel,
     handleModalReset,
@@ -116,8 +118,8 @@ export function RegistrationToken() {
       limit == null
         ? undefined
         : limit === 0
-        ? 100
-        : round1((100 * uses) / limit);
+          ? 100
+          : round1((100 * uses) / limit);
     const usageLabel =
       pct == null
         ? `${uses}/${limit ?? "∞"} (–%)`
@@ -174,7 +176,7 @@ export function RegistrationToken() {
         key: "license",
         label: "License",
         span: 3,
-        children: token.customize?.license || "None",
+        children: <LicenseSummary licenseId={token.customize?.license} />,
       },
     ];
 
@@ -448,6 +450,7 @@ export function RegistrationToken() {
         onCancel={handleModalCancel}
         onSave={handleModalSave}
         onReset={handleModalReset}
+        error={modalError}
         form={form}
         newRandomToken={newRandomToken}
         saving={saving}

--- a/src/packages/frontend/admin/registration-token.tsx
+++ b/src/packages/frontend/admin/registration-token.tsx
@@ -18,6 +18,7 @@ import {
 import type { DescriptionsProps } from "antd";
 import { List } from "immutable";
 import { sortBy } from "lodash";
+import dayjs from "dayjs";
 
 import { CopyOutlined, DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import { Alert } from "@cocalc/frontend/antd-bootstrap";
@@ -40,7 +41,6 @@ import {
 } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { PassportStrategyFrontend } from "@cocalc/util/types/passport-types";
-import dayjs from "dayjs";
 
 import RegistrationTokenDialog from "./registration-token-dialog";
 import {
@@ -169,6 +169,12 @@ export function RegistrationToken() {
         key: "disableInternet",
         label: "Disable internet",
         children: token.customize?.disableInternet ? "Yes" : "No",
+      },
+      {
+        key: "license",
+        label: "License",
+        span: 3,
+        children: token.customize?.license || "None",
       },
     ];
 

--- a/src/packages/frontend/admin/registration-token.tsx
+++ b/src/packages/frontend/admin/registration-token.tsx
@@ -147,7 +147,7 @@ export function RegistrationToken() {
         label: "Ephemeral link",
         span: 2,
         children: ephemeralLink ? (
-          <Copyable value={ephemeralLink} />
+          <Copyable value={ephemeralLink} size={"small"} />
         ) : (
           "Not available"
         ),

--- a/src/packages/frontend/admin/registration-token.tsx
+++ b/src/packages/frontend/admin/registration-token.tsx
@@ -12,6 +12,7 @@ import {
   Descriptions,
   Popconfirm,
   Progress,
+  Space,
   Switch,
   Table,
 } from "antd";
@@ -44,7 +45,6 @@ import { PassportStrategyFrontend } from "@cocalc/util/types/passport-types";
 
 import RegistrationTokenDialog from "./registration-token-dialog";
 import {
-  ephemeralSignupUrl,
   formatEphemeralHours,
   useRegistrationTokens,
 } from "./registration-token-hook";
@@ -74,6 +74,7 @@ export function RegistrationToken() {
     modalVisible,
     editingToken,
     modalError,
+    licenseInputKey,
     handleModalOpen,
     handleModalCancel,
     handleModalReset,
@@ -83,7 +84,7 @@ export function RegistrationToken() {
   function render_buttons() {
     const any_selected = selRows.length > 0;
     return (
-      <AntdButton.Group style={{ margin: "10px 0" }}>
+      <Space.Compact style={{ margin: "10px 0" }}>
         <AntdButton
           type={!any_selected ? "primary" : "default"}
           disabled={any_selected}
@@ -107,8 +108,17 @@ export function RegistrationToken() {
           <Icon name="refresh" />
           Refresh
         </AntdButton>
-      </AntdButton.Group>
+      </Space.Compact>
     );
+  }
+
+  function ephemeralSignupUrl(token: Token): string {
+    if (!token || token.ephemeral == null) return "";
+    if (typeof window === "undefined") {
+      return `/ephemeral?token=${token.token}`;
+    }
+    const { protocol, host } = window.location;
+    return `${protocol}//${host}/ephemeral?token=${token.token}`;
   }
 
   function render_expanded_row(token: Token): Rendered {
@@ -128,7 +138,7 @@ export function RegistrationToken() {
       token.ephemeral != null
         ? seconds2hms(token.ephemeral / 1000, true)
         : "No";
-    const ephemeralLink = ephemeralSignupUrl(token.token);
+    const ephemeralLink = ephemeralSignupUrl(token);
 
     const items: DescriptionsProps["items"] = [
       {
@@ -185,10 +195,7 @@ export function RegistrationToken() {
 
   function render_view(): Rendered {
     const table_data = sortBy(
-      Object.values(data).map((v) => {
-        v.key = v.token;
-        return v;
-      }),
+      Object.values(data).map((v) => ({ ...v, key: v.token })),
       "token",
     );
     const rowSelection = {
@@ -263,7 +270,7 @@ export function RegistrationToken() {
             dataIndex="ephemeral"
             render={(value, token) => {
               if (value == null) return "-";
-              const url = ephemeralSignupUrl(token.token);
+              const url = ephemeralSignupUrl(token);
               return (
                 <div
                   style={{
@@ -454,6 +461,7 @@ export function RegistrationToken() {
         form={form}
         newRandomToken={newRandomToken}
         saving={saving}
+        licenseInputKey={licenseInputKey}
       />
     );
   }

--- a/src/packages/frontend/admin/types.ts
+++ b/src/packages/frontend/admin/types.ts
@@ -4,6 +4,8 @@
  */
 import type { Dayjs } from "dayjs";
 
+import type { RegistrationTokenCustomize } from "@cocalc/util/types/registration-token";
+
 export interface Token {
   key?: string; // used in the table, not for the database
   token: string;
@@ -14,11 +16,7 @@ export interface Token {
   limit?: number;
   counter?: number;
   ephemeral?: number;
-  customize?: {
-    disableCollaborators?: boolean;
-    disableAI?: boolean;
-    disableInternet?: boolean;
-  };
+  customize?: RegistrationTokenCustomize;
 }
 
 export const HOUR_MS = 60 * 60 * 1000;

--- a/src/packages/frontend/admin/types.ts
+++ b/src/packages/frontend/admin/types.ts
@@ -1,0 +1,42 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2025 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+import type { Dayjs } from "dayjs";
+
+export interface Token {
+  key?: string; // used in the table, not for the database
+  token: string;
+  disabled?: boolean;
+  active?: boolean;
+  descr?: string;
+  expires?: Dayjs;
+  limit?: number;
+  counter?: number;
+  ephemeral?: number;
+  customize?: {
+    disableCollaborators?: boolean;
+    disableAI?: boolean;
+    disableInternet?: boolean;
+  };
+}
+
+export const HOUR_MS = 60 * 60 * 1000;
+
+export const EPHEMERAL_PRESETS = [
+  { key: "6h", label: "6 hours", value: 6 * HOUR_MS },
+  { key: "1d", label: "1 day", value: 24 * HOUR_MS },
+  { key: "1w", label: "1 week", value: 7 * 24 * HOUR_MS },
+] as const;
+
+export const CUSTOM_PRESET_KEY = "custom";
+
+export function msToHours(value?: number): number | undefined {
+  if (value == null) return undefined;
+  return value / HOUR_MS;
+}
+
+export function findPresetKey(value?: number): string | undefined {
+  if (value == null) return undefined;
+  return EPHEMERAL_PRESETS.find((preset) => preset.value === value)?.key;
+}

--- a/src/packages/frontend/admin/types.ts
+++ b/src/packages/frontend/admin/types.ts
@@ -28,6 +28,7 @@ export const EPHEMERAL_PRESETS = [
 ] as const;
 
 export const CUSTOM_PRESET_KEY = "custom";
+export const EPHEMERAL_OFF_KEY = "off";
 
 export function msToHours(value?: number): number | undefined {
   if (value == null) return undefined;

--- a/src/packages/frontend/client/query.ts
+++ b/src/packages/frontend/client/query.ts
@@ -19,6 +19,79 @@ export class QueryClient {
     this.client = client;
   }
 
+  private doChangefeed = async (opts: {
+    query: object;
+    options?: object[];
+    cb: CB;
+  }): Promise<void> => {
+    let changefeed;
+    try {
+      changefeed = new ConatChangefeed({
+        account_id: this.client.account_id,
+        query: opts.query,
+        options: opts.options,
+      });
+      // id for canceling this changefeed
+      const id = uuid();
+      const initval = await changefeed.connect();
+      const query = {
+        [Object.keys(opts.query)[0]]: initval,
+      };
+      this.changefeeds[id] = changefeed;
+      opts.cb(undefined, { query, id });
+      changefeed.on("update", (change) => {
+        opts.cb(undefined, change);
+      });
+    } catch (err) {
+      opts.cb(`${err}`);
+    }
+  };
+
+  private doQuery = async (opts: {
+    query: object;
+    options?: object[];
+    timeout?: number;
+  }): Promise<any> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const queryPromise = this.client.conat_client.hub.db.userQuery({
+        query: opts.query,
+        options: opts.options,
+        timeout: opts.timeout,
+      });
+
+      // Add client-side timeout if explicitly requested
+      if (opts.timeout != null) {
+        let timedOut = false;
+
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            timedOut = true; // Set flag before rejecting
+            reject(new Error(`Query timed out after ${opts.timeout} ms`));
+          }, opts.timeout);
+        });
+
+        // Prevent unhandled rejection if timeout fires first
+        queryPromise.catch((err) => {
+          if (timedOut) {
+            // Timeout already happened, this is an orphaned rejection - just log it
+            console.warn("Query failed after client-side timeout:", err);
+          }
+          // If not timed out, error is handled by the race
+        });
+
+        return await Promise.race([queryPromise, timeoutPromise]);
+      } else {
+        return await queryPromise;
+      }
+    } finally {
+      if (timer != null) {
+        clearTimeout(timer);
+      }
+    }
+  };
+
   // This works like a normal async function when
   // opts.cb is NOT specified.  When opts.cb is specified,
   // it works like a cb and returns nothing.    For changefeeds
@@ -30,84 +103,50 @@ export class QueryClient {
     timeout?: number; // ms
     cb?: CB; // support old cb interface
   }): Promise<any> => {
-    const timeoutMs = opts.timeout ?? 15000;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timer = setTimeout(
-        () => reject(new Error(`Query timed out after ${timeoutMs} ms`)),
-        timeoutMs,
-      );
-    });
+    // Deprecation warnings:
+    for (const field of ["standby", "no_post", "ignore_response"]) {
+      if (opts[field] != null) {
+        console.trace(`WARNING: passing '${field}' to query is deprecated`);
+      }
+    }
+    if (opts.options != null && !is_array(opts.options)) {
+      // should never happen...
+      throw Error("options must be an array");
+    }
+    if (opts.changes) {
+      const { cb } = opts;
+      if (cb == null) {
+        throw Error("for changefeed, must specify opts.cb");
+      }
+      await this.doChangefeed({
+        query: opts.query,
+        options: opts.options,
+        cb,
+      });
+    } else {
+      try {
+        const err = validate_client_query(opts.query, this.client.account_id);
+        if (err) {
+          throw Error(err);
+        }
 
-    try {
-      // Deprecation warnings:
-      for (const field of ["standby", "no_post", "ignore_response"]) {
-        if (opts[field] != null) {
-          console.trace(`WARNING: passing '${field}' to query is deprecated`);
-        }
-      }
-      if (opts.options != null && !is_array(opts.options)) {
-        // should never happen...
-        throw Error("options must be an array");
-      }
-      if (opts.changes) {
-        const { cb } = opts;
-        if (cb == null) {
-          throw Error("for changefeed, must specify opts.cb");
-        }
-        let changefeed;
-        try {
-          changefeed = new ConatChangefeed({
-            account_id: this.client.account_id,
-            query: opts.query,
-            options: opts.options,
-          });
-          // id for canceling this changefeed
-          const id = uuid();
-          const initval = await changefeed.connect();
-          const query = {
-            [Object.keys(opts.query)[0]]: initval,
-          };
-          this.changefeeds[id] = changefeed;
-          cb(undefined, { query, id });
-          changefeed.on("update", (change) => {
-            cb(undefined, change);
-          });
-        } catch (err) {
-          cb(`${err}`);
-          return;
-        }
-      } else {
-        try {
-          const err = validate_client_query(opts.query, this.client.account_id);
-          if (err) {
-            throw Error(err);
-          }
-          const query = await Promise.race([
-            this.client.conat_client.hub.db.userQuery({
-              query: opts.query,
-              options: opts.options,
-              timeout: opts.timeout,
-            }),
-            timeoutPromise,
-          ]);
+        const query = await this.doQuery({
+          query: opts.query,
+          options: opts.options,
+          timeout: opts.timeout,
+        });
 
-          if (opts.cb == null) {
-            return { query };
-          } else {
-            opts.cb(undefined, { query });
-          }
-        } catch (err) {
-          if (opts.cb == null) {
-            throw err;
-          } else {
-            opts.cb(err);
-          }
+        if (opts.cb == null) {
+          return { query };
+        } else {
+          opts.cb(undefined, { query });
         }
-      }
-    } finally {
-      if (timer != null) {
-        clearTimeout(timer);
+      } catch (err) {
+        if (opts.cb == null) {
+          throw err;
+        } else {
+          opts.cb(err);
+        }
       }
     }
   };

--- a/src/packages/frontend/frame-editors/generic/client.ts
+++ b/src/packages/frontend/frame-editors/generic/client.ts
@@ -258,6 +258,7 @@ interface QueryOpts {
   changes?: boolean;
   options?: object[]; // e.g., [{limit:5}],
   no_post?: boolean;
+  timeout?: number; // ms
 }
 
 export async function query(opts: QueryOpts): Promise<any> {

--- a/src/packages/frontend/project/anonymous-name.tsx
+++ b/src/packages/frontend/project/anonymous-name.tsx
@@ -9,15 +9,16 @@
 
 import { useState } from "react";
 import { Alert, Input } from "antd";
+
 import {
   React,
   redux,
   useActions,
   useRedux,
   useTypedRedux,
-} from "../app-framework";
-import { Icon, Gap } from "../components";
-const { SiteName } = require("../customize");
+} from "@cocalc/frontend/app-framework";
+import { Icon, Gap } from "@cocalc/frontend/components";
+const { SiteName } = require("@cocalc/frontend/customize");
 const HOUR_MS = 60 * 60 * 1000;
 
 function formatTimeDelta(ms: number | undefined): string {
@@ -46,7 +47,7 @@ interface Props {
 export const AnonymousName: React.FC<Props> = React.memo(({ project_id }) => {
   const is_anonymous = useTypedRedux("account", "is_anonymous");
   if (!is_anonymous) {
-    // no need to do thisencourage a name -- they are by themself.
+    // no need to encourage a name -- they are by themselves.
     return <></>;
   }
   return <AnonymousNameInput project_id={project_id} />;
@@ -156,6 +157,7 @@ const AnonymousNameInput: React.FC<Props> = React.memo(({ project_id }) => {
       style={{ marginBottom: "5px" }}
       type="warning"
       message={mesg}
-    ></Alert>
+      banner
+    />
   );
 });

--- a/src/packages/server/accounts/account-creation-actions.ts
+++ b/src/packages/server/accounts/account-creation-actions.ts
@@ -8,6 +8,7 @@ import getOneProject from "@cocalc/server/projects/get-one";
 import { getProject } from "@cocalc/server/projects/control";
 import { getLogger } from "@cocalc/backend/logger";
 import getProjects from "@cocalc/server/projects/get";
+import { type RegistrationTokenCustomize } from "@cocalc/util/types/registration-token";
 
 const log = getLogger("server:accounts:creation-actions");
 
@@ -18,6 +19,7 @@ export default async function accountCreationActions({
   noFirstProject,
   dontStartProject,
   ephemeral,
+  customize,
 }: {
   email_address?: string;
   account_id: string;
@@ -27,6 +29,7 @@ export default async function accountCreationActions({
   // if set, create the first project but do not start it. Only applies if noFirstProject is false.
   dontStartProject?: boolean;
   ephemeral?: number;
+  customize?: RegistrationTokenCustomize;
 }): Promise<void> {
   log.debug({ account_id, email_address, tags });
 
@@ -66,6 +69,7 @@ export default async function accountCreationActions({
               tags,
               dontStartProject,
               ephemeral,
+              customize,
             });
           }
         } catch (err) {

--- a/src/packages/server/accounts/first-project.ts
+++ b/src/packages/server/accounts/first-project.ts
@@ -8,6 +8,7 @@ import { getProject } from "@cocalc/server/projects/control";
 import callProject from "@cocalc/server/projects/call";
 import getKernels from "@cocalc/server/jupyter/kernels";
 import { isValidUUID } from "@cocalc/util/misc";
+import type { RegistrationTokenCustomize } from "@cocalc/util/types/registration-token";
 
 // If true, create welcome files based on tags.
 // disabled because based on data with users, it doesn't help.
@@ -24,11 +25,13 @@ export default async function firstProject({
   tags,
   dontStartProject,
   ephemeral,
+  customize,
 }: {
   account_id: string;
   tags?: string[];
   dontStartProject?: boolean;
   ephemeral?: number;
+  customize?: RegistrationTokenCustomize;
 }): Promise<string> {
   log.debug(account_id, tags);
   if (!isValidUUID(account_id)) {
@@ -38,6 +41,7 @@ export default async function firstProject({
     account_id,
     title: "My First Project",
     ephemeral,
+    customize,
   });
   log.debug("created new project", project_id);
   if (!dontStartProject) {

--- a/src/packages/server/accounts/first-project.ts
+++ b/src/packages/server/accounts/first-project.ts
@@ -39,7 +39,7 @@ export default async function firstProject({
   }
   const project_id = await createProject({
     account_id,
-    title: "My First Project",
+    title: ephemeral ? "My Project" : "My First Project",
     ephemeral,
     customize,
   });

--- a/src/packages/server/projects/create.ts
+++ b/src/packages/server/projects/create.ts
@@ -68,8 +68,6 @@ export default async function createProject(opts: CreateProjectOptions) {
     return true;
   });
 
-  // Convert back to comma-separated string for database
-  let license = licenses.length > 0 ? licenses.join(",") : undefined;
   let project_id;
   if (opts.project_id) {
     if (!account_id || !(await isAdmin(account_id))) {
@@ -80,7 +78,7 @@ export default async function createProject(opts: CreateProjectOptions) {
     // Try to get from pool if no license and no image specified (so the default),
     // and not "noPool".  NOTE: we may improve the pool to also provide some
     // basic licensed projects later, and better support for images.  Maybe.
-    if (!noPool && !license && account_id != null) {
+    if (!noPool && licenses.length === 0 && account_id != null) {
       project_id = await getFromPool({
         account_id,
         title,
@@ -99,9 +97,9 @@ export default async function createProject(opts: CreateProjectOptions) {
   const users =
     account_id == null ? null : { [account_id]: { group: "owner" } };
   let site_license;
-  if (license) {
+  if (licenses.length > 0) {
     site_license = {};
-    for (const license_id of license.split(",")) {
+    for (const license_id of licenses) {
       site_license[license_id] = {};
     }
   } else {

--- a/src/packages/util/db-schema/projects.ts
+++ b/src/packages/util/db-schema/projects.ts
@@ -11,6 +11,7 @@ import {
   ExecuteCodeOptionsAsyncGet,
   ExecuteCodeOutput,
 } from "@cocalc/util/types/execute-code";
+import { type RegistrationTokenCustomize } from "@cocalc/util/types/registration-token";
 import { DEFAULT_QUOTAS } from "@cocalc/util/upgrade-spec";
 
 import { NOTES } from "./crm";
@@ -745,6 +746,8 @@ export interface CreateProjectOptions {
   project_id?: string;
   // if set, project should be treated as expiring after this many milliseconds since creation
   ephemeral?: number;
+  // account customization settings to apply to project (e.g., disableInternet)
+  customize?: RegistrationTokenCustomize;
 }
 
 interface BaseCopyOptions {

--- a/src/packages/util/quota.test.ts
+++ b/src/packages/util/quota.test.ts
@@ -2744,3 +2744,39 @@ describe("test pay-you-go-quota inclusion", () => {
     });
   });
 });
+
+describe("ephemeral projects", () => {
+  it("disables network when project settings request no internet", () => {
+    const projectSettings = { disableInternet: true };
+    const licenses = {
+      "abcd1234-0000-0000-0000-000000000001": {
+        quota: {
+          cpu: 1,
+          ram: 1,
+          disk: 1,
+          network: 1,
+        },
+        status: "active",
+      },
+    };
+    const q = quota(projectSettings, {}, licenses, {});
+    expect(q.network).toBe(false);
+  });
+
+  it("still enables network when project settings have, but don't request, no internet", () => {
+    const projectSettings = { disableInternet: false };
+    const licenses = {
+      "abcd1234-0000-0000-0000-000000000001": {
+        quota: {
+          cpu: 1,
+          ram: 1,
+          disk: 1,
+          network: 1,
+        },
+        status: "active",
+      },
+    };
+    const q = quota(projectSettings, {}, licenses, {});
+    expect(q.network).toBe(true);
+  });
+});

--- a/src/packages/util/types/registration-token.ts
+++ b/src/packages/util/types/registration-token.ts
@@ -1,0 +1,35 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020-2025 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+/**
+ * Customization settings that can be applied via registration tokens.
+ * These settings restrict or modify the behavior of accounts and their projects.
+ */
+export interface RegistrationTokenCustomize {
+  /**
+   * If true, prevents users from adding collaborators to their projects.
+   * The "Add Collaborators" UI will be hidden.
+   */
+  disableCollaborators?: boolean;
+
+  /**
+   * If true, disables all AI/language model features for this account.
+   */
+  disableAI?: boolean;
+
+  /**
+   * If true, disables internet access for projects created by this account.
+   * This is enforced at the project level via project settings.
+   */
+  disableInternet?: boolean;
+
+  /**
+   * Optional site license ID to apply to projects created via this token.
+   */
+  license?: string;
+}
+
+// Backwards compatibility alias
+export type EphemeralCustomize = RegistrationTokenCustomize;

--- a/src/packages/util/upgrades/quota.ts
+++ b/src/packages/util/upgrades/quota.ts
@@ -131,6 +131,7 @@ interface Settings {
   privileged?: number;
   network?: number;
   always_running?: number;
+  disableInternet?: boolean; // project setting to explicitly disable network
 }
 
 export interface Upgrades {
@@ -1053,6 +1054,11 @@ export function quota_with_reasons(
   if (pay_as_you_go != null) {
     // do this after any other processing or it would just go away, e.g., when min'ing with max's
     total_quota.pay_as_you_go = pay_as_you_go;
+  }
+
+  // Project-level setting to explicitly disable internet overrides any license/network grants.
+  if (settings?.disableInternet) {
+    total_quota.network = false;
   }
 
   return { quota: total_quota, reasons };


### PR DESCRIPTION
This moves some fields into an expandable row, otherwise table too wide. Some tweaks to the columns. Buttons to copy token or ephemeral URL. Add/Edit is a dialog now.

This also adds adding a license id and storing the disable internet info in the ephemeral project.

Extra: adding a client-side timeout for that `client.conat_client.hub.db.userQuery` call. there is a timeout flag, but it  is passed on to conat, and kind of dropped. what's certainly missing is a frontend timeout.

<img width="1084" height="460" alt="Screenshot from 2025-12-17 12-46-33" src="https://github.com/user-attachments/assets/69268cfd-f549-49f0-be92-1dd4bd974cd9" />



"Custom" can be edited


<img width="791" height="751" alt="Screenshot from 2025-12-17 18-50-17" src="https://github.com/user-attachments/assets/272cbc90-e499-407c-ab78-9608fa068fa9" />

