### PR TITLE
frontend/projects: fix recent-files menu hydration

### DIFF
--- a/src/packages/frontend/project/page/file-tabs.tsx
+++ b/src/packages/frontend/project/page/file-tabs.tsx
@@ -284,7 +284,11 @@ export default function FileTabs({ openFiles, project_id, activeTab }) {
   }
 
   return (
-    <Dropdown trigger={["contextMenu"]} menu={recentFilesMenu}>
+    <Dropdown
+      trigger={["contextMenu"]}
+      menu={recentFilesMenu}
+      onOpenChange={setRecentFilesMenuOpen}
+    >
       <div style={{ width: "100%" }}>
         <SortableTabs
           items={keys}

--- a/src/packages/frontend/projects/projects-actions-menu.tsx
+++ b/src/packages/frontend/projects/projects-actions-menu.tsx
@@ -16,7 +16,7 @@
 import type { ProjectTableRecord } from "./projects-table-columns";
 
 import { Dropdown, MenuProps, Modal } from "antd";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 
 import {
@@ -95,13 +95,11 @@ function HydratedProjectActionsMenu({
     { project_id: record.project_id },
     "directory_listings",
   );
-  // Initialize project_log when menu opens if not already loaded
-  function handleOpenChange(newOpen: boolean) {
-    setOpen(newOpen);
-    if (newOpen && project_log == null) {
-      redux.getProjectStore(record.project_id).init_table("project_log");
-    }
-  }
+
+  useEffect(() => {
+    if (!open || project_log != null) return;
+    redux.getProjectStore(record.project_id).init_table("project_log");
+  }, [open, project_log, record.project_id]);
 
   // Check if user is owner of this project
   const isOwner =
@@ -339,7 +337,7 @@ function HydratedProjectActionsMenu({
         menu={{ items: menuItems, onClick: handleMenuClick }}
         trigger={["click"]}
         open={open}
-        onOpenChange={handleOpenChange}
+        onOpenChange={setOpen}
       >
         <span style={{ fontSize: "18px", padding: "4px 8px" }}>
           <Icon name="ellipsis" rotate="90" />


### PR DESCRIPTION
## Summary

Fix two follow-up regressions in recent-files menus after #8820.

- hydrate recent files when opening the file-tab context menu via right-click
- initialize `project_log` on the first open of the project actions menu

## Root Cause

The recent-files loading path was tied to menu-open state, but two entry paths were missed during the render-churn refactor:

- the file-tab context-menu path never updated `recentFilesMenuOpen`, so `useRecentFiles(..., 0, ...)` stayed disabled and `project_log` was never initialized
- the project actions menu only called `init_table("project_log")` from `onOpenChange`, but the first hydrated render set `open=true` before that handler had a chance to run, so the Recent Files submenu could render empty on first use

## User Impact

This restores recent-file entries for users who:

- open the file-tab menu with right-click instead of the chevron button
- open the project actions menu for the first time on a cold `project_log`

## Validation

- `cd src/packages/frontend && pnpm tsc --noEmit`
- `cd src/packages/static && pnpm build-dev`
- manual verification of both menu paths after refresh
