### PR TITLE
jupyter minimal: limit code column height to match output

### DIFF
--- a/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-cell.tsx
@@ -120,6 +120,8 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
     const [mdHovered, setMdHovered] = useState(false);
     const [menuOpen, setMenuOpen] = useState(false);
     const [rowHovered, setRowHovered] = useState(false);
+    const outputRef = useRef<HTMLDivElement>(null);
+    const [outputHeight, setOutputHeight] = useState<number>(0);
 
     // FileContext that suppresses CellButtonBar and other extras in minimal mode
     const minimalFileContext = { ...fileContext, disableExtraButtons: true };
@@ -331,6 +333,24 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
       return "Run this cell";
     }, [cellStart, cellEnd]);
 
+    // Measure output *content* height (not the flex-stretched container)
+    const outputContentRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+      const el = outputContentRef.current;
+      if (!el) return;
+      const ro = new ResizeObserver(([entry]) => {
+        setOutputHeight(entry.contentRect.height);
+      });
+      ro.observe(el);
+      return () => ro.disconnect();
+    }, []);
+
+    const viewportHalf = frameHeight ? Math.round(frameHeight * 0.5) : 400;
+    // View mode: match output height (the code fades out if taller)
+    const codePreviewMaxHeight = outputHeight || undefined;
+    // Edit mode: max of output height and 50% viewport
+    const codeEditMaxHeight = Math.max(outputHeight, viewportHalf);
+
     // Show section divider for the first cell in every block
     const isBlockStart = positionInBlock === 0;
     const showSectionDivider = isBlockStart;
@@ -478,6 +498,7 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
           <div style={{ display: "flex", flexDirection: "row", alignItems: "stretch", flex: 1 }}>
         {/* Output column */}
         <div
+          ref={outputRef}
           style={{
             flex: `${outputFlex} 1 0`,
             minWidth: 0,
@@ -487,6 +508,7 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
             position: "relative",
           }}
         >
+          <div ref={outputContentRef}>
           {/* Zen mode: floating toolbar inside output area */}
           {zenMode && (
             <div
@@ -665,6 +687,7 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
               </Tooltip>
             </div>
           )}
+          </div>{/* end outputContentRef */}
         </div>
 
         {/* Code column — hidden entirely in zen + wide mode */}
@@ -720,6 +743,7 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
               fontSize={font_size}
               onActivate={handleActivateCode}
               highlighted={rowHovered}
+              maxHeight={codePreviewMaxHeight}
             />
           )}
           {isCode && !isActiveEditing && sourceHidden && (
@@ -740,7 +764,12 @@ export const MinimalCell: React.FC<MinimalCellProps> = React.memo(
           )}
           {isCode && isActiveEditing && (
             <div
-              style={{ position: "relative" }}
+              style={{
+                position: "relative",
+                maxHeight: `${codeEditMaxHeight}px`,
+                overflowY: "auto",
+                overflowX: "hidden",
+              }}
               onBlur={(e) => {
                 // Close editor when focus leaves the entire editing area
                 // (but not when clicking buttons inside it)

--- a/src/packages/frontend/jupyter/minimal/minimal-code-preview.tsx
+++ b/src/packages/frontend/jupyter/minimal/minimal-code-preview.tsx
@@ -3,7 +3,7 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { CodeMirrorStatic } from "@cocalc/frontend/jupyter/codemirror-static";
 import {
@@ -12,6 +12,8 @@ import {
   CODE_OPACITY_HOVER,
 } from "./styles";
 
+const MIN_HEIGHT = 50;
+
 interface MinimalCodePreviewProps {
   value: string;
   cmOptions: { mode?: string | { name?: string }; theme?: string };
@@ -19,16 +21,27 @@ interface MinimalCodePreviewProps {
   onActivate: () => void;
   /** When true (e.g. row hovered), show at full opacity */
   highlighted?: boolean;
+  /** Max height in px — content fades out at the bottom when clipped */
+  maxHeight?: number;
 }
 
 export const MinimalCodePreview: React.FC<MinimalCodePreviewProps> = React.memo(
-  ({ value, cmOptions, fontSize, onActivate, highlighted }) => {
+  ({ value, cmOptions, fontSize, onActivate, highlighted, maxHeight }) => {
     const [hovered, setHovered] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [isClipped, setIsClipped] = useState(false);
 
     const scaledFontSize = Math.round(fontSize * CODE_FONT_SCALE);
 
+    useEffect(() => {
+      const el = containerRef.current;
+      if (!el) return;
+      setIsClipped(el.scrollHeight > el.clientHeight + 2);
+    }, [value, maxHeight]);
+
     return (
       <div
+        ref={containerRef}
         style={{
           opacity: hovered || highlighted ? CODE_OPACITY_HOVER : CODE_OPACITY_DEFAULT,
           transition: "opacity 150ms ease",
@@ -36,6 +49,8 @@ export const MinimalCodePreview: React.FC<MinimalCodePreviewProps> = React.memo(
           position: "relative",
           overflow: "hidden",
           padding: "4px",
+          minHeight: `${MIN_HEIGHT}px`,
+          maxHeight: maxHeight ? `${Math.max(MIN_HEIGHT, maxHeight)}px` : undefined,
         }}
         onClick={onActivate}
         onMouseEnter={() => setHovered(true)}
@@ -65,6 +80,20 @@ export const MinimalCodePreview: React.FC<MinimalCodePreviewProps> = React.memo(
             pointerEvents: "none",
           }}
         />
+        {/* Fade-out on the bottom edge — only when content is clipped */}
+        {isClipped && (
+          <div
+            style={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              width: "100%",
+              height: "32px",
+              background: "linear-gradient(to bottom, transparent, white)",
+              pointerEvents: "none",
+            }}
+          />
+        )}
       </div>
     );
   },


### PR DESCRIPTION
## Summary
- Code preview height capped at output content height with bottom fade-out when clipped
- Edit mode height capped at max(output height, 50% viewport) with scrollbar
- Bottom fade only shown when content is actually clipped
- 50px minimum to avoid collapsing single-line cells

## Test plan
- [ ] Long code cells: code column fades out at bottom, matching output height
- [ ] Short code cells: no bottom fade, 50px minimum respected
- [ ] Edit mode: scrollbar appears for tall code, capped at 50% viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)