### PR TITLE
fix: software env dropdown and upgrade banner for 22.04 EOL

### DIFF
--- a/src/packages/frontend/project/page/software-env-upgrade.tsx
+++ b/src/packages/frontend/project/page/software-env-upgrade.tsx
@@ -141,7 +141,7 @@ const SoftwareEnvUpgradeAlert: React.FC<Props> = (props: Props) => {
 
     const oldname = software_envs[compute_image].title;
     const name2004 = software_envs[UBUNTU2004_DEPRECATED].title;
-    const name2204 = software_envs[UBUNTU2204].title;
+    const name2204 = software_envs[UBUNTU2204].short ?? software_envs[UBUNTU2204].title;
     const name2404 = software_envs[default_compute_image].title;
 
     const KEEP_IMAGE = only2204
@@ -180,10 +180,10 @@ const SoftwareEnvUpgradeAlert: React.FC<Props> = (props: Props) => {
         return (
           <>
             <Button
-              onClick={() => set_image(DISMISS_IMG_2004)}
+              onClick={() => set_image(DISMISS_IMG_2204)}
               bsStyle={"default"}
             >
-              {name2004}
+              {name2204}
             </Button>
             <Button
               onClick={() => set_image(default_compute_image)}
@@ -242,7 +242,7 @@ const SoftwareEnvUpgradeAlert: React.FC<Props> = (props: Props) => {
       } else if (only2004) {
         return (
           <>
-            <A href={DOC_UBUNTU_2004}>{name2004}</A>,{" "}
+            <A href={DOC_UBUNTU_2204}>{name2204}</A>,{" "}
             <strong>
               <A href={DOC_UBUNTU_2404}>{name2404}</A>
             </strong>

--- a/src/packages/util/compute-images.ts
+++ b/src/packages/util/compute-images.ts
@@ -78,6 +78,7 @@ const COMPUTE_IMAGES: { [key: string]: ComputeImageProd } = {
     descr:
       "Ubuntu 22.04-based software stack, superseded by 24.04 in June 2025",
     group: "Main",
+    hidden: true, // any project that is set to "ubuntu2204" will be shown a banner → either update to ubuntu2404 or keep ubuntu2204-eol
   },
   [DISMISS_IMG_2204]: {
     order: 1,


### PR DESCRIPTION
## Summary
- Hide `ubuntu2204` from the software environment dropdown so only one 22.04 entry (`ubuntu2204-eol`) appears in the Main group — matching the existing pattern for `ubuntu2004`
- Fix the upgrade banner for `ubuntu2004` projects: offer Ubuntu 22.04 (EOL) as the middle upgrade option instead of a duplicate "Keep" action
- Use shorter title for 22.04 in banner buttons

## Test plan
- [x] `ubuntu2204` project → banner shows with Keep + Upgrade to 24.04
- [x] `ubuntu2204` Keep → sets to `ubuntu2204-eol`, banner gone
- [x] `ubuntu2204` Upgrade → sets to `ubuntu2404`, banner gone
- [x] `ubuntu2004` project → banner shows with Keep + 22.04 (EOL) + 24.04
- [x] `ubuntu2004` Keep → sets to `ubuntu2004-eol`, banner gone
- [x] `ubuntu2004` 22.04 button → sets to `ubuntu2204-eol`, banner gone
- [x] `ubuntu2004` 24.04 button → sets to `ubuntu2404`, banner gone
- [x] No banner for `ubuntu2204-eol`, `ubuntu2004-eol`, `ubuntu2404`
- [x] Dropdown shows only one 22.04 entry in Main group

🤖 Generated with [Claude Code](https://claude.com/claude-code)