### PR TITLE
jupyter: fix "Cannot read properties of undefined (reading 'store')" on minimal<->regular toggle

### DIFF
--- a/src/packages/frontend/frame-editors/jupyter-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/actions.ts
@@ -50,10 +50,29 @@ export class JupyterEditorActions extends BaseActions<JupyterEditorState> {
     this.init_new_frame();
     this.init_changes_state();
 
-    this.store.on("close-frame", async ({ id }) => {
-      if (this.frame_actions[id] != null) {
-        await delay(1);
-        this.frame_actions[id].close();
+    this.store.on("close-frame", async ({ id, type: oldType }) => {
+      // Capture the specific instance so that a rapid frame-type toggle
+      // (which emits close-frame twice in quick succession) can't end up
+      // closing a freshly-created replacement instance after the delay.
+      const actions = this.frame_actions[id];
+      if (actions == null) return;
+      await delay(1);
+      // Toggling between jupyter_cell_notebook and jupyter_minimal uses
+      // the same CellNotebook component and the same NotebookFrameActions
+      // works for both types.  Closing and recreating on toggle just wipes
+      // this.jupyter_actions/this.store on the instance that still-mounted
+      // cell components hold via useNotebookFrameActions refs, so the next
+      // cell click crashes with "Cannot read properties of undefined
+      // (reading 'store')".  Keep the existing instance in that case.
+      const newType = this._get_frame_type(id);
+      if (
+        isJupyterNotebookFrameType(oldType) &&
+        isJupyterNotebookFrameType(newType)
+      ) {
+        return;
+      }
+      actions.close();
+      if (this.frame_actions[id] === actions) {
         delete this.frame_actions[id];
       }
     });

--- a/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/cell-notebook/actions.ts
@@ -99,11 +99,14 @@ export class NotebookFrameActions {
   }
 
   private init_syncdb_change_hook(): void {
-    this.jupyter_actions.store.on(
+    // jupyter_actions (or its store) may be undefined during a rapid
+    // frame-type toggle or while TimeTravel is still loading — guard
+    // with optional chaining, matching the pattern above.
+    this.jupyter_actions?.store?.on(
       "syncdb-before-change",
       this.syncdb_before_change,
     );
-    this.jupyter_actions.store.on(
+    this.jupyter_actions?.store?.on(
       "syncdb-after-change",
       this.syncdb_after_change,
     );
@@ -199,19 +202,20 @@ export class NotebookFrameActions {
   }
 
   public close(): void {
-    this.jupyter_actions.store.removeListener(
+    if (this._is_closed) return;
+    this.jupyter_actions?.store?.removeListener(
       "syncdb-before-change",
       this.syncdb_before_change,
     );
-    this.jupyter_actions.store.removeListener(
+    this.jupyter_actions?.store?.removeListener(
       "cell-list-recompute",
       this.update_cur_id,
     );
-    this.jupyter_actions.store.removeListener(
+    this.jupyter_actions?.store?.removeListener(
       "syncdb-after-change",
       this.syncdb_after_change,
     );
-    this.store.close();
+    this.store?.close();
     close(this);
     this._is_closed = true;
   }

--- a/src/packages/frontend/frame-editors/jupyter-editor/util.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/util.ts
@@ -7,6 +7,8 @@
  * Returns true if the given frame type is any Jupyter notebook frame
  * (standard or minimal).
  */
-export function isJupyterNotebookFrameType(type: string): boolean {
+export function isJupyterNotebookFrameType(
+  type: string | undefined,
+): boolean {
   return type === "jupyter_cell_notebook" || type === "jupyter_minimal";
 }


### PR DESCRIPTION
## Summary
- Fixes a production crash: toggling between the regular (`jupyter_cell_notebook`) and minimal (`jupyter_minimal`) notebook frames — especially while a notebook is starting up — leaves components holding stale `NotebookFrameActions` refs whose `jupyter_actions`/`store` got wiped by `misc.close(this)`. The next CodeMirror cell click then crashes with `TypeError: Cannot read properties of undefined (reading 'store')`, and keeps crashing on every subsequent click.
- Both jupyter frame types use the same `CellNotebook` component and the same `NotebookFrameActions` works for both, so the `close-frame` handler now skips the close when both the old and new types are jupyter notebook frame types.
- Also hardens the teardown path: capture the instance before `await delay(1)` so a rapid double-toggle can't close a replacement; make `NotebookFrameActions.close()` idempotent; guard listener removal with optional chaining (matching the existing pattern at line 79).
- `isJupyterNotebookFrameType` now accepts `string | undefined` so `_get_frame_type`'s return can be passed directly.

## Test plan
- [ ] Open a Jupyter notebook; while it's still starting up, rapidly click the Minimal/Regular toggle in the status bar several times.
- [ ] Click into a CodeMirror code cell afterwards — should activate normally, no console TypeError.
- [ ] Verify running cells, editing cells, markdown editing still work after several toggles.
- [ ] Verify transitioning from a Jupyter notebook frame to a non-notebook frame (e.g. Table of Contents, Console) still correctly tears down the old `NotebookFrameActions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)