### PR TITLE
hub/blobs: harden blob serving against stored XSS

### DIFF
--- a/src/packages/hub/servers/app/blobs.ts
+++ b/src/packages/hub/servers/app/blobs.ts
@@ -1,4 +1,6 @@
 import { Router } from "express";
+import { basename, extname } from "node:path";
+
 import { database } from "../database";
 import { is_valid_uuid_string } from "@cocalc/util/misc";
 import { database_is_working } from "@cocalc/server/metrics/hub_register";
@@ -6,6 +8,28 @@ import { callback2 } from "@cocalc/util/async-utils";
 import { getLogger } from "@cocalc/hub/logger";
 
 const logger = getLogger("hub:servers:app:blobs");
+
+const SAFE_INLINE_IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".avif",
+  ".bmp",
+  ".ico",
+]);
+
+function safeFilenameFromPath(pathname: string): string {
+  const name = basename(pathname || "") || "blob";
+  return name.replace(/[^\w.\-()+ ]+/g, "_");
+}
+
+function shouldInlineByFilename(filename: string): boolean {
+  const ext = extname(filename).toLowerCase();
+  return SAFE_INLINE_IMAGE_EXTENSIONS.has(ext);
+}
+
 export default function init(router: Router) {
   // return uuid-indexed blobs (mainly used for graphics)
   router.get("/blobs/{*splat}", async (req, res) => {
@@ -29,14 +53,18 @@ export default function init(router: Router) {
       if (data == null) {
         res.status(404).send(`blob ${uuid} not found`);
       } else {
-        const filename = req.path.slice(req.path.lastIndexOf("/") + 1);
-        if (req.query.download != null) {
-          // tell browser to download the link as a file instead
-          // of displaying it in browser
+        const filename = safeFilenameFromPath(req.path);
+        const forceDownload =
+          req.query.download != null || !shouldInlineByFilename(filename);
+        if (forceDownload) {
+          // Force download for anything that is not an explicitly safe inline
+          // type, to avoid serving executable content (e.g. HTML/SVG/JS) on
+          // hub origin.
           res.attachment(filename);
         } else {
           res.type(filename);
         }
+        res.set("X-Content-Type-Options", "nosniff");
         // Cache as long as possible (e.g., One year in seconds), since
         // what we are returning is defined by a sha1 hash, so cannot change.
         res.set("Cache-Control", `public, max-age=${365 * 24 * 60 * 60}`);
@@ -51,7 +79,7 @@ export default function init(router: Router) {
       }
     } catch (err) {
       logger.error(`internal error ${err} getting blob ${uuid}`);
-      res.status(500).send(`internal error: ${err}`);
+      res.status(500).send("internal error getting blob");
     }
   });
 }


### PR DESCRIPTION
## Summary
- Force-download non-image blob types (HTML, SVG, JS, etc.) to prevent stored XSS via malicious files served on the hub origin
- Add `X-Content-Type-Options: nosniff` header to all blob responses
- Use proper HTTP status codes (401 for unauthenticated, 403 for unauthorized) instead of 500
- Sanitize error messages so internal details are logged server-side only, not leaked to clients
- Add `cleanupUploadKey()` to prevent upload state accumulation on error paths

## Test plan
- [ ] Upload a `.png` image as a blob — verify it still renders inline in the browser
- [ ] Upload a `.html` file as a blob — verify the browser downloads it instead of rendering
- [ ] Upload a `.svg` file as a blob — verify forced download
- [ ] Check response headers include `X-Content-Type-Options: nosniff`
- [ ] Attempt blob upload without auth — verify 401 response
- [ ] Attempt blob upload to non-collaborator project — verify 403 response
- [ ] Trigger an upload error — verify the response says "upload failed" without internal details

🤖 Generated with [Claude Code](https://claude.com/claude-code)