### PR TITLE
frontend/app: lock SPA root container to viewport

### DIFF
--- a/src/packages/frontend/index.sass
+++ b/src/packages/frontend/index.sass
@@ -147,10 +147,11 @@ body
   width      : 100vw
   overflow-x : hidden
 
-div#smc-react-container
+div#smc-react-container,
+div#cocalc-webapp-container
   overflow   : hidden
   position   : absolute
-  top        : 0px
+  inset      : 0
 
 
 


### PR DESCRIPTION
## Summary
- apply the SPA root-locking styles to `#cocalc-webapp-container` as well as the legacy `#smc-react-container`
- keep the app root pinned to the viewport so body-level focus/portal activity cannot scroll the whole SPA upward
- use `inset: 0` for the viewport lock

## Verification
- `pnpm -C packages/static build-dev`
- loaded `/app` and verified `#cocalc-webapp-container` is `position:absolute` with `overflow:hidden`
- verified `document.body.scrollHeight` is `0` on the live page after rebuild