### PR TITLE
jupyter minimal: fix MiniTOC edit mode, font size, and scrollbar conflicts

### DIFF
--- a/src/packages/frontend/jupyter/_jupyter.sass
+++ b/src/packages/frontend/jupyter/_jupyter.sass
@@ -137,11 +137,16 @@ cocalc-lumino-adapter
 .minimal-cell-toolbar > div
   margin-left: 0 !important
 
-// Hide native scrollbar when minimap is active
+// Hide native scrollbar when minimap is active (must also target child
+// Virtuoso scroller, which otherwise gets forced-visible by _editor.sass)
 .minimap-hide-scrollbar
   scrollbar-width: none
   &::-webkit-scrollbar
     display: none
+  [data-virtuoso-scroller="true"]
+    scrollbar-width: none !important
+    &::-webkit-scrollbar
+      display: none !important
 
 // Minimap: blink for the actively running cell
 @keyframes minimap-blink

--- a/src/packages/frontend/jupyter/cell-list.tsx
+++ b/src/packages/frontend/jupyter/cell-list.tsx
@@ -201,9 +201,16 @@ export const CellList: React.FC<CellListProps> = (props: CellListProps) => {
   const handleCellListRef = useCallback((node: any) => {
     cellListDivRef.current = node;
     frameActions.current?.set_cell_list_div(node);
-    // Hide native scrollbar when minimap is active
-    if (node && cellViewMode === "minimal") {
+  }, []);
+
+  // Toggle native scrollbar visibility reactively when cellViewMode changes
+  useEffect(() => {
+    const node = cellListDivRef.current;
+    if (!node) return;
+    if (cellViewMode === "minimal") {
       node.classList.add("minimap-hide-scrollbar");
+    } else {
+      node.classList.remove("minimap-hide-scrollbar");
     }
   }, [cellViewMode]);
 

--- a/src/packages/frontend/jupyter/minimal/mini-toc.tsx
+++ b/src/packages/frontend/jupyter/minimal/mini-toc.tsx
@@ -101,6 +101,7 @@ export const MiniTOC: React.FC<MiniTOCProps> = React.memo(
               className={isCurrent ? undefined : "mini-toc-entry"}
               onClick={() => {
                 const cellId = sectionBlocks[blockIndex].startCellId;
+                frameActions.current?.set_mode("escape");
                 frameActions.current?.set_cur_id(cellId);
                 frameActions.current?.scroll("cell top");
               }}
@@ -119,13 +120,13 @@ export const MiniTOC: React.FC<MiniTOCProps> = React.memo(
               title={actions ? `${title} — double-click to run section` : title}
               style={{
                 color: isCurrent ? COLORS.GRAY_M : COLORS.GRAY_L,
-                fontSize: `${Math.round((fontSize ?? 14) * 0.78)}px`,
+                fontSize: `${Math.round((fontSize ?? 14) * 0.9)}px`,
                 cursor: "pointer",
                 textAlign: "right",
                 whiteSpace: "nowrap",
                 overflow: "hidden",
                 textOverflow: "ellipsis",
-                lineHeight: `${Math.round((fontSize ?? 14) * 1.15)}px`,
+                lineHeight: `${Math.round((fontSize ?? 14) * 1.3)}px`,
                 fontWeight: isCurrent ? 600 : 400,
                 userSelect: "none",
               }}

--- a/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
@@ -128,6 +128,7 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
     const isCode = cellType === "code";
     const isMarkdown = cellType === "markdown";
     const input = cell.get("input") || "";
+    const sourceHidden = !!cell.getIn(["metadata", "jupyter", "source_hidden"]);
 
     // Track whether cell input changed since last execution
     const lastExecHashRef = useRef<{ execCount: number | undefined; hash: number } | null>(null);
@@ -684,6 +685,8 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
                 gap: "2px",
                 alignItems: "center",
                 visibility: rowHovered || menuOpen ? "visible" : "hidden",
+                position: "relative",
+                zIndex: 2,
               }}
               onClick={(e) => e.stopPropagation()}
             >
@@ -705,7 +708,7 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
               />
             </div>
           )}
