### PR TITLE
next/api: add /api/v2/exec e2e + fix async exec

### DIFF
--- a/.github/workflows/make-and-test.yml
+++ b/.github/workflows/make-and-test.yml
@@ -285,6 +285,17 @@ jobs:
           PGUSER: smc
           PGHOST: localhost
 
+      - name: Run api/v2 exec e2e tests
+        run: |
+          export COCALC_API_KEY=$(cat src/api_key.txt)
+          export COCALC_HOST=http://localhost:5000
+          export COCALC_PROJECT_ID=$(cd src/python/cocalc-api && make ci-create-project)
+          cd src/packages/next && pnpm run test-apiv2-e2e
+        env:
+          PGDATABASE: smc
+          PGUSER: smc
+          PGHOST: localhost
+
       - name: Stop CoCalc Hub
         if: always()
         run: |
@@ -338,4 +349,3 @@ jobs:
           reporter: jest-junit
           use-actions-summary: 'true'
           fail-on-error: false
-

--- a/src/packages/next/package.json
+++ b/src/packages/next/package.json
@@ -36,6 +36,7 @@
     "start-project": "unset PGHOST PGUSER COCALC_ROOT; export PORT=5000 BASE_PATH=/$COCALC_PROJECT_ID/port/5000; echo https://cocalc.com$BASE_PATH; pnpm start",
     "test": "NODE_ENV='dev' pnpm exec jest",
     "test-api": "NODE_ENV='production' pnpm exec jest ./lib/api/framework.test.ts",
+    "test-apiv2-e2e": "COCALC_E2E=true NODE_ENV='production' pnpm exec jest pages/api/v2/exec.e2e.test.ts",
     "depcheck": "pnpx depcheck --ignores @openapitools/openapi-generator-cli,eslint-config-next,locales,components,lib,public,pages,software-inventory,pg",
     "prepublishOnly": "pnpm test",
     "patch-openapi": "sed '/^interface NrfOasData {/s/^interface/export interface/' node_modules/next-rest-framework/dist/index.d.ts > node_modules/next-rest-framework/dist/index.d.ts.temp && mv node_modules/next-rest-framework/dist/index.d.ts.temp node_modules/next-rest-framework/dist/index.d.ts",

--- a/src/packages/next/pages/api/v2/exec.e2e.test.ts
+++ b/src/packages/next/pages/api/v2/exec.e2e.test.ts
@@ -1,0 +1,113 @@
+/** @jest-environment node */
+
+const runE2E = process.env.COCALC_E2E === "true";
+const describeE2E = runE2E ? describe : describe.skip;
+
+describeE2E("/api/v2/exec e2e", () => {
+  const apiKey = process.env.COCALC_API_KEY ?? "";
+  const projectId = process.env.COCALC_PROJECT_ID ?? "";
+  const host = process.env.COCALC_HOST ?? "http://localhost:5000";
+
+  beforeAll(() => {
+    if (!apiKey || !projectId) {
+      throw new Error(
+        "COCALC_API_KEY and COCALC_PROJECT_ID must be set when COCALC_E2E=true",
+      );
+    }
+  });
+
+  test("exec date -Is", async () => {
+    const auth = Buffer.from(`${apiKey}:`).toString("base64");
+    const response = await fetch(`${host}/api/v2/exec`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+      body: JSON.stringify({
+        project_id: projectId,
+        command: "date",
+        args: ["-Is"],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    if (data?.error) {
+      throw new Error(`API error: ${data.error}`);
+    }
+
+    const stdout = String(data.stdout ?? "").trim();
+    const stderr = String(data.stderr ?? "").trim();
+
+    expect(data.exit_code).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/,
+    );
+  });
+
+  test("exec async_call with async_get", async () => {
+    const auth = Buffer.from(`${apiKey}:`).toString("base64");
+    const startResp = await fetch(`${host}/api/v2/exec`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+      body: JSON.stringify({
+        project_id: projectId,
+        bash: true,
+        command:
+          "echo $TEST_ENV; for i in $(seq 10); do echo i=$i; sleep 0.1; done",
+        timeout: 10,
+        async_call: true,
+        env: {
+          TEST_ENV: "123",
+        },
+      }),
+    });
+
+    expect(startResp.status).toBe(200);
+    const startData = await startResp.json();
+    if (startData?.error) {
+      throw new Error(`API error: ${startData.error}`);
+    }
+
+    expect(startData.type).toBe("async");
+    expect(startData.job_id).toBeTruthy();
+    expect(["running", "completed"]).toContain(startData.status);
+
+    const pollResp = await fetch(`${host}/api/v2/exec`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${auth}`,
+      },
+      body: JSON.stringify({
+        project_id: projectId,
+        async_get: startData.job_id,
+        async_stats: true,
+        async_await: true,
+      }),
+    });
+
+    expect(pollResp.status).toBe(200);
+    const pollData = await pollResp.json();
+    if (pollData?.error) {
+      throw new Error(`API error: ${pollData.error}`);
+    }
+
+    const stdout = String(pollData.stdout ?? "").trim();
+    const stderr = String(pollData.stderr ?? "").trim();
+
+    expect(pollData.type).toBe("async");
+    expect(pollData.job_id).toBe(startData.job_id);
+    expect(pollData.status).toBe("completed");
+    expect(pollData.exit_code).toBe(0);
+    expect(stderr).toBe("");
+    const stdoutLines = stdout.split("\n");
+    expect(stdoutLines[0]).toBe("123");
+    expect(stdout).toContain("i=10");
+  });
+});

--- a/src/packages/project/exec_shell_code.ts
+++ b/src/packages/project/exec_shell_code.ts
@@ -28,7 +28,7 @@ export async function exec_shell_code(socket: CoCalcSocket, mesg) {
   D(`command=${mesg.command} args=${mesg.args} path=${mesg.path}`);
 
   try {
-    const ret = handleExecShellCode(mesg);
+    const ret = await handleExecShellCode(mesg);
     socket.write_mesg("json", message.project_exec_output(ret));
   } catch (err) {
     let error = `Error executing command '${mesg.command}' with args '${mesg.args}' -- ${err}`;
@@ -68,4 +68,3 @@ export async function handleExecShellCode(mesg) {
   }
   return ret;
 }
-


### PR DESCRIPTION
## Summary
- await project exec responses so /api/v2/exec returns correctly
- add opt-in /api/v2/exec e2e tests (blocking + async)
- run new e2e test in CI after cocalc-api tests
