### PR TITLE
feat: submenu icon pinning for frame editor toolbar

### DIFF
--- a/src/docs/frame-editor-menus.md
+++ b/src/docs/frame-editor-menus.md
@@ -1,0 +1,275 @@
+# Frame Editor Menus, Toolbar, and Icon Pinning
+
+This document describes the command/menu system in CoCalc's frame editor —
+how menus are built, how the symbol bar (quick-access toolbar) works, and how
+users pin/unpin icons from menus to the toolbar.
+
+Companion docs: `frame-editors.md` (layout tree, editor specs),
+`frame-editor-dnd.md` (drag-and-drop).
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ [≡ Slate ▾]  File  Edit  Format  View  Go  Help   [≡][×][⊡]  │  ← menus + frame controls
+│  Bold  Italic  Header  Font  Color  AI  Sync  ToC             │  ← symbol bar (pinned buttons)
+├─────────────────────────────────────────────────────────────────┤
+│                        Editor Content                          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Each menu item has an icon on its left. Clicking the **icon** toggles whether
+that command is pinned to the symbol bar. Clicking the **label** executes the
+command. Pinned icons appear highlighted (`background: #ddd`) in the menu.
+
+## Architecture
+
+```
+commands/types.ts       Command interface, MenuSpec, Group types
+commands/commands.ts    COMMANDS registry + addCommands()
+commands/menus.ts       MENUS & GROUPS registries + addMenus(), addCommandsToMenus()
+commands/generic-menus.ts   Standard menu definitions (file, edit, view, go, help, …)
+commands/generic-commands.tsx   Common commands (save, undo, zoom, frame ops, …)
+commands/format-commands.tsx    Format submenu commands (bold, font, header, …)
+commands/editor-menus.ts    addEditorMenus() helper for editor-specific menus
+commands/manage.tsx     ManageCommands class — visibility, rendering, pinning
+title-bar.tsx           FrameTitleBar component — renders menus + symbol bar
+```
+
+## Registration: Commands, Groups, and Menus
+
+### Hierarchy
+
+```
+Menu (e.g. "edit")
+  └─ Group (e.g. "undo-redo", "find", "copy", "ai", "format", "config")
+       └─ Command (e.g. "undo", "redo", "find", "replace", …)
+```
+
+- **`MENUS`** (`menus.ts`): top-level dropdown menus. Each has a `label`, `pos`
+  (sort order), and `groups[]` listing which groups it contains.
+- **`GROUPS`** (`menus.ts`): maps group name → array of command names.
+- **`COMMANDS`** (`commands.ts`): maps command name → `Command` object.
+
+### Registration flow
+
+```typescript
+// 1. Register menu structure (generic-menus.ts)
+addMenus({
+  edit: { label: menu.edit, pos: 1, groups: ["undo-redo", "find", "copy", "ai", "format", "config"] },
+  // ...
+});
+
+// 2. Register commands — automatically added to their group via addCommandsToMenus()
+addCommands({
+  undo: { group: "undo-redo", pos: 0, icon: "undo", label: "Undo", onClick: ... },
+  redo: { group: "undo-redo", pos: 1, icon: "redo", label: "Redo", onClick: ... },
+});
+```
+
+### Editor-specific registration
+
+Each editor type can add its own menus and commands via `addEditorMenus()` helper
+(in `editor-menus.ts`). This builds both menu groups and command objects from a
+simpler specification format, supporting nested children for submenus.
+
+Example: `format-commands.tsx` registers format commands with submenu children
+(font size, font family, headers, colors, etc.).
+
+## The Command Interface
+
+```typescript
+interface Command {
+  group: Group;             // which menu group this belongs to
+  pos?: number;             // sort position within group (default: 1e6)
+  icon?: IconName | ReactNode | ((opts: ManageCommands) => ReactNode);
+  iconRotate?: IconRotation;
+  label?: CommandText;      // text shown in menus
+  button?: CommandText;     // text shown on toolbar button (if different from label)
+  title?: CommandText;      // tooltip text
+  onClick?: OnClick;        // handler; falls back to actions[commandName](frameId)
+  children?: Command[] | ((opts: ManageCommands) => Command[]); // submenu items
+  keyboard?: ReactNode;     // shortcut display (desktop only)
+  isVisible?: string | ((opts) => boolean);  // visibility predicate
+  disabled?: (opts) => boolean;              // grayed-out predicate
+  alwaysShow?: boolean;     // override all visibility checks
+  neverVisibleOnMobile?: boolean;
+  stayOpenOnClick?: boolean; // keep dropdown open after click
+  popconfirm?: PopconfirmOpts | ((opts) => PopconfirmOpts);
+  disable?: keyof StudentProjectFunctionality; // educational restrictions
+  search?: string;          // extra search terms for command search
+}
+```
+
+### Icon types
+
+Icons can be one of three forms:
+- **String** (`IconName`): e.g. `"bold"`, `"undo"`, `"colors"` — renders via `<Icon name={...} />`
+- **ReactNode**: e.g. `<span style={{fontSize: 18}}>A</span>` — custom rendering
+- **Function**: `(opts: ManageCommands) => ReactNode` — dynamic icon based on state
+
+## ManageCommands Class (`manage.tsx`)
+
+Central class instantiated per frame title bar. Handles:
+
+### Visibility
+
+```typescript
+isVisible(name, cmd?): boolean
+```
+
+Checks (in order):
+1. Explicitly hidden by spec (`spec.commands["-commandName"]`) → false
+2. `alwaysShow` → true
+3. `neverVisibleOnMobile` + mobile → false
+4. Student project restrictions → false
+5. Custom `isVisible` predicate
+6. Must be in `spec.commands` or `spec.customizeCommands`
+
+### Menu rendering
+
+```typescript
+commandToMenuItem({ name, cmd, key, noChildren, button }): MenuItem
+```
+
+Converts a `Command` into an antd `MenuItem`. When `button=true`, renders in
+toolbar style (icon + optional small label). When `button=false`, renders in
+menu style (icon + full label + keyboard shortcut).
+
+### Icon pinning
+
+```typescript
+// Check if command is pinned to the toolbar
+isOnButtonBar(name): boolean
+  → editorSettings.getIn(["buttons", editorType(), name])
+  ?? spec.buttons?.[name]  // fallback to editor default
+
+// Toggle pin state — persisted to account settings
+toggleButton(name): void
+  → set_account_table({ editor_settings: { buttons: { [editorType]: { [name]: bool } } } })
+
+// Get ordered list of pinned button names
+getToolbarButtons(): string[]
+  → merges user-customized buttons + spec default buttons
+  → sorted by command position (menu order)
+```
+
+**Editor type key**: `"${filename_extension}-${frame_type}"` (e.g. `"md-slate"`,
+`"ipynb-jupyter"`, `"tex-cm"`). This means pinning is per file-extension and
+per frame-type.
+
+### Storage
+
+Pin state is stored in the user's account table:
+```
+account.editor_settings.buttons = {
+  "md-slate": { "format-bold": true, "format-header": true, ... },
+  "tex-cm":   { "build": true, "sync": true, ... },
+  ...
+}
+```
+
+- `true` = explicitly pinned
+- `false` = explicitly unpinned (overrides editor default)
+- `undefined` = falls back to editor spec default
+
+### Toolbar management commands
+
+- **Remove All**: `removeAllToolbarButtons()` — sets all spec defaults to `false`
+- **Reset**: `resetToolbar()` — clears all user customizations, restoring spec defaults
+
+## Title Bar Rendering (`title-bar.tsx`)
+
+### Menu rendering
+
+```typescript
+getMenuItems(name)   // builds MenuItem[] from groups for a named menu
+renderMenu(name)     // wraps getMenuItems in a DropdownMenu component
+renderMenus()        // iterates all MENUS, renders dropdowns sorted by pos
+```
+
+Items within groups are sorted by `pos`. Groups are separated by dividers.
+
+### Symbol bar rendering
+
+```typescript
+renderButtonBar(popup?)
+  → manageCommands.getToolbarButtons()   // get ordered button names
+  → renderButtonBarButton(name)          // render each as icon + optional label
+```
+
+Each toolbar button:
+- If the command has `children` → renders as a `DropdownMenu` (click opens submenu)
+- Otherwise → renders as a simple `Button` with icon + tooltip
+
+### Symbol bar labels
+
+Users can toggle labels below icons via right-click context menu on the symbol bar.
+Stored in `account.other_settings.show_symbol_bar_labels`.
+
+When labels are shown:
+- Symbol bar moves to its own row below the menu bar
+- Each button shows a small label (11px) below the icon, truncated to 50px
+
+When labels are hidden:
+- Symbol bar is inline with the menu bar (more compact)
+
+### Pin toggle UI in menus
+
+When `extra_button_bar` is enabled (the toolbar is visible), each top-level menu
+item's icon becomes a clickable button:
+
+```
+ [🔤]  Bold            ← click icon = toggle pin; click "Bold" = execute
+ [🔤]  Italic           gray bg on icon = currently pinned
+```
+
+The icon shows a tooltip: "Click icon to add/remove from toolbar".
+Only top-level commands (not submenu children) have this toggle.
+
+## Default Pinned Buttons per Editor
+
+Each `EditorDescription` can declare default toolbar buttons:
+
+```typescript
+const slate: EditorDescription = {
+  type: "slate",
+  // ...
+  buttons: {
+    "format-ai_formula": true,
+    "format-header": true,
+    "format-text": true,
+    "format-font": true,
+    "format-color": true,
+    "sync": true,
+    "show_table_of_contents": true,
+  },
+};
+```
+
+These appear on the toolbar by default until the user explicitly unpins them.
+
+### Examples of editor defaults
+
+- **Jupyter**: insert cell, run cell, interrupt kernel, restart kernel, cell type
+- **LaTeX**: AI formula, sync, header, text, font, color, build, build-on-save, ToC
+- **Markdown/Slate**: AI formula, sync, header, text, font, color, ToC
+- **Code**: (minimal — typically just undo/redo from generic commands)
+
+## Data Flow Summary
+
+```
+Editor spec (editor.ts)
+  → EditorDescription.commands    # which commands are available
+  → EditorDescription.buttons     # which are pinned by default
+  → EditorDescription.customizeCommands  # overrides per editor
+
+User interaction
+  → click icon in menu → toggleButton(name) → account.editor_settings.buttons
+  → right-click toolbar → toggle labels → account.other_settings.show_symbol_bar_labels
+
+Rendering
+  → ManageCommands.isVisible()        # filter commands
+  → ManageCommands.getToolbarButtons() # merge defaults + user prefs
+  → title-bar.tsx renders menus + symbol bar
+```

