### PR TITLE
util/db-schema: add GPT-5.5 pricing and quotas

### DIFF
--- a/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent-utils.test.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent-utils.test.ts
@@ -403,6 +403,20 @@ describe("compactAssistantMessageForHistory", () => {
     expect(result).toContain("truncated");
     expect(result).toContain("5000 chars total");
   });
+
+  // Empty / whitespace-only assistant turns happen when a streaming call
+  // is cancelled mid-flight or the provider hiccups. Returning "" here
+  // would later poison the conversation: Anthropic's API rejects empty
+  // text content blocks with a 400 error, breaking every follow-up turn.
+  test("returns a non-empty placeholder for empty assistant text", () => {
+    const result = compactAssistantMessageForHistory("");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("returns a non-empty placeholder for whitespace-only text", () => {
+    const result = compactAssistantMessageForHistory("   \n\n\t  ");
+    expect(result.length).toBeGreaterThan(0);
+  });
 });
 
 describe("compactToolResultForHistory", () => {

--- a/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent-utils.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent-utils.ts
@@ -465,6 +465,8 @@ export function parseToolBlocks(text: string): ToolCall[] {
   return blocks;
 }
 
+export const EMPTY_ASSISTANT_PLACEHOLDER = "[no response]";
+
 export function compactAssistantMessageForHistory(text: string): string {
   const toolCalls = parseToolBlocks(text);
   const prose = text
@@ -478,7 +480,14 @@ export function compactAssistantMessageForHistory(text: string): string {
       : "";
 
   if (!prose) {
-    return toolSummary || truncate(text, MAX_ASSISTANT_HISTORY_CHARS);
+    if (toolSummary) return toolSummary;
+    // Anthropic and OpenAI reject messages with empty text content
+    // blocks. When an assistant turn has neither prose nor tool calls
+    // (e.g. provider hiccup, cancelled mid-stream, or model returned
+    // whitespace), substitute a non-empty placeholder so the next
+    // turn's history doesn't break the API call.
+    const fallback = truncate(text, MAX_ASSISTANT_HISTORY_CHARS).trim();
+    return fallback || EMPTY_ASSISTANT_PLACEHOLDER;
   }
 
   const compactProse = truncate(prose, MAX_ASSISTANT_HISTORY_CHARS);

--- a/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent.tsx
+++ b/src/packages/frontend/frame-editors/jupyter-editor/notebook-agent.tsx
@@ -798,7 +798,23 @@ export function NotebookAgent({
     if (msg.event === "tool_result") {
       return formatToolResultForDisplay(content);
     }
-    if (!content) return null;
+    if (!content) {
+      // Tool-only assistant turn: render a faint indicator so the user
+      // sees that the model did something. Without this, models that
+      // emit only tool blocks (no prose) leave a blank message bubble.
+      if (msg.sender === "assistant") {
+        const toolCalls = parseToolBlocks(msg.content);
+        if (toolCalls.length > 0) {
+          return (
+            <div style={TOOL_RESULT_STYLE}>
+              Used tool{toolCalls.length > 1 ? "s" : ""}:{" "}
+              {toolCalls.map((t) => t.name).join(", ")}
+            </div>
+          );
+        }
+      }
+      return null;
+    }
     return (
       <FileContext.Provider value={{ disableMarkdownCodebar: true }}>
         <StaticMarkdown value={content} />
@@ -961,7 +977,13 @@ export function NotebookAgent({
             key={inputKey}
             value={input}
             autoFocus
-            defaultMode="editor"
+            // Default to plain-text input. The slate WYSIWYG mode escapes
+            // 17 markdown metachars on serialize ("foo(x)" -> "foo\(x\)",
+            // "<" -> "&lt;", "-U" -> "\-U"), which silently corrupts
+            // prompts sent to the LLM. Defaulting to markdown avoids that
+            // for most users; the editbar toggle is still available for
+            // anyone who wants WYSIWYG.
+            defaultMode="markdown"
             onChange={handleInputChange}
             onShiftEnter={(value) => {
               handleSubmit(value);

--- a/src/packages/frontend/frame-editors/llm/coding-agent.tsx
+++ b/src/packages/frontend/frame-editors/llm/coding-agent.tsx
@@ -1064,6 +1064,13 @@ function CodingAgentCore({
           <MarkdownInput
             key={inputKey}
             value={input}
+            // Default to plain-text input. The slate WYSIWYG mode escapes
+            // 17 markdown metachars on serialize ("foo(x)" -> "foo\(x\)",
+            // "<" -> "&lt;", "-U" -> "\-U"), which silently corrupts
+            // prompts sent to the LLM. Defaulting to markdown avoids that
+            // for most users; the editbar toggle is still available for
+            // anyone who wants WYSIWYG.
+            defaultMode="markdown"
             onChange={handleInputChange}
             onShiftEnter={(value) => {
               handleSubmit(value);

--- a/src/packages/server/llm/chat-history.test.ts
+++ b/src/packages/server/llm/chat-history.test.ts
@@ -1,0 +1,61 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import { transformHistoryToMessages } from "./chat-history";
+
+describe("transformHistoryToMessages", () => {
+  test("alternates roles starting with user", () => {
+    const { messages } = transformHistoryToMessages([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+      { role: "user", content: "ok" },
+    ]);
+    expect(messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+  });
+
+  // Empty/whitespace assistant turns get persisted in agent sessions when
+  // a stream is cancelled or a provider returns no content. Anthropic's
+  // API rejects empty text content blocks with a 400, so the next turn
+  // would otherwise fail with "messages: text content blocks must be
+  // non-empty". Substitute a non-empty placeholder.
+  test("replaces empty content with a non-empty placeholder", () => {
+    const { messages } = transformHistoryToMessages([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "" },
+      { role: "user", content: "what?" },
+    ]);
+    expect(messages).toHaveLength(3);
+    for (const m of messages) {
+      expect(m.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("treats whitespace-only content as empty", () => {
+    const { messages } = transformHistoryToMessages([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "   \n\t " },
+    ]);
+    expect(messages[1].content.trim().length).toBeGreaterThan(0);
+  });
+
+  test("preserves alternation when an entry is empty", () => {
+    const { messages } = transformHistoryToMessages([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "" },
+      { role: "user", content: "third" },
+      { role: "assistant", content: "fourth" },
+    ]);
+    expect(messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+  });
+});

--- a/src/packages/server/llm/chat-history.ts
+++ b/src/packages/server/llm/chat-history.ts
@@ -11,6 +11,13 @@ export interface HistoryMessage {
   content: string;
 }
 
+// Anthropic and OpenAI reject messages whose text content is empty.
+// One bad turn (e.g. an empty assistant response stored in session
+// history) would otherwise break every subsequent call. Substitute a
+// short placeholder rather than dropping the entry, since the
+// alternation logic below assumes one history slot per stored turn.
+const EMPTY_CONTENT_PLACEHOLDER = "[empty]";
+
 // Reconstruct the chat history from CoCalc's data.
 // Assumes alternating user/assistant messages starting from user.
 export function transformHistoryToMessages(history?: History): {
@@ -23,8 +30,12 @@ export function transformHistoryToMessages(history?: History): {
   if (history) {
     let nextRole: "user" | "assistant" = "user";
     for (const { content } of history) {
-      tokens += numTokens(content);
-      messages.push({ role: nextRole, content });
+      const safe =
+        typeof content === "string" && content.trim().length > 0
+          ? content
+          : EMPTY_CONTENT_PLACEHOLDER;
+      tokens += numTokens(safe);
+      messages.push({ role: nextRole, content: safe });
       nextRole = nextRole === "user" ? "assistant" : "user";
     }
   }

--- a/src/packages/server/llm/index.test.ts
+++ b/src/packages/server/llm/index.test.ts
@@ -1,0 +1,92 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import { normalizeOpenAIModel } from "./index";
+
+describe("normalizeOpenAIModel", () => {
+  // The function looks up an explicit OPENAI_VERSION entry to find the
+  // OpenAI API model name. Bugs here are very expensive: a mismatch
+  // silently routes the request to the wrong model and the user is
+  // billed/credited under the originally selected name.
+
+  describe("8k variants resolve to canonical model", () => {
+    test("gpt-5.4-8k -> gpt-5.4", () => {
+      expect(normalizeOpenAIModel("gpt-5.4-8k")).toBe("gpt-5.4");
+    });
+
+    test("gpt-5.4-mini-8k -> gpt-5.4-mini", () => {
+      expect(normalizeOpenAIModel("gpt-5.4-mini-8k")).toBe("gpt-5.4-mini");
+    });
+
+    test("gpt-5.2-8k -> gpt-5.2", () => {
+      expect(normalizeOpenAIModel("gpt-5.2-8k")).toBe("gpt-5.2");
+    });
+
+    test("gpt-5-mini-8k -> gpt-5-mini", () => {
+      expect(normalizeOpenAIModel("gpt-5-mini-8k")).toBe("gpt-5-mini");
+    });
+
+    test("gpt-5-8k -> gpt-5", () => {
+      expect(normalizeOpenAIModel("gpt-5-8k")).toBe("gpt-5");
+    });
+
+    test("gpt-4o-8k -> gpt-4o", () => {
+      expect(normalizeOpenAIModel("gpt-4o-8k")).toBe("gpt-4o");
+    });
+  });
+
+  describe("canonical names are idempotent", () => {
+    test("gpt-5.5", () => {
+      expect(normalizeOpenAIModel("gpt-5.5")).toBe("gpt-5.5");
+    });
+
+    test("gpt-5.4", () => {
+      expect(normalizeOpenAIModel("gpt-5.4")).toBe("gpt-5.4");
+    });
+
+    test("gpt-5.4-mini", () => {
+      expect(normalizeOpenAIModel("gpt-5.4-mini")).toBe("gpt-5.4-mini");
+    });
+
+    test("gpt-5", () => {
+      expect(normalizeOpenAIModel("gpt-5")).toBe("gpt-5");
+    });
+  });
+
+  // Regression test for the prefix-collision bug found by Codex review.
+  // Before refactoring to an explicit OPENAI_VERSION map, the
+  // normalization used prefix matching, and "gpt-5.5" silently matched
+  // the more general "gpt-5" prefix first — getting routed to the
+  // older model.
+  describe("must not collide with shorter prefixes", () => {
+    test("gpt-5.5 must not be routed to gpt-5", () => {
+      expect(normalizeOpenAIModel("gpt-5.5")).not.toBe("gpt-5");
+    });
+
+    test("gpt-5.4-8k must not be routed to gpt-5", () => {
+      expect(normalizeOpenAIModel("gpt-5.4-8k")).not.toBe("gpt-5");
+    });
+
+    test("gpt-5.4-mini-8k must not be routed to gpt-5-mini or gpt-5", () => {
+      const result = normalizeOpenAIModel("gpt-5.4-mini-8k");
+      expect(result).not.toBe("gpt-5-mini");
+      expect(result).not.toBe("gpt-5");
+    });
+
+    test("gpt-5-mini-8k must not be routed to gpt-5", () => {
+      expect(normalizeOpenAIModel("gpt-5-mini-8k")).not.toBe("gpt-5");
+    });
+  });
+
+  describe("invalid input rejected", () => {
+    test("non-OpenAI model throws", () => {
+      expect(() => normalizeOpenAIModel("claude-4-6-sonnet-8k")).toThrow();
+    });
+
+    test("nonsense string throws", () => {
+      expect(() => normalizeOpenAIModel("not-a-real-model")).toThrow();
+    });
+  });
+});

--- a/src/packages/server/llm/index.ts
+++ b/src/packages/server/llm/index.ts
@@ -21,7 +21,6 @@ import {
   LLM_USERNAMES,
   LanguageModel,
   LanguageServiceCore,
-  OpenAIModel,
   getLLMCost,
   isAnthropicModel,
   isCoreLanguageModel,
@@ -31,6 +30,7 @@ import {
   isMistralModel,
   isOllamaLLM,
   isOpenAIModel,
+  OPENAI_VERSION,
   isUserDefinedModel,
   isValidModel,
   isXaiModel,
@@ -245,26 +245,19 @@ async function evaluateImpl({
   return output;
 }
 
-export function normalizeOpenAIModel(model): OpenAIModel {
-  // the *-8k variants are artificial – the input is already limited/truncated to 8k
-  // convert *-preview and all *-8k to their base model names
-  const modelPrefixes = [
-    "gpt-5.4-mini",
-    "gpt-5.4",
-    "gpt-5.2",
-    "gpt-5-mini",
-    "gpt-5",
-  ];
-
-  for (const prefix of modelPrefixes) {
-    if (model.startsWith(prefix)) {
-      model = prefix;
-      break;
-    }
-  }
-
+// Resolve an OpenAIModel (which may be a context-limited "-8k" alias)
+// to the actual model name accepted by OpenAI's API.
+//
+// Looks up an explicit entry in OPENAI_VERSION rather than doing prefix
+// matching. The previous prefix-based version silently misrouted
+// "gpt-5.5" to "gpt-5" because it shared a prefix with the older model.
+export function normalizeOpenAIModel(model): string {
   if (!isOpenAIModel(model)) {
-    throw new Error(`Internal problem normalizing OpenAI model name: ${model}`);
+    throw new Error(`Not an OpenAI model: ${model}`);
   }
-  return model;
+  const apiName = OPENAI_VERSION[model];
+  if (apiName == null) {
+    throw new Error(`OpenAI model ${model} is no longer supported`);
+  }
+  return apiName;
 }

--- a/src/packages/util/db-schema/llm-utils.test.ts
+++ b/src/packages/util/db-schema/llm-utils.test.ts
@@ -67,7 +67,7 @@ describe("llm", () => {
   });
 
   test("model2service handles gpt-5.5 models", () => {
-    expect(model2service("gpt-5.5-8k")).toBe("openai-gpt-5.5-8k");
+    expect(model2service("gpt-5.5")).toBe("openai-gpt-5.5");
   });
 
   test("Gemini 3 Flash description omits preview", () => {
@@ -94,8 +94,8 @@ describe("llm", () => {
     expect(1_000_000 * LLM_COST["claude-3-opus"].completion_tokens).toBeCloseTo(
       75,
     );
-    expect(1_000_000 * LLM_COST["gpt-5.5-8k"].prompt_tokens).toBeCloseTo(5);
-    expect(1_000_000 * LLM_COST["gpt-5.5-8k"].completion_tokens).toBeCloseTo(
+    expect(1_000_000 * LLM_COST["gpt-5.5"].prompt_tokens).toBeCloseTo(5);
+    expect(1_000_000 * LLM_COST["gpt-5.5"].completion_tokens).toBeCloseTo(
       30,
     );
   });
@@ -144,7 +144,7 @@ describe("llm", () => {
     // not disabled
     expect(getModel("mistral-large-latest")).toEqual("mistral-large-latest");
     expect(getModel("gpt-5.4-mini-8k")).toEqual("gpt-5.4-mini-8k");
-    expect(getModel("gpt-5.5-8k")).toEqual("gpt-5.5-8k");
+    expect(getModel("gpt-5.5")).toEqual("gpt-5.5");
     expect(getModel(DEFAULT_MODEL)).toEqual(DEFAULT_MODEL);
     expect(getModel("magistral-medium-latest")).toEqual(DEFAULT_MODEL);
     expect(getModel("mistral-large-latest")).toEqual("mistral-large-latest");

--- a/src/packages/util/db-schema/llm-utils.test.ts
+++ b/src/packages/util/db-schema/llm-utils.test.ts
@@ -66,8 +66,8 @@ describe("llm", () => {
     );
   });
 
-  test("model2service handles gpt-5.2 models", () => {
-    expect(model2service("gpt-5.2-8k")).toBe("openai-gpt-5.2-8k");
+  test("model2service handles gpt-5.5 models", () => {
+    expect(model2service("gpt-5.5-8k")).toBe("openai-gpt-5.5-8k");
   });
 
   test("Gemini 3 Flash description omits preview", () => {
@@ -93,6 +93,10 @@ describe("llm", () => {
     expect(1_000_000 * LLM_COST["claude-3-opus"].prompt_tokens).toBeCloseTo(15);
     expect(1_000_000 * LLM_COST["claude-3-opus"].completion_tokens).toBeCloseTo(
       75,
+    );
+    expect(1_000_000 * LLM_COST["gpt-5.5-8k"].prompt_tokens).toBeCloseTo(5);
+    expect(1_000_000 * LLM_COST["gpt-5.5-8k"].completion_tokens).toBeCloseTo(
+      30,
     );
   });
 
@@ -140,6 +144,7 @@ describe("llm", () => {
     // not disabled
     expect(getModel("mistral-large-latest")).toEqual("mistral-large-latest");
     expect(getModel("gpt-5.4-mini-8k")).toEqual("gpt-5.4-mini-8k");
+    expect(getModel("gpt-5.5-8k")).toEqual("gpt-5.5-8k");
     expect(getModel(DEFAULT_MODEL)).toEqual(DEFAULT_MODEL);
     expect(getModel("magistral-medium-latest")).toEqual(DEFAULT_MODEL);
     expect(getModel("mistral-large-latest")).toEqual("mistral-large-latest");

--- a/src/packages/util/db-schema/llm-utils.ts
+++ b/src/packages/util/db-schema/llm-utils.ts
@@ -149,7 +149,7 @@ export const MODELS_OPENAI = [
   "gpt-5",
   "gpt-5.2-8k", // context limited
   "gpt-5.2",
-  "gpt-5.5-8k", // context limited
+  "gpt-5.5", // context limited (no 128k variant exposed)
   "gpt-5.4-8k", // context limited
   "gpt-5.4",
   "gpt-5-mini-8k", // context limited
@@ -163,6 +163,53 @@ export type OpenAIModel = (typeof MODELS_OPENAI)[number];
 export function isOpenAIModel(model: unknown): model is OpenAIModel {
   return MODELS_OPENAI.includes(model as any);
 }
+
+// Maps each user-selectable / internally-tracked OpenAI model to its
+// actual OpenAI API model name (or null if no longer supported).
+//
+// Mirrors ANTHROPIC_VERSION below — explicit mapping replaces fragile
+// prefix matching, which previously misrouted "gpt-5.5" to "gpt-5"
+// because it shared a prefix with the older model.
+//
+// Adding a new model? Add it here too. The TypeScript exhaustiveness
+// check on `[name in OpenAIModel]` will catch a missing entry at
+// build time.
+export const OPENAI_VERSION: { [name in OpenAIModel]: string | null } = {
+  "gpt-3.5-turbo": "gpt-3.5-turbo",
+  "gpt-3.5-turbo-16k": "gpt-3.5-turbo-16k",
+  "gpt-4": "gpt-4",
+  "gpt-4-32k": "gpt-4-32k",
+  "gpt-4.1": "gpt-4.1",
+  "gpt-4.1-mini": "gpt-4.1-mini",
+  "gpt-4-turbo-preview-8k": "gpt-4-turbo-preview",
+  "gpt-4-turbo-preview": "gpt-4-turbo-preview",
+  "gpt-4-turbo-8k": "gpt-4-turbo",
+  "gpt-4-turbo": "gpt-4-turbo",
+  "gpt-4o-mini-8k": "gpt-4o-mini",
+  "gpt-4o-mini": "gpt-4o-mini",
+  "gpt-4o-8k": "gpt-4o",
+  "gpt-4o": "gpt-4o",
+  o1: "o1",
+  "o1-8k": "o1",
+  "o1-mini": "o1-mini",
+  "o1-mini-8k": "o1-mini",
+  o3: "o3",
+  "o3-8k": "o3",
+  "o4-mini": "o4-mini",
+  "o4-mini-8k": "o4-mini",
+  "gpt-5": "gpt-5",
+  "gpt-5-8k": "gpt-5",
+  "gpt-5.2": "gpt-5.2",
+  "gpt-5.2-8k": "gpt-5.2",
+  "gpt-5.5": "gpt-5.5",
+  "gpt-5.4": "gpt-5.4",
+  "gpt-5.4-8k": "gpt-5.4",
+  "gpt-5-mini": "gpt-5-mini",
+  "gpt-5-mini-8k": "gpt-5-mini",
+  "gpt-5.4-mini": "gpt-5.4-mini",
+  "gpt-5.4-mini-8k": "gpt-5.4-mini",
+  "text-embedding-ada-002": "text-embedding-ada-002",
+} as const;
 
 // ATTN: when you modify this list, also change frontend/.../llm/llm-selector.tsx!
 export const MISTRAL_MODELS = [
@@ -395,7 +442,7 @@ export const USER_SELECTABLE_LLMS_BY_VENDOR: {
   [vendor in LLMServiceName]: Readonly<LanguageModelCore[]>;
 } = {
   openai: MODELS_OPENAI.filter(
-    (m) => m === "gpt-5.5-8k" || m === "gpt-5.4-8k" || m === "gpt-5.4-mini-8k",
+    (m) => m === "gpt-5.5" || m === "gpt-5.4-8k" || m === "gpt-5.4-mini-8k",
   ),
   google: [
     "gemini-3.1-pro-preview-8k",
@@ -975,7 +1022,7 @@ export const LLM_USERNAMES: LLM2String = {
   "gpt-5": "GPT-5 128k",
   "gpt-5.2-8k": "GPT-5.2",
   "gpt-5.2": "GPT-5.2 128k",
-  "gpt-5.5-8k": "GPT-5.5",
+  "gpt-5.5": "GPT-5.5",
   "gpt-5.4-8k": "GPT-5.4",
   "gpt-5.4": "GPT-5.4 128k",
   "gpt-5-mini-8k": "GPT-5 Mini",
@@ -1105,7 +1152,7 @@ export const LLM_DESCR: LLM2String = {
     "OpenAI's most advanced model with built-in reasoning (50k token context)",
   "gpt-5.2":
     "OpenAI's most advanced model with built-in reasoning (128k token context)",
-  "gpt-5.5-8k":
+  "gpt-5.5":
     "OpenAI's smartest model for coding and professional work (50k token context)",
   "gpt-5.4-8k":
     "OpenAI's most powerful model for professional work (50k token context)",
@@ -1581,7 +1628,7 @@ export const LLM_COST: { [name in LanguageModelCore]: Cost } = {
     max_tokens: 128000,
     free: false,
   },
-  "gpt-5.5-8k": {
+  "gpt-5.5": {
     prompt_tokens: usd1Mtokens(5),
     completion_tokens: usd1Mtokens(30),
     max_tokens: 50_000,

--- a/src/packages/util/db-schema/llm-utils.ts
+++ b/src/packages/util/db-schema/llm-utils.ts
@@ -149,6 +149,7 @@ export const MODELS_OPENAI = [
   "gpt-5",
   "gpt-5.2-8k", // context limited
   "gpt-5.2",
+  "gpt-5.5-8k", // context limited
   "gpt-5.4-8k", // context limited
   "gpt-5.4",
   "gpt-5-mini-8k", // context limited
@@ -394,7 +395,7 @@ export const USER_SELECTABLE_LLMS_BY_VENDOR: {
   [vendor in LLMServiceName]: Readonly<LanguageModelCore[]>;
 } = {
   openai: MODELS_OPENAI.filter(
-    (m) => m === "gpt-5.4-8k" || m === "gpt-5.4-mini-8k",
+    (m) => m === "gpt-5.5-8k" || m === "gpt-5.4-8k" || m === "gpt-5.4-mini-8k",
   ),
   google: [
     "gemini-3.1-pro-preview-8k",
@@ -974,6 +975,7 @@ export const LLM_USERNAMES: LLM2String = {
   "gpt-5": "GPT-5 128k",
   "gpt-5.2-8k": "GPT-5.2",
   "gpt-5.2": "GPT-5.2 128k",
+  "gpt-5.5-8k": "GPT-5.5",
   "gpt-5.4-8k": "GPT-5.4",
   "gpt-5.4": "GPT-5.4 128k",
   "gpt-5-mini-8k": "GPT-5 Mini",
@@ -997,7 +999,7 @@ export const LLM_DESCR: LLM2String = {
   "gpt-4":
     "Powerful OpenAI model. Can follow complex instructions and solve difficult problems. (OpenAI, 8k token context)",
   "gpt-4.1":
-    "Powerful OpenAI model. Can follow complex instructions and solve difficult problems. (OpenAI, 8k token context)",
+    "Powerful OpenAI model. Can follow complex instructions and solve difficult problems. (OpenAI, 50k token context)",
   "gpt-4-32k": "",
   "gpt-3.5-turbo": "Fast, great for everyday tasks. (OpenAI, 4k token context)",
   "gpt-3.5-turbo-16k": `Same as ${LLM_USERNAMES["gpt-3.5-turbo"]} but with larger 16k token context`,
@@ -1008,11 +1010,11 @@ export const LLM_DESCR: LLM2String = {
     "Faster, fresher knowledge, and lower price than GPT-4. (OpenAI, 8k token context)",
   "gpt-4-turbo": "Like GPT-4 Turbo, but with up to 128k token context",
   "gpt-4o-8k":
-    "Most powerful, fastest, and cheapest (OpenAI, 8k token context)",
+    "Most powerful, fastest, and cheapest (OpenAI, 50k token context)",
   "gpt-4o": "Most powerful fastest, and cheapest (OpenAI, 128k token context)",
   "gpt-4o-mini-8k":
-    "Most cost-efficient small model (OpenAI, 8k token context)",
-  "gpt-4.1-mini": "Most cost-efficient small model (OpenAI, 8k token context)",
+    "Most cost-efficient small model (OpenAI, 50k token context)",
+  "gpt-4.1-mini": "Most cost-efficient small model (OpenAI, 50k token context)",
   "gpt-4o-mini": "Most cost-efficient small model (OpenAI, 128k token context)",
   "text-embedding-ada-002": "Text embedding Ada 002 by OpenAI", // TODO: this is for embeddings, should be moved to a different place
   "o1-8k": "Spends more time thinking (8k token context)",
@@ -1037,13 +1039,13 @@ export const LLM_DESCR: LLM2String = {
   "gemini-2.0-flash-lite-8k":
     "Google's Gemini 2.0 Flash Lite Generative AI model (8k token context)",
   "gemini-2.5-flash-8k":
-    "Google's Gemini 2.5 Flash Generative AI model (8k token context)",
+    "Google's Gemini 2.5 Flash Generative AI model (50k token context)",
   "gemini-2.5-pro-8k":
-    "Google's Gemini 2.5 Pro Generative AI model (8k token context)",
+    "Google's Gemini 2.5 Pro Generative AI model (50k token context)",
   "gemini-3-pro-preview-8k":
-    "Google's Gemini 3 Pro Generative AI model (8k token context)",
+    "Google's Gemini 3 Pro Generative AI model (50k token context)",
   "gemini-3.1-pro-preview-8k":
-    "Google's Gemini 3.1 Pro model with enhanced reasoning (8k token context)",
+    "Google's Gemini 3.1 Pro model with enhanced reasoning (50k token context)",
   "mistral-small-latest":
     "Small general purpose tasks, text classification, customer service. (Mistral AI, 4k token context)",
   "mistral-medium-latest":
@@ -1071,17 +1073,17 @@ export const LLM_DESCR: LLM2String = {
   "claude-4-opus-8k":
     "Excels at writing and complex tasks (Anthropic, 8k token context)",
   "claude-4-5-sonnet-8k":
-    "Most intelligent model with advanced reasoning (Anthropic, 8k token context)",
+    "Most intelligent model with advanced reasoning (Anthropic, 50k token context)",
   "claude-4-6-sonnet-8k":
-    "Advanced reasoning and coding model (Anthropic, 8k token context)",
+    "Advanced reasoning and coding model (Anthropic, 50k token context)",
   "claude-4-5-opus-8k":
-    "Flagship model excelling at complex tasks and writing (Anthropic, 8k token context)",
+    "Flagship model excelling at complex tasks and writing (Anthropic, 50k token context)",
   "claude-4-6-opus-8k":
-    "Most intelligent model for agents and coding (Anthropic, 8k token context)",
+    "Most intelligent model for agents and coding (Anthropic, 50k token context)",
   "claude-4-7-opus-8k":
-    "Latest flagship model for agents and coding (Anthropic, 8k token context)",
+    "Latest flagship model for agents and coding (Anthropic, 50k token context)",
   "claude-4-5-haiku-8k":
-    "Fastest and most cost-efficient model (Anthropic, 8k token context)",
+    "Fastest and most cost-efficient model (Anthropic, 50k token context)",
   "claude-3-sonnet-4k":
     "Best combination of performance and speed (Anthropic, 4k token context)",
   "claude-3-opus":
@@ -1089,10 +1091,10 @@ export const LLM_DESCR: LLM2String = {
   "claude-3-opus-8k":
     "Excels at writing and complex tasks (Anthropic, 8k token context)",
   "o3-8k":
-    "Advanced reasoning model with enhanced thinking capabilities (8k token context)",
+    "Advanced reasoning model with enhanced thinking capabilities (50k token context)",
   o3: "Advanced reasoning model with enhanced thinking capabilities (128k token context)",
   "o4-mini-8k":
-    "Cost-efficient reasoning model with strong performance (8k token context)",
+    "Cost-efficient reasoning model with strong performance (50k token context)",
   "o4-mini":
     "Cost-efficient reasoning model with strong performance (128k token context)",
   "gpt-5-8k":
@@ -1100,30 +1102,31 @@ export const LLM_DESCR: LLM2String = {
   "gpt-5":
     "OpenAI's most advanced model with built-in reasoning (128k token context)",
   "gpt-5.2-8k":
-    "OpenAI's most advanced model with built-in reasoning (8k token context)",
+    "OpenAI's most advanced model with built-in reasoning (50k token context)",
   "gpt-5.2":
     "OpenAI's most advanced model with built-in reasoning (128k token context)",
+  "gpt-5.5-8k":
+    "OpenAI's smartest model for coding and professional work (50k token context)",
   "gpt-5.4-8k":
-    "OpenAI's most powerful model for professional work (8k token context)",
+    "OpenAI's most powerful model for professional work (50k token context)",
   "gpt-5.4":
     "OpenAI's most powerful model for professional work (128k token context)",
   "gpt-5-mini-8k":
-    "Fast and cost-efficient version of GPT-5 (8k token context)",
+    "Fast and cost-efficient version of GPT-5 (50k token context)",
   "gpt-5-mini": "Fast and cost-efficient version of GPT-5 (128k token context)",
   "gpt-5.4-mini-8k":
-    "Powerful and cost-efficient mini model for coding and agents (8k token context)",
+    "Powerful and cost-efficient mini model for coding and agents (50k token context)",
   "gpt-5.4-mini":
     "Powerful and cost-efficient mini model for coding and agents (128k token context)",
   "gemini-3-flash-preview-16k":
-    "Google's Gemini 3 Flash model (16k token context)",
+    "Google's Gemini 3 Flash model (50k token context)",
   "grok-4-1-fast-non-reasoning-16k":
-    "xAI's Grok 4.1 fast non-reasoning model (16k token context)",
+    "xAI's Grok 4.1 fast non-reasoning model (50k token context)",
   "grok-4-1-fast-reasoning-16k":
-    "xAI's Grok 4.1 fast reasoning model (16k token context)",
+    "xAI's Grok 4.1 fast reasoning model (50k token context)",
   "grok-code-fast-1-16k":
-    "xAI's Grok Code Fast model, specialized for coding tasks (16k token context)",
-  "glm-5.1":
-    "Z.AI's flagship model, top-tier coding and long-horizon tasks",
+    "xAI's Grok Code Fast model, specialized for coding tasks (50k token context)",
+  "glm-5.1": "Z.AI's flagship model, top-tier coding and long-horizon tasks",
 } as const;
 
 export function isFreeModel(model: unknown, isCoCalcCom: boolean): boolean {
@@ -1576,6 +1579,12 @@ export const LLM_COST: { [name in LanguageModelCore]: Cost } = {
     prompt_tokens: usd1Mtokens(1.25),
     completion_tokens: usd1Mtokens(10),
     max_tokens: 128000,
+    free: false,
+  },
+  "gpt-5.5-8k": {
+    prompt_tokens: usd1Mtokens(5),
+    completion_tokens: usd1Mtokens(30),
+    max_tokens: 50_000,
     free: false,
   },
   "gpt-5.4-8k": {

--- a/src/packages/util/db-schema/purchase-quotas.ts
+++ b/src/packages/util/db-schema/purchase-quotas.ts
@@ -295,7 +295,7 @@ export const QUOTA_SPEC: QuotaSpec = {
   "openai-gpt-5": GPT_5_128k,
   "openai-gpt-5.2-8k": GPT_5_2_8K,
   "openai-gpt-5.2": GPT_5_2_128k,
-  "openai-gpt-5.5-8k": GPT_5_5_8K,
+  "openai-gpt-5.5": GPT_5_5_8K,
   "openai-gpt-5.4-8k": GPT_5_4_8K,
   "openai-gpt-5.4": GPT_5_4_128k,
   "openai-gpt-5-mini-8k": GPT_5_MINI_8K,

--- a/src/packages/util/db-schema/purchase-quotas.ts
+++ b/src/packages/util/db-schema/purchase-quotas.ts
@@ -141,6 +141,12 @@ const GPT_5_2_128k: Spec = {
   display: "OpenAI GPT-5.2 128k",
 } as const;
 
+const GPT_5_5_8K: Spec = {
+  display: "OpenAI GPT-5.5",
+  color: OPENAI_COLOR,
+  category: "ai",
+} as const;
+
 const GPT_5_4_8K: Spec = {
   display: "OpenAI GPT-5.4",
   color: OPENAI_COLOR,
@@ -289,6 +295,7 @@ export const QUOTA_SPEC: QuotaSpec = {
   "openai-gpt-5": GPT_5_128k,
   "openai-gpt-5.2-8k": GPT_5_2_8K,
   "openai-gpt-5.2": GPT_5_2_128k,
+  "openai-gpt-5.5-8k": GPT_5_5_8K,
   "openai-gpt-5.4-8k": GPT_5_4_8K,
   "openai-gpt-5.4": GPT_5_4_128k,
   "openai-gpt-5-mini-8k": GPT_5_MINI_8K,


### PR DESCRIPTION
## Summary
Add GPT-5.5 to the util LLM schema and purchase quota tables so CoCalc is ready once the API model is available.

## What changed
- added `gpt-5.5-8k` and `gpt-5.5` to the OpenAI model list
- added display names and descriptions for GPT-5.5
- added published GPT-5.5 pricing to `LLM_COST`
- added purchase quota entries for GPT-5.5
- updated focused util tests to cover the new model wiring and pricing

## Why
OpenAI announced GPT-5.5 on April 23, 2026 and published API pricing, but public API availability still appears to be pending. This prepares the schema and billing metadata ahead of rollout.

## Validation
- `cd src/packages/util && pnpm build`
- `cd src/packages/util && pnpm test -- db-schema/llm-utils.test.ts`

## Notes
This PR is intentionally left as draft. No end-to-end testing was run yet.
