### PR TITLE
frontend/build-coordinator: guard closed DKV handles

### DIFF
--- a/src/packages/frontend/frame-editors/generic/build-coordinator.ts
+++ b/src/packages/frontend/frame-editors/generic/build-coordinator.ts
@@ -305,10 +305,12 @@ export class BuildCoordinator {
     // Detach change listener before closing the ref-counted DKV.
     // The DKV may stay alive if other editors in the same project
     // still hold references — without this, stale listeners accumulate.
-    if (this.changeHandler && this.dkv) {
-      this.dkv.off("change", this.changeHandler);
+    const dkv = this.dkv;
+    this.dkv = undefined;
+    if (this.changeHandler && dkv) {
+      dkv.off("change", this.changeHandler);
       this.changeHandler = undefined;
     }
-    this.dkv?.close();
+    dkv?.close();
   }
 }


### PR DESCRIPTION
## Summary

- Add `getOpenDkv()` guard that checks `isClosed()` before accessing the DKV handle, preventing errors when operating on a closed ephemeral DKV
- Fix `close()` to capture the DKV reference locally before nulling `this.dkv`, avoiding a race between detaching the listener and closing

## Test plan

- [x] New test: "closed DKV handle is treated like a missing entry"
- [ ] Verify LaTeX/Rmd/Qmd builds don't throw when DKV closes mid-build (multi-user scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)