### PR TITLE
Flyout file explorer: respect disableActions for student projects

### DIFF
--- a/src/packages/frontend/project/page/flyouts/file-list-item.tsx
+++ b/src/packages/frontend/project/page/flyouts/file-list-item.tsx
@@ -501,7 +501,9 @@ export const FileListItem = React.memo((props: Readonly<FileListItemProps>) => {
     }
 
     // the file or directory actions
-    makeContextMenuEntries(ctx, item, multiple);
+    if (!student_project_functionality.disableActions) {
+      makeContextMenuEntries(ctx, item, multiple);
+    }
 
     // view/download buttons at the bottom
     const showDownload = !student_project_functionality.disableActions;

--- a/src/packages/frontend/project/page/flyouts/files-controls.tsx
+++ b/src/packages/frontend/project/page/flyouts/files-controls.tsx
@@ -9,6 +9,7 @@ import { useIntl } from "react-intl";
 
 import { useActions, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { Icon, TimeAgo } from "@cocalc/frontend/components";
+import { useStudentProjectFunctionality } from "@cocalc/frontend/course";
 import {
   ACTION_BUTTONS_DIR,
   ACTION_BUTTONS_FILE,
@@ -53,6 +54,9 @@ export function FilesSelectedControls({
   const intl = useIntl();
   const current_path = useTypedRedux({ project_id }, "current_path");
   const actions = useActions({ project_id });
+  const student_project_functionality =
+    useStudentProjectFunctionality(project_id);
+  const disableActions = student_project_functionality.disableActions;
 
   const singleFile = useSingleFile({
     checked_files,
@@ -195,6 +199,7 @@ export function FilesSelectedControls({
   }
 
   function renderButtons(names) {
+    if (disableActions) return;
     if (mode === "top" && checked_files.size === 0) return;
 
     return (
@@ -242,8 +247,8 @@ export function FilesSelectedControls({
           ? renderButtons(ACTION_BUTTONS_DIR)
           : renderButtons(ACTION_BUTTONS_FILE.filter((n) => n !== "download"))
         : checked_files.size > 1
-        ? renderButtons(ACTION_BUTTONS_MULTI)
-        : undefined}
+          ? renderButtons(ACTION_BUTTONS_MULTI)
+          : undefined}
       {renderFileInfo()}
     </Space>
   );

--- a/src/packages/frontend/project/page/flyouts/files.tsx
+++ b/src/packages/frontend/project/page/flyouts/files.tsx
@@ -137,6 +137,7 @@ export function FilesFlyout({
   const [selectionOnMouseDown, setSelectionOnMouseDown] = useState<string>("");
   const student_project_functionality =
     useStudentProjectFunctionality(project_id);
+  const disableActions = student_project_functionality.disableActions ?? false;
   const disableUploads = student_project_functionality.disableUploads ?? false;
   const virtuosoRef = useRef<VirtuosoHandle>(null as any);
   const virtuosoScroll = useVirtuosoScrollHook({
@@ -617,14 +618,19 @@ export function FilesFlyout({
         onPublic={() => showFileSharingDialog(directoryFiles[index])}
         selected={isSelected}
         showCheckbox={
-          mode === "select" ||
-          checked_files?.size > 0 ||
-          showCheckboxIndex === index
+          !disableActions &&
+          (mode === "select" ||
+            checked_files?.size > 0 ||
+            showCheckboxIndex === index)
         }
-        setShowCheckboxIndex={setShowCheckboxIndex}
-        onChecked={(nextState: boolean) => {
-          toggleSelected(index, item.name, nextState);
-        }}
+        setShowCheckboxIndex={disableActions ? undefined : setShowCheckboxIndex}
+        onChecked={
+          disableActions
+            ? undefined
+            : (nextState: boolean) => {
+                toggleSelected(index, item.name, nextState);
+              }
+        }
         checked_files={checked_files}
         isStarred={isStarred}
         onStar={(starState: boolean) => {


### PR DESCRIPTION
## Summary
- The flyout panel's file explorer was not respecting the course `disableActions` setting, which is used by instructors to block file operations (delete, rename, move, copy, compress, share, duplicate, download) in student projects
- The main file explorer correctly hides checkboxes and all action buttons when `disableActions` is true, but the flyout still exposed these actions via right-click context menus, action button panels, and file selection checkboxes
- Fixed by gating context menu entries, action buttons, and checkbox/selection UI on `disableActions` in three flyout components

## Test plan
- [x] Set `disableActions` on a student project via course configuration
- [x] Verify the main file explorer hides checkboxes and action buttons (existing behavior)
- [x] Verify the flyout file explorer now also hides checkboxes, context menu file actions, and action buttons
- [x] Verify file opening/navigation still works normally in the flyout when actions are disabled
- [x] Verify everything works normally in the flyout when actions are NOT disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)