### PR TITLE
fix: move IS_MOBILE guard below hooks in quick-actions

### DIFF
--- a/src/packages/frontend/file-clipboard/quick-actions.tsx
+++ b/src/packages/frontend/file-clipboard/quick-actions.tsx
@@ -92,7 +92,6 @@ export const QuickActionButtons: React.FC<QuickActionButtonsProps> = React.memo(
     style,
   }) => {
     const intl = useIntl();
-    if (IS_MOBILE) return null;
     const { tail: name } = path_split(path);
     const btnStyle = btnSize === "middle" ? BTN_STYLE_MIDDLE : BTN_STYLE_SMALL;
 
@@ -198,6 +197,8 @@ export const QuickActionButtons: React.FC<QuickActionButtonsProps> = React.memo(
       [project_id, path, isdir, current_path],
     );
     */
+
+    if (IS_MOBILE) return null;
 
     // Helper: style for a button — visible with indicator bg if it's the
     // active clipboard icon, hidden if another icon is active, normal otherwise


### PR DESCRIPTION
## Summary
- The previous mobile-disable commit (#8792) placed `if (IS_MOBILE) return null` before `useCallback` hooks, violating React's rules-of-hooks lint rule and breaking the CI build.
- Moves the early return below all hook calls so hooks are always called in the same order.

## Test plan
- [ ] CI ESLint passes (no `react-hooks/rules-of-hooks` errors)
- [ ] Quick action buttons still work on desktop
- [ ] Component still returns null on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)