### PR TITLE
frontend/misc/llm: remove noisy numTokensEstimate timing log

### DIFF
--- a/src/packages/frontend/misc/llm.ts
+++ b/src/packages/frontend/misc/llm.ts
@@ -35,10 +35,11 @@ const numTokensEstimateImpl = (content: string, maxTokens?: number): number => {
   return estimate;
 };
 
-export const numTokensEstimate = timed(
-  "frontend/misc/llm.ts#numTokensEstimate",
-  numTokensEstimateImpl,
-);
+// export const numTokensEstimate = timed(
+//   "frontend/misc/llm.ts#numTokensEstimate",
+//   numTokensEstimateImpl,
+// );
+export const numTokensEstimate = numTokensEstimateImpl;
 
 const numTokensUpperBoundImpl = (
   content: string,


### PR DESCRIPTION
## Summary
- Removed the `timed()` wrapper from `numTokensEstimate` to eliminate excessive log output
- Function remains fully functional by directly exporting the implementation
- No changes needed to the 9 files that import and use this function

## Test plan
- [x] Verify all callers of `numTokensEstimate` continue to work correctly
- [x] Confirm log line with "ts#numTokensEstimate" no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)