### PR TITLE
server/auth: preserve signed-in SSO link context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ The root-level `src/workspaces.py` script orchestrates operations across all pac
 ### Development
 
 - **IMPORTANT**: Always run `prettier -w [filename]` immediately after editing any .ts, .tsx, .md, or .json file to ensure consistent styling
+- **IMPORTANT**: In tests and code comments, use only generic names, email addresses, and company names. Do not include customer or real-world identifiers, except for `Sagemath, Inc.` or when the developer explicitly says otherwise.
 
 #### When Working on Frontend Code
 

--- a/src/packages/server/auth/sso/consts.ts
+++ b/src/packages/server/auth/sso/consts.ts
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2022 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2022-2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -29,3 +29,6 @@ export const BLACKLISTED_STRATEGIES = [
 ] as const;
 
 export const SSO_API_KEY_COOKIE_NAME = base_path + "get_api_key";
+export const SSO_LINK_ACCOUNT_CACHE_NAME = "sso-link-account";
+export const SSO_LINK_ACCOUNT_COOKIE_NAME = base_path + "sso_link_account";
+export const SSO_LINK_ACCOUNT_MAX_AGE_MS = 60 * 60 * 1000;

--- a/src/packages/server/auth/sso/passport-login.test.ts
+++ b/src/packages/server/auth/sso/passport-login.test.ts
@@ -1,0 +1,231 @@
+import { getPassportCache } from "@cocalc/database/postgres/passport-store";
+import isBanned from "@cocalc/server/accounts/is-banned";
+import clientSideRedirect from "@cocalc/server/auth/client-side-redirect";
+import { getAccountIdFromRememberMe } from "@cocalc/server/auth/get-account";
+import { PassportLogin } from "./passport-login";
+import { SSO_LINK_ACCOUNT_COOKIE_NAME } from "./consts";
+
+jest.mock("cookies", () => ({
+  __esModule: true,
+  __mock: {
+    setValues(values: Record<string, string>) {
+      this.values = new Map(Object.entries(values));
+    },
+    values: new Map<string, string>(),
+  },
+  default: class MockCookies {
+    constructor(_req, _res?) {}
+
+    get(name: string) {
+      return jest.requireMock("cookies").__mock.values.get(name);
+    }
+
+    set(name: string, value?: string) {
+      if (value == null) {
+        jest.requireMock("cookies").__mock.values.delete(name);
+        return;
+      }
+      jest.requireMock("cookies").__mock.values.set(name, value);
+    }
+  },
+}));
+jest.mock("@cocalc/database/postgres/passport-store", () => ({
+  __esModule: true,
+  getPassportCache: jest.fn(),
+}));
+jest.mock("@cocalc/server/accounts/account-creation-actions", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("@cocalc/server/accounts/get-email-address", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("@cocalc/server/accounts/is-banned", () => ({
+  __esModule: true,
+  default: jest.fn(async () => false),
+}));
+jest.mock("@cocalc/server/auth/get-account", () => ({
+  __esModule: true,
+  getAccountIdFromRememberMe: jest.fn(),
+}));
+jest.mock("@cocalc/server/auth/client-side-redirect", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("@cocalc/server/auth/set-sign-in-cookies", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("@cocalc/server/auth/sso/sanitize-id", () => ({
+  __esModule: true,
+  sanitizeID: jest.fn(),
+}));
+jest.mock("@cocalc/server/auth/sso/sanitize-profile", () => ({
+  __esModule: true,
+  sanitizeProfile: jest.fn(),
+}));
+
+const mockedGetPassportCache = getPassportCache as jest.MockedFunction<
+  typeof getPassportCache
+>;
+const mockedClientSideRedirect = clientSideRedirect as jest.MockedFunction<
+  typeof clientSideRedirect
+>;
+const mockedIsBanned = isBanned as jest.MockedFunction<typeof isBanned>;
+const mockedGetAccountIdFromRememberMe =
+  getAccountIdFromRememberMe as jest.MockedFunction<
+    typeof getAccountIdFromRememberMe
+  >;
+const mockedCookies = jest.requireMock("cookies").__mock as {
+  setValues: (values: Record<string, string>) => void;
+};
+
+const ACCOUNT_ID = "11111111-1111-1111-1111-111111111111";
+const OTHER_ACCOUNT_ID = "22222222-2222-2222-2222-222222222222";
+const TEST_EMAIL = "user@example.com";
+
+function createLogin(databaseOverrides: Partial<any> = {}) {
+  const database = {
+    account_exists: jest.fn(),
+    create_passport: jest.fn(),
+    get_remember_me: jest.fn(),
+    passport_exists: jest.fn(),
+    ...databaseOverrides,
+  };
+
+  return {
+    database,
+    login: new PassportLogin({
+      passports: {
+        saml: {
+          strategy: "saml",
+          conf: { type: "saml" },
+          info: { display: "Example SSO" },
+        },
+      },
+      database: database as any,
+      host: "localhost",
+      id: "saml-user-1",
+      profile: { id: "saml-user-1" },
+      strategyName: "saml",
+      emails: [TEST_EMAIL],
+      first_name: "Test",
+      last_name: "User",
+      req: {},
+      res: {},
+      site_url: "https://example.com/app",
+      update_on_login: false,
+    }),
+  };
+}
+
+describe("PassportLogin authenticated linking", () => {
+  beforeEach(() => {
+    mockedCookies.setValues({});
+    mockedClientSideRedirect.mockReset();
+    mockedIsBanned.mockResolvedValue(false);
+    mockedGetAccountIdFromRememberMe.mockReset();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("uses the authenticated link cookie to attach SSO to the current account", async () => {
+    const getAsync = jest.fn(async () =>
+      JSON.stringify({
+        account_id: ACCOUNT_ID,
+        remember_me_hash: "active-remember-me-hash",
+      }),
+    );
+    const removeAsync = jest.fn(async () => undefined);
+    mockedGetAccountIdFromRememberMe.mockResolvedValue(ACCOUNT_ID);
+    mockedGetPassportCache.mockReturnValue({
+      getAsync,
+      removeAsync,
+      saveAsync: jest.fn(),
+    } as any);
+    mockedCookies.setValues({
+      [SSO_LINK_ACCOUNT_COOKIE_NAME]: "link-token",
+    });
+
+    const { login, database } = createLogin({
+      passport_exists: jest.fn(async () => undefined),
+    });
+
+    await expect(login.login()).resolves.toBeUndefined();
+
+    expect(getAsync).toHaveBeenCalledWith("link-token");
+    expect(mockedGetAccountIdFromRememberMe).toHaveBeenCalledWith(
+      "active-remember-me-hash",
+    );
+    expect(removeAsync).toHaveBeenCalledWith("link-token");
+    expect(database.create_passport).toHaveBeenCalledWith({
+      account_id: ACCOUNT_ID,
+      strategy: "saml",
+      id: "saml-user-1",
+      profile: { id: "saml-user-1" },
+      email_address: TEST_EMAIL,
+      first_name: "Test",
+      last_name: "User",
+    });
+    expect(database.account_exists).not.toHaveBeenCalled();
+    expect(mockedClientSideRedirect).toHaveBeenCalled();
+  });
+
+  test("still rejects matching email addresses when there is no authenticated linking context", async () => {
+    mockedGetAccountIdFromRememberMe.mockResolvedValue(undefined);
+    mockedGetPassportCache.mockReturnValue({
+      getAsync: jest.fn(async () => null),
+      removeAsync: jest.fn(async () => undefined),
+      saveAsync: jest.fn(),
+    } as any);
+
+    const { login, database } = createLogin({
+      account_exists: jest.fn(({ email_address, cb }) =>
+        cb(undefined, email_address === TEST_EMAIL ? OTHER_ACCOUNT_ID : null),
+      ),
+      passport_exists: jest.fn(async () => undefined),
+    });
+
+    await expect(login.login()).rejects.toThrow(
+      `There is already an account with email address ${TEST_EMAIL}; please sign in using that email account, then link saml to it in account settings.`,
+    );
+
+    expect(database.create_passport).not.toHaveBeenCalled();
+  });
+
+  test("ignores stale link cookies if the original remember_me session was revoked", async () => {
+    mockedGetAccountIdFromRememberMe.mockResolvedValue(undefined);
+    mockedGetPassportCache.mockReturnValue({
+      getAsync: jest.fn(async () =>
+        JSON.stringify({
+          account_id: ACCOUNT_ID,
+          remember_me_hash: "stale-remember-me-hash",
+        }),
+      ),
+      removeAsync: jest.fn(async () => undefined),
+      saveAsync: jest.fn(),
+    } as any);
+    mockedCookies.setValues({
+      [SSO_LINK_ACCOUNT_COOKIE_NAME]: "link-token",
+    });
+
+    const { login, database } = createLogin({
+      account_exists: jest.fn(({ email_address, cb }) =>
+        cb(undefined, email_address === TEST_EMAIL ? OTHER_ACCOUNT_ID : null),
+      ),
+      passport_exists: jest.fn(async () => undefined),
+    });
+
+    await expect(login.login()).rejects.toThrow(
+      `There is already an account with email address ${TEST_EMAIL}; please sign in using that email account, then link saml to it in account settings.`,
+    );
+
+    expect(mockedGetAccountIdFromRememberMe).toHaveBeenCalledWith(
+      "stale-remember-me-hash",
+    );
+    expect(database.create_passport).not.toHaveBeenCalled();
+  });
+});

--- a/src/packages/server/auth/sso/passport-login.ts
+++ b/src/packages/server/auth/sso/passport-login.ts
@@ -26,6 +26,7 @@ import { REMEMBER_ME_COOKIE_NAME } from "@cocalc/backend/auth/cookie-names";
 import base_path from "@cocalc/backend/base-path";
 import getLogger from "@cocalc/backend/logger";
 import { set_email_address_verified } from "@cocalc/database/postgres/account-queries";
+import { getPassportCache } from "@cocalc/database/postgres/passport-store";
 import type {
   PostgreSQL,
   UpdateAccountInfoAndPassportOpts,
@@ -39,6 +40,7 @@ import accountCreationActions from "@cocalc/server/accounts/account-creation-act
 import getEmailAddress from "@cocalc/server/accounts/get-email-address";
 import isBanned from "@cocalc/server/accounts/is-banned";
 import clientSideRedirect from "@cocalc/server/auth/client-side-redirect";
+import { getAccountIdFromRememberMe } from "@cocalc/server/auth/get-account";
 import generateHash from "@cocalc/server/auth/hash";
 import setSignInCookies from "@cocalc/server/auth/set-sign-in-cookies";
 import { sanitizeID } from "@cocalc/server/auth/sso/sanitize-id";
@@ -51,9 +53,19 @@ import {
 import { is_valid_email_address } from "@cocalc/util/misc";
 import { ssoNormalizeExclusiveDomains } from "@cocalc/util/sso-normalize-domains";
 import { HELP_EMAIL } from "@cocalc/util/theme";
-import { SSO_API_KEY_COOKIE_NAME } from "./consts";
+import {
+  SSO_API_KEY_COOKIE_NAME,
+  SSO_LINK_ACCOUNT_CACHE_NAME,
+  SSO_LINK_ACCOUNT_COOKIE_NAME,
+  SSO_LINK_ACCOUNT_MAX_AGE_MS,
+} from "./consts";
 
 const logger = getLogger("server:auth:sso:passport-login");
+
+interface LinkAccountState {
+  account_id: string;
+  remember_me_hash: string;
+}
 
 export class PassportLogin {
   private readonly passports: { [k: string]: PassportStrategyDB } = {};
@@ -137,6 +149,9 @@ export class PassportLogin {
     try {
       // do we have a valid remember me cookie for a given account_id already?
       await this.checkRememberMeCookie(locals);
+      // Cross-site SSO callbacks can lose the remember_me cookie, so preserve an
+      // explicit "link this strategy to my current account" intent separately.
+      await this.checkLinkAccountCookie(locals);
       // do we already have a passport?
       await this.checkPassportExists(this.opts, locals);
       // there might be accounts already with that email address
@@ -219,6 +234,52 @@ export class PassportLogin {
         return;
       }
     }
+  }
+
+  private async checkLinkAccountCookie(
+    locals: PassportLoginLocals,
+  ): Promise<void> {
+    if (locals.has_valid_remember_me || locals.account_id != null) {
+      return;
+    }
+
+    const linkAccountId = locals.cookies.get(SSO_LINK_ACCOUNT_COOKIE_NAME);
+    if (linkAccountId == null) {
+      return;
+    }
+
+    // The browser cookie is just an opaque pointer. The actual account context
+    // is stored server-side with a short expiry in passport_store.
+    const cache = getPassportCache(
+      SSO_LINK_ACCOUNT_CACHE_NAME,
+      SSO_LINK_ACCOUNT_MAX_AGE_MS,
+    );
+    const cached = await cache.getAsync(linkAccountId);
+    await cache.removeAsync(linkAccountId);
+    locals.cookies.set(SSO_LINK_ACCOUNT_COOKIE_NAME);
+
+    if (cached == null) {
+      return;
+    }
+
+    let state: LinkAccountState;
+    try {
+      state = JSON.parse(cached);
+    } catch {
+      return;
+    }
+
+    // Revalidate the original remember_me session before treating this callback
+    // as an authenticated "link SSO to my current account" flow.
+    const account_id = await getAccountIdFromRememberMe(state.remember_me_hash);
+    if (account_id == null || account_id !== state.account_id) {
+      return;
+    }
+
+    // From this point on, the shared PassportLogin flow can handle the SSO
+    // callback exactly like a still-signed-in linking request.
+    locals.account_id = state.account_id;
+    locals.has_valid_remember_me = true;
   }
 
   // this adds a passport to an existing account

--- a/src/packages/server/hub/auth.ts
+++ b/src/packages/server/hub/auth.ts
@@ -95,7 +95,12 @@ import {
   BLACKLISTED_STRATEGIES,
   DEFAULT_LOGIN_INFO,
   SSO_API_KEY_COOKIE_NAME,
+  SSO_LINK_ACCOUNT_CACHE_NAME,
+  SSO_LINK_ACCOUNT_COOKIE_NAME,
+  SSO_LINK_ACCOUNT_MAX_AGE_MS,
 } from "@cocalc/server/auth/sso/consts";
+import { getAccountIdFromRememberMe } from "@cocalc/server/auth/get-account";
+import { getRememberMeHash } from "@cocalc/server/auth/remember-me";
 import {
   FacebookStrategyConf,
   GithubStrategyConf,
@@ -234,6 +239,53 @@ export class PassportManager {
     }
     next();
   }
+
+  private stashAuthenticatedLinkAccount = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const cookies = new Cookies(req, res);
+    let rememberMeHash: string | undefined;
+    try {
+      rememberMeHash = getRememberMeHash(req);
+    } catch {
+      rememberMeHash = undefined;
+    }
+    if (rememberMeHash == null) {
+      // Setting a cookie with no value clears any stale link-account marker.
+      cookies.set(SSO_LINK_ACCOUNT_COOKIE_NAME);
+      next();
+      return;
+    }
+
+    const account_id = await getAccountIdFromRememberMe(rememberMeHash);
+    if (account_id == null) {
+      // Setting a cookie with no value clears any stale link-account marker.
+      cookies.set(SSO_LINK_ACCOUNT_COOKIE_NAME);
+      next();
+      return;
+    }
+
+    const linkId = uuidv4();
+    await getPassportCache(
+      SSO_LINK_ACCOUNT_CACHE_NAME,
+      SSO_LINK_ACCOUNT_MAX_AGE_MS,
+    ).saveAsync(
+      linkId,
+      JSON.stringify({ account_id, remember_me_hash: rememberMeHash }),
+    );
+
+    const secure = req.protocol === "https";
+    cookies.set(SSO_LINK_ACCOUNT_COOKIE_NAME, linkId, {
+      httpOnly: true,
+      maxAge: SSO_LINK_ACCOUNT_MAX_AGE_MS,
+      overwrite: true,
+      sameSite: secure ? "none" : undefined,
+      secure,
+    });
+    next();
+  };
 
   // this is for pure backwards compatibility. at some point remove this!
   // it only returns a string[] array of the legacy authentication strategies
@@ -804,6 +856,7 @@ export class PassportManager {
     this.router.get(
       strategyUrl,
       this.handle_get_api_key,
+      this.stashAuthenticatedLinkAccount,
       this.setState(name, type, auth_opts),
       passport.authenticate(name, auth_opts),
     );


### PR DESCRIPTION
## Summary
- preserve the initiating account across SSO round-trips with a short-lived link token
- let PassportLogin treat that token like an authenticated link context when remember_me is unavailable
- add regression coverage for linking to the signed-in account vs. rejecting a true duplicate-email sign-in

## Testing
- pnpm -C src/packages/server test -- auth/sso/passport-login.test.ts
- pnpm -C src/packages/server build