### PR TITLE
fix: disable quick-action hover buttons on mobile

### DIFF
--- a/src/packages/frontend/file-clipboard/quick-actions.tsx
+++ b/src/packages/frontend/file-clipboard/quick-actions.tsx
@@ -13,6 +13,7 @@ import { useIntl } from "react-intl";
 
 import { redux } from "@cocalc/frontend/app-framework";
 import { Icon, type IconName } from "@cocalc/frontend/components";
+import { IS_MOBILE } from "@cocalc/frontend/feature";
 import { labels } from "@cocalc/frontend/i18n";
 // delete_files used by commented-out direct delete path
 // import { delete_files } from "@cocalc/frontend/project/delete-files";
@@ -91,6 +92,7 @@ export const QuickActionButtons: React.FC<QuickActionButtonsProps> = React.memo(
     style,
   }) => {
     const intl = useIntl();
+    if (IS_MOBILE) return null;
     const { tail: name } = path_split(path);
     const btnStyle = btnSize === "middle" ? BTN_STYLE_MIDDLE : BTN_STYLE_SMALL;
 


### PR DESCRIPTION
## Summary
- Disable the hover-based quick-action buttons (cut/copy/delete) on mobile devices
- Hover interactions don't exist on touch devices, so these buttons would never appear or behave unpredictably
- Simple early return of `null` from `QuickActionButtons` when `IS_MOBILE` is detected

## Test plan
- [ ] Verify quick-action hover buttons still appear on desktop file explorer rows
- [ ] Verify quick-action hover buttons still appear on desktop flyout file list items
- [ ] Verify no quick-action buttons render on mobile/touch devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)