--- a/src/packages/frontend/frame-editors/frame-tree/commands/editor-menus.ts
+++ b/src/packages/frontend/frame-editors/frame-tree/commands/editor-menus.ts
@@ -108,6 +108,9 @@ export function addEditorMenus({
         `command "${name}" not fully defined -- getCommand returned null`,
       );
     }
+    if (!c.name) {
+      c = { ...c, name };
+    }
     if (!c.label) {
       c = { ...c, label: capitalize(name) };
     }

--- a/src/packages/frontend/frame-editors/frame-tree/commands/manage.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/commands/manage.tsx
@@ -291,6 +291,29 @@ export class ManageCommands {
     }
   };
 
+  // Resolve a possibly compound key like "format-font/bold" into the
+  // child command object.  For simple keys (no "/"), returns null so
+  // callers fall back to normal lookup via getCommandInfo.
+  resolveCompoundCommand = (
+    compoundKey: string,
+  ): Partial<Command> | null => {
+    const i = compoundKey.indexOf("/");
+    if (i === -1) {
+      return null;
+    }
+    const parentName = compoundKey.slice(0, i);
+    const childName = compoundKey.slice(i + 1);
+    const parentCmd = COMMANDS[parentName];
+    if (parentCmd == null) {
+      return null;
+    }
+    const children = this.getCommandChildren(parentCmd);
+    if (children == null) {
+      return null;
+    }
+    return children.find((c) => c.name === childName) ?? null;
+  };
+
   private getCommandIcon = (cmd: Partial<Command>) => {
     const rotate = cmd.iconRotate;
     let icon = cmd.icon;
@@ -364,9 +387,9 @@ export class ManageCommands {
     }
     let icon;
     if (!name || !this.editorSettings.get("extra_button_bar")) {
-      // do not show toggleable icon if no command name (so not top level)
-      // or the button bar is completely disabled (i.e. user doesn't
-      // want it at all).
+      // do not show toggleable icon if no command name (unnamed submenu
+      // children can't be pinned) or the button bar is completely
+      // disabled (i.e. user doesn't want it at all).
       icon = (
         <div style={{ width, marginRight: "10px", display: "inline-block" }}>
           {this.getCommandIcon(cmd)}
@@ -421,6 +444,17 @@ export class ManageCommands {
   };
 
   button = (name: string) => {
+    // Handle compound keys like "format-font/bold" for pinned submenu items
+    const childCmd = this.resolveCompoundCommand(name);
+    if (childCmd != null) {
+      return this.commandToMenuItem({
+        name,
+        cmd: childCmd,
+        key: name,
+        noChildren: true,
+        button: true,
+      });
+    }
     const cmd = this.getCommandInfo(name);
     if (cmd == null) {
       return null;
@@ -514,6 +548,10 @@ export class ManageCommands {
       ? undefined
       : this.getCommandChildren(cmd)?.map((x, i) =>
           this.commandToMenuItem({
+            // If the child has a name and this is a top-level command (name is set),
+            // construct a compound key "parent/child" so the pin toggle works for
+            // submenu items.
+            name: x.name && name ? `${name}/${x.name}` : "",
             cmd: x,
             key: `${key}-${i}-${x.stayOpenOnClick ? STAY_OPEN_ON_CLICK : ""}`,
             noChildren,
@@ -682,9 +720,34 @@ export class ManageCommands {
     //       return [];
     //     }
 
-    // TODO: sort w.
+    // Sort buttons by their position in the menu hierarchy.
+    // For compound keys like "format-font/bold", use the parent command's
+    // position plus a fractional offset based on the child's index within
+    // the submenu, so siblings preserve their menu order.
     const positions = this.getAllCommandPositions();
-    w.sort((a, b) => cmp(positions[a] ?? 0, positions[b] ?? 0));
+    const getPosition = (key: string): number => {
+      if (positions[key] != null) return positions[key];
+      const slashIdx = key.indexOf("/");
+      if (slashIdx !== -1) {
+        const parentName = key.slice(0, slashIdx);
+        const childName = key.slice(slashIdx + 1);
+        const base = positions[parentName] ?? 0;
+        const parentCmd = COMMANDS[parentName];
+        if (parentCmd != null) {
+          const children = this.getCommandChildren(parentCmd);
+          if (children != null) {
+            const idx = children.findIndex((c) => c.name === childName);
+            if (idx !== -1) {
+              // fractional offset keeps children after parent, in menu order
+              return base + (idx + 1) / (children.length + 1);
+            }
+          }
+        }
+        return base;
+      }
+      return 0;
+    };
+    w.sort((a, b) => cmp(getPosition(a), getPosition(b)));
     return w;
   };
 

--- a/src/packages/frontend/frame-editors/frame-tree/types.ts
+++ b/src/packages/frontend/frame-editors/frame-tree/types.ts
@@ -166,8 +166,8 @@ export interface EditorDescription {
   customizeCommands?: { [commandName: string]: Partial<Command> };
 
   // which commands will also appear in the button bar (if available)
-  // If a command is in a submenu, use '->' to link them together, i.e.,
-  // 'format-font -> bold' means the item named "bold" in the submenu
+  // If a command is in a submenu, use '/' to link them together, i.e.,
+  // 'format-font/bold' means the item named "bold" in the submenu
   // named 'format-font'.
   buttons?: { [commandName: string]: boolean };
 


### PR DESCRIPTION
## Summary
- Submenu children (e.g., **Bold** inside Format → Font) can now be pinned to the symbol bar via their icon in the menu, just like top-level commands
- Uses compound keys (`"format-font/bold"`) in the existing flat `buttons` storage map — no schema or type changes needed
- Adds `src/docs/frame-editor-menus.md` documenting the full menu/toolbar/icon-pinning architecture

## How it works
- `editor-menus.ts`: preserves child `name` through the command resolution pipeline
- `manage.tsx`: new `resolveCompoundCommand()` splits compound keys → looks up parent → finds matching child
- Pin toggle now appears on named submenu items in dropdown menus
- Pinned submenu items render as standalone buttons on the toolbar (not as dropdowns)
- Children without a `name` property gracefully skip the pin toggle

## Test plan
- [x] Open a `.md` file in Slate mode
- [x] Open Format → Font submenu — verify pin toggle icons appear next to Bold, Italic, etc.
- [x] Click pin icon on Bold — verify it appears as a standalone button on the symbol bar
- [x] Click pin icon again in menu — verify Bold is removed from the symbol bar
- [x] Pin a submenu item, reload page — verify it persists
- [x] Verify top-level pinning still works as before