### PR TITLE
stripe: prevent duplicate customers and student-pay transactions

### DIFF
--- a/src/packages/database/postgres/stripe/customer-id.ts
+++ b/src/packages/database/postgres/stripe/customer-id.ts
@@ -1,5 +1,6 @@
 import getPool from "@cocalc/database/pool";
 import getLogger from "@cocalc/backend/logger";
+import type { PoolClient } from "@cocalc/database/pool";
 
 const log = getLogger("database:stripe:customer-id");
 
@@ -7,26 +8,27 @@ const log = getLogger("database:stripe:customer-id");
 // account_id, then this is a NO-OP (not an error).
 export async function setStripeCustomerId(
   account_id: string,
-  customer_id: string
+  customer_id: string,
+  client?: PoolClient,
 ): Promise<void> {
   log.debug("setting customer id of ", account_id, " to ", customer_id);
-  const pool = getPool();
-  await pool.query(
+  const db = client ?? getPool();
+  await db.query(
     "UPDATE accounts SET stripe_customer_id=$1::TEXT WHERE account_id=$2",
-    [customer_id, account_id]
+    [customer_id, account_id],
   );
 }
 
 // Get the stripe id in our database of this user (or undefined if no
 // stripe_id or no such user).
 export async function getStripeCustomerId(
-  account_id: string
+  account_id: string,
 ): Promise<string | undefined> {
   log.debug("getting customer id for ", account_id);
   const pool = getPool();
   const { rows } = await pool.query(
     "SELECT stripe_customer_id FROM accounts WHERE account_id=$1",
-    [account_id]
+    [account_id],
   );
   return rows[0]?.stripe_customer_id;
 }

--- a/src/packages/server/purchases/stripe/get-checkout-session.ts
+++ b/src/packages/server/purchases/stripe/get-checkout-session.ts
@@ -10,9 +10,14 @@ import type {
   CheckoutSessionSecret,
   CheckoutSessionOptions,
 } from "@cocalc/util/stripe/types";
+import { STUDENT_PAY } from "@cocalc/util/db-schema/purchases";
 import { isEqual } from "lodash";
 import { decimalToStripe, decimalAdd } from "@cocalc/util/stripe/calc";
 import { url } from "@cocalc/server/messages/send";
+import {
+  studentPayAssertNotPaying,
+  studentPaySetCheckoutSession,
+} from "@cocalc/server/purchases/student-pay";
 
 const logger = getLogger("purchases:stripe:get-checkout-session");
 const LINE_ITEMS_METADATA_KEY = "line_items_json";
@@ -45,6 +50,12 @@ export default async function getCheckoutSession({
     throw Error("purpose must be set");
   }
   assertValidUserMetadata(metadata);
+  if (purpose == STUDENT_PAY) {
+    if (!project_id) {
+      throw Error("project_id must be set for student-pay checkout");
+    }
+    await studentPayAssertNotPaying({ project_id });
+  }
 
   let total = 0;
   for (const { amount } of lineItems) {
@@ -125,6 +136,12 @@ export default async function getCheckoutSession({
           session_id: session.id,
           session_created: session.created,
         });
+        if (purpose == STUDENT_PAY) {
+          await studentPaySetCheckoutSession({
+            project_id: project_id!,
+            checkoutSessionId: session.id,
+          });
+        }
         // Reuse the existing open session when the checkout inputs still match.
         return { clientSecret: session.client_secret };
       }
@@ -203,6 +220,12 @@ export default async function getCheckoutSession({
     project_id,
     session_id: session.id,
   });
+  if (purpose == STUDENT_PAY) {
+    await studentPaySetCheckoutSession({
+      project_id: project_id!,
+      checkoutSessionId: session.id,
+    });
+  }
 
   return { clientSecret: session.client_secret };
 }

--- a/src/packages/server/purchases/stripe/util.ts
+++ b/src/packages/server/purchases/stripe/util.ts
@@ -1,7 +1,7 @@
 import getLogger from "@cocalc/backend/logger";
 import { currency, round2 } from "@cocalc/util/misc";
 import getConn from "@cocalc/server/stripe/connection";
-import getPool from "@cocalc/database/pool";
+import getPool, { getTransactionClient } from "@cocalc/database/pool";
 import stripeName from "@cocalc/util/stripe/name";
 import { setStripeCustomerId } from "@cocalc/database/postgres/stripe";
 import { getServerSettings } from "@cocalc/database/settings/server-settings";
@@ -15,35 +15,52 @@ const MINIMUM_STRIPE_TRANSACTION = 0.5; // Stripe requires transactions to be at
 
 const logger = getLogger("purchases:stripe:util");
 
-async function createStripeCustomer(account_id: string): Promise<string> {
-  logger.debug("createStripeCustomer", account_id);
-  const db = getPool();
-  const { rows } = await db.query(
-    "SELECT email_address, first_name, last_name FROM accounts WHERE account_id=$1",
-    [account_id],
-  );
-  if (rows.length == 0) {
-    throw Error(`no account ${account_id}`);
-  }
-  const email = rows[0].email_address;
-  const description = stripeName(rows[0].first_name, rows[0].last_name);
-  const stripe = await getConn();
-  const { id } = await stripe.customers.create({
-    description,
-    name: description,
-    email,
-    metadata: {
+async function getOrCreateStripeCustomer(account_id: string): Promise<string> {
+  logger.debug("getOrCreateStripeCustomer", account_id);
+  const client = await getTransactionClient();
+  try {
+    const { rows } = await client.query(
+      "SELECT email_address, first_name, last_name, stripe_customer_id FROM accounts WHERE account_id=$1 FOR UPDATE",
+      [account_id],
+    );
+    if (rows.length == 0) {
+      throw Error(`no account ${account_id}`);
+    }
+    const existingCustomerId = rows[0].stripe_customer_id;
+    if (existingCustomerId) {
+      await client.query("COMMIT");
+      logger.debug("getOrCreateStripeCustomer", "reusing existing", {
+        account_id,
+        stripe_customer_id: existingCustomerId,
+      });
+      return existingCustomerId;
+    }
+    const email = rows[0].email_address;
+    const description = stripeName(rows[0].first_name, rows[0].last_name);
+    const stripe = await getConn();
+    const { id } = await stripe.customers.create({
+      description,
+      name: description,
+      email,
+      metadata: {
+        account_id,
+      },
+    });
+    logger.debug("getOrCreateStripeCustomer", "created ", {
+      id,
+      description,
+      email,
       account_id,
-    },
-  });
-  logger.debug("createStripeCustomer", "created ", {
-    id,
-    description,
-    email,
-    account_id,
-  });
-  await setStripeCustomerId(account_id, id);
-  return id;
+    });
+    await setStripeCustomerId(account_id, id, client);
+    await client.query("COMMIT");
+    return id;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 export async function getStripeCustomerId({
@@ -68,7 +85,7 @@ export async function getStripeCustomerId({
     return stripe_customer_id;
   }
   if (create) {
-    return await createStripeCustomer(account_id);
+    return await getOrCreateStripeCustomer(account_id);
   } else {
     return undefined;
   }

--- a/src/packages/server/purchases/student-pay.ts
+++ b/src/packages/server/purchases/student-pay.ts
@@ -294,14 +294,38 @@ export async function studentPaySetPaymentIntent({
   );
 }
 
-// call this if trying to create a new student payment attempt for a course project
-export async function studentPayAssertNotPaying({ project_id }) {
-  if (!isValidUUID(project_id)) {
-    throw Error(`project_id=${project_id} is not a valid UUID`);
-  }
+export async function studentPaySetCheckoutSession({
+  project_id,
+  checkoutSessionId,
+}: {
+  project_id: string;
+  checkoutSessionId: string;
+}) {
+  logger.debug("studentPaySetCheckoutSession", {
+    project_id,
+    checkoutSessionId,
+  });
+  const pool = getPool();
+  await pool.query(
+    `UPDATE projects SET course = jsonb_set(course, '{checkout_session_id}', $2::jsonb) WHERE project_id = $1`,
+    [project_id, JSON.stringify(checkoutSessionId)],
+  );
+}
+
+async function getOutstandingStudentPayment(project_id: string): Promise<
+  | {
+      type: "payment_intent";
+      id: string;
+    }
+  | {
+      type: "checkout_session";
+      id: string;
+    }
+  | undefined
+> {
   const pool = getPool();
   const { rows } = await pool.query(
-    "SELECT course#>>'{payment_intent_id}' as payment_intent_id FROM projects WHERE project_id=$1",
+    "SELECT course#>>'{payment_intent_id}' as payment_intent_id, course#>>'{checkout_session_id}' as checkout_session_id FROM projects WHERE project_id=$1",
     [project_id],
   );
   const payment_intent_id = rows[0]?.payment_intent_id;
@@ -313,9 +337,36 @@ export async function studentPayAssertNotPaying({ project_id }) {
       intent.status != "succeeded" &&
       intent.metadata["deleted"] != "true"
     ) {
+      return { type: "payment_intent", id: payment_intent_id };
+    }
+  }
+
+  const checkout_session_id = rows[0]?.checkout_session_id;
+  if (checkout_session_id) {
+    const stripe = await getConn();
+    const session =
+      await stripe.checkout.sessions.retrieve(checkout_session_id);
+    if (session.status == "open" || session.payment_status == "paid") {
+      return { type: "checkout_session", id: checkout_session_id };
+    }
+  }
+  return undefined;
+}
+
+// call this if trying to create a new student payment attempt for a course project
+export async function studentPayAssertNotPaying({ project_id }) {
+  if (!isValidUUID(project_id)) {
+    throw Error(`project_id=${project_id} is not a valid UUID`);
+  }
+  const outstanding = await getOutstandingStudentPayment(project_id);
+  if (outstanding) {
+    if (outstanding.type == "payment_intent") {
       throw Error(
-        `There is an outstanding payment for this course right now (payment intent id ${payment_intent_id}).  [Pay that invoice or cancel it](${await url("settings/payments")}).`,
+        `There is an outstanding payment for this course right now (payment intent id ${outstanding.id}).  [Pay that invoice or cancel it](${await url("settings/payments")}).`,
       );
     }
+    throw Error(
+      `There is already an in-progress payment for this course right now (checkout session id ${outstanding.id}).  Please try again later or contact support if this does not resolve itself.`,
+    );
   }
 }


### PR DESCRIPTION
Stripe customer creation is now serialized under a database row lock, so concurrent requests are much less likely to create two Stripe customers for the same CoCalc account.

The checkout-session path for student-pay now participates in the same “outstanding payment” guard that previously only covered payment-intent/invoice flows. Before creating a new student-pay checkout session, CoCalc now checks whether that course project already has an active payment in progress. It records the checkout session id on the project so later retries can detect that state. This closes the gap where a checkout-based course payment could be charged twice in Stripe while CoCalc only recorded a single course purchase.

The user-facing behavior is split by payment type. If there is an outstanding payment intent, users still get the old actionable message directing them to the payments page. If the outstanding object is an open checkout session, users now get a message telling them to try again later or contact support, since the payments page is not a reliable place to cancel or complete a Checkout-backed payment.