### PR TITLE
conat/sync: comment unreachable change tracking in core-stream

### DIFF
--- a/src/packages/conat/sync/core-stream.ts
+++ b/src/packages/conat/sync/core-stream.ts
@@ -315,7 +315,9 @@ export class CoreStream<T = any> extends EventEmitter {
     await until(
       async () => {
         let messages: StoredMessage[] = [];
-        let changes: (SetOperation | DeleteOperation | StoredMessage)[] = [];
+        // TODO: tracking changes during getAll and suppressing sending duplicates
+        // via the changefeed is not implemented.
+        // let changes: (SetOperation | DeleteOperation | StoredMessage)[] = [];
         try {
           if (this.isClosed()) {
             return true;
@@ -359,12 +361,12 @@ export class CoreStream<T = any> extends EventEmitter {
           noEmit,
           noSeqCheck: true,
         });
-        if (changes.length > 0) {
-          this.processPersistentMessages(changes, {
-            noEmit,
-            noSeqCheck: false,
-          });
-        }
+        // if (changes.length > 0) {
+        //   this.processPersistentMessages(changes, {
+        //     noEmit,
+        //     noSeqCheck: false,
+        //   });
+        // }
         // success!
         return true;
       },


### PR DESCRIPTION
fixes https://github.com/sagemathinc/cocalc/issues/8707

## Summary
- Comment out the unreachable change-tracking lines in `getAllFromPersist`.
- Add a TODO documenting the intended behavior (track changes during `getAll` and suppress duplicate changefeed emits).

## Notes / Rationale
The `changes` array was never populated, so the branch was dead code. Leaving the lines commented (instead of removing) keeps intent visible while preserving behavior.

## Possible future implementation (not done here)
- Track the max seq processed during `getAllFromPersist` and suppress changefeed emits for seq <= that value.
- Or buffer changefeed updates while `getAll` runs and replay them with `noSeqCheck=false` after completion.
- Either avoids duplicate change events after reconnect without changing persistence semantics.

Refs: #8707