-          {isCode && !isActiveEditing && (
+          {isCode && !isActiveEditing && !sourceHidden && (
             <MinimalCodePreview
               value={input}
               cmOptions={cmOpts}
@@ -713,6 +716,22 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
               onActivate={handleActivateCode}
               highlighted={rowHovered}
             />
+          )}
+          {isCode && !isActiveEditing && sourceHidden && (
+            <div
+              style={{
+                color: COLORS.GRAY_L,
+                fontSize: "14px",
+                padding: "4px 8px",
+                cursor: "pointer",
+              }}
+              title="Input is hidden — click to show"
+              onClick={() => {
+                actions?.toggle_jupyter_metadata_boolean(id, "source_hidden");
+              }}
+            >
+              <Icon name="ellipsis" />
+            </div>
           )}
           {isCode && isActiveEditing && (
             <div

--- a/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
@@ -129,6 +129,8 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
     const isMarkdown = cellType === "markdown";
     const input = cell.get("input") || "";
     const sourceHidden = !!cell.getIn(["metadata", "jupyter", "source_hidden"]);
+    const isNotEditable = !cell.getIn(["metadata", "editable"], true);
+    const isNotDeletable = !cell.getIn(["metadata", "deletable"], true);
 
     // Track whether cell input changed since last execution
     const lastExecHashRef = useRef<{ execCount: number | undefined; hash: number } | null>(null);
@@ -458,6 +460,8 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
           start={cell.get("start")}
           end={cell.get("end")}
           isDirty={isDirty}
+          isNotEditable={isNotEditable}
+          isNotDeletable={isNotDeletable}
         />
 
         {/* Content area — toolbar + output/code columns */}
@@ -668,9 +672,10 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
           style={{
             flex: `${codeFlex} 1 0`,
             minWidth: 0,
-            overflow: "hidden",
+            overflow: "visible",
             transition: COLUMN_TRANSITION,
             position: "relative",
+            zIndex: 1,
             borderLeft: zenMode ? "none" : "1px solid #eee",
           }}
         >{showCode && (<>

--- a/src/packages/frontend/jupyter/minimal/minimal-gutter.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-gutter.tsx
@@ -74,6 +74,10 @@ interface MinimalGutterProps {
   end?: number;
   /** Cell input changed since last execution */
   isDirty?: boolean;
+  /** Cell metadata: editable=false */
+  isNotEditable?: boolean;
+  /** Cell metadata: deletable=false */
+  isNotDeletable?: boolean;
 }
 
 const CURRENT_COLOR = "#42a5f5"; // blue, same as default notebook
@@ -98,6 +102,8 @@ export const MinimalGutter: React.FC<MinimalGutterProps> = React.memo(
     start,
     end,
     isDirty,
+    isNotEditable,
+    isNotDeletable,
   }) => {
     const [hovered, setHovered] = useState(false);
     const { project_id, path } = useFrameContext();
@@ -218,6 +224,22 @@ export const MinimalGutter: React.FC<MinimalGutterProps> = React.memo(
               <span style={{ fontSize: "13px" }}>{index + 1}</span>
             </div>
           </Tooltip>
+
+          {/* Lock / protected indicators */}
+          {isNotEditable && (
+            <Tooltip title="Protected from modifications" placement="left">
+              <span style={{ color: COLORS.GRAY_M, fontSize: "12px", zIndex: 2, marginTop: "2px" }}>
+                <Icon name="lock" />
+              </span>
+            </Tooltip>
+          )}
+          {isNotDeletable && (
+            <Tooltip title="Protected from deletion" placement="left">
+              <span style={{ color: COLORS.GRAY_M, fontSize: "12px", zIndex: 2, marginTop: "2px" }}>
+                <Icon name="ban" />
+              </span>
+            </Tooltip>
+          )}
 
           {/* Play / Stop button */}
           {isCode && !read_only && onRun && (() => {


### PR DESCRIPTION
## Summary
- MiniTOC click now sets escape mode before navigating, preventing markdown cells from entering edit mode
- Increased MiniTOC font size for better readability
- Fixed scrollbar CSS conflict: minimap-hide-scrollbar now also targets the child Virtuoso scroller, and the class is properly toggled via useEffect when cellViewMode changes
- Respect input collapse (source_hidden) in minimal mode: show "..." instead of code; click to expand
- Fix z-index on code column toolbar so Run/Assistant buttons don't hide behind the output column in narrow layouts

## Test plan
- [ ] Click a MiniTOC entry — cell scrolls to top without entering edit mode
- [ ] MiniTOC text is visibly larger and readable
- [ ] Minimal mode: no Virtuoso scrollbar appears alongside the minimap
- [ ] Regular mode: scrollbar remains visible when switching from minimal
- [ ] Hide input via Edit → Toggle Hide Input — minimal mode shows "..." in code column
- [ ] Click "..." to expand hidden input
- [ ] In narrow layout, Run/Assistant toolbar stays visible above output bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)