### PR TITLE
frontend/latex: fix TOC issue and safeguard sync-doc itself

### DIFF
--- a/src/packages/sync/editor/generic/sync-doc.ts
+++ b/src/packages/sync/editor/generic/sync-doc.ts
@@ -1005,7 +1005,11 @@ export class SyncDoc extends EventEmitter {
 
   private syncstring_table_get_one = (): Map<string, any> => {
     if (this.syncstring_table == null) {
-      throw Error("syncstring_table must be defined");
+      logger.warn("syncstring_table missing", {
+        path: this.path,
+        state: this.state,
+      });
+      return Map();
     }
     const t = this.syncstring_table.get_one();
     if (t == null) {
@@ -2703,6 +2707,13 @@ export class SyncDoc extends EventEmitter {
 
   private handle_syncstring_update = async (): Promise<void> => {
     if (this.state === "closed") {
+      return;
+    }
+    if (this.syncstring_table == null) {
+      logger.warn("handle_syncstring_update without syncstring_table", {
+        path: this.path,
+        state: this.state,
+      });
       return;
     }
     const dbg = this.dbg("handle_syncstring_update");


### PR DESCRIPTION
ref #8658

ignore *.toc

```
sync-doc.ts:1008 Uncaught (in promise) Error: syncstring_table must be defined
    at SyncDoc._this1.syncstring_table_get_one (sync-doc.ts:1008:1)
    at eval (sync-doc.ts:2711:1)
    at step (sync-doc.js:289:23)
    at Object.eval [as next] (sync-doc.js:230:20)
    at asyncGeneratorStep (sync-doc.js:22:28)
    at _next (sync-doc.js:40:17)
    at eval (sync-doc.js:45:13)
    at new Promise (<anonymous>)
    at eval (sync-doc.js:37:16)
    at SyncDoc._this1.handle_syncstring_update (sync-doc.ts:2726:1)
```