### PR TITLE
fix: prevent LaTeX build tab spinner from getting stuck in multi-user scenarios

### DIFF
--- a/src/packages/frontend/frame-editors/latex-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/actions.ts
@@ -214,7 +214,13 @@ export class Actions extends BaseActions<LatexEditorState> {
       this.init_latexmk();
       // This breaks browser spellcheck.
       // this._init_spellcheck();
-      this.init_config();
+      // init_config is async — it must complete (setting build_command)
+      // before the BuildCoordinator is created, otherwise a late-join
+      // attempt may fire with an empty build_command and silently bail.
+      this.init_config().then(() => {
+        if (this._state === "closed") return;
+        this._init_build_coordinator();
+      });
       if (!this.knitr) {
         this.output_directory = this.output_directory_path();
       }
@@ -233,7 +239,6 @@ export class Actions extends BaseActions<LatexEditorState> {
         .getProjectStore(this.project_id)
         .on("started", this._project_started_listener);
       void this._init_pdf_directory_watcher();
-      this._init_build_coordinator();
     }
     this.word_count = reuseInFlight(this._word_count.bind(this));
   }
@@ -256,8 +261,14 @@ export class Actions extends BaseActions<LatexEditorState> {
       setBuilding: (v) => {
         this.is_building = v;
         this.setState({ building: v });
-        if (!v && !this._buildWasStopped) {
-          this._lastBuiltTime = this.last_save_time();
+        if (!v) {
+          // When build finishes, clean up any stale running entries in build_logs.
+          // This is especially important for joinBuild paths where the exec stream
+          // may error without properly finalizing the build_logs entry.
+          this.cleanupStaleBuildLogs();
+          if (!this._buildWasStopped) {
+            this._lastBuiltTime = this.last_save_time();
+          }
         }
       },
       setError: (err) => this.set_error(err),
@@ -1088,6 +1099,10 @@ export class Actions extends BaseActions<LatexEditorState> {
       // and finally, wait for word count to finish -- to make clear the whole operation is done
       await run_word_count;
     }
+
+    // Safety net: clean up any build_logs entries stuck in "running" status.
+    // This catches edge cases where a sub-step errored without finalizing its entry.
+    this.cleanupStaleBuildLogs();
   }
 
   private async run_knitr(time: number, force: boolean): Promise<void> {
@@ -1109,6 +1124,8 @@ export class Actions extends BaseActions<LatexEditorState> {
     } catch (err) {
       this.set_error(err);
       this.setState({ knitr_error: true });
+      // Mark as errored so the spinner stops, but keep partial output visible
+      this.markBuildLogError("knitr");
       return;
     } finally {
       this.set_status("");
@@ -1212,6 +1229,9 @@ export class Actions extends BaseActions<LatexEditorState> {
     } catch (err) {
       //console.info("LaTeX Editor/actions/run_latex error=", err);
       this.set_error(err);
+      // Mark the build_logs entry as errored so the build tab spinner stops,
+      // but preserve any partial output for the user to diagnose the failure.
+      this.markBuildLogError("latex");
       return;
     } finally {
       // In all cases, we want the status info to clear
@@ -1453,6 +1473,8 @@ export class Actions extends BaseActions<LatexEditorState> {
       await this.run_latex(time + 1, force);
     } catch (err) {
       this.set_error(err);
+      // Mark as errored so the spinner stops, but keep partial output visible
+      this.markBuildLogError("sagetex");
       this.update_pdf(time, force);
     } finally {
       this._last_sagetex_hash = hash;
@@ -1494,6 +1516,8 @@ export class Actions extends BaseActions<LatexEditorState> {
     } catch (err) {
       this.set_error(err);
       // this.setState({ pythontex_error: true });
+      // Mark as errored so the spinner stops, but keep partial output visible
+      this.markBuildLogError("pythontex");
       this.update_pdf(time, force);
       return;
     } finally {
@@ -1795,6 +1819,37 @@ export class Actions extends BaseActions<LatexEditorState> {
   // Public method to save local view state (delegates to parent's debounced method)
   save_local_view_state(): void {
     (this as any)._save_local_view_state();
+  }
+
+  // Mark a build_logs entry as "error" while preserving any partial output
+  // (stdout/stderr) so the user can still see what happened before the failure.
+  private markBuildLogError(stage: BuildSpecName): void {
+    const build_logs: BuildLogs | undefined = this.store.get("build_logs");
+    if (!build_logs) return;
+    const entry = build_logs.get(stage);
+    if (!entry) return;
+    const js: BuildLog = entry.toJS();
+    if (js.type === "async" && js.status === "running") {
+      js.status = "error";
+      this.set_build_logs({ [stage]: js });
+    }
+  }
+
+  // Safety net: after a build completes, clean up any build_logs entries
+  // that are still stuck in "running" status.  This can happen when an exec
+  // stream errors out after the "job" event set status to "running" but
+  // before the "done" event could finalize it.
+  // Preserves partial output so the user can diagnose the failure.
+  private cleanupStaleBuildLogs(): void {
+    const build_logs: BuildLogs | undefined = this.store.get("build_logs");
+    if (!build_logs) return;
+    build_logs.forEach((entry, key) => {
+      const js: BuildLog = entry?.toJS();
+      if (js?.type === "async" && js?.status === "running") {
+        js.status = "error";
+        this.set_build_logs({ [key]: js });
+      }
+    });
   }
 
   private set_build_logs(obj: { [K in keyof IBuildSpecs]?: BuildLog }): void {

--- a/src/packages/frontend/frame-editors/latex-editor/util.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/util.ts
@@ -181,6 +181,22 @@ export async function runJob(opts: RunJobOpts): Promise<ExecOutput> {
       resolve(result);
     });
 
+    // Stream reconciliation: if the stream ends (e.g., connection drop),
+    // finalize the job info so build_logs reflect the actual output.
+    // The promise is resolved/rejected by "done"/"error" events above;
+    // this just ensures the UI shows the final output snapshot.
+    stream.on("end", (output: ExecOutput) => {
+      if (current_job_info && output) {
+        const final_job_info: ExecuteCodeOutputAsync = {
+          ...current_job_info,
+          stdout: (output.stdout || "").toString(),
+          stderr: (output.stderr || "").toString(),
+          exit_code: output.exit_code,
+        };
+        set_job_info(final_job_info);
+      }
+    });
+
     stream.on("error", (err) => {
       reject(new Error(`Unable to run the compilation. ${err}`));
     });


### PR DESCRIPTION
## Summary

- **Fix stuck build tab spinner**: When an exec stream errors after the "job" event fires, error handlers now mark `build_logs` entries as "error" (preserving partial output) instead of leaving them permanently "running"
- **Safety net cleanup**: Added `cleanupStaleBuildLogs()` called after `run_build` completes and when `setBuilding(false)` fires, catching any remaining stale "running" entries
- **Stream reconciliation**: Added "end" handler to LaTeX `runJob` (matching the RMD version) so `build_logs` are finalized on connection drops
- **Init race fix**: Deferred `BuildCoordinator` creation until async `init_config()` completes, preventing silent bail on empty `build_command` when a late-join fires before config is ready

## Context

In production, the build tab spinner would get stuck for minutes with no build output when two users worked on the same `.tex` file. Clicking "Stop" then rebuilding was the only workaround. Root cause: the `build_logs` (which drives the spinner via `status === "running"`) and the `building` Redux flag (which drives the PDF preview button) are separate state — when a build step errored, only `building` was cleared but `build_logs` was left with a stale "running" entry.

## Test plan

- [ ] Open a `.tex` file with two browser sessions, trigger a build from one, verify the other session joins and the spinner clears when done
- [ ] Kill a build mid-stream (e.g., close tab), reopen — verify no stuck spinner
- [ ] Trigger a build error (e.g., malformed LaTeX) — verify spinner clears and partial output is visible in the build tab
- [ ] Verify single-user builds still work normally (build, force build, clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)