### PR TITLE
static: use [contenthash] instead of [chunkhash] for chunk filenames

### DIFF
--- a/src/packages/static/src/rspack.config.ts
+++ b/src/packages/static/src/rspack.config.ts
@@ -188,14 +188,14 @@ export default function getConfig({ middleware }: Options = {}): Configuration {
         dependOn: "load",
       },
     },
-    /* Why chunkhash below, rather than contenthash? This says contenthash is a special
-     thing for css and other text files only (??):
-        https://medium.com/@sahilkkrazy/hash-vs-chunkhash-vs-contenthash-e94d38a32208
-  */
+    // [contenthash] (together with optimization.realContentHash, default-on
+    // in production) hashes the final emitted bytes; [chunkhash] is computed
+    // before module-id assignment and can collide across builds whose only
+    // difference is module-id order.
     output: {
       path: OUTPUT,
-      filename: PRODMODE ? "[name]-[chunkhash].js" : "[id]-[chunkhash].js",
-      chunkFilename: PRODMODE ? "[chunkhash].js" : "[id]-[chunkhash].js",
+      filename: PRODMODE ? "[name]-[contenthash].js" : "[id]-[contenthash].js",
+      chunkFilename: PRODMODE ? "[contenthash].js" : "[id]-[contenthash].js",
     },
     module: moduleRules(RSPACK_DEV_SERVER),
     resolve: {


### PR DESCRIPTION
## Summary
- `[chunkhash]` is computed before module-id assignment, so two builds whose only late-stage difference is module-id order can emit chunks with the same filename but different bytes. This caused the 2026-04-23 staging crash (`TypeError: Cannot read properties of undefined (reading 'call')` in webpack runtime): two server images shared filenames `015f891da7a27cd9.js` / `40a92d6caf64c408.js` but differed by exactly 5 bytes — the module id of `@react-hook/mouse-position` (`91068` vs `68687`). NFS holding a mix of chunks from different builds let the app-bundle reference an id not defined in the loaded chunk.
- `[contenthash]` + `optimization.realContentHash` (default `true` in production) re-hashes the final emitted bytes post-emission, so same filename ⇔ same bytes by construction.
- Compatible with the deploy policy of retaining prior-build chunks on NFS for in-flight clients — each distinct byte sequence now gets its own filename, so old chunks coexist with new ones without collision.

## Test plan
- [ ] Merge, let CI build the static image on the server.
- [ ] Deploy and confirm no `undefined .call` crash on boot.
- [ ] Sanity-check: chunk filenames in `dist/` are content-addressed (identical bytes across two local builds produce identical filenames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)