### PR TITLE
jupyter: minimal/regular toggle fixes

### DIFF
--- a/src/packages/frontend/jupyter/minimal/frame-type-toggle.tsx
+++ b/src/packages/frontend/jupyter/minimal/frame-type-toggle.tsx
@@ -11,7 +11,10 @@ import { Button, Tag, Tooltip } from "antd";
 import React from "react";
 
 import { useFrameContext } from "@cocalc/frontend/frame-editors/frame-tree/frame-context";
+import { webapp_client } from "@cocalc/frontend/webapp-client";
 import { COLORS } from "@cocalc/util/theme";
+
+const SHOW_TAGS = webapp_client.server_time() < new Date("2026-05-01");
 
 const TAG_STYLE: React.CSSProperties = {
   fontSize: 10,
@@ -22,8 +25,26 @@ const TAG_STYLE: React.CSSProperties = {
   verticalAlign: "super",
 };
 
+function hasFrameOfType(actions: any, type: string): boolean {
+  const leafIds = actions._get_leaf_ids();
+  for (const id in leafIds) {
+    if (actions._get_frame_type(id) === type) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isMultiFrame(actions: any): boolean {
+  return Object.keys(actions._get_leaf_ids()).length > 1;
+}
+
 export function SwitchToMinimalButton() {
   const { actions, id } = useFrameContext();
+
+  if (isMultiFrame(actions) && hasFrameOfType(actions, "jupyter_minimal")) {
+    return null;
+  }
 
   return (
     <Tooltip title="Switch this notebook frame to minimal mode. You can switch back any time.">
@@ -33,7 +54,7 @@ export function SwitchToMinimalButton() {
         onClick={() => actions.set_frame_type(id, "jupyter_minimal")}
       >
         Minimal
-        <Tag color="blue" style={TAG_STYLE}>New</Tag>
+        {SHOW_TAGS && <Tag color="blue" style={TAG_STYLE}>New</Tag>}
       </Button>
     </Tooltip>
   );
@@ -41,6 +62,10 @@ export function SwitchToMinimalButton() {
 
 export function SwitchToRegularButton() {
   const { actions, id } = useFrameContext();
+
+  if (isMultiFrame(actions) && hasFrameOfType(actions, "jupyter_cell_notebook")) {
+    return null;
+  }
 
   return (
     <Tooltip title="Switch this notebook frame back to the regular Jupyter notebook view.">
@@ -50,7 +75,7 @@ export function SwitchToRegularButton() {
         onClick={() => actions.set_frame_type(id, "jupyter_cell_notebook")}
       >
         Regular
-        <Tag color={COLORS.GRAY_D} style={TAG_STYLE}>Old</Tag>
+        {SHOW_TAGS && <Tag color={COLORS.GRAY_D} style={TAG_STYLE}>Old</Tag>}
       </Button>
     </Tooltip>
   );


### PR DESCRIPTION
## Summary
- Hide the minimal/regular toggle button in the status bar when the target frame type already exists in a split view (use frame menu to switch instead)
- Expire the "New"/"Old" tags on the toggle buttons after 2026-05-01

## Test plan
- [ ] Open a Jupyter notebook, split into two frames — verify toggle button is hidden when both types are present
- [ ] Verify frame menu still allows switching frame type
- [ ] After 2026-05-01, verify New/Old tags are not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)