### PR TITLE
Fix checkout session burst

### DIFF
--- a/src/packages/next/pages/api/v2/purchases/is-purchase-allowed.ts
+++ b/src/packages/next/pages/api/v2/purchases/is-purchase-allowed.ts
@@ -16,11 +16,21 @@ RETURNS:
 import getAccountId from "lib/account/get-account";
 import { isPurchaseAllowed } from "@cocalc/server/purchases/is-purchase-allowed";
 import getParams from "lib/api/get-params";
+import getLogger from "@cocalc/backend/logger";
+
+const logger = getLogger("next-api:purchases:is-purchase-allowed");
 
 export default async function handle(req, res) {
   try {
     res.json(await get(req));
   } catch (err) {
+    const { service, cost } = getParams(req);
+    logger.warn("is-purchase-allowed request failed", {
+      account_id: await getAccountId(req),
+      service,
+      cost,
+      error: `${err.message}`,
+    });
     res.json({ error: `${err.message}` });
     return;
   }

--- a/src/packages/server/purchases/stripe/get-checkout-session.ts
+++ b/src/packages/server/purchases/stripe/get-checkout-session.ts
@@ -31,9 +31,11 @@ export default async function getCheckoutSession({
   return_url,
   metadata,
 }: Options): Promise<CheckoutSessionSecret> {
+  const project_id = metadata?.project_id;
   logger.debug("getCheckoutSession", {
     account_id,
     purpose,
+    project_id,
     description,
     lineItems,
     return_url,
@@ -70,6 +72,13 @@ export default async function getCheckoutSession({
     status: "open",
     customer,
   });
+  logger.debug("getCheckoutSession: listed open checkout sessions", {
+    account_id,
+    purpose,
+    project_id,
+    customer,
+    open_session_count: openSessions.data.length,
+  });
   // cutoff = an hour ago in stripe time.  Restricting only to status='open'
   // as above should work, but doesn't, since we had many reports of users
   // with open checkout sessions that didn't work. This might help.
@@ -90,11 +99,32 @@ export default async function getCheckoutSession({
         ) ||
         session.created <= cutoff
       ) {
-        logger.debug("getCheckoutSession: expiring checkout session");
+        logger.debug("getCheckoutSession: expiring checkout session", {
+          account_id,
+          purpose,
+          project_id,
+          session_id: session.id,
+          session_created: session.created,
+          line_items_match: isEqual(
+            session.metadata?.[LINE_ITEMS_METADATA_KEY],
+            JSON.stringify(lineItems),
+          ),
+          description_match: isEqual(
+            session.metadata?.[DESCRIPTION_METADATA_KEY],
+            description ?? "",
+          ),
+          older_than_cutoff: session.created <= cutoff,
+        });
         // The line items or description changed or its older than an hour, so don't use it.
         await stripe.checkout.sessions.expire(session.id);
       } else {
-        logger.debug("getCheckoutSession: using existing checkout session");
+        logger.debug("getCheckoutSession: using existing checkout session", {
+          account_id,
+          purpose,
+          project_id,
+          session_id: session.id,
+          session_created: session.created,
+        });
         // Reuse the existing open session when the checkout inputs still match.
         return { clientSecret: session.client_secret };
       }
@@ -110,6 +140,14 @@ export default async function getCheckoutSession({
     [DESCRIPTION_METADATA_KEY]: description ?? "",
     total_excluding_tax_usd: `${total_excluding_tax_usd}`,
   };
+  logger.debug("getCheckoutSession: creating checkout session", {
+    account_id,
+    purpose,
+    project_id,
+    customer,
+    line_item_count: lineItemsWithoutCredit.length,
+    total_excluding_tax_usd,
+  });
   const session = await stripe.checkout.sessions.create({
     customer,
     ui_mode: "embedded",
@@ -158,6 +196,13 @@ export default async function getCheckoutSession({
   if (!session.client_secret) {
     throw Error("unable to create session");
   }
+
+  logger.debug("getCheckoutSession: created checkout session", {
+    account_id,
+    purpose,
+    project_id,
+    session_id: session.id,
+  });
 
   return { clientSecret: session.client_secret };
 }


### PR DESCRIPTION
A student reports consistent `too many requests to purchases/is-purchase-allowed; try again in 1 second (rule: at most 7 requests per second)` when trying to pay the course fee. Stripe showed many "Checkout Session expired" events, which I have seen before.

codex analysis and fix which in principle makes sense, and it even mentioned that adding a payment method first mitigates the problem, but I can't meaningfully assess changes myself:

**Root cause:** in the embedded checkout path, `get-checkout-session` tried to reuse an existing open Stripe Checkout Session by comparing the current checkout inputs to metadata on the existing session, but that metadata was never written when the session was created. So every later request treated the current open session as stale, expired it, and created a new one.

**Fix:** store a deterministic fingerprint of the checkout inputs in the session metadata and use that for reuse decisions, so identical requests reuse the existing open session instead of expiring it.

Also added lightweight logging around checkout-session reuse/expiry/create decisions and failed `is-purchase-allowed` requests so we can correlate any remaining bursty behavior in production logs.