### PR TITLE
npm: fix @isaacs/brace-expansion DoS vulnerability

### DIFF
--- a/src/packages/package.json
+++ b/src/packages/package.json
@@ -40,7 +40,8 @@
       "axios@<1.12.0": "^1.12.0",
       "tmp@<0.2.4": "^0.2.4",
       "lodash@>=4.0.0 <4.17.23": "4.17.23",
-      "lodash-es@>=4.0.0 <4.17.23": "4.17.23"
+      "lodash-es@>=4.0.0 <4.17.23": "4.17.23",
+      "@isaacs/brace-expansion@<=5.0.0": "5.0.1"
     },
     "onlyBuiltDependencies": [
       "websocket-sftp",

--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   tmp@<0.2.4: ^0.2.4
   lodash@>=4.0.0 <4.17.23: 4.17.23
   lodash-es@>=4.0.0 <4.17.23: 4.17.23
+  '@isaacs/brace-expansion@<=5.0.0': 5.0.1
 
 importers:
 
@@ -3061,8 +3062,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -13765,7 +13766,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -21355,7 +21356,7 @@ snapshots:
 
   minimatch@10.0.3:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Override `@isaacs/brace-expansion@<=5.0.0` → `5.0.1` to fix GHSA-7h2j-956f-4vf2
- The fix adds a 100K item expansion limit to prevent DoS from malicious brace patterns
- No functional impact for normal usage (glob/minimatch file matching)

Fixes #551 (Dependabot alert)
