### PR TITLE
Fix crash when collaborator avatar has no cursor locs

### DIFF
--- a/src/packages/frontend/frame-editors/code-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/code-editor/actions.ts
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2020-2025 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -1170,7 +1170,11 @@ export class Actions<
           : "always",
       })
       .forEach((info, account_id) => {
-        info.get("locs").forEach((loc) => {
+        const locs = info.get("locs");
+        if (locs == null) {
+          return;
+        }
+        locs.forEach((loc) => {
           loc = loc.set("time", info.get("time"));
           const locs = cursors.get(account_id, List()).push(loc);
           cursors = cursors.set(account_id, locs as any);
@@ -1222,7 +1226,7 @@ export class Actions<
         if (!locs) return;
         locs.map((loc) => {
           const y = loc.get("y");
-          if (y != null) {
+          if (typeof y === "number") {
             omit_lines[y] = true;
           }
         });

--- a/src/packages/frontend/frame-editors/jupyter-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/actions.ts
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2020-2025 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -568,18 +568,21 @@ export class JupyterEditorActions extends BaseActions<JupyterEditorState> {
   }
 
   gotoUser(account_id: string, frameId?: string) {
-    const cursors = this.jupyter_actions.syncdb
-      .get_cursors({ maxAge: 0, excludeSelf: "never" })
-      ?.toJS();
-    const locs = cursors?.[account_id]?.locs;
+    const cursors = this.jupyter_actions.syncdb.get_cursors({
+      maxAge: 0,
+      excludeSelf: "never",
+    });
+    const info = cursors.get(account_id);
+    const locs = info?.get("locs");
     if (locs == null) {
       return; // no info
     }
     for (const loc of locs) {
-      if (loc.id != null) {
+      const id = loc.get("id");
+      if (typeof id === "string") {
         const frameActions = this.get_frame_actions(frameId);
         if (frameActions != null) {
-          frameActions.set_cur_id(loc.id);
+          frameActions.set_cur_id(id);
           frameActions.scroll("cell visible");
           return;
         }

--- a/src/packages/frontend/frame-editors/whiteboard-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/whiteboard-editor/actions.ts
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2022-2025 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -1023,14 +1023,18 @@ export class Actions<T extends State = State> extends BaseActions<T | State> {
   }
 
   gotoUser(account_id: string, frameId?: string) {
-    const cursors = this._syncstring
-      .get_cursors({ maxAge: 0, excludeSelf: "never" })
-      ?.toJS();
-    if (cursors == null) return; // no info
-    const locs = cursors[account_id]?.locs;
+    const cursors = this._syncstring.get_cursors({
+      maxAge: 0,
+      excludeSelf: "never",
+    });
+    const info = cursors.get(account_id);
+    if (info == null) return; // no info
+    const locs = info.get("locs");
+    if (locs == null) return; // no info
     for (const loc of locs) {
-      if (loc.id != null) {
-        this.scrollElementIntoView(loc.id, frameId);
+      const id = loc.get("id");
+      if (typeof id === "string") {
+        this.scrollElementIntoView(id, frameId);
         return;
       }
     }

--- a/src/packages/sync/editor/generic/sync-doc.ts
+++ b/src/packages/sync/editor/generic/sync-doc.ts
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2020-2025 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -108,6 +108,7 @@ import { SortedPatchList } from "./sorted-patch-list";
 import type {
   Client,
   CompressedPatch,
+  CursorMap,
   DocType,
   Document,
   FileWatcher,
@@ -199,7 +200,7 @@ export class SyncDoc extends EventEmitter {
   private throttled_file_use?: Function;
 
   private cursors: boolean = false; // if true, also provide cursor tracking functionality
-  private cursor_map: Map<string, any> = Map();
+  private cursor_map: CursorMap = Map() as CursorMap;
   private cursor_last_time: Date = new Date(0);
 
   // doctype: object describing document constructor
@@ -2068,7 +2069,7 @@ export class SyncDoc extends EventEmitter {
   }: {
     maxAge?: number;
     excludeSelf?: "always" | "never" | "heuristic";
-  } = {}): Map<string, any> => {
+  } = {}): CursorMap => {
     this.assert_not_closed("get_cursors");
     if (!this.cursors) {
       throw Error("cursors are not enabled");

--- a/src/packages/sync/editor/generic/types.ts
+++ b/src/packages/sync/editor/generic/types.ts
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2020-2025 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -8,6 +8,8 @@
  */
 
 // A Patch is an entry in the patches table, as represented in memory locally here.
+
+import type { List, Map as ImmutableMap } from "immutable";
 
 import { SyncTable } from "@cocalc/sync/table/synctable";
 import { type CompressedPatch } from "@cocalc/util/dmp";
@@ -18,6 +20,33 @@ import type {
   CallConatServiceFunction,
   CreateConatServiceFunction,
 } from "@cocalc/conat/service";
+
+export type CursorLoc = ImmutableMap<string, unknown>;
+
+export type CursorInfo = ImmutableMap<string, unknown> & {
+  get(key: "locs"): List<CursorLoc> | undefined;
+  get(key: "time"): number | Date | undefined;
+  get(key: "user_id"): number | undefined;
+};
+
+export type CursorMap = ImmutableMap<string, CursorInfo>;
+
+export type CursorLocJS = {
+  id?: string;
+  x?: number;
+  y?: number;
+  type?: string;
+  time?: number | Date;
+  [key: string]: unknown;
+};
+
+export interface CursorInfoJS {
+  locs?: CursorLocJS[] | null;
+  time?: number | Date;
+  user_id?: number;
+}
+
+export type CursorMapJS = Record<string, CursorInfoJS | undefined>;
 
 export interface Patch {
   // time = LOGICAL time of when patch made; this used to be ms since the epoch, but just


### PR DESCRIPTION
- treat cursor locs as optional in sync types and guard when missing
- use immutable cursor maps for gotoUser in whiteboard/jupyter
- add cursor id/type guards in cursor handling
- fixes #8628