### PR TITLE
fix notebook agent: strip unclosed tool blocks from display

### DIFF
--- a/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent-utils.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent-utils.ts
@@ -469,6 +469,7 @@ export function compactAssistantMessageForHistory(text: string): string {
   const toolCalls = parseToolBlocks(text);
   const prose = text
     .replace(/^```tool\n[\s\S]*?\n```\s*$/gm, "")
+    .replace(/^```tool\n[\s\S]*/m, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
   const toolSummary =

--- a/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent.tsx
+++ b/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent.tsx
@@ -764,6 +764,8 @@ export function NotebookAgent({
     if (msg.sender === "assistant") {
       // Strip tool invocation blocks (machine-readable JSON)
       content = content.replace(/^```tool\n[\s\S]*?\n```\s*$/gm, "").trim();
+      // Also strip unclosed tool blocks — some models omit the closing ```
+      content = content.replace(/^```tool\n[\s\S]*/m, "").trim();
       // Some LLMs echo the tool call JSON or code with literal \n escapes
       // in their prose. Convert escaped newlines to real ones so
       // StaticMarkdown can render them properly — but only outside


### PR DESCRIPTION
## Summary
- `parseToolBlocks()` has a fallback regex for unclosed tool blocks (when the LLM omits the closing ` ``` `), but the display-side stripping in `renderMessage` and `compactAssistantMessageForHistory` did not
- This caused the raw tool JSON to render as a large code block above the nicely-formatted tool result
- Added matching unclosed-block stripping to both locations

## Test plan
- [ ] Open notebook agent, ask it to edit a cell (triggers `set_cell` tool)
- [ ] Verify only the nicely-formatted tool result appears, no raw JSON code block above it
- [ ] Existing tests pass (`npx jest notebook-agent-utils.test.ts` — 45/45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)