### PR TITLE
jupyter minimal: gutter insert-cell button + AI code generation link

### DIFF
--- a/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
@@ -342,7 +342,7 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
           positionInBlock={positionInBlock}
           blockSize={blockSize}
           showBlockLine={true}
-          isLastInBlock={positionInBlock === blockSize - 1}
+
           cellRunState={cellRunState}
           onRun={isCode ? handleRun : undefined}
           onInsertCell={

--- a/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
@@ -7,8 +7,10 @@ import { Button, Tooltip } from "antd";
 import type { Map } from "immutable";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { redux } from "@cocalc/frontend/app-framework";
 import { Icon } from "@cocalc/frontend/components";
 import useNotebookFrameActions from "@cocalc/frontend/frame-editors/jupyter-editor/cell-notebook/hook";
+import { openAssistantWithPrefill } from "@cocalc/frontend/frame-editors/llm/assistant-seed";
 import { clear_selection } from "@cocalc/frontend/misc/clear-selection";
 import MostlyStaticMarkdown from "@cocalc/frontend/editors/slate/mostly-static-markdown";
 import type { LLMTools } from "@cocalc/jupyter/types";
@@ -449,9 +451,30 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
             </ScrollToBottomOutput>
           )}
           {isCode && cell.get("output") == null && !input.trim() && !read_only && !zenMode && (
-            <div style={{ color: COLORS.GRAY_M, padding: "8px 4px", fontSize: "13px" }}>
-              <a onClick={handleActivateCode} style={{ color: COLORS.GRAY_M }}>
+            <div style={{ color: COLORS.GRAY_L, padding: "8px 4px", fontSize: "13px" }}>
+              <a onClick={handleActivateCode} style={{ color: COLORS.GRAY_L }}>
                 Write code
+              </a>
+              {" or "}
+              <a
+                style={{ color: COLORS.GRAY_L }}
+                onClick={() => {
+                  if (!actions || !project_id) return;
+                  const cellList = (actions as any).store?.get("cell_list");
+                  const cellIds = cellList?.toJS() as string[] | undefined;
+                  const cellIndex = cellIds ? cellIds.indexOf(id) : -1;
+                  const cellLabel = cellIndex >= 0 ? `cell #${cellIndex + 1}` : "this cell";
+                  openAssistantWithPrefill({
+                    redux,
+                    project_id,
+                    path: (actions as any).path,
+                    prompt: `Generate code in ${cellLabel} that does: `,
+                  }).catch((err) =>
+                    console.warn("openAssistantWithPrefill failed:", err),
+                  );
+                }}
+              >
+                generate using AI...
               </a>
             </div>
           )}

--- a/src/packages/frontend/jupyter/minimal/minimal-gutter.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-gutter.tsx
@@ -57,7 +57,7 @@ interface MinimalGutterProps {
   positionInBlock: number;
   blockSize: number;
   showBlockLine: boolean;
-  isLastInBlock: boolean;
+
   cellRunState: CellRunState;
   onRun?: () => void;
   onInsertCell?: () => void;
@@ -89,7 +89,7 @@ export const MinimalGutter: React.FC<MinimalGutterProps> = React.memo(
     onToggleSection,
     blockHighlighted,
     onHoverBlock,
-    isLastInBlock,
+
     isCurrent,
     isSelected,
     read_only,
@@ -238,8 +238,8 @@ export const MinimalGutter: React.FC<MinimalGutterProps> = React.memo(
             </Tooltip>
           )}
 
-          {/* [+] insert cell at end of section */}
-          {isLastInBlock && !read_only && onInsertCell && (
+          {/* [+] insert cell below — visible on hover for every cell */}
+          {!read_only && onInsertCell && (
             <Tooltip title="Insert cell below" placement="right">
               <Button
                 type="text"
@@ -252,10 +252,11 @@ export const MinimalGutter: React.FC<MinimalGutterProps> = React.memo(
                   onInsertCell();
                 }}
                 style={{
-                  color: hovered ? COLORS.GRAY_D : COLORS.GRAY_LL,
+                  color: COLORS.GRAY_D,
                   marginTop: "auto",
-                  transition: "color 150ms ease",
+                  transition: "opacity 150ms ease",
                   zIndex: 2,
+                  opacity: hovered ? 1 : 0,
                 }}
               />
             </Tooltip>


### PR DESCRIPTION
## Summary
- Show a hover "+" button in the gutter of every cell (not just the last cell in a section) to insert a new cell below
- Add "generate using AI..." link next to "Write code" in empty code cell placeholders, opening the assistant with a prefilled prompt

## Test plan
- [ ] Open a notebook in minimal view mode
- [ ] Hover over any cell gutter — "+" button should fade in
- [ ] Click "+" — a new cell should be inserted below
- [ ] Create an empty code cell — should show "Write code or generate using AI..."
- [ ] Click "generate using AI..." — assistant sidebar should open with prefilled prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)