### PR TITLE
Coding agent: interpret deictic references from editor context

### DIFF
--- a/src/packages/frontend/frame-editors/llm/coding-agent-utils.ts
+++ b/src/packages/frontend/frame-editors/llm/coding-agent-utils.ts
@@ -643,6 +643,13 @@ export function buildSystemPrompt(
     lines.push(
       `Selected text:\n${selFence}\n${truncatedSelection}\n${selFence}`,
     );
+    lines.push(
+      `When the user says "this", "this paragraph", "this section", "this code", "it", or similar references, they mean the selected text shown above.`,
+    );
+  } else if (ctx.cursorLine != null) {
+    lines.push(
+      `When the user says "this line", "this paragraph", "this section", "this code", "here", or similar references, they are referring to the content at or near the cursor position (line ${ctx.cursorLine + 1}).`,
+    );
   }
 
   const contextWindow = getDocumentContextWindow(ctx.content, {


### PR DESCRIPTION
## Summary
- The coding agent's system prompt included cursor position and selected text but never instructed the LLM to connect user references like "this paragraph", "here", "this section" to that context data
- Weaker models (e.g. GPT-5.4 Mini) would ask the user to provide the text instead of using the already-captured selection/cursor info
- Adds explicit instructions after selection/cursor info telling the LLM what "this", "here", etc. refer to

## Test plan
- [ ] Open a LaTeX document, select a paragraph, open the coding agent, and ask to "translate this paragraph" — the LLM should use the selected text without asking
- [ ] Place cursor on a line (no selection), ask "explain this line" — the LLM should reference the content at the cursor position
- [ ] Test with a weaker model (e.g. GPT-5.4 Mini free) to verify it follows the instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)