### PR TITLE
Add DPA and clean up policies list

### DIFF
--- a/src/packages/next/components/landing/index-list.tsx
+++ b/src/packages/next/components/landing/index-list.tsx
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2021-2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -38,7 +38,7 @@ type ItemProcessed = Omit<Item, "description" | "link"> & {
 
 interface Props {
   title: ReactNode;
-  description: ReactNode;
+  description?: ReactNode;
   dataSource: Item[];
   updated?: string;
   filter?: (item) => boolean;
@@ -64,7 +64,7 @@ export default function IndexList({ title, description, dataSource }: Props) {
               : item.description,
           link:
             typeof item.link === "function"
-              ? item.link(customize) ?? ""
+              ? (item.link(customize) ?? "")
               : item.link,
         };
       });
@@ -93,7 +93,9 @@ export default function IndexList({ title, description, dataSource }: Props) {
         >
           {title}
         </Title>
-        <Paragraph style={{ fontSize: "13pt" }}>{description}</Paragraph>
+        {description ? (
+          <Paragraph style={{ fontSize: "13pt" }}>{description}</Paragraph>
+        ) : undefined}
         <DataList dataSource={filteredDataSource} />
       </Paragraph>
     </Layout.Content>

--- a/src/packages/next/components/landing/sub-nav.tsx
+++ b/src/packages/next/components/landing/sub-nav.tsx
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2021-2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -105,6 +105,7 @@ export const POLICIES = {
   terms: { label: "Terms of Service", hide: (c) => !c.onCoCalcCom },
   copyright: { label: "Copyright", hide: (c) => !c.onCoCalcCom },
   privacy: { label: "Privacy", hide: (c) => !c.onCoCalcCom },
+  dpa: { label: "DPA", hide: (c) => !c.onCoCalcCom },
   trust: { label: "Trust", hide: (c) => !c.onCoCalcCom },
   thirdparties: { label: "Third Parties", hide: (c) => !c.onCoCalcCom },
   ferpa: { label: "FERPA", hide: (c) => !c.onCoCalcCom },

--- a/src/packages/next/components/landing/sub-nav.tsx
+++ b/src/packages/next/components/landing/sub-nav.tsx
@@ -102,12 +102,12 @@ const pricing = {
 
 export const POLICIES = {
   index: {},
-  terms: { label: "Terms of Service", hide: (c) => !c.onCoCalcCom },
-  copyright: { label: "Copyright", hide: (c) => !c.onCoCalcCom },
+  terms: { label: "Terms", hide: (c) => !c.onCoCalcCom },
   privacy: { label: "Privacy", hide: (c) => !c.onCoCalcCom },
   dpa: { label: "DPA", hide: (c) => !c.onCoCalcCom },
   trust: { label: "Trust", hide: (c) => !c.onCoCalcCom },
   thirdparties: { label: "Third Parties", hide: (c) => !c.onCoCalcCom },
+  copyright: { label: "Copyright", hide: (c) => !c.onCoCalcCom },
   ferpa: { label: "FERPA", hide: (c) => !c.onCoCalcCom },
   accessibility: { label: "Accessibility", hide: (c) => !c.onCoCalcCom },
   imprint: { label: "Imprint", hide: (c) => !c.imprint },

--- a/src/packages/next/pages/policies/dpa.tsx
+++ b/src/packages/next/pages/policies/dpa.tsx
@@ -1,0 +1,237 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import { Layout } from "antd";
+
+import { COLORS } from "@cocalc/util/theme";
+import A from "components/misc/A";
+import Footer from "components/landing/footer";
+import Head from "components/landing/head";
+import Header from "components/landing/header";
+import { MAX_WIDTH } from "lib/config";
+import { Customize, type CustomizeType } from "lib/customize";
+import withCustomize from "lib/with-customize";
+
+interface Props {
+  customize: CustomizeType;
+}
+
+export default function DataProcessingAddendumPage({ customize }: Props) {
+  return (
+    <Customize value={customize}>
+      <Head title="Data Processing Addendum" />
+      <Layout>
+        <Header page="policies" subPage="dpa" />
+        <Layout.Content
+          style={{
+            backgroundColor: COLORS.WHITE,
+          }}
+        >
+          <div
+            style={{
+              maxWidth: MAX_WIDTH,
+              margin: "15px auto",
+              padding: "15px",
+              fontSize: "12pt",
+            }}
+          >
+            <div style={{ textAlign: "center" }}>
+              <h1>CoCalc - Data Processing Addendum</h1>
+              <p>Last Updated: April 15, 2026</p>
+            </div>
+            <div>
+              <p>
+                This Data Processing Addendum ("<b>DPA</b>") is incorporated
+                into the SageMath, Inc. Terms of Service ("<b>Agreement</b>")
+                and applies to the processing of Personal Data by SageMath, Inc.
+                on behalf of its Users.
+              </p>
+              <h1>1. Nature and Purpose of Processing</h1>
+              <p>
+                SageMath, Inc. provides a collaborative cloud-based platform
+                (CoCalc) for research, analysis, and scientific publishing. The
+                Subject Matter of the processing is the data uploaded, created,
+                or processed by the User within the CoCalc environment.
+              </p>
+              <ul>
+                <li>
+                  <b>Hosted Platform</b>: Data is stored and processed on
+                  SageMath, Inc. infrastructure to provide core platform
+                  functionality.
+                </li>
+                <li>
+                  <b>User-Directed Compute</b>: Users may explicitly choose the
+                  geographic location and infrastructure provider for specific
+                  compute tasks. In such cases, SageMath, Inc. processes data in
+                  the location selected by the User.
+                </li>
+                <li>
+                  <b>AI-Assisted Features</b>: SageMath, Inc. provides optional
+                  integrations with third-party AI providers. Data is
+                  transmitted to these providers only upon explicit initiation
+                  by the User.
+                </li>
+              </ul>
+              <h1>2. Sub-processors</h1>
+              <p>
+                The Controller (User) provides a general authorization for
+                SageMath, Inc. to engage sub-processors.
+              </p>
+              <ul>
+                <li>
+                  <b>Current List</b>: A current list of sub-processors is
+                  maintained at the{" "}
+                  <b>
+                    SageMath, Inc. Trust Center (
+                    <A href="https://trust.cocalc.com/">
+                      https://trust.cocalc.com/
+                    </A>
+                    )
+                  </b>
+                  .
+                </li>
+                <li>
+                  <b>Notification of Changes</b>: Users may subscribe to
+                  notifications of changes to the sub-processor list directly
+                  via the Trust Center. SageMath, Inc. will provide at least{" "}
+                  <b>15 days&apos; notice</b> before authorizing any new
+                  sub-processor to process Customer Data, during which time the
+                  Controller may object to the change in writing.
+                </li>
+              </ul>
+              <h1>3. Security of Processing</h1>
+              <p>
+                SageMath, Inc. shall implement and maintain appropriate
+                technical and organizational measures to protect Customer Data
+                against unauthorized access, loss, or disclosure. These measures
+                include, but are not limited to:
+              </p>
+              <ul>
+                <li>
+                  <b>Encryption</b>: Data is encrypted at rest and in transit
+                  using industry-standard protocols.
+                </li>
+                <li>
+                  <b>Access Control</b>: Access to production environments is
+                  restricted to authorized personnel on a "need-to-know" basis.
+                </li>
+                <li>
+                  <b>Audit</b>: SageMath, Inc. undergoes regular security
+                  assessments and maintains documentation of its security
+                  controls (e.g., SOC 2 Type II report).
+                </li>
+              </ul>
+              <h1>4. GDPR Representation</h1>
+              <p>
+                Pursuant to Article 27 of the GDPR, SageMath, Inc. has appointed
+                the following representatives for data protection matters in the
+                EU and UK:
+              </p>
+              <ul>
+                <li>
+                  <b>EU Representative</b>: Adam Brogden, Instant EU GDPR
+                  Representative Ltd (Ireland). Contact:{" "}
+                  <A href="mailto:contact@gdprlocal.com">
+                    contact@gdprlocal.com
+                  </A>
+                  .
+                </li>
+                <li>
+                  <b>UK Representative</b>: Adam Brogden, GDPRLocal Ltd.
+                  Contact:{" "}
+                  <A href="mailto:contact@gdprlocal.com">
+                    contact@gdprlocal.com
+                  </A>
+                  .
+                </li>
+              </ul>
+              <h1>5. Data Subject Rights and Collaboration</h1>
+              <ul>
+                <li>
+                  <b>User-Controlled Deletion</b>: SageMath, Inc. provides the
+                  Controller with the ability to delete files, projects, and
+                  accounts directly through the CoCalc interface.
+                </li>
+                <li>
+                  <b>Requests to SageMath, Inc.</b>: If SageMath, Inc. receives
+                  a request from a Data Subject to exercise their rights
+                  regarding data contained within a project owned by another
+                  User, SageMath, Inc. will forward that request to the project
+                  owner.
+                </li>
+                <li>
+                  <b>Collaborative Integrity</b>: The Controller acknowledges
+                  that in a collaborative environment, the deletion of a Data
+                  Subject&apos;s account may not result in the deletion of data
+                  contained within projects owned by other Users, as that data
+                  is part of the other User&apos;s records.
+                </li>
+              </ul>
+              <h1>6. International Data Transfers</h1>
+              <ul>
+                <li>
+                  <b>Standard Contractual Clauses (SCCs)</b>: For transfers of
+                  Personal Data from the EU/EEA to countries that do not ensure
+                  an adequate level of data protection, the parties hereby
+                  incorporate by reference the{" "}
+                  <b>
+                    Standard Contractual Clauses (Module Two:
+                    Controller-to-Processor)
+                  </b>
+                  .
+                </li>
+                <li>
+                  <b>UK Addendum</b>: For transfers from the UK, the{" "}
+                  <b>International Data Transfer Addendum</b> to the EU SCCs is
+                  hereby incorporated.
+                </li>
+                <li>
+                  <b>Hierarchy</b>: In the event of a conflict between this DPA
+                  and the SCCs, the SCCs shall prevail.
+                </li>
+              </ul>
+              <h1>7. Data Deletion and Return</h1>
+              <p>
+                Upon termination of the Agreement or at the Controller&apos;s
+                request, SageMath, Inc. shall delete or return all Customer Data
+                in its possession, unless applicable law requires continued
+                storage. Data is typically deleted within 60 days of contract
+                termination.
+              </p>
+              <h1>8. Audit and Compliance</h1>
+              <p>
+                SageMath, Inc. shall make available to the Controller all
+                information reasonably necessary to demonstrate compliance with
+                Article 28 of the GDPR. The Controller acknowledges that
+                SageMath, Inc.&apos;s maintenance of a <b>SOC 2 Type II</b>{" "}
+                report satisfies the Controller&apos;s right to audit SageMath,
+                Inc.&apos;s technical and organizational measures.
+              </p>
+              <h1>9. Liability</h1>
+              <p>
+                The total liability of each party under this DPA shall be
+                subject to the limitation of liability provisions set forth in
+                the SageMath, Inc. Terms of Service.
+              </p>
+              <hr />
+              <p>
+                <b>
+                  This DPA is incorporated into the SageMath, Inc. Terms of
+                  Service by reference and is effective as of the date the User
+                  first accesses the CoCalc platform.
+                </b>
+              </p>
+            </div>
+          </div>
+          <Footer />
+        </Layout.Content>
+      </Layout>
+    </Customize>
+  );
+}
+
+export async function getServerSideProps(context) {
+  return await withCustomize({ context });
+}

--- a/src/packages/next/pages/policies/index.tsx
+++ b/src/packages/next/pages/policies/index.tsx
@@ -17,11 +17,34 @@ import withCustomize from "lib/with-customize";
 const dataSourceCoCalcCom = [
   {
     link: "/policies/terms",
-    title: "Terms of service",
+    title: "Terms of Service",
     logo: "thumbs-up",
     description: (
       <>
         The <A href="/policies/terms">Terms of Service</A> govern use of CoCalc.
+      </>
+    ),
+  },
+  {
+    link: "/policies/privacy",
+    title: "Privacy Policy",
+    logo: "user-secret",
+    description: (
+      <>
+        The <A href="/policies/privacy">Privacy Policy</A> describes how
+        SageMath, Inc. collects, uses, and discloses personal data.
+      </>
+    ),
+  },
+  {
+    link: "/policies/dpa",
+    title: "Data Processing Addendum",
+    logo: "file",
+    description: (
+      <>
+        The <A href="/policies/dpa">Data Processing Addendum</A> sets out the
+        terms that apply when SageMath, Inc. processes personal data on a
+        user&apos;s behalf.
       </>
     ),
   },
@@ -31,68 +54,43 @@ const dataSourceCoCalcCom = [
     logo: "lock-outlined",
     description: (
       <>
-        The <A href="/policies/trust">{POLICIES.trust.label}</A> page highlights
-        our compliance with laws and frameworks, such as GDPR and SOC 2. We
-        adhere to rigorous standards to protect your data and maintain
-        transparency and accountability in all our operations.
-      </>
-    ),
-  },
-  {
-    link: "/policies/copyright",
-    title: "Copyright policies",
-    logo: "dot-circle",
-    description: (
-      <>
-        The <A href="/policies/copyright">Copyright Policy</A> explains how
-        SageMath, Inc. respects copyright policies, and provides a site that
-        does not infringe on others' copyright.
-      </>
-    ),
-  },
-  {
-    link: "/policies/privacy",
-    title: "Privacy",
-    logo: "user-secret",
-    description: (
-      <>
-        The <A href="/policies/privacy">Privacy Policy</A> describes how
-        SageMath, Inc. respects the privacy of its users.
-      </>
-    ),
-  },
-  {
-    link: "/policies/dpa",
-    title: "Data Processing Addendum (DPA)",
-    logo: "file",
-    description: (
-      <>
-        The <A href="/policies/dpa">Data Processing Addendum</A> sets out
-        contractual terms for the processing of personal data on behalf of our
-        customers.
+        Our <A href="/policies/trust">{POLICIES.trust.label}</A> page summarizes
+        CoCalc&apos;s security and compliance posture, including GDPR and SOC 2
+        information.
       </>
     ),
   },
   {
     link: "/policies/thirdparties",
-    title: "Third parties",
+    title: "Third Parties",
     logo: "users",
     description: (
       <>
-        Our <A href="/policies/thirdparties">List of third parties</A>{" "}
-        enumerates what is used to provide CoCalc.
+        The <A href="/policies/thirdparties">Third Parties</A> page lists key
+        service providers used to operate CoCalc.
+      </>
+    ),
+  },
+  {
+    link: "/policies/copyright",
+    title: "Copyright Policy",
+    logo: "dot-circle",
+    description: (
+      <>
+        The <A href="/policies/copyright">Copyright Policy</A> explains how
+        SageMath, Inc. handles copyright complaints and DMCA notices.
       </>
     ),
   },
   {
     link: "/policies/ferpa",
-    title: "FERPA compliance statement",
+    title: "FERPA Compliance Statement",
     logo: "graduation-cap",
     description: (
       <>
-        <A href="/policies/ferpa">CoCalc's FERPA Compliance statement</A>{" "}
-        explains how we address FERPA requirements at US educational
-        instituations.
+        The <A href="/policies/ferpa">FERPA Compliance Statement</A> explains
+        how CoCalc supports FERPA requirements for U.S. educational
+        institutions.
       </>
     ),
   },
@@ -102,11 +100,8 @@ const dataSourceCoCalcCom = [
     logo: "eye",
     description: (
       <>
-        CoCalc's{" "}
-        <A href="/policies/accessibility">
-          Voluntary Product Accessibility Template (VPAT)
-        </A>{" "}
-        describes how we address accessibility issues.
+        The <A href="/policies/accessibility">Accessibility page</A> provides
+        CoCalc&apos;s VPAT and general accessibility information.
       </>
     ),
   },
@@ -137,9 +132,6 @@ export default function Policies({ customize }) {
   const dataSource = customize.onCoCalcCom
     ? dataSourceCoCalcCom
     : dataSourceOnPrem();
-  const description = customize.onCoCalcCom
-    ? "SageMath, Inc.'s terms of service, copyright, privacy and other policies."
-    : "";
   return (
     <Customize value={customize}>
       <Head title="Policies" />
@@ -147,7 +139,6 @@ export default function Policies({ customize }) {
         <Header page="policies" />
         <IndexList
           title={`${customize.siteName} Policies`}
-          description={description}
           dataSource={dataSource}
         />
         <Footer />{" "}

--- a/src/packages/next/pages/policies/index.tsx
+++ b/src/packages/next/pages/policies/index.tsx
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2021-2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -58,6 +58,18 @@ const dataSourceCoCalcCom = [
       <>
         The <A href="/policies/privacy">Privacy Policy</A> describes how
         SageMath, Inc. respects the privacy of its users.
+      </>
+    ),
+  },
+  {
+    link: "/policies/dpa",
+    title: "Data Processing Addendum (DPA)",
+    logo: "file",
+    description: (
+      <>
+        The <A href="/policies/dpa">Data Processing Addendum</A> sets out
+        contractual terms for the processing of personal data on behalf of our
+        customers.
       </>
     ),
   },

--- a/src/packages/next/pages/policies/terms.tsx
+++ b/src/packages/next/pages/policies/terms.tsx
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2021-2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -33,7 +33,7 @@ export default function TermsOfService({ customize }) {
           >
             <div style={{ textAlign: "center", color: "#444" }}>
               <h1 style={{ fontSize: "28pt" }}>CoCalc - Terms of Service</h1>
-              <h2>Last Updated: January 27, 2025</h2>
+              <h2>Last Updated: April 15, 2026</h2>
             </div>
             <div style={{ fontSize: "12pt" }}>
               <p>
@@ -172,7 +172,8 @@ export default function TermsOfService({ customize }) {
                 You may access your Account data via our application programming
                 interface ("<b>API</b>"). Your use of the API, including use
                 through a third party product that accesses the Services, is
-                subject to these Terms as well as the following specific terms:{" "}
+                subject to these Terms as well as the following specific
+                terms:{" "}
               </p>
               <ul>
                 <li>
@@ -273,7 +274,11 @@ export default function TermsOfService({ customize }) {
                   https://cocalc.com/policies/privacy
                 </A>
                 ) for information on how we collect, use and disclose
-                information from our users.{" "}
+                information from our users. Where SageMath, Inc. processes
+                personal data on your behalf as a Data Processor, such
+                processing is governed by our Data Processing Addendum (
+                <A href="/policies/dpa">https://cocalc.com/policies/dpa</A>),
+                which is hereby incorporated into these Terms by reference.{" "}
               </p>
               <h1>Content and Content Rights</h1>
               <p>
@@ -298,7 +303,8 @@ export default function TermsOfService({ customize }) {
                 copyright, trademark, and other laws of the United States and
                 foreign countries. You agree not to remove, alter or obscure any
                 copyright, trademark, service mark or other proprietary rights
-                notices incorporated in or accompanying the Services or Content.{" "}
+                notices incorporated in or accompanying the Services or
+                Content.{" "}
               </p>
               <h2>Rights in User Content Granted by You</h2>
               <p>
@@ -311,7 +317,8 @@ export default function TermsOfService({ customize }) {
                 you hereby grant to Account holders and non-Account holder users
                 of the Services who are permitted access to your Files the right
                 to use your Files in accordance with the applicable File
-                Licenses you have indicated govern use of your Files (if any).{" "}
+                Licenses you have indicated govern use of your Files (if
+                any).{" "}
               </p>
               <p>
                 You are solely responsible for all your User Content. You
@@ -396,7 +403,8 @@ export default function TermsOfService({ customize }) {
                   Avoid, bypass, remove, deactivate, impair, descramble or
                   otherwise circumvent any technological measure implemented by
                   SMI or any of SMI’s providers or any other third party
-                  (including another user) to protect the Services or Content;{" "}
+                  (including another user) to protect the Services or
+                  Content;{" "}
                 </li>
                 <li>
                   Attempt to access or search the Services or Content or
@@ -513,7 +521,8 @@ export default function TermsOfService({ customize }) {
                 HORSES, WORMS, OR OTHER COMPUTER PROGRAMMING DEVICES WHICH MAY
                 DAMAGE A USER’S COMPUTER, SYSTEM OR DATA OR PREVENT THE USER
                 FROM USING ITS COMPUTER, SYSTEM OR DATA. YOU KNOWINGLY AND
-                FREELY ASSUME ALL RISK WHEN USING THE SERVICES AND THE CONTENT.{" "}
+                FREELY ASSUME ALL RISK WHEN USING THE SERVICES AND THE
+                CONTENT.{" "}
               </p>
               <p className="uppercase">
                 THE CONTENT PROVIDED BY ACCOUNT HOLDERS AND THE USE OF CONTENT


### PR DESCRIPTION
Currently the order of policies is different in the header and on the overall page, with both orders being not ideal. With this change:
<img width="1300" height="2006" alt="policies_list" src="https://github.com/user-attachments/assets/21b9c594-b44d-468a-8557-10808e466621" />
<img width="1496" height="1624" alt="dpa1" src="https://github.com/user-attachments/assets/cc024293-5e5f-4371-bc68-db7335cf6f8d" />
<img width="1501" height="1867" alt="dpa2" src="https://github.com/user-attachments/assets/dff82cd2-30f2-4eb3-bc86-f848f2730ef0" />
