### PR TITLE
Fix invite email link to point to sign-up page

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -198,6 +198,7 @@ CoCalc is organized as a monorepo with key packages:
 - When creating a new file, run `git add [filename]` to track the file.
 - Prefix git commits with the package and general area. e.g. 'frontend/latex: ...' if it concerns latex editor changes in the packages/frontend/... code.
 - When pushing a new branch to Github, track it upstream. e.g. `git push --set-upstream origin feature-foo` for branch "feature-foo".
+- **Branch naming**: New branches should follow the pattern `[some-key-words]-[issue-number]`. e.g. `fix-invite-email-signup-link-8757` for issue #8757.
 
 ## React-intl / Internationalization (i18n)
 

--- a/src/packages/next/components/auth/sign-up.tsx
+++ b/src/packages/next/components/auth/sign-up.tsx
@@ -51,6 +51,7 @@ interface SignUpProps {
   showSignIn?: boolean;
   signInAction?: () => void; // if given, replaces the default sign-in link behavior.
   requireTags: boolean;
+  defaultEmail?: string; // pre-fill the email field (e.g., from invite link)
 }
 
 export default function SignUp(props: SignUpProps) {
@@ -77,6 +78,7 @@ function SignUp0({
   signInAction,
   showSignIn,
   requireTags,
+  defaultEmail,
 }: SignUpProps) {
   const {
     anonymousSignup,
@@ -89,7 +91,7 @@ function SignUp0({
   } = useCustomize();
   const [tags, setTags] = useState<Set<string>>(new Set());
   const [signupReason, setSignupReason] = useState<string>("");
-  const [email, setEmail] = useState<string>("");
+  const [email, setEmail] = useState<string>(defaultEmail ?? "");
   const [registrationToken, setRegistrationToken] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [firstName, setFirstName] = useState<string>("");
@@ -480,26 +482,26 @@ function SignUp0({
                 what,
               )}`
             : requiresToken2 && !registrationToken
-            ? "Enter the secret registration token"
-            : !email
-            ? "How will you sign in?"
-            : !isValidEmailAddress(email)
-            ? "Enter a valid email address above"
-            : requiredSSO != null
-            ? "You must sign up via SSO"
-            : !password || password.length < MIN_PASSWORD_LENGTH
-            ? `Choose password with at least ${MIN_PASSWORD_LENGTH} characters`
-            : password &&
-              password.length >= MIN_PASSWORD_LENGTH &&
-              passwordStrength.score <= MIN_PASSWORD_STRENGTH
-            ? "Make your password more complex"
-            : !firstName?.trim()
-            ? "Enter your first name above"
-            : !lastName?.trim()
-            ? "Enter your last name above"
-            : signingUp
-            ? ""
-            : "Sign Up!"}
+              ? "Enter the secret registration token"
+              : !email
+                ? "How will you sign in?"
+                : !isValidEmailAddress(email)
+                  ? "Enter a valid email address above"
+                  : requiredSSO != null
+                    ? "You must sign up via SSO"
+                    : !password || password.length < MIN_PASSWORD_LENGTH
+                      ? `Choose password with at least ${MIN_PASSWORD_LENGTH} characters`
+                      : password &&
+                          password.length >= MIN_PASSWORD_LENGTH &&
+                          passwordStrength.score <= MIN_PASSWORD_STRENGTH
+                        ? "Make your password more complex"
+                        : !firstName?.trim()
+                          ? "Enter your first name above"
+                          : !lastName?.trim()
+                            ? "Enter your last name above"
+                            : signingUp
+                              ? ""
+                              : "Sign Up!"}
           {signingUp && (
             <span style={{ marginLeft: "15px" }}>
               <Loading>Signing Up...</Loading>
@@ -549,10 +551,10 @@ function EmailOrSSO(props: EmailOrSSOProps) {
           {hideSSO
             ? "Sign up using your single sign-on provider"
             : strategies.length > 0 && emailSignup
-            ? "Sign up using either your email address or a single sign-on provider."
-            : emailSignup
-            ? "Enter the email address you will use to sign in."
-            : "Sign up using a single sign-on provider."}
+              ? "Sign up using either your email address or a single sign-on provider."
+              : emailSignup
+                ? "Enter the email address you will use to sign in."
+                : "Sign up using a single sign-on provider."}
         </p>
       </div>
       {renderSSO()}

--- a/src/packages/next/pages/auth/sign-up.tsx
+++ b/src/packages/next/pages/auth/sign-up.tsx
@@ -20,6 +20,8 @@ import withCustomize from "lib/with-customize";
 export default function SignUpPage({ customize, requiresToken, requireTags }) {
   const { siteName, isCommercial } = customize;
   const router = useRouter();
+  const defaultEmail =
+    typeof router.query.email === "string" ? router.query.email : undefined;
 
   function openRoot() {
     router.push("/");
@@ -49,6 +51,7 @@ export default function SignUpPage({ customize, requiresToken, requireTags }) {
             requiresToken={requiresToken}
             onSuccess={onSuccess}
             requireTags={requireTags}
+            defaultEmail={defaultEmail}
           />
           <Footer />
         </Layout.Content>

--- a/src/packages/server/hub/email.ts
+++ b/src/packages/server/hub/email.ts
@@ -325,7 +325,7 @@ function create_email_body(
 <br/><br/>
 <b>To accept the invitation:
 <ol>
-<li>Open <a href="${base_url}/app">CoCalc</a></li>
+<li>Open <a href="${base_url}/auth/sign-up?email=${encodeURIComponent(email_address)}">CoCalc</a></li>
 <li>Sign up/in using <i>exactly</i> your email address <code>${email_address}</code></li>
 <li>${direct_link}</li>
 </ol></b>


### PR DESCRIPTION
## Summary

- Invite emails linked to `/app` which has no sign-up button — unhelpful for new users receiving invitations
- Changed the "Open CoCalc" link to `/auth/sign-up?email=<encoded_email>` so invited users land directly on the sign-up page
- The sign-up page now reads the `email` query parameter and pre-fills the email field, preventing mismatched email addresses
- Also added branch naming convention (`[key-words]-[issue-number]`) to AGENTS.md

Fixes #8757

## Test plan

- [ ] Send a test invite email and verify the "Open CoCalc" link points to `/auth/sign-up?email=...`
- [ ] Click the link and verify the sign-up page loads with the email field pre-filled
- [ ] Verify special characters in email addresses (e.g., `+`, `.`) are properly URL-encoded
- [ ] Verify that already-signed-in users clicking the link are redirected to the homepage (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)