### PR TITLE
fix: ctrl+wheel zoom for PDF, whiteboard, and slides

### DIFF
--- a/src/packages/frontend/frame-editors/frame-tree/pinch-to-zoom.ts
+++ b/src/packages/frontend/frame-editors/frame-tree/pinch-to-zoom.ts
@@ -56,6 +56,7 @@ export default function usePinchToZoom({
   smooth: _smooth = 5,
   disabled,
   getFontSize,
+  wheelSpeed = 1,
 }: {
   target: MutableRefObject<any>; // reference to element that we want pinch zoom.
   min?: number;
@@ -65,6 +66,7 @@ export default function usePinchToZoom({
   smooth?: number;
   disabled?: boolean;
   getFontSize?: () => number; // function that gets current font size for application; useful so that zoom starts at out right value, in case changed externally
+  wheelSpeed?: number; // multiplier for ctrl+wheel zoom speed (default 1)
 }) {
   const { actions, id } = useFrameContext();
 
@@ -119,10 +121,10 @@ export default function usePinchToZoom({
         wheelFontSizeRef.current =
           getFontSizeRef.current?.() ?? (max + min) / 2;
       }
-      // Multiplicative scaling: each tick changes zoom by ~5-8%.
+      // Multiplicative scaling: each tick changes zoom by a percentage.
       // Cap the exponent to prevent fast-scroll jumps.
-      const MAX_STEP = 0.16;
-      const rawExp = -e.deltaY / 750;
+      const MAX_STEP = 0.16 * wheelSpeed;
+      const rawExp = (-e.deltaY / 750) * wheelSpeed;
       const clampedExp = Math.max(-MAX_STEP, Math.min(MAX_STEP, rawExp));
       const newSize = Math.min(
         max,
@@ -146,7 +148,7 @@ export default function usePinchToZoom({
       el.removeEventListener("wheel", onWheel, { capture: true });
       clearTimeout(zoomEndTimer);
     };
-  }, [disabled, min, max]);
+  }, [disabled, min, max, wheelSpeed]);
 
   // usePinch: handles touch pinch gestures only (ctrl+wheel is blocked
   // by the native listener above via stopImmediatePropagation).

--- a/src/packages/frontend/frame-editors/latex-editor/pdfjs.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/pdfjs.tsx
@@ -124,14 +124,7 @@ export function PDFJS({
             // Default behavior: set font size directly when no parent callback provided
             actions.set_font_size(id, data.fontSize);
           },
-    ...(zoom != null
-      ? {
-          getFontSize: () => {
-            // Convert current zoom back to fontSize for pinch calculations
-            return zoom * 14;
-          },
-        }
-      : {}),
+    getFontSize: zoom != null ? () => zoom * 14 : () => font_size,
   };
 
   usePinchToZoom(pinchToZoomConfig);

--- a/src/packages/frontend/frame-editors/whiteboard-editor/canvas.tsx
+++ b/src/packages/frontend/frame-editors/whiteboard-editor/canvas.tsx
@@ -204,6 +204,7 @@ export default function Canvas({
     min: MIN_FONT_SIZE,
     max: MAX_FONT_SIZE,
     throttleMs: 100,
+    wheelSpeed: 2,
     getFontSize: () => font_size ?? DEFAULT_FONT_SIZE,
     onZoom: ({ fontSize, first }) => {
       lastPinchRef.current = Date.now();


### PR DESCRIPTION
## Summary
- **PDF zoom jumps wildly**: always pass `getFontSize` to pinch-to-zoom so the initial wheel event starts from the actual font size instead of `(max+min)/2`
- **Whiteboard/slides zoom too slow**: add `wheelSpeed` parameter to pinch-to-zoom (default 1), set to 2 for whiteboard — doubles the logarithmic zoom step per scroll tick

## Test plan
- [ ] Ctrl+wheel zoom in PDF viewer — smooth, no jumps
- [ ] Ctrl+wheel zoom in whiteboard — noticeably faster than before
- [ ] Ctrl+wheel zoom in slides — same as whiteboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)