### PR TITLE
LaTeX chat anchors as collaborative TODOs (resolve flow + TOC indexing)

### DIFF
--- a/src/packages/frontend/chat/actions.ts
+++ b/src/packages/frontend/chat/actions.ts
@@ -52,6 +52,7 @@ import type {
   ChatMessageTyped,
   Feedback,
   MessageHistory,
+  ResolvedMeta,
 } from "./types";
 import {
   anchorIdOf,
@@ -1550,6 +1551,56 @@ export class ChatActions extends Actions<ChatState> {
     this.setPendingAnchorThread({ id, label, path });
     this.setSelectedThread(null);
     return null;
+  };
+
+  // Mark an anchored root message as resolved (LaTeX collaborative-TODO
+  // flow). Stamps `resolved` metadata preserving the former anchor info, and
+  // clears the active `id`/`path` so the thread no longer matches its source
+  // anchor — `findOrCreateAnchorThread` and `useAnchoredThreads` will skip
+  // it. Idempotent.
+  //
+  // The caller is responsible for actually removing the source-document
+  // marker(s); see the LaTeX editor's `resolveChatMarker`.
+  resolveAnchorThread = (rootDate: Date): void => {
+    if (this.syncdb == null) return;
+    const cur = this.syncdb.get_one({ event: "chat", date: rootDate });
+    if (cur == null) return;
+    if (cur.get("resolved") != null) return;
+    const anchorId = cur.get("id") ?? cur.get("cell_id");
+    if (typeof anchorId !== "string" || anchorId.length === 0) {
+      // Not anchored — nothing to resolve.
+      return;
+    }
+    const account_id = this.redux.getStore("account").get_account_id();
+    const path = cur.get("path");
+    const editorActions: any = this.frameTreeActions;
+    const labelRaw =
+      typeof editorActions?.getAnchorLabel === "function"
+        ? editorActions.getAnchorLabel(anchorId)
+        : undefined;
+    const at = webapp_client.server_time().toISOString();
+    const resolved: ResolvedMeta = {
+      account_id,
+      at,
+      anchorId,
+    };
+    if (typeof path === "string" && path.length > 0) {
+      resolved.path = path;
+    }
+    if (typeof labelRaw === "string" && labelRaw.length > 0) {
+      resolved.label = labelRaw;
+    }
+    // Setting `id`/`path` to null clears the persisted values so the thread
+    // is no longer matched as an active anchor. `anchorIdOf` also has a
+    // belt-and-suspenders check on `resolved`.
+    this.syncdb.set({
+      resolved,
+      id: null,
+      path: null,
+      date: rootDate.toISOString(),
+    });
+    this.syncdb.commit();
+    this.save_to_disk();
   };
 }
 

--- a/src/packages/frontend/chat/chat-log.tsx
+++ b/src/packages/frontend/chat/chat-log.tsx
@@ -50,6 +50,7 @@ import {
   getRootMessage,
   getSelectedHashtagsSearch,
   getThreadRootDate,
+  isThreadResolved,
   newest_content,
 } from "./utils";
 
@@ -671,7 +672,11 @@ export function MessageList({
     // visible. This handles threads where all messages fit in the viewport
     // and no further scroll events will fire.
     const replayVisibleRange = (retries = 0) => {
-      if (!selectedThread || !actions?.updateLastRead || sortedDates.length === 0) {
+      if (
+        !selectedThread ||
+        !actions?.updateLastRead ||
+        sortedDates.length === 0
+      ) {
         return;
       }
       if (lastEndIndexRef.current < 0) {
@@ -684,9 +689,7 @@ export function MessageList({
         return;
       }
       const visibleDateStr =
-        sortedDates[
-          Math.min(lastEndIndexRef.current, sortedDates.length - 1)
-        ];
+        sortedDates[Math.min(lastEndIndexRef.current, sortedDates.length - 1)];
       if (visibleDateStr) {
         const visibleDateMs = parseFloat(visibleDateStr);
         if (Number.isFinite(visibleDateMs)) {
@@ -876,7 +879,16 @@ export function MessageList({
                 }
                 allowReply={
                   !singleThreadView &&
-                  messages.getIn([sortedDates[index + 1], "reply_to"]) == null
+                  messages.getIn([sortedDates[index + 1], "reply_to"]) ==
+                    null &&
+                  // Resolved threads are read-only archives: hide the
+                  // per-thread Reply button even in all-threads view, so
+                  // the only way to "continue" the discussion is the
+                  // ResolvedThreadPanel's "Start new chat thread" flow.
+                  !isThreadResolved({
+                    date: parseFloat(date),
+                    messages,
+                  })
                 }
                 costEstimate={costEstimate}
                 threadViewMode={singleThreadView}

--- a/src/packages/frontend/chat/chatroom.tsx
+++ b/src/packages/frontend/chat/chatroom.tsx
@@ -60,6 +60,8 @@ import {
 } from "./threads";
 import type { ThreadListItem, ThreadSection } from "./threads";
 import { ThreadAnchorButton } from "./thread-anchor-button";
+import { ThreadResolveButton } from "./thread-resolve-button";
+import { ResolvedThreadPanel } from "./resolved-thread-panel";
 
 const FILTER_RECENT_NONE = {
   value: 0,
@@ -237,6 +239,10 @@ export function ChatPanel({
   );
   const [allowAutoSelectThread, setAllowAutoSelectThread] =
     useState<boolean>(true);
+  // Resolved-section collapse state. Default collapsed so resolved threads
+  // don't compete for visual real estate with active conversations; user
+  // expands when they want to revisit a closed TODO.
+  const [resolvedExpanded, setResolvedExpanded] = useState<boolean>(false);
   const submitMentionsRef = useRef<SubmitMentionsFn | undefined>(undefined);
   const scrollToBottomRef = useRef<any>(null);
   const selectedThreadDate = useMemo(() => {
@@ -308,6 +314,30 @@ export function ChatPanel({
     return anchorIdOf(thread?.rootMessage);
   }, [singleThreadView, selectedThreadKey, threads]);
 
+  // Resolved-thread metadata for the currently-selected thread (LaTeX
+  // collaborative-TODO flow). When non-null we render a read-only panel in
+  // place of the reply input.
+  const selectedThreadResolved = useMemo<{
+    account_id: string;
+    at: string;
+  } | null>(() => {
+    if (!singleThreadView || !selectedThreadKey) return null;
+    const thread = threads.find((t) => t.key === selectedThreadKey);
+    if (!thread?.resolved) return null;
+    const raw = thread.rootMessage?.get("resolved");
+    if (raw == null) return null;
+    const account_id =
+      typeof (raw as any).get === "function"
+        ? (raw as any).get("account_id")
+        : (raw as any).account_id;
+    const at =
+      typeof (raw as any).get === "function"
+        ? (raw as any).get("at")
+        : (raw as any).at;
+    if (typeof account_id !== "string" || typeof at !== "string") return null;
+    return { account_id, at };
+  }, [singleThreadView, selectedThreadKey, threads]);
+
   useEffect(() => {
     if (
       storedThreadFromDesc != null &&
@@ -340,7 +370,12 @@ export function ChatPanel({
     if (pendingAnchorThread) return;
     const exists = threads.some((thread) => thread.key === selectedThreadKey);
     if (!exists && allowAutoSelectThread) {
-      setSelectedThreadKey(threads[0].key);
+      // Skip resolved threads when auto-picking — they're archival, not
+      // where the user wants to land on chat open.
+      const firstLive = threads.find((t) => !t.resolved);
+      if (firstLive) {
+        setSelectedThreadKey(firstLive.key);
+      }
     }
   }, [threads, selectedThreadKey, allowAutoSelectThread, pendingAnchorThread]);
 
@@ -507,7 +542,7 @@ export function ChatPanel({
     },
   });
 
-  const renderThreadRow = (thread: ThreadMeta) => {
+  const renderThreadRow = (thread: ThreadMeta, isResolvedRow = false) => {
     const { key, displayLabel, hasCustomName, unreadCount, isAI, isPinned } =
       thread;
     const plainLabel = stripHtml(displayLabel);
@@ -532,10 +567,25 @@ export function ChatPanel({
             setHoveredThread((prev) => (prev === key ? null : prev))
           }
         >
-          <Tooltip title={iconTooltip}>
-            <Icon name={isAI ? "robot" : "users"} style={{ color: "#888" }} />
+          <Tooltip title={isResolvedRow ? "Resolved chat" : iconTooltip}>
+            <Icon
+              name={isResolvedRow ? "check-circle" : isAI ? "robot" : "users"}
+              style={{ color: isResolvedRow ? COLORS.GRAY_M : COLORS.GRAY }}
+            />
           </Tooltip>
-          <div style={THREAD_ITEM_LABEL_STYLE}>{plainLabel}</div>
+          <div
+            style={{
+              ...THREAD_ITEM_LABEL_STYLE,
+              ...(isResolvedRow
+                ? {
+                    textDecoration: "line-through",
+                    color: COLORS.GRAY_M,
+                  }
+                : {}),
+            }}
+          >
+            {plainLabel}
+          </div>
           {unreadCount > 0 && !isHovered && (
             <Badge count={unreadCount} size="small" overflowCount={99} />
           )}
@@ -602,30 +652,77 @@ export function ChatPanel({
     if (!list || list.length === 0) {
       return null;
     }
-    const items = list.map(renderThreadRow);
+    const isResolvedSection = key === "resolved";
+    const collapsed = isResolvedSection && !resolvedExpanded;
+    const items = list.map((thread) =>
+      renderThreadRow(thread, isResolvedSection),
+    );
+    const headerStyle = isResolvedSection
+      ? {
+          ...THREAD_SECTION_HEADER_STYLE,
+          color: COLORS.GRAY_M,
+          cursor: "pointer",
+        }
+      : THREAD_SECTION_HEADER_STYLE;
     return (
       <div key={key} style={{ marginBottom: "18px" }}>
-        <div style={THREAD_SECTION_HEADER_STYLE}>
-          <span style={{ fontWeight: 600 }}>{title}</span>
-          {renderUnreadBadge(unreadCount, section)}
+        <div
+          style={headerStyle}
+          onClick={
+            isResolvedSection ? () => setResolvedExpanded((v) => !v) : undefined
+          }
+        >
+          <span
+            style={{
+              fontWeight: 600,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            {isResolvedSection && (
+              <Icon
+                name={collapsed ? "caret-right" : "caret-down"}
+                style={{ fontSize: "0.85em" }}
+              />
+            )}
+            {title}
+            {isResolvedSection && collapsed && (
+              <span
+                style={{
+                  marginLeft: 6,
+                  fontWeight: 400,
+                  color: COLORS.GRAY_M,
+                  fontSize: "0.85em",
+                }}
+              >
+                ({list.length})
+              </span>
+            )}
+          </span>
+          {!isResolvedSection && renderUnreadBadge(unreadCount, section)}
         </div>
-        <Menu
-          mode="inline"
-          selectedKeys={selectedThreadKey ? [selectedThreadKey] : []}
-          onClick={({ key: menuKey }) => {
-            setAllowAutoSelectThread(true);
-            setSelectedThreadKey(String(menuKey));
-            if (isCompact) {
-              setSidebarVisible(false);
-            }
-          }}
-          items={items}
-          style={{
-            border: "none",
-            background: "transparent",
-            padding: "0 10px",
-          }}
-        />
+        {!collapsed && (
+          <div style={isResolvedSection ? { opacity: 0.7 } : undefined}>
+            <Menu
+              mode="inline"
+              selectedKeys={selectedThreadKey ? [selectedThreadKey] : []}
+              onClick={({ key: menuKey }) => {
+                setAllowAutoSelectThread(true);
+                setSelectedThreadKey(String(menuKey));
+                if (isCompact) {
+                  setSidebarVisible(false);
+                }
+              }}
+              items={items}
+              style={{
+                border: "none",
+                background: "transparent",
+                padding: "0 10px",
+              }}
+            />
+          </div>
+        )}
       </div>
     );
   };
@@ -930,21 +1027,36 @@ export function ChatPanel({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            color: "#888",
+            color: COLORS.GRAY,
             fontSize: "14px",
           }}
         >
           <div style={{ textAlign: "center" }}>
             <div style={{ fontWeight: 600, marginBottom: "4px" }}>
-              Start discussion for{" "}
-              {pendingAnchorThread.label ?? "this anchor"}
+              Start discussion for {pendingAnchorThread.label ?? "this anchor"}
             </div>
             <div>Type your first message below to create the thread.</div>
             <Button
               size="small"
               style={{ marginTop: "8px" }}
               onClick={() => {
-                actions.setPendingAnchorThread?.(null);
+                // Editor-generic discard: clears the staged anchor AND
+                // removes the just-inserted source marker (only if no
+                // chat message ever referenced this hash). Editors that
+                // don't expose this just lose the cleanup half — fall
+                // back to the bare anchor clear.
+                const editorActions: any = actions.frameTreeActions;
+                if (
+                  typeof editorActions?.cancelPendingAnchorThread === "function"
+                ) {
+                  editorActions.cancelPendingAnchorThread({
+                    id: pendingAnchorThread.id,
+                    label: pendingAnchorThread.label,
+                    path: pendingAnchorThread.path,
+                  });
+                } else {
+                  actions.setPendingAnchorThread?.(null);
+                }
               }}
             >
               Cancel
@@ -981,102 +1093,110 @@ export function ChatPanel({
           </div>
         </div>
       )}
-      <div style={{ display: "flex", marginBottom: "5px", overflow: "auto" }}>
-        <div
-          style={{
-            flex: "1",
-            padding: "0px 5px 0px 2px",
-          }}
-        >
-          <ChatInput
-            fontSize={fontSize}
-            autoFocus
-            cacheId={`${path}${project_id}-new`}
-            input={input}
-            on_send={on_send}
-            height={INPUT_HEIGHT}
-            onChange={(value) => {
-              setInput(value);
-              const inputText =
-                submitMentionsRef.current?.(undefined, true) ?? value;
-              actions?.llmEstimateCost({ date: 0, input: inputText });
+      {selectedThreadResolved ? (
+        <ResolvedThreadPanel
+          actions={actions}
+          account_id={selectedThreadResolved.account_id}
+          at={selectedThreadResolved.at}
+        />
+      ) : (
+        <div style={{ display: "flex", marginBottom: "5px", overflow: "auto" }}>
+          <div
+            style={{
+              flex: "1",
+              padding: "0px 5px 0px 2px",
             }}
-            submitMentionsRef={submitMentionsRef}
-            syncdb={actions.syncdb}
-            date={0}
-            editBarStyle={{ overflow: "auto" }}
-          />
-        </div>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            padding: "0",
-            marginBottom: "0",
-          }}
-        >
-          <div style={{ flex: 1 }} />
-          {costEstimate?.get("date") == 0 && (
-            <LLMCostEstimationChat
-              costEstimate={costEstimate?.toJS()}
-              compact
-              style={{
-                flex: 0,
-                fontSize: "85%",
-                textAlign: "center",
-                margin: "0 0 5px 0",
-              }}
-            />
-          )}
-          <Tooltip
-            title={
-              <FormattedMessage
-                id="chatroom.chat_input.send_button.tooltip"
-                defaultMessage={"Send message (shift+enter)"}
-              />
-            }
           >
+            <ChatInput
+              fontSize={fontSize}
+              autoFocus
+              cacheId={`${path}${project_id}-new`}
+              input={input}
+              on_send={on_send}
+              height={INPUT_HEIGHT}
+              onChange={(value) => {
+                setInput(value);
+                const inputText =
+                  submitMentionsRef.current?.(undefined, true) ?? value;
+                actions?.llmEstimateCost({ date: 0, input: inputText });
+              }}
+              submitMentionsRef={submitMentionsRef}
+              syncdb={actions.syncdb}
+              date={0}
+              editBarStyle={{ overflow: "auto" }}
+            />
+          </div>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              padding: "0",
+              marginBottom: "0",
+            }}
+          >
+            <div style={{ flex: 1 }} />
+            {costEstimate?.get("date") == 0 && (
+              <LLMCostEstimationChat
+                costEstimate={costEstimate?.toJS()}
+                compact
+                style={{
+                  flex: 0,
+                  fontSize: "85%",
+                  textAlign: "center",
+                  margin: "0 0 5px 0",
+                }}
+              />
+            )}
+            <Tooltip
+              title={
+                <FormattedMessage
+                  id="chatroom.chat_input.send_button.tooltip"
+                  defaultMessage={"Send message (shift+enter)"}
+                />
+              }
+            >
+              <Button
+                onClick={() => sendMessage()}
+                disabled={input.trim() === ""}
+                type="primary"
+                style={{ height: "47.5px" }}
+                icon={<Icon name="paper-plane" />}
+              >
+                <FormattedMessage
+                  id="chatroom.chat_input.send_button.label"
+                  defaultMessage={"Send"}
+                />
+              </Button>
+            </Tooltip>
+            <div style={{ height: "5px" }} />
             <Button
-              onClick={() => sendMessage()}
-              disabled={input.trim() === ""}
-              type="primary"
+              type={showPreview ? "dashed" : undefined}
+              onClick={() => actions.setShowPreview(!showPreview)}
               style={{ height: "47.5px" }}
-              icon={<Icon name="paper-plane" />}
             >
               <FormattedMessage
-                id="chatroom.chat_input.send_button.label"
-                defaultMessage={"Send"}
+                id="chatroom.chat_input.preview_button.label"
+                defaultMessage={"Preview"}
               />
             </Button>
-          </Tooltip>
-          <div style={{ height: "5px" }} />
-          <Button
-            type={showPreview ? "dashed" : undefined}
-            onClick={() => actions.setShowPreview(!showPreview)}
-            style={{ height: "47.5px" }}
-          >
-            <FormattedMessage
-              id="chatroom.chat_input.preview_button.label"
-              defaultMessage={"Preview"}
-            />
-          </Button>
-          <div style={{ height: "5px" }} />
-          <Button
-            style={{ height: "47.5px" }}
-            onClick={() => {
-              const message = actions?.frameTreeActions
-                ?.getVideoChat()
-                .startChatting(actions);
-              if (!message) {
-                return;
-              }
-              sendMessage(undefined, "\n\n" + message);
-            }}
-          >
-            <Icon name="video-camera" /> Video
-          </Button>
+            <div style={{ height: "5px" }} />
+            <Button
+              style={{ height: "47.5px" }}
+              onClick={() => {
+                const message = actions?.frameTreeActions
+                  ?.getVideoChat()
+                  .startChatting(actions);
+                if (!message) {
+                  return;
+                }
+                sendMessage(undefined, "\n\n" + message);
+              }}
+            >
+              <Icon name="video-camera" /> Video
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 
@@ -1105,6 +1225,7 @@ export function ChatPanel({
         style={{
           padding: "10px",
           display: "flex",
+          flexWrap: "wrap",
           gap: "8px",
           alignItems: "center",
         }}
@@ -1115,8 +1236,14 @@ export function ChatPanel({
             actions={actions}
           />
         )}
-        <div style={{ flex: 1 }} />
+        {selectedThreadAnchorId && !selectedThreadResolved && (
+          <ThreadResolveButton
+            anchorId={selectedThreadAnchorId}
+            actions={actions}
+          />
+        )}
         <Button
+          style={{ marginLeft: "auto" }}
           icon={<Icon name="bars" />}
           onClick={() => setSidebarVisible(true)}
         >

--- a/src/packages/frontend/chat/resolved-thread-panel.tsx
+++ b/src/packages/frontend/chat/resolved-thread-panel.tsx
@@ -1,0 +1,136 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020-2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+/*
+Read-only "this thread is resolved" panel that replaces the reply input on
+a resolved (LaTeX collaborative-TODO) thread. Shows who resolved it and
+when, plus a "Start new chat thread" affordance that — after the user
+confirms the target file/line — calls the editor's `insertChatMarker`.
+
+The panel is editor-agnostic at the UI layer: it discovers the marker
+target via `frameTreeActions.previewMarkerInsertion()` and then fires
+`frameTreeActions.insertChatMarker()` on confirm. Editors that don't
+provide those methods just hide the button (defensive — only LaTeX wires
+this in for now).
+*/
+
+import { useState } from "react";
+import { Button, Popconfirm } from "antd";
+
+import { redux, useTypedRedux } from "@cocalc/frontend/app-framework";
+import { Icon } from "@cocalc/frontend/components";
+import { COLORS } from "@cocalc/util/theme";
+
+import type { ChatActions } from "./actions";
+
+interface Props {
+  actions: ChatActions;
+  account_id: string;
+  at: string; // ISO timestamp
+}
+
+export function ResolvedThreadPanel({ actions, account_id, at }: Props) {
+  const userMap = useTypedRedux("users", "user_map");
+  const meAccountId = redux.getStore("account")?.get_account_id();
+
+  const resolvedAt = new Date(at);
+  const resolvedDateText = isNaN(resolvedAt.valueOf())
+    ? at
+    : resolvedAt.toLocaleString();
+
+  let resolverName = "Someone";
+  if (account_id && account_id === meAccountId) {
+    resolverName = "You";
+  } else if (account_id && userMap != null) {
+    const u = userMap.get(account_id);
+    const first = u?.get("first_name") ?? "";
+    const last = u?.get("last_name") ?? "";
+    const full = `${first} ${last}`.trim();
+    if (full) resolverName = full;
+  }
+
+  const [target, setTarget] = useState<{ path: string; line: number } | null>(
+    null,
+  );
+  const editorActions: any = actions.frameTreeActions;
+  const canStartNew =
+    typeof editorActions?.previewMarkerInsertion === "function" &&
+    typeof editorActions?.insertChatMarker === "function";
+
+  const handleOpenStartNew = () => {
+    if (!canStartNew) return;
+    try {
+      setTarget(editorActions.previewMarkerInsertion());
+    } catch {
+      setTarget(null);
+    }
+  };
+  const handleConfirmStartNew = () => {
+    if (!canStartNew) return;
+    void editorActions.insertChatMarker({});
+    setTarget(null);
+  };
+
+  return (
+    <div
+      style={{
+        margin: "5px 10px",
+        padding: "12px 16px",
+        background: COLORS.GRAY_LL,
+        border: `1px solid ${COLORS.GRAY_L}`,
+        borderRadius: 6,
+        color: COLORS.GRAY_DD,
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <Icon
+        name="check-circle"
+        style={{ color: COLORS.GRAY_M, fontSize: "1.1em" }}
+      />
+      <div style={{ flex: 1 }}>
+        <div style={{ fontWeight: 500 }}>This chat is resolved.</div>
+        <div style={{ fontSize: "0.9em", color: COLORS.GRAY_M }}>
+          Resolved by {resolverName} on {resolvedDateText}. Replies are disabled
+          — start a new thread to continue the discussion at a fresh location.
+        </div>
+      </div>
+      {canStartNew && (
+        <Popconfirm
+          title="Start a new chat thread?"
+          description={
+            <div style={{ maxWidth: 320 }}>
+              {target == null ? (
+                <span>
+                  No active editor pane. Click into a <code>.tex</code> file
+                  first so the new marker has a target.
+                </span>
+              ) : (
+                <span>
+                  This will insert a new <code>% chat:</code> marker in{" "}
+                  <code>{target.path}</code> at line {target.line + 1} and open
+                  a fresh chat thread there.
+                </span>
+              )}
+            </div>
+          }
+          okText={target == null ? undefined : "Insert marker"}
+          cancelText="Cancel"
+          okButtonProps={{ disabled: target == null }}
+          onConfirm={handleConfirmStartNew}
+          onOpenChange={(open) => {
+            if (open) handleOpenStartNew();
+          }}
+          placement="topRight"
+        >
+          <Button type="primary" size="small">
+            <Icon name="comment" /> Start new chat thread
+          </Button>
+        </Popconfirm>
+      )}
+    </div>
+  );
+}

--- a/src/packages/frontend/chat/thread-anchor-button.tsx
+++ b/src/packages/frontend/chat/thread-anchor-button.tsx
@@ -24,8 +24,14 @@ export function ThreadAnchorButton({ anchorId, actions }: Props) {
   if (!editorActions || typeof editorActions.jumpToAnchor !== "function") {
     return null;
   }
-  const label: string =
-    editorActions.getAnchorLabel?.(anchorId) ?? "Jump to anchor";
+  // Prefer the location-only label (`path:line`); the opaque hash is
+  // not useful in a "Jump to ..." button. Fall back to the full label
+  // (which includes the hash) only when no jump-label is available, and
+  // finally to a bare "Jump to anchor".
+  const jumpTarget: string | undefined =
+    editorActions.getAnchorJumpLabel?.(anchorId) ??
+    editorActions.getAnchorLabel?.(anchorId);
+  const label = jumpTarget ? `Jump to ${jumpTarget}` : "Jump to anchor";
 
   return (
     <Tooltip title="Jump to this anchor in the source">

--- a/src/packages/frontend/chat/thread-resolve-button.tsx
+++ b/src/packages/frontend/chat/thread-resolve-button.tsx
@@ -1,0 +1,66 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020-2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+/*
+"Resolve" affordance shown next to the ThreadAnchorButton at the top of
+an anchored thread's side chat. Mirrors the inline marker-tail check so
+the user doesn't have to find the marker in the source first.
+
+Editor-agnostic at the UI level: only renders when the host editor
+exposes `resolveChatMarker(hash)` (currently only LaTeX); other editors
+can ignore this and the button silently hides.
+*/
+
+import { Button, Popconfirm, Tooltip } from "antd";
+
+import { Icon } from "@cocalc/frontend/components";
+import { COLORS } from "@cocalc/util/theme";
+
+import type { ChatActions } from "./actions";
+
+interface Props {
+  anchorId: string;
+  actions: ChatActions;
+}
+
+const BUTTON_STYLE = {
+  // Match the green of the inline tail's check icon so the visual ties
+  // these two entry points together as the "resolve" action.
+  background: COLORS.BS_GREEN_LL,
+  borderColor: COLORS.ANTD_GREEN,
+  color: COLORS.BS_GREEN_D,
+} as const;
+
+export function ThreadResolveButton({ anchorId, actions }: Props) {
+  const editorActions = actions.frameTreeActions as any;
+  if (
+    editorActions == null ||
+    typeof editorActions.resolveChatMarker !== "function"
+  ) {
+    return null;
+  }
+  return (
+    <Popconfirm
+      title="Resolve chat and remove marker?"
+      description={
+        <div style={{ maxWidth: 320 }}>
+          Marks the chat thread as <b>resolved</b> and removes every{" "}
+          <code>% chat: …</code> marker from all files. The thread is kept in{" "}
+          <code>.sage-chat</code> as a read-only archive.
+        </div>
+      }
+      okText="Resolve"
+      cancelText="Cancel"
+      onConfirm={() => {
+        void editorActions.resolveChatMarker(anchorId);
+      }}
+      placement="bottomRight"
+    >
+      <Tooltip title="Resolve this chat (mark TODO done) and remove its markers">
+        <Button style={BUTTON_STYLE} icon={<Icon name="check-circle" />} />
+      </Tooltip>
+    </Popconfirm>
+  );
+}

--- a/src/packages/frontend/chat/threads.ts
+++ b/src/packages/frontend/chat/threads.ts
@@ -6,7 +6,7 @@ import { React, redux, useRedux } from "@cocalc/frontend/app-framework";
 import { chatFile } from "@cocalc/frontend/frame-editors/generic/chat";
 
 import type { ChatMessageTyped, ChatMessages } from "./types";
-import { anchorIdOf, newest_content } from "./utils";
+import { anchorIdOf, formerAnchorIdOf, newest_content } from "./utils";
 
 export const ALL_THREADS_KEY = "__ALL_THREADS__";
 
@@ -20,6 +20,12 @@ export interface ThreadListItem {
   // the lastread timestamp (ms epoch) for the given account, if set
   lastReadTimestamp: number | undefined;
   rootMessage?: ChatMessageTyped;
+  // True iff the root message has been marked resolved (LaTeX
+  // collaborative-TODO flow). Resolved threads are excluded from the
+  // main list and shown in a separate "Resolved" section.
+  resolved?: boolean;
+  // ms-epoch when the thread was resolved, if known.
+  resolvedAt?: number;
 }
 
 export type ThreadSectionKey =
@@ -27,7 +33,8 @@ export type ThreadSectionKey =
   | "today"
   | "yesterday"
   | "last7days"
-  | "older";
+  | "older"
+  | "resolved";
 
 export interface ThreadSection<T extends ThreadListItem = ThreadListItem> {
   key: ThreadSectionKey;
@@ -123,6 +130,19 @@ export function useThreadList(
           unreadCount = Math.max(entry.messageCount - readCount, 0);
         }
       }
+      const resolvedRaw = entry.rootMessage?.get("resolved");
+      const resolved = resolvedRaw != null;
+      let resolvedAt: number | undefined;
+      if (resolved) {
+        const atRaw =
+          typeof (resolvedRaw as any).get === "function"
+            ? (resolvedRaw as any).get("at")
+            : (resolvedRaw as any).at;
+        if (typeof atRaw === "string") {
+          const parsed = Date.parse(atRaw);
+          if (Number.isFinite(parsed)) resolvedAt = parsed;
+        }
+      }
       items.push({
         key: entry.key,
         label: deriveThreadLabel(entry.rootMessage, entry.key),
@@ -131,6 +151,8 @@ export function useThreadList(
         unreadCount,
         lastReadTimestamp,
         rootMessage: entry.rootMessage,
+        resolved,
+        resolvedAt,
       });
     }
 
@@ -140,9 +162,11 @@ export function useThreadList(
 }
 
 /**
- * Filter threads down to those anchored at the given id. An "anchor" is a
- * source-document location (jupyter cell UUID, LaTeX marker hash, etc.) that
- * an editor associates with a thread by stamping `id` on the root message.
+ * Filter threads down to those *actively* anchored at the given id. An
+ * "anchor" is a source-document location (jupyter cell UUID, LaTeX marker
+ * hash, etc.) that an editor associates with a thread by stamping `id` on
+ * the root message. Resolved threads are excluded — see
+ * `useResolvedAnchoredThreads` for those.
  */
 export function useAnchoredThreads(
   project_id: string,
@@ -172,6 +196,39 @@ export function useAnchoredThreads(
   return { anchoredThreads, totalMessages, totalUnread };
 }
 
+/**
+ * Threads whose root message is *resolved* AND whose former anchor matches
+ * `anchorId`. Used by stale-marker rendering: a `% chat: <hash>` marker in
+ * the source whose hash matches a resolved thread is "stale" — the
+ * conversation is over, and the marker is leftover (typically because it
+ * lived in a sub-file that wasn't open at resolve time). Returns
+ * `hasResolved: true` so callers can decide rendering without iterating.
+ */
+export function useResolvedAnchoredThreads(
+  project_id: string,
+  path: string,
+  anchorId: string,
+): {
+  resolvedThreads: ThreadListItem[];
+  hasResolved: boolean;
+} {
+  const account_id = redux.getStore("account")?.get_account_id();
+  const chatPath = chatFile(path);
+  const chatMessages = useRedux(["messages"], project_id, chatPath);
+  const allThreads = useThreadList(chatMessages, account_id);
+  const resolvedThreads = React.useMemo(
+    () =>
+      allThreads.filter(
+        (t) => t.resolved && formerAnchorIdOf(t.rootMessage) === anchorId,
+      ),
+    [allThreads, anchorId],
+  );
+  return {
+    resolvedThreads,
+    hasResolved: resolvedThreads.length > 0,
+  };
+}
+
 export function deriveThreadLabel(
   rootMessage: ChatMessageTyped | undefined,
   fallbackKey: string,
@@ -197,12 +254,11 @@ export function deriveThreadLabel(
   return "Untitled Thread";
 }
 
-
 interface GroupOptions {
   now?: number;
 }
 
-type RecencyKey = Exclude<ThreadSectionKey, "pinned">;
+type RecencyKey = Exclude<ThreadSectionKey, "pinned" | "resolved">;
 
 const RECENCY_SECTIONS: { key: RecencyKey; title: string }[] = [
   { key: "today", title: "Today" },
@@ -232,8 +288,13 @@ export function groupThreadsByRecency<
   }
   const now = options.now ?? Date.now();
   const sections: ThreadSection<T>[] = [];
-  const pinned = threads.filter((thread) => !!thread.isPinned);
-  const remainder = threads.filter((thread) => !thread.isPinned);
+  // Resolved threads are pulled out and shown in their own section at the
+  // very bottom — never pinned/today/etc., never affecting recency
+  // counts. The chatroom dims them visually.
+  const resolved = threads.filter((thread) => thread.resolved);
+  const live = threads.filter((thread) => !thread.resolved);
+  const pinned = live.filter((thread) => !!thread.isPinned);
+  const remainder = live.filter((thread) => !thread.isPinned);
   if (pinned.length > 0) {
     sections.push({ key: "pinned", title: "Pinned", threads: pinned });
   }
@@ -252,6 +313,18 @@ export function groupThreadsByRecency<
     if (list.length > 0) {
       sections.push({ key: def.key, title: def.title, threads: list });
     }
+  }
+  if (resolved.length > 0) {
+    // Resolved threads sort newest-resolved first so the most recently
+    // closed TODO is visible without expanding too far.
+    const sortedResolved = [...resolved].sort(
+      (a, b) => (b.resolvedAt ?? 0) - (a.resolvedAt ?? 0),
+    );
+    sections.push({
+      key: "resolved",
+      title: "Resolved",
+      threads: sortedResolved,
+    });
   }
   return sections;
 }

--- a/src/packages/frontend/chat/types.ts
+++ b/src/packages/frontend/chat/types.ts
@@ -29,6 +29,19 @@ export interface MessageHistory {
   date: string; // date.toISOString()
 }
 
+// Stamped on a root message when its anchored thread has been "resolved"
+// (LaTeX collaborative-TODO flow). On resolve, the active `id` and `path`
+// are cleared (so the thread no longer matches its source-document anchor)
+// and the former values are preserved here so the chat keeps the reference
+// it once had and stale-marker detection has the hash to match against.
+export interface ResolvedMeta {
+  account_id: string;
+  at: string; // ISO timestamp
+  anchorId: string; // former root id / LaTeX marker hash
+  path?: string; // former marker path, if known
+  label?: string; // section-context label captured at resolve time
+}
+
 export interface ChatMessage {
   event: "chat";
   sender_id: string;
@@ -46,6 +59,7 @@ export interface ChatMessage {
   // identifies which sub-file the anchor lives in for multi-file editors.
   id?: string;
   path?: string;
+  resolved?: ResolvedMeta;
 }
 
 // this type isn't explicitly used anywhere yet, but the actual structure is and I just
@@ -82,6 +96,7 @@ export type ChatMessageTyped = TypedMap<{
   // utils.ts) so those threads remain discoverable.
   cell_id?: string;
   path?: string;
+  resolved?: TypedMap<ResolvedMeta>;
 }>;
 
 export type ChatMessages = TypedMap<{

--- a/src/packages/frontend/chat/utils.ts
+++ b/src/packages/frontend/chat/utils.ts
@@ -24,15 +24,39 @@ import { is_date as isDate } from "@cocalc/util/misc";
 export const INPUT_HEIGHT = "125px";
 
 /**
- * Read the anchor id stamped on a chat message's root, preferring the
- * current `id` field but falling back to the legacy `cell_id` field so
+ * Read the *active* anchor id stamped on a chat message's root, preferring
+ * the current `id` field but falling back to the legacy `cell_id` field so
  * notebooks with pre-rename chat data continue to find their threads.
+ *
+ * Returns `undefined` when the root message has been marked `resolved`, so
+ * resolved (LaTeX collaborative-TODO) threads are never treated as live
+ * anchors regardless of whether the `id` field was actually cleared. Use
+ * `formerAnchorIdOf` to read the hash a resolved thread once had.
  */
 export function anchorIdOf(
   msg: ChatMessageTyped | undefined,
 ): string | undefined {
   if (msg == null) return undefined;
+  if (msg.get("resolved") != null) return undefined;
   const v = msg.get("id") ?? msg.get("cell_id");
+  return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * Read the former anchor id of a resolved root message, or `undefined` if
+ * the message is not resolved (or wasn't anchored). Used by stale-marker
+ * detection in the LaTeX editor.
+ */
+export function formerAnchorIdOf(
+  msg: ChatMessageTyped | undefined,
+): string | undefined {
+  if (msg == null) return undefined;
+  const r = msg.get("resolved");
+  if (r == null) return undefined;
+  const v =
+    typeof (r as any).get === "function"
+      ? (r as any).get("anchorId")
+      : (r as any).anchorId;
   return typeof v === "string" ? v : undefined;
 }
 
@@ -221,6 +245,27 @@ export function getThreadRootDate({
   }
   const d = getReplyToRoot({ message, messages });
   return d?.valueOf() ?? 0;
+}
+
+/**
+ * True iff the thread containing this message has been resolved (LaTeX
+ * collaborative-TODO flow). Walks to the thread root and checks
+ * `resolved`. Used to gate per-thread Reply buttons in the all-threads
+ * view, where the per-thread composer doesn't run.
+ */
+export function isThreadResolved({
+  date,
+  messages,
+}: {
+  date: number;
+  messages?: ChatMessages;
+}): boolean {
+  if (messages == null) return false;
+  const rootMs = getThreadRootDate({ date, messages });
+  if (!rootMs) return false;
+  const root = messages.get(`${rootMs}`);
+  if (root == null) return false;
+  return root.get("resolved") != null;
 }
 
 // Use heuristics to try to turn "date", whatever it might be,

--- a/src/packages/frontend/frame-editors/latex-editor/actions.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/actions.ts
@@ -53,6 +53,7 @@ import {
   getSideChatActions,
 } from "@cocalc/frontend/frame-editors/generic/chat";
 import { initChat } from "@cocalc/frontend/chat/register";
+import { formerAnchorIdOf } from "@cocalc/frontend/chat/utils";
 
 import { type AccountStore } from "@cocalc/frontend/account";
 import { Store, TypedMap } from "@cocalc/frontend/app-framework";
@@ -934,11 +935,7 @@ export class Actions extends BaseActions<LatexEditorState> {
 
   // Frame types (EDITOR_SPEC keys) that already display build errors.
   // https://github.com/sagemathinc/cocalc/issues/8659
-  private static ERROR_DISPLAY_FRAMES = [
-    "output",
-    "build",
-    "error",
-  ] as const;
+  private static ERROR_DISPLAY_FRAMES = ["output", "build", "error"] as const;
 
   private hasErrorDisplayFrame(): boolean {
     try {
@@ -1522,9 +1519,7 @@ export class Actions extends BaseActions<LatexEditorState> {
     const lvs = this.store.get("local_view_state");
     const persisted = lvs?.get("switch_to_files");
     if (persisted == null) return;
-    const arr = (persisted as any).toJS
-      ? (persisted as any).toJS()
-      : persisted;
+    const arr = (persisted as any).toJS ? (persisted as any).toJS() : persisted;
     if (!Array.isArray(arr) || arr.length === 0) return;
     const filtered = arr.filter(
       (p: unknown) => typeof p === "string" && p.length > 0,
@@ -2314,9 +2309,7 @@ export class Actions extends BaseActions<LatexEditorState> {
         this.project_id,
         path_normalize(sourcePath),
       ) as BaseActions<CodeEditorState> | undefined;
-      const subSs = (subActions as any)?._syncstring as
-        | SyncString
-        | undefined;
+      const subSs = (subActions as any)?._syncstring as SyncString | undefined;
       sourceText = subSs?.try_to_str();
     }
     if (sourceText == null) {
@@ -2332,6 +2325,7 @@ export class Actions extends BaseActions<LatexEditorState> {
     const contents = fromJS(
       parseTableOfContents(sourceText, {
         includeBookmarks: true,
+        includeChatMarkers: true,
       }),
     ) as any;
     this.setState({ contents, contents_path: resolvedPath });
@@ -2698,15 +2692,12 @@ export class Actions extends BaseActions<LatexEditorState> {
       }
       const markers = scanMarkers(text);
       const cur =
-        this.store.get("chat_markers") ?? IMap<string, List<TypedMap<ChatMarker>>>();
+        this.store.get("chat_markers") ??
+        IMap<string, List<TypedMap<ChatMarker>>>();
       const prevForPath = cur.get(path);
       const next = cur.set(
         path,
-        List(
-          markers.map(
-            (m) => fromJS(m) as unknown as TypedMap<ChatMarker>,
-          ),
-        ),
+        List(markers.map((m) => fromJS(m) as unknown as TypedMap<ChatMarker>)),
       );
       if (!cur.equals(next)) {
         this.setState({ chat_markers: next });
@@ -2873,8 +2864,7 @@ export class Actions extends BaseActions<LatexEditorState> {
     }
 
     const perCm =
-      this._chatGutterHosts[path] ??
-      (this._chatGutterHosts[path] = new Map());
+      this._chatGutterHosts[path] ?? (this._chatGutterHosts[path] = new Map());
     const liveCms = new Set<CodeMirror.Editor>(cms);
 
     // Prune entries for CMs that no longer exist (pane unmounted).
@@ -3147,10 +3137,7 @@ export class Actions extends BaseActions<LatexEditorState> {
    * line — unless that line already has a marker, in which case the host
    * is detached from the gutter.
    */
-  private _refreshChatCursorInsert(
-    path: string,
-    cm: CodeMirror.Editor,
-  ): void {
+  private _refreshChatCursorInsert(path: string, cm: CodeMirror.Editor): void {
     const entry = this._chatCursorInsertHosts[path]?.get(cm);
     if (entry == null) return;
 
@@ -3280,8 +3267,7 @@ export class Actions extends BaseActions<LatexEditorState> {
     if (cms.length === 0) return;
 
     const tmMap =
-      this._chatTextMarkers[path] ??
-      (this._chatTextMarkers[path] = new Map());
+      this._chatTextMarkers[path] ?? (this._chatTextMarkers[path] = new Map());
     const bmMap =
       this._chatDeleteBookmarks[path] ??
       (this._chatDeleteBookmarks[path] = new Map());
@@ -3389,7 +3375,17 @@ export class Actions extends BaseActions<LatexEditorState> {
               onOpen: () => {
                 void this.openAnchorChat(hashForBookmark, path);
               },
-              onConfirmDelete: () =>
+              // Default × action: resolve the chat AND remove every marker
+              // we know about for this hash. Callback closes over the hash
+              // (not line/col) because resolveChatMarker walks all scanned
+              // files and deletes bottom-up, which is safer than deleting
+              // by stale (line, col) coords from this render snapshot.
+              onConfirmResolve: () => {
+                void this.resolveChatMarker(hashForBookmark);
+              },
+              // Stale form: just remove this single marker line/col; the
+              // thread is already resolved.
+              onConfirmRemoveStale: () =>
                 this.deleteChatMarker(path, lineForBookmark, colForBookmark),
             }),
           );
@@ -3477,6 +3473,13 @@ export class Actions extends BaseActions<LatexEditorState> {
         const hash = (m as any).chatHash as string | undefined;
         if (typeof hash === "string") {
           event.preventDefault();
+          // Stale marker: hash matches the former anchor of a resolved
+          // thread, no active thread exists. Clicking through would
+          // stage a fresh pending anchor on a retired hash and break
+          // the resolved-archive invariant. The inline tail's stale ×
+          // is the supported path to remove the leftover marker — this
+          // click just no-ops.
+          if (this._isStaleChatHash(hash)) return;
           void this.openAnchorChat(hash, path);
           return;
         }
@@ -3484,13 +3487,36 @@ export class Actions extends BaseActions<LatexEditorState> {
     });
   }
 
+  /**
+   * True iff `hash` is a "stale" chat anchor: at least one root message
+   * has been resolved with this hash as its former anchor, AND no
+   * active anchored thread for this hash exists. Used by the CM text
+   * click handler to refuse opening chat on retired hashes.
+   */
+  private _isStaleChatHash(hash: string): boolean {
+    const chatActions = getSideChatActions({
+      project_id: this.project_id,
+      path: this.path,
+    });
+    const messages = chatActions?.store?.get("messages");
+    if (messages == null) return false;
+    let hasResolved = false;
+    for (const [, msg] of messages) {
+      if (msg == null || msg.get("reply_to")) continue;
+      const active = msg.get("id") ?? msg.get("cell_id");
+      if (active === hash && msg.get("resolved") == null) {
+        // Active thread exists for this hash — not stale.
+        return false;
+      }
+      if (formerAnchorIdOf(msg) === hash) hasResolved = true;
+    }
+    return hasResolved;
+  }
+
   /** CM instances that already have the Shift-Ctrl-M keymap bound. */
   private _chatKeybindingInstalled: WeakSet<CodeMirror.Editor> = new WeakSet();
 
-  private _ensureChatKeybindings(
-    cm: CodeMirror.Editor,
-    path: string,
-  ): void {
+  private _ensureChatKeybindings(cm: CodeMirror.Editor, path: string): void {
     if (this._chatKeybindingInstalled.has(cm)) return;
     this._chatKeybindingInstalled.add(cm);
     cm.addKeyMap({
@@ -3820,6 +3846,27 @@ export class Actions extends BaseActions<LatexEditorState> {
     return `${hash} (${basename}:${loc.line + 1})`;
   }
 
+  /**
+   * Short, human-readable "where does this anchor live" label suitable
+   * for jump-to-source button text. Returns just `basename:line` (or
+   * `basename` if the line is unknown), without the opaque hash —
+   * complementary to `getAnchorLabel`, which prefixes the hash for
+   * places that need an unambiguous thread identifier (e.g. the auto
+   * thread name written to the chat root).
+   *
+   * Returns `undefined` when no location is known, so the caller can
+   * decide whether to show a generic "Jump to anchor" fallback or hide
+   * the button entirely.
+   */
+  public getAnchorJumpLabel(hash: string): string | undefined {
+    const locs = this.getAnchorLocations(hash);
+    if (locs.length === 0) return undefined;
+    if (locs.length > 1) return `${locs.length} locations`;
+    const [loc] = locs;
+    const basename = loc.path.split("/").pop() ?? loc.path;
+    return loc.line < 0 ? basename : `${basename}:${loc.line + 1}`;
+  }
+
   public async jumpToAnchor(hash: string): Promise<void> {
     const locs = this.getAnchorLocations(hash);
     if (locs.length === 0) return;
@@ -3907,6 +3954,12 @@ export class Actions extends BaseActions<LatexEditorState> {
     if (gen !== this._anchorChatOpenGeneration) return;
 
     if (chatActions.store?.get("messages") != null) {
+      // Re-check stale-anchor state with hydrated messages: a click
+      // landed before chat sync was ready would have passed the
+      // gutter/text/TOC stale gates (they returned false on
+      // un-hydrated stores), but we must not stage a fresh pending
+      // thread on a hash whose only history is a resolve.
+      if (this._isStaleChatHash(hash)) return;
       chatActions.findOrCreateAnchorThread(hash, label, path);
       return;
     }
@@ -3916,6 +3969,7 @@ export class Actions extends BaseActions<LatexEditorState> {
       if (this._state === "closed") return;
       if (gen !== this._anchorChatOpenGeneration) return;
       if (chatActions.store?.get("messages") != null) {
+        if (this._isStaleChatHash(hash)) return;
         chatActions.findOrCreateAnchorThread(hash, label, path);
         return;
       }
@@ -3938,11 +3992,7 @@ export class Actions extends BaseActions<LatexEditorState> {
    * The associated thread in `.sage-chat` is left intact (orphaned). If the
    * user wants to re-anchor, they insert a fresh marker.
    */
-  public deleteChatMarker(
-    targetPath: string,
-    line: number,
-    col: number,
-  ): void {
+  public deleteChatMarker(targetPath: string, line: number, col: number): void {
     const fileActions = this.redux.getEditorActions(
       this.project_id,
       path_normalize(targetPath),
@@ -3986,16 +4036,15 @@ export class Actions extends BaseActions<LatexEditorState> {
       // line without newline if it's the last line).
       const lastLine = cm.lastLine();
       if (line < lastLine) {
-        cm.replaceRange(
-          "",
-          { line, ch: 0 },
-          { line: line + 1, ch: 0 },
-        );
+        cm.replaceRange("", { line, ch: 0 }, { line: line + 1, ch: 0 });
       } else {
         // last line: remove leading newline of the line being removed
         cm.replaceRange(
           "",
-          { line: Math.max(0, line - 1), ch: cm.getLine(line - 1)?.length ?? 0 },
+          {
+            line: Math.max(0, line - 1),
+            ch: cm.getLine(line - 1)?.length ?? 0,
+          },
           { line, ch: lineText.length },
         );
       }
@@ -4005,14 +4054,170 @@ export class Actions extends BaseActions<LatexEditorState> {
       while (startCh > 0 && /\s/.test(lineText[startCh - 1])) {
         startCh -= 1;
       }
-      cm.replaceRange(
-        "",
-        { line, ch: startCh },
-        { line, ch: lineText.length },
-      );
+      cm.replaceRange("", { line, ch: startCh }, { line, ch: lineText.length });
     }
     fileActions.set_syncstring_to_codemirror();
     (fileActions as any)._syncstring?.commit?.();
+  }
+
+  /**
+   * Resolve a chat thread anchored at `hash`: stamp `resolved` metadata on
+   * each anchored root message in the side-chat syncdb, clear its active
+   * `id`/`path`, and then remove every `% chat: <hash>` marker we know
+   * about across currently-scanned files.
+   *
+   * Markers in sub-files that aren't open at the time of resolve persist as
+   * "stale" markers — see `useResolvedAnchoredThreads` and the gutter/tail
+   * stale rendering. A subsequent open of that file will surface them with
+   * a quick "remove stale marker" affordance.
+   */
+  public async resolveChatMarker(hash: string): Promise<void> {
+    if (typeof hash !== "string" || hash.length === 0) return;
+    const chatActions = await this._waitForChatActions();
+    if (chatActions == null) return;
+
+    // 1. Resolve every active anchored root message for this hash. Snapshot
+    // the dates first so we don't iterate over a store that's mutating.
+    const messages = chatActions.store?.get("messages");
+    const rootDates: Date[] = [];
+    if (messages != null) {
+      for (const [, msg] of messages) {
+        if (msg == null) continue;
+        if (msg.get("reply_to")) continue;
+        if (msg.get("resolved") != null) continue;
+        const anchor = msg.get("id") ?? msg.get("cell_id");
+        if (anchor !== hash) continue;
+        const date = msg.get("date");
+        if (date instanceof Date) rootDates.push(date);
+      }
+    }
+    for (const d of rootDates) {
+      chatActions.resolveAnchorThread(d);
+    }
+
+    // 2. Collect every marker line for this hash across scanned paths.
+    // Group by path and sort descending so deletions don't shift later
+    // lines we still plan to touch within the same file.
+    const all = this.store.get("chat_markers");
+    if (all != null) {
+      const byPath: { [path: string]: { line: number; col: number }[] } = {};
+      for (const [path, list] of all.entries()) {
+        if (list == null) continue;
+        for (const entry of list) {
+          const m = entry.toJS() as ChatMarker;
+          if (m.hash === hash) {
+            (byPath[path] ??= []).push({ line: m.line, col: m.col });
+          }
+        }
+      }
+      for (const [path, lines] of Object.entries(byPath)) {
+        lines.sort((a, b) =>
+          b.line !== a.line ? b.line - a.line : b.col - a.col,
+        );
+        for (const { line, col } of lines) {
+          this.deleteChatMarker(path, line, col);
+        }
+        // Force the scanner to immediately reflect the post-delete state so
+        // any UI driven off `chat_markers` is consistent before we return.
+        this._chatMarkerScanners[path]?.flush?.();
+      }
+    }
+  }
+
+  /**
+   * Discard a pending (just-inserted but no-message-yet) chat marker.
+   * Called from the side chat's "Cancel" button on the empty pending
+   * compose, so canceling out also removes the source marker the user
+   * wanted to abandon.
+   *
+   * Safety: only removes markers for `pending.id` if no chat message
+   * (active OR resolved) has ever referenced that hash. The callsite
+   * already guards on `pendingAnchorThread != null` (which by definition
+   * means no root message exists yet), but a concurrent message-send
+   * could land between user click and our store read; this guard means
+   * we never delete markers for a real conversation.
+   *
+   * Always clears the pending anchor regardless — clearing is what the
+   * caller actually requested.
+   */
+  public cancelPendingAnchorThread(pending: {
+    id: string;
+    path?: string;
+    label?: string;
+  }): void {
+    const hash = pending?.id;
+    const chatActions = getSideChatActions({
+      project_id: this.project_id,
+      path: this.path,
+    });
+    chatActions?.setPendingAnchorThread(null);
+    if (typeof hash !== "string" || hash.length === 0) return;
+    // Bail if any chat message ever referenced this hash — this should
+    // never be true for a true pending anchor, but it's the cheap
+    // safety net Codex flagged.
+    const messages = chatActions?.store?.get("messages");
+    if (messages != null) {
+      for (const [, msg] of messages) {
+        if (msg == null) continue;
+        const active = msg.get("id") ?? msg.get("cell_id");
+        if (active === hash) return;
+        const resolvedRaw = msg.get("resolved");
+        if (resolvedRaw != null) {
+          const formerId =
+            typeof (resolvedRaw as any).get === "function"
+              ? (resolvedRaw as any).get("anchorId")
+              : (resolvedRaw as any).anchorId;
+          if (formerId === hash) return;
+        }
+      }
+    }
+    // Delete every marker with this hash in scanned files. Bottom-up
+    // per file so line numbers don't shift mid-batch — same dance as
+    // resolveChatMarker's marker step.
+    const all = this.store.get("chat_markers");
+    if (all == null) return;
+    const byPath: { [path: string]: { line: number; col: number }[] } = {};
+    for (const [path, list] of all.entries()) {
+      if (list == null) continue;
+      for (const entry of list) {
+        const m = entry.toJS() as ChatMarker;
+        if (m.hash === hash) {
+          (byPath[path] ??= []).push({ line: m.line, col: m.col });
+        }
+      }
+    }
+    for (const [path, lines] of Object.entries(byPath)) {
+      lines.sort((a, b) =>
+        b.line !== a.line ? b.line - a.line : b.col - a.col,
+      );
+      for (const { line, col } of lines) {
+        this.deleteChatMarker(path, line, col);
+      }
+      this._chatMarkerScanners[path]?.flush?.();
+    }
+  }
+
+  /**
+   * For the "Start new chat thread" affordance on a resolved chat panel:
+   * report where a new marker would land if we called `insertChatMarker()`
+   * right now (active CM's path + cursor line). Used to populate the
+   * confirmation popup so the user isn't surprised. Returns `null` when no
+   * CM is currently focused.
+   */
+  public previewMarkerInsertion(): {
+    path: string;
+    line: number;
+  } | null {
+    const path = this._activeCmPath();
+    const fileActions = this.redux.getEditorActions(
+      this.project_id,
+      path_normalize(path),
+    ) as BaseActions<CodeEditorState> | undefined;
+    if (fileActions == null) return null;
+    const cm = this._cmForInsert(fileActions);
+    if (cm == null) return null;
+    const line = cm.getCursor().line;
+    return { path, line };
   }
 
   // ----- Marker insertion --------------------------------------------------
@@ -4022,12 +4227,14 @@ export class Actions extends BaseActions<LatexEditorState> {
    * frame's path (defaulting to the master file). If `mode === "auto"`, pick
    * inline if the target line has tex content, block otherwise.
    */
-  public async insertChatMarker(opts: {
-    targetPath?: string;
-    targetLine?: number;
-    mode?: "inline" | "block" | "auto";
-    cm?: CodeMirror.Editor;
-  } = {}): Promise<void> {
+  public async insertChatMarker(
+    opts: {
+      targetPath?: string;
+      targetLine?: number;
+      mode?: "inline" | "block" | "auto";
+      cm?: CodeMirror.Editor;
+    } = {},
+  ): Promise<void> {
     const targetPath = opts.targetPath ?? this._activeCmPath();
     const fileActions = this.redux.getEditorActions(
       this.project_id,
@@ -4144,11 +4351,13 @@ export class Actions extends BaseActions<LatexEditorState> {
    * Unlike chat markers, bookmarks are free-form text and never become
    * read-only.
    */
-  public async insertBookmark(opts: {
-    targetPath?: string;
-    targetLine?: number;
-    cm?: CodeMirror.Editor;
-  } = {}): Promise<void> {
+  public async insertBookmark(
+    opts: {
+      targetPath?: string;
+      targetLine?: number;
+      cm?: CodeMirror.Editor;
+    } = {},
+  ): Promise<void> {
     const targetPath = opts.targetPath ?? this._activeCmPath();
     const fileActions = this.redux.getEditorActions(
       this.project_id,

--- a/src/packages/frontend/frame-editors/latex-editor/chat-marker-gutter.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/chat-marker-gutter.tsx
@@ -10,11 +10,20 @@ that mirrors the jupyter per-cell chat UX:
  - red badge with unread count when there are unread messages for this anchor
  - gray badge with total message count when everything is read.
 
-Clicking opens the side chat focused on that anchor's thread.
+When the marker is *stale* (its hash matches a resolved thread, no active
+thread exists — typically a marker in a sub-file that wasn't open at
+resolve time), the icon is muted and clicking it does nothing on its own;
+the inline tail is the place to remove the stale marker.
+
+Clicking on a non-stale marker opens the side chat focused on that
+anchor's thread.
 */
 
 import { Popconfirm, Tooltip } from "antd";
-import { useAnchoredThreads } from "@cocalc/frontend/chat/threads";
+import {
+  useAnchoredThreads,
+  useResolvedAnchoredThreads,
+} from "@cocalc/frontend/chat/threads";
 import { Icon } from "@cocalc/frontend/components";
 import { COLORS } from "@cocalc/util/theme";
 
@@ -49,10 +58,17 @@ export function ChatMarkerGutter({
     masterPath,
     hash,
   );
+  const { hasResolved } = useResolvedAnchoredThreads(
+    project_id,
+    masterPath,
+    hash,
+  );
+  const isStale = hasResolved && anchoredThreads.length === 0;
   const hasUnread = totalUnread > 0;
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (isStale) return;
     if (hasUnread) {
       const newestUnread = anchoredThreads
         .filter((t) => t.unreadCount > 0)
@@ -66,15 +82,27 @@ export function ChatMarkerGutter({
   };
 
   return (
-    <Tooltip title="Open chat thread for this anchor" placement="right">
+    <Tooltip
+      title={
+        isStale
+          ? "Stale marker — its chat thread was resolved. Use × to remove."
+          : "Open chat thread for this anchor"
+      }
+      placement="right"
+    >
       <span
         onClick={handleClick}
         style={{
           display: "inline-flex",
           alignItems: "center",
-          cursor: "pointer",
+          cursor: isStale ? "default" : "pointer",
           marginLeft: -9,
-          color: hasUnread ? COLORS.ANTD_RED : COLORS.GRAY_M,
+          color: isStale
+            ? COLORS.GRAY_L
+            : hasUnread
+              ? COLORS.ANTD_RED
+              : COLORS.GRAY_M,
+          opacity: isStale ? 0.6 : 1,
         }}
       >
         <Icon name="comment" />
@@ -88,29 +116,42 @@ export function ChatMarkerGutter({
  * `% chat: <hash>`. It shows a message-count pill (red "N unread" when the
  * user has unread messages, gray "N messages" once everything is read, and
  * nothing at all while the thread has no messages yet) followed by a gray
- * `×` with an antd Popconfirm to remove the marker.
+ * `×` whose Popconfirm resolves the chat (marks the thread resolved AND
+ * removes the marker). Stale markers (hash matches a resolved thread, no
+ * active thread) skip the count pill entirely and offer a plain "remove
+ * stale marker" affordance instead.
  */
 export function ChatMarkerInlineTail({
   hash,
   masterPath,
   project_id,
   onOpen,
-  onConfirmDelete,
+  onConfirmResolve,
+  onConfirmRemoveStale,
 }: {
   hash: string;
   masterPath: string;
   project_id: string;
   onOpen: () => void;
-  onConfirmDelete: () => void;
+  /** Mark the anchored thread(s) resolved AND remove the marker. */
+  onConfirmResolve: () => void;
+  /** Stale marker only: just remove the marker; thread already resolved. */
+  onConfirmRemoveStale: () => void;
 }) {
-  const { totalMessages, totalUnread } = useAnchoredThreads(
+  const { totalMessages, totalUnread, anchoredThreads } = useAnchoredThreads(
     project_id,
     masterPath,
     hash,
   );
+  const { hasResolved } = useResolvedAnchoredThreads(
+    project_id,
+    masterPath,
+    hash,
+  );
+  const isStale = hasResolved && anchoredThreads.length === 0;
   const hasUnread = totalUnread > 0;
   const pillText =
-    totalMessages <= 0
+    isStale || totalMessages <= 0
       ? null
       : hasUnread
         ? `${totalUnread} unread`
@@ -143,29 +184,66 @@ export function ChatMarkerInlineTail({
               lineHeight: 1.4,
               fontWeight: 500,
               cursor: "pointer",
-              backgroundColor: hasUnread ? "#ff4d4f" : "#e0e0e0",
-              color: hasUnread ? "white" : "#555",
+              backgroundColor: hasUnread ? COLORS.ANTD_RED : COLORS.GRAY_LL,
+              color: hasUnread ? COLORS.WHITE : COLORS.GRAY_DD,
             }}
           >
             {pillText}
           </span>
         </Tooltip>
       )}
+      {isStale && (
+        <Tooltip title="Stale marker — chat is resolved" placement="top">
+          <span
+            onMouseDown={(e) => e.stopPropagation()}
+            style={{
+              display: "inline-block",
+              padding: "0 10px",
+              borderRadius: 10,
+              fontSize: "0.85em",
+              lineHeight: 1.4,
+              fontStyle: "italic",
+              color: COLORS.GRAY_M,
+              backgroundColor: COLORS.GRAY_LL,
+            }}
+          >
+            resolved
+          </span>
+        </Tooltip>
+      )}
       <Popconfirm
-        title="Remove chat marker?"
+        title={
+          isStale ? "Remove stale marker?" : "Resolve chat and remove marker?"
+        }
         description={
-          <div style={{ maxWidth: 280 }}>
-            This removes the marker from the source. The chat thread itself
-            is kept in the <code>.sage-chat</code> file but loses its link
-            to this location.
+          <div style={{ maxWidth: 320 }}>
+            {isStale ? (
+              <>
+                The chat thread was already resolved. This just removes the
+                leftover <code>% chat: …</code> marker from the source.
+              </>
+            ) : (
+              <>
+                Marks the chat thread as <b>resolved</b> and removes every{" "}
+                <code>% chat: …</code> marker from all files. The thread is kept
+                in <code>.sage-chat</code> as a read-only archive.
+              </>
+            )}
           </div>
         }
-        okText="Remove"
+        okText={isStale ? "Remove" : "Resolve"}
         cancelText="Cancel"
-        onConfirm={onConfirmDelete}
+        onConfirm={isStale ? onConfirmRemoveStale : onConfirmResolve}
         placement="right"
       >
-        <Tooltip title="Remove this chat marker" placement="right">
+        <Tooltip
+          title={
+            isStale
+              ? "Remove this stale marker"
+              : "Resolve chat and remove this marker"
+          }
+          placement="right"
+        >
           <span
             onMouseDown={(e) => {
               // Prevent CM's mousedown handler from treating this as a
@@ -175,13 +253,17 @@ export function ChatMarkerInlineTail({
             style={{
               display: "inline-block",
               cursor: "pointer",
-              color: COLORS.GRAY_L,
-              fontSize: "0.9em",
-              marginLeft: 6,
-              padding: "0 2px",
+              // Stale-remove stays subdued; the resolve check is a
+              // primary action (turns a chat into a closed TODO), so
+              // give it a clearly readable green and a slightly bigger
+              // hit target.
+              color: isStale ? COLORS.GRAY_L : COLORS.BS_GREEN_D,
+              fontSize: isStale ? "0.9em" : "1.1em",
+              marginLeft: 8,
+              padding: "0 4px",
             }}
           >
-            <Icon name="times-circle" />
+            <Icon name={isStale ? "times-circle" : "check-circle"} />
           </span>
         </Tooltip>
       </Popconfirm>

--- a/src/packages/frontend/frame-editors/latex-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/editor.ts
@@ -14,7 +14,6 @@ import { WORD_COUNT_ICON } from "./constants";
 import { CodemirrorEditor } from "../code-editor/codemirror-editor";
 import { createEditor } from "../frame-tree/editor";
 import { EditorDescription } from "../frame-tree/types";
-import { TableOfContents } from "../markdown-editor/table-of-contents";
 import { terminal } from "../terminal-editor/editor";
 import { time_travel } from "../time-travel-editor/editor";
 import { Build } from "./build";
@@ -23,6 +22,7 @@ import { LatexWordCount } from "./latex-word-count";
 import { Output } from "./output";
 import { PDFEmbed } from "./pdf-embed";
 import { PDFJS } from "./pdfjs";
+import { LatexTableOfContents } from "./table-of-contents-frame";
 
 export const pdfjsCommands = set([
   "print",
@@ -191,7 +191,7 @@ const latex_table_of_contents: EditorDescription = {
   short: editor.table_of_contents_short,
   name: editor.table_of_contents_name,
   icon: "align-right",
-  component: TableOfContents,
+  component: LatexTableOfContents,
   commands: set(["decrease_font_size", "increase_font_size"]),
 } as const;
 

--- a/src/packages/frontend/frame-editors/latex-editor/output.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/output.tsx
@@ -33,11 +33,11 @@ import type { Data } from "@cocalc/frontend/frame-editors/frame-tree/pinch-to-zo
 import { React, useEffect, useRedux } from "@cocalc/frontend/app-framework";
 import {
   Icon,
-  TableOfContents,
   TableOfContentsEntryList,
   Text,
   Tip,
 } from "@cocalc/frontend/components";
+import { LatexTOCBody } from "./table-of-contents-frame";
 import { EditorState } from "@cocalc/frontend/frame-editors/frame-tree/types";
 import { project_api } from "@cocalc/frontend/frame-editors/generic/client";
 import { editor, labels } from "@cocalc/frontend/i18n";
@@ -141,6 +141,11 @@ export function Output(props: OutputProps) {
     name,
     "contents",
   ]);
+  // Path the TOC was parsed from (master or active sub-file). Forward
+  // it to LatexTOCBody so opening a chat from a TOC row preserves the
+  // marker's source path on the resulting pending anchor.
+  const contentsPath: string =
+    useRedux([name, "contents_path"]) ?? actions.path;
 
   // List of LaTeX files in the project
   const switch_to_files: List<string> = useRedux([name, "switch_to_files"]);
@@ -413,25 +418,39 @@ export function Output(props: OutputProps) {
             </Button>
           </div>
           <div style={{ flex: 1, overflow: "hidden" }}>
-            <TableOfContents
-              contents={contents}
-              fontSize={uiFontSize}
-              scrollTo={actions.scrollToHeading.bind(actions)}
-              ifEmpty={
-                <Alert
-                  type="info"
-                  message="Table of Contents is empty"
-                  description={
-                    <>
-                      Add <Text code>{"\\section{...}"}</Text> and{" "}
-                      <Text code>{"\\subsection{...}"}</Text> commands to your
-                      LaTeX document to create a table of contents.
-                    </>
-                  }
-                  style={{ margin: "15px" }}
-                />
-              }
-            />
+            {contents == null ? (
+              <Alert
+                type="info"
+                message="Loading…"
+                style={{ margin: "15px" }}
+              />
+            ) : (
+              <LatexTOCBody
+                contents={contents}
+                fontSize={uiFontSize}
+                project_id={actions.project_id}
+                masterPath={actions.path}
+                sourcePath={contentsPath}
+                scrollTo={actions.scrollToHeading.bind(actions)}
+                openAnchorChat={(hash, srcPath) => {
+                  void actions.openAnchorChat(hash, srcPath);
+                }}
+                ifEmpty={
+                  <Alert
+                    type="info"
+                    message="Table of Contents is empty"
+                    description={
+                      <>
+                        Add <Text code>{"\\section{...}"}</Text> and{" "}
+                        <Text code>{"\\subsection{...}"}</Text> commands to your
+                        LaTeX document to create a table of contents.
+                      </>
+                    }
+                    style={{ margin: "15px" }}
+                  />
+                }
+              />
+            )}
           </div>
         </div>
       ),

--- a/src/packages/frontend/frame-editors/latex-editor/table-of-contents-frame.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/table-of-contents-frame.tsx
@@ -1,0 +1,356 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020-2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+/*
+LaTeX-specific TOC frame component. Wraps the shared markdown-editor TOC
+behavior, but renders chat-marker entries with a live-updating count pill
+sourced from `useAnchoredThreads`. Heading and bookmark entries use the
+same look-and-feel as the shared component (small visual duplication is
+intentional — exporting the shared `Header` would broaden a private API for
+a single caller).
+*/
+
+import { useEffect, useMemo } from "react";
+
+import { useRedux } from "@cocalc/frontend/app-framework";
+import {
+  useAnchoredThreads,
+  useResolvedAnchoredThreads,
+} from "@cocalc/frontend/chat/threads";
+import {
+  Icon,
+  IconName,
+  Loading,
+  Markdown,
+  TableOfContentsEntry,
+  TableOfContentsEntryList,
+  TableOfContentsEntryMap,
+} from "@cocalc/frontend/components";
+import { COLORS } from "@cocalc/util/theme";
+
+import { Actions as LatexActions } from "./actions";
+
+interface Props {
+  font_size: number;
+  actions: LatexActions;
+}
+
+export function LatexTableOfContents({ font_size, actions }: Props) {
+  useEffect(() => {
+    // Mirror the shared component: defer one tick so the redux subscription
+    // below sees the first parse.
+    setTimeout(() => actions.updateTableOfContents(true));
+  }, []);
+  const contents: TableOfContentsEntryList | undefined = useRedux([
+    actions.name,
+    "contents",
+  ]);
+  // The TOC may have been parsed from a sub-file (when the user is
+  // focused on `\input{f1.tex}` etc.); contents_path tracks which file.
+  // Fall back to the master path when not yet set.
+  const contentsPath: string =
+    useRedux([actions.name, "contents_path"]) ?? actions.path;
+
+  if (contents == null) {
+    return <Loading theme="medium" />;
+  }
+  return (
+    <LatexTOCBody
+      contents={contents}
+      fontSize={font_size}
+      project_id={actions.project_id}
+      masterPath={actions.path}
+      sourcePath={contentsPath}
+      scrollTo={actions.scrollToHeading.bind(actions)}
+      openAnchorChat={(hash, srcPath) => {
+        void actions.openAnchorChat(hash, srcPath);
+      }}
+    />
+  );
+}
+
+/**
+ * Renders an immutable list of TOC entries with a chat-marker dispatcher:
+ * entries whose `extra.kind === "chat"` get a row component that calls
+ * `useAnchoredThreads` for a live count pill; everything else uses the
+ * plain row (heading/bookmark) styling. Exported so the Output frame's
+ * Contents tab can reuse the same rendering as the standalone TOC frame.
+ */
+export function LatexTOCBody({
+  contents,
+  fontSize,
+  project_id,
+  masterPath,
+  sourcePath,
+  scrollTo,
+  openAnchorChat,
+  ifEmpty,
+}: {
+  contents: TableOfContentsEntryList;
+  fontSize?: number;
+  project_id: string;
+  /** Master file path — used to look up anchored threads (per-master sage-chat). */
+  masterPath: string;
+  /**
+   * The path the contents were parsed from. When the TOC reflects a
+   * sub-file, this differs from `masterPath` and is what we forward
+   * with `openAnchorChat` so a fresh pending thread saves the correct
+   * `path` field on its root message — without it, jump-to-anchor
+   * fallback after reload can't find the marker on clients that
+   * haven't scanned the sub-file. Defaults to `masterPath`.
+   */
+  sourcePath?: string;
+  scrollTo: (entry: TableOfContentsEntry) => void;
+  /**
+   * Called when the user clicks the chat-marker row's count pill — opens
+   * the side chat focused on this anchor's thread (vs. clicking the row's
+   * heading link, which jumps to the source location). The `path`
+   * argument is forwarded so the chat actions stage a pending anchor
+   * with that path for empty threads.
+   */
+  openAnchorChat?: (hash: string, path: string) => void;
+  ifEmpty?: React.ReactNode;
+}) {
+  const effectiveSourcePath = sourcePath ?? masterPath;
+  return useMemo(() => {
+    if (contents.size === 0 && ifEmpty != null) {
+      return <>{ifEmpty}</>;
+    }
+    const rows: React.JSX.Element[] = [];
+    for (const entry of contents) {
+      const id = entry.get("id");
+      const extra = entry.get("extra") as
+        | { kind?: string; hash?: string }
+        | undefined;
+      const isChat =
+        extra != null &&
+        (typeof (extra as any).get === "function"
+          ? (extra as any).get("kind")
+          : extra.kind) === "chat";
+      if (isChat) {
+        const hashRaw =
+          typeof (extra as any).get === "function"
+            ? (extra as any).get("hash")
+            : extra?.hash;
+        if (typeof hashRaw === "string") {
+          rows.push(
+            <ChatRow
+              key={id}
+              entry={entry}
+              hash={hashRaw}
+              project_id={project_id}
+              masterPath={masterPath}
+              onScrollTo={() => scrollTo(entry.toJS())}
+              onOpenChat={
+                openAnchorChat
+                  ? () => openAnchorChat(hashRaw, effectiveSourcePath)
+                  : undefined
+              }
+            />,
+          );
+          continue;
+        }
+      }
+      rows.push(
+        <PlainRow
+          key={id}
+          entry={entry}
+          onClick={() => scrollTo(entry.toJS())}
+        />,
+      );
+    }
+    return (
+      <div
+        style={{
+          overflowY: "auto",
+          height: "100%",
+          paddingTop: "15px",
+          fontSize: `${fontSize ?? 14}px`,
+        }}
+      >
+        {rows}
+      </div>
+    );
+  }, [
+    contents,
+    fontSize,
+    project_id,
+    masterPath,
+    effectiveSourcePath,
+    ifEmpty,
+    openAnchorChat,
+  ]);
+}
+
+function PlainRow({
+  entry,
+  onClick,
+}: {
+  entry: TableOfContentsEntryMap;
+  onClick: () => void;
+}) {
+  return (
+    <div onClick={onClick} style={{ cursor: "pointer" }}>
+      <RowHeader
+        level={entry.get("level", 1)}
+        value={entry.get("value")}
+        icon={entry.get("icon")}
+        iconColor={entry.get("iconColor")}
+      />
+    </div>
+  );
+}
+
+function ChatRow({
+  entry,
+  hash,
+  project_id,
+  masterPath,
+  onScrollTo,
+  onOpenChat,
+}: {
+  entry: TableOfContentsEntryMap;
+  hash: string;
+  project_id: string;
+  masterPath: string;
+  /** Click on the row's heading link → jump to source location. */
+  onScrollTo: () => void;
+  /** Click on the count pill → open the side chat at this anchor. */
+  onOpenChat?: () => void;
+}) {
+  const { anchoredThreads, totalMessages, totalUnread } = useAnchoredThreads(
+    project_id,
+    masterPath,
+    hash,
+  );
+  const { hasResolved } = useResolvedAnchoredThreads(
+    project_id,
+    masterPath,
+    hash,
+  );
+  // Stale = the marker is still in source, but its chat thread is
+  // resolved (no active anchored thread). Render muted, no count, no
+  // open-chat affordance — clicking the pill in this state would stage
+  // a fresh pending thread on a hash that's already retired, which is
+  // exactly what the resolved-archive design prohibits.
+  const isStale = hasResolved && anchoredThreads.length === 0;
+  const hasUnread = !isStale && totalUnread > 0;
+  const pillText = isStale
+    ? "resolved"
+    : hasUnread
+      ? `${totalUnread} unread`
+      : `${totalMessages} message${totalMessages === 1 ? "" : "s"}`;
+  const pillTitle = isStale
+    ? "Stale marker — its chat thread was resolved"
+    : onOpenChat
+      ? hasUnread
+        ? `${totalUnread} unread of ${totalMessages} — click to open chat`
+        : `${totalMessages} message${totalMessages === 1 ? "" : "s"} — click to open chat`
+      : pillText;
+  const pillClickable = !isStale && onOpenChat != null;
+  return (
+    <div
+      onClick={onScrollTo}
+      style={{
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        opacity: isStale ? 0.6 : 1,
+      }}
+      title={`Chat anchor ${hash}`}
+    >
+      <RowHeader
+        level={entry.get("level", 6)}
+        value={entry.get("value")}
+        icon={entry.get("icon", "comment")}
+        iconColor={entry.get("iconColor")}
+      />
+      <span
+        title={pillTitle}
+        onClick={
+          pillClickable
+            ? (e) => {
+                e.stopPropagation();
+                onOpenChat!();
+              }
+            : undefined
+        }
+        style={{
+          display: "inline-block",
+          marginLeft: 8,
+          padding: "0 8px",
+          borderRadius: 10,
+          fontSize: "0.8em",
+          lineHeight: 1.4,
+          fontWeight: 500,
+          fontStyle: isStale ? "italic" : "normal",
+          backgroundColor: hasUnread ? COLORS.ANTD_RED : COLORS.GRAY_LL,
+          color: hasUnread ? COLORS.WHITE : COLORS.GRAY_M,
+          whiteSpace: "nowrap",
+          cursor: pillClickable ? "pointer" : "default",
+        }}
+      >
+        {pillText}
+      </span>
+    </div>
+  );
+}
+
+function RowHeader({
+  level,
+  value,
+  icon,
+  iconColor,
+}: {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  value: string;
+  icon?: IconName;
+  iconColor?: string;
+}) {
+  if (level < 1) level = 1;
+  if (level > 6) level = 6;
+  const indent = INDENTS[level];
+  return (
+    <div
+      style={{
+        whiteSpace: "nowrap",
+        fontWeight: level == 1 ? "bold" : undefined,
+      }}
+    >
+      <span style={{ width: indent.gutter, display: "inline-block" }}>
+        {icon && (
+          <Icon
+            name={icon}
+            style={{
+              color: iconColor ?? COLORS.GRAY_M,
+              marginLeft: indent.iconLeft,
+            }}
+          />
+        )}
+      </span>
+      <a
+        style={{
+          display: "inline-block",
+          marginBottom: "-1em",
+          marginLeft: "10px",
+        }}
+      >
+        <Markdown value={"&nbsp;" + value} />
+      </a>
+    </div>
+  );
+}
+
+const INDENTS: Record<
+  1 | 2 | 3 | 4 | 5 | 6,
+  { gutter: string; iconLeft: string }
+> = {
+  1: { gutter: "15px", iconLeft: "5px" },
+  2: { gutter: "25px", iconLeft: "15px" },
+  3: { gutter: "35px", iconLeft: "25px" },
+  4: { gutter: "45px", iconLeft: "35px" },
+  5: { gutter: "55px", iconLeft: "45px" },
+  6: { gutter: "65px", iconLeft: "55px" },
+};

--- a/src/packages/frontend/frame-editors/latex-editor/table-of-contents.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/table-of-contents.ts
@@ -7,12 +7,25 @@ change them.
 */
 
 import { TableOfContentsEntry as Entry } from "@cocalc/frontend/components";
+import { COLORS } from "@cocalc/util/theme";
 
-import { scanBookmarks } from "./chat-markers";
+import { scanBookmarks, scanMarkers } from "./chat-markers";
+
+/**
+ * Information stashed under `entry.extra` for chat-marker TOC rows. The
+ * latex-specific TOC component dispatches on `kind === "chat"` and renders
+ * a custom row that looks up live unread/total counts via
+ * `useAnchoredThreads(masterPath, hash)`. Heading and bookmark rows leave
+ * `extra` unset.
+ */
+export interface ChatTocExtra {
+  kind: "chat";
+  hash: string;
+}
 
 export function parseTableOfContents(
   latex: string,
-  opts: { includeBookmarks?: boolean } = {},
+  opts: { includeBookmarks?: boolean; includeChatMarkers?: boolean } = {},
 ): Entry[] {
   let id = 0;
   const entries: Entry[] = [];
@@ -30,6 +43,21 @@ export function parseTableOfContents(
       seenTexts.add(b.text);
       if (!bookmarksByLine.has(b.line)) {
         bookmarksByLine.set(b.line, b.text);
+      }
+    }
+  }
+
+  // Optional chat-marker overlay. Like bookmarks, we dedupe by hash and
+  // keep the first occurrence — duplicate markers anchored to the same
+  // thread are reference copies; surfacing each one would clutter the TOC.
+  const chatByLine = new Map<number, string>();
+  if (opts.includeChatMarkers) {
+    const seenHashes = new Set<string>();
+    for (const m of scanMarkers(latex)) {
+      if (seenHashes.has(m.hash)) continue;
+      seenHashes.add(m.hash);
+      if (!chatByLine.has(m.line)) {
+        chatByLine.set(m.line, m.hash);
       }
     }
   }
@@ -53,7 +81,26 @@ export function parseTableOfContents(
         value: bookmarkText,
         id: `${id}b`,
         icon: "bookmark",
-        iconColor: "#1677ff",
+        iconColor: COLORS.ANTD_LINK_BLUE,
+      });
+    }
+
+    // Chat-marker entry for this line (if any). Format: `Chat <hash>
+    // (line N)` — the hash is mnemonic and unique, the line number
+    // disambiguates duplicate hashes (rare but supported). The
+    // latex-specific TOC component reads `extra.hash` and renders a live
+    // count pill alongside this label.
+    const chatHash = chatByLine.get(lineIdx);
+    if (chatHash != null) {
+      const label = `Chat ${chatHash} (line ${lineIdx + 1})`;
+      const extra: ChatTocExtra = { kind: "chat", hash: chatHash };
+      entries.push({
+        level: 6,
+        value: label,
+        id: `${id}c`,
+        icon: "comment",
+        iconColor: COLORS.ANTD_LINK_BLUE,
+        extra,
       });
     }
 

--- a/src/packages/frontend/project/history/log-entry.tsx
+++ b/src/packages/frontend/project/history/log-entry.tsx
@@ -41,7 +41,7 @@ import { COLORS } from "@cocalc/util/theme";
 import { FormattedMessage, useIntl } from "react-intl";
 import { SOFTWARE_ENVIRONMENT_ICON } from "../settings/software-consts";
 import { SystemProcess } from "./system-process";
-import { handleFileEntryClick } from "./utils";
+import { handleFileEntryClick, normalizeLogFilename } from "./utils";
 import type {
   AIAssistanceEvent,
   AssistantEvent,
@@ -156,12 +156,15 @@ export const LogEntry: React.FC<Props> = React.memo(
     const dimFileExtensions = !!otherSettings?.get("dim_file_extensions");
 
     function render_open_file(event: OpenFile): React.JSX.Element {
+      // `event.filename` is typed as string but at runtime may be an
+      // object `{ ext, path, editorId }` written by a newer client.
+      const filename = normalizeLogFilename(event.filename) ?? "";
       return (
         <span>
           Opened
           <Gap />
           <PathLink
-            path={event.filename}
+            path={filename}
             full={true}
             style={cursor ? selected_item : undefined}
             trunc={TRUNC}
@@ -171,7 +174,7 @@ export const LogEntry: React.FC<Props> = React.memo(
               track("open-file", {
                 how: "project-log",
                 type: "open_file",
-                path: event.filename,
+                path: filename,
                 project_id,
               })
             }
@@ -1016,7 +1019,9 @@ export const LogEntry: React.FC<Props> = React.memo(
         case "open_project":
           return "folder-open";
         case "open": // open a file
-          const ext = misc.filename_extension(event.filename);
+          const ext = misc.filename_extension(
+            normalizeLogFilename(event.filename) ?? "",
+          );
           const info = file_associations[ext];
           if (info == null) return "file-code";
           let x = info.icon;

--- a/src/packages/frontend/project/history/search.tsx
+++ b/src/packages/frontend/project/history/search.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from "../../hooks";
 import { SearchInput } from "../../components";
 import { ProjectActions } from "@cocalc/frontend/project_store";
 import { EventRecordMap } from "./types";
+import { normalizeLogFilename } from "./utils";
 
 interface Props {
   search?: string;
@@ -35,8 +36,10 @@ export const LogSearch: React.FC<Props> = ({
 
       switch (e.get("event")) {
         case "open":
-          const target = e.get("filename");
-          if (target != null) {
+          // `filename` may be a string (legacy) or an object/Map carrying
+          // the path under `.path` (newer clients) — see normalizeLogFilename.
+          const target = normalizeLogFilename(e.get("filename"));
+          if (target) {
             actions.open_file({
               path: target,
               foreground: !info.ctrl_down,

--- a/src/packages/frontend/project/history/search.tsx
+++ b/src/packages/frontend/project/history/search.tsx
@@ -50,7 +50,7 @@ export const LogSearch: React.FC<Props> = ({
           actions.set_active_tab("settings");
       }
     },
-    [selected, actions]
+    [selected, actions],
   );
 
   const on_change = useDebounce(
@@ -59,9 +59,9 @@ export const LogSearch: React.FC<Props> = ({
         reset_cursor();
         actions.setState({ search: value });
       },
-      [reset_cursor, actions]
+      [reset_cursor, actions],
     ),
-    150
+    150,
   );
 
   return (

--- a/src/packages/frontend/project/history/utils.test.ts
+++ b/src/packages/frontend/project/history/utils.test.ts
@@ -1,0 +1,77 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2020-2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import { fromJS, Map as IMap } from "immutable";
+
+import { getOpenEventFilename, normalizeLogFilename } from "./utils";
+
+describe("normalizeLogFilename", () => {
+  it("returns a plain string unchanged", () => {
+    expect(normalizeLogFilename("foo.tex")).toBe("foo.tex");
+  });
+
+  it("returns the .path of a plain object", () => {
+    expect(
+      normalizeLogFilename({
+        ext: "tex",
+        path: "foo.tex",
+        editorId: "cocalc/latex-editor",
+      }),
+    ).toBe("foo.tex");
+  });
+
+  it("returns the .path of an Immutable Map", () => {
+    const m = IMap({ ext: "csv", path: "data.csv", editorId: "x" });
+    expect(normalizeLogFilename(m)).toBe("data.csv");
+  });
+
+  it("returns the .path of a fromJS-wrapped object", () => {
+    const m = fromJS({ ext: "csv", path: "data.csv", editorId: "x" });
+    expect(normalizeLogFilename(m)).toBe("data.csv");
+  });
+
+  it("returns undefined for null/undefined", () => {
+    expect(normalizeLogFilename(null)).toBeUndefined();
+    expect(normalizeLogFilename(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when the path field is missing or non-string", () => {
+    expect(normalizeLogFilename({ ext: "csv" })).toBeUndefined();
+    expect(normalizeLogFilename({ path: 42 })).toBeUndefined();
+    expect(normalizeLogFilename(IMap({ ext: "csv" }))).toBeUndefined();
+  });
+});
+
+describe("getOpenEventFilename", () => {
+  it("reads a string filename out of an Immutable entry", () => {
+    const entry = fromJS({ event: { event: "open", filename: "foo.tex" } });
+    expect(getOpenEventFilename(entry as any)).toBe("foo.tex");
+  });
+
+  it("reads the .path out of an object filename", () => {
+    const entry = fromJS({
+      event: {
+        event: "open",
+        filename: { ext: "tex", path: "foo.tex", editorId: "x" },
+      },
+    });
+    expect(getOpenEventFilename(entry as any)).toBe("foo.tex");
+  });
+
+  it("returns the fallback when filename is missing", () => {
+    const entry = fromJS({ event: { event: "open" } });
+    expect(getOpenEventFilename(entry as any)).toBeUndefined();
+    expect(getOpenEventFilename(entry as any, "x.txt")).toBe("x.txt");
+    expect(getOpenEventFilename(entry as any, "")).toBe("");
+  });
+
+  it("survives a malformed object filename without throwing", () => {
+    const entry = fromJS({
+      event: { event: "open", filename: { ext: "tex" } },
+    });
+    expect(getOpenEventFilename(entry as any)).toBeUndefined();
+    expect(getOpenEventFilename(entry as any, "")).toBe("");
+  });
+});

--- a/src/packages/frontend/project/history/utils.ts
+++ b/src/packages/frontend/project/history/utils.ts
@@ -7,6 +7,56 @@ import { redux } from "@cocalc/frontend/app-framework";
 import type { FragmentId } from "@cocalc/frontend/misc/fragment-id";
 import { should_open_in_foreground } from "@cocalc/frontend/lib/should-open-in-foreground";
 
+/**
+ * Coerce a project_log `event.filename` value to a string, accepting both
+ * shapes the codebase has used:
+ *
+ *   - legacy: a plain string.
+ *   - newer:  `{ ext, path, editorId }` (or an Immutable Map of the same
+ *             after fromJS), in which case the real filename is `.path`.
+ *
+ * Older code paths called `.toLowerCase()` on the raw value; the moment
+ * a project_log row written by a newer client lands in an older client
+ * (cross-version downgrade — same browser session, switched git
+ * branches, etc.), the call crashes. This helper is the canonical place
+ * to coerce the value; future shape changes should be added here.
+ *
+ * Returns `undefined` when no usable string can be extracted. Pass an
+ * empty-string fallback when you want to chain `.toLowerCase()` etc.
+ * without nil-checking, via `normalizeLogFilename(value) ?? ""`.
+ */
+export function normalizeLogFilename(raw: unknown): string | undefined {
+  if (typeof raw === "string") return raw;
+  if (raw == null) return undefined;
+  // Immutable Map: has a .get function returning the inner path.
+  const asMap = raw as { get?: (k: string) => unknown };
+  if (typeof asMap.get === "function") {
+    const path = asMap.get("path");
+    if (typeof path === "string") return path;
+    return undefined;
+  }
+  // Plain object — likely from a path that bypassed fromJS.
+  if (typeof raw === "object" && typeof (raw as any).path === "string") {
+    return (raw as any).path;
+  }
+  return undefined;
+}
+
+/**
+ * Convenience wrapper around `normalizeLogFilename` for the common case
+ * of reading `event.filename` from an Immutable Map entry. Returns
+ * `fallback` (default `undefined`) when the entry has no usable
+ * filename. Pass `""` for chaining `.toLowerCase()` etc. without
+ * nil-checks.
+ */
+export function getOpenEventFilename(
+  entry: { getIn: (path: any[]) => any },
+  fallback?: string,
+): string | undefined {
+  const fn = normalizeLogFilename(entry.getIn(["event", "filename"]));
+  return fn ?? fallback;
+}
+
 // used when clicking/opening a file open entry in the project activity log and similar
 export function handleFileEntryClick(
   e: React.MouseEvent | React.KeyboardEvent | undefined,

--- a/src/packages/frontend/project/page/flyouts/log.tsx
+++ b/src/packages/frontend/project/page/flyouts/log.tsx
@@ -30,7 +30,10 @@ import {
   EventRecordMap,
   to_search_string,
 } from "@cocalc/frontend/project/history/types";
-import { handleFileEntryClick } from "@cocalc/frontend/project/history/utils";
+import {
+  getOpenEventFilename,
+  handleFileEntryClick,
+} from "@cocalc/frontend/project/history/utils";
 import track from "@cocalc/frontend/user-tracking";
 import { User } from "@cocalc/frontend/users";
 import {
@@ -83,7 +86,7 @@ function deriveFiles(
     .valueSeq()
     .filter(
       (entry: EventRecordMap) =>
-        entry.getIn(["event", "filename"]) &&
+        getOpenEventFilename(entry, undefined) != null &&
         entry.getIn(["event", "event"]) === "open",
     )
     .sort((a, b) => getTime(b) - getTime(a))
@@ -91,20 +94,21 @@ function deriveFiles(
       // pick all files if not deduplicated
       if (!deduplicate) return true;
       // otherwise, we check if the filename already appeared in the sorted list
-      const fn = entry.getIn(["event", "filename"]);
+      const fn = getOpenEventFilename(entry, undefined);
+      if (fn == null) return false;
       if (dedupe.includes(fn)) return false;
       dedupe.push(fn);
       return true;
     })
     .filter((entry: EventRecordMap) => {
       if (searchTerm === "") return true;
-      const fName = entry.getIn(["event", "filename"], "").toLowerCase();
+      const fName = getOpenEventFilename(entry, "")!.toLowerCase();
       return search_match(fName, searchWords);
     })
     .slice(0, max)
     .map((entry: EventRecordMap) => {
       return {
-        filename: entry.getIn(["event", "filename"]),
+        filename: getOpenEventFilename(entry, "") as string,
         time: entry.get("time"),
         account_id: entry.get("account_id"),
       };
@@ -146,9 +150,9 @@ function isProjectEvent(event: string, entry: EventRecordMap): boolean {
 
 function isFileEvent(event: string, entry: EventRecordMap): boolean {
   if (event === "open") {
-    if (typeof entry.getIn(["event", "filename"]) === "string") {
-      return true;
-    }
+    // Older entries store `filename` as a string; newer ones store
+    // `{ ext, path, editorId }`. Both count as a file event.
+    return getOpenEventFilename(entry, undefined) != null;
   }
   return false;
 }

--- a/src/packages/frontend/projects/util.tsx
+++ b/src/packages/frontend/projects/util.tsx
@@ -13,6 +13,7 @@ import { useStudentProjectFunctionality } from "@cocalc/frontend/course";
 import { file_options } from "@cocalc/frontend/editor-tmp";
 import { isIntlMessage } from "@cocalc/frontend/i18n";
 import { EventRecordMap } from "@cocalc/frontend/project/history/types";
+import { getOpenEventFilename } from "@cocalc/frontend/project/history/utils";
 import {
   SPEC as SERVER_SPEC,
   serverURL,
@@ -276,25 +277,25 @@ export function useRecentFiles(
       .valueSeq()
       .filter(
         (entry: EventRecordMap) =>
-          entry.getIn(["event", "filename"]) &&
+          getOpenEventFilename(entry, undefined) != null &&
           entry.getIn(["event", "event"]) === "open",
       )
       .sort((a, b) => getTime(b) - getTime(a))
       .filter((entry: EventRecordMap) => {
-        const fn = entry.getIn(["event", "filename"]);
+        const fn = getOpenEventFilename(entry, undefined);
+        if (fn == null) return false;
         if (dedupe.includes(fn)) return false;
         dedupe.push(fn);
         return true;
       })
       .filter((entry: EventRecordMap) =>
-        entry
-          .getIn(["event", "filename"], "")
+        getOpenEventFilename(entry, "")!
           .toLowerCase()
           .includes(searchLower),
       )
       .filter((entry: EventRecordMap) => {
         if (directory_listings == null) return true;
-        const filename = entry.getIn(["event", "filename"]);
+        const filename = getOpenEventFilename(entry, undefined);
         if (!filename) return true;
         const { head: parentDir, tail: baseName } = path_split(filename);
         if (!baseName) return true;
@@ -319,7 +320,7 @@ export function useRecentFiles(
       })
       .slice(0, max)
       .map((entry: EventRecordMap) => ({
-        filename: entry.getIn(["event", "filename"]),
+        filename: getOpenEventFilename(entry, "") as string,
         time: entry.get("time"),
         account_id: entry.get("account_id"),
       }))

--- a/src/packages/frontend/projects/util.tsx
+++ b/src/packages/frontend/projects/util.tsx
@@ -289,9 +289,7 @@ export function useRecentFiles(
         return true;
       })
       .filter((entry: EventRecordMap) =>
-        getOpenEventFilename(entry, "")!
-          .toLowerCase()
-          .includes(searchLower),
+        getOpenEventFilename(entry, "")!.toLowerCase().includes(searchLower),
       )
       .filter((entry: EventRecordMap) => {
         if (directory_listings == null) return true;


### PR DESCRIPTION
## Summary
- Extend LaTeX chat markers (`% chat: <hash>`) into a collaborative-TODO workflow: a green **✓** on the inline marker tail and on the side-chat header resolves the chat — the source markers are removed and the thread is kept in `.sage-chat` as a read-only archive (`resolved: { account_id, at, anchorId, path?, label? }` on the root, `id`/`path` cleared so `useAnchoredThreads` filters it).
- Resolved threads land in a collapsed **Resolved** section at the bottom of the side chat (dimmed, strikethrough). Selected resolved thread shows a **read-only panel** with "Resolved by ⟨name⟩ on ⟨date⟩" and a **Start new chat thread** button — Popconfirm preview shows target file + line so it's never surprising. Per-thread Reply is also hidden in all-threads view for resolved threads.
- LaTeX **Table of Contents** indexes chat markers alongside bookmarks (`Chat <hash> (line N)`) with a live count pill — red "N unread", gray "N messages", "0 messages" — driven by `useAnchoredThreads`. Pill click opens chat; blue label click jumps to source. Stale markers (hash whose thread is resolved) render muted with no clickable affordance.
- Stale-marker robustness: gutter / inline tail / TOC pill / CM text-marker click / `openAnchorChat` itself all gate on `_isStaleChatHash` (with a central recheck on hydrated chat-store, closing the startup-race window).
- Inline-tail `×` Popconfirm reads "Resolve chat and remove marker?" / "removes every `% chat: …` marker from all files." TOC source path is preserved through `LatexTOCBody` so empty-thread chats opened from the Contents tab save the correct `path` on the root.
- **Cancel** in the empty pending-anchor compose now removes the just-inserted marker too — implemented as an editor-generic `frameTreeActions.cancelPendingAnchorThread(pending)`. Per-codex safety: only deletes markers when no chat message (active or resolved) has ever referenced the hash.
- Anchor jump button label is now **"Jump to ⟨path⟩:⟨line⟩"** (no opaque hash). Falls back to the legacy `getAnchorLabel` for editors that don't ship the new `getAnchorJumpLabel` (Jupyter still works — verified).
- Bonus defensive fix in a separate commit (`5272c61f`): `project_log` `event.filename` may be a plain string (legacy) or `{ ext, path, editorId }` (newer clients). Older code called `.toLowerCase()` directly; new `normalizeLogFilename` / `getOpenEventFilename` helpers handle both shapes. Used in `projects/util.tsx`, `flyouts/log.tsx`, `history/log-entry.tsx`, `history/search.tsx`. 10 unit tests added in `history/utils.test.ts`.

## Implementation notes

- New `resolved` field on `ChatMessage` (and `ResolvedMeta` interface in `chat/types.ts`). `anchorIdOf` returns undefined for resolved roots (belt + suspenders); new `formerAnchorIdOf` reads the stored hash for stale-marker matching.
- New `ChatActions.resolveAnchorThread(rootDate)` — atomic `syncdb.set({ resolved, id: null, path: null })`, verified in browser that `id` is genuinely null on disk.
- `useAnchoredThreads` returns only active threads; new `useResolvedAnchoredThreads` hook surfaces stale state for the gutter / inline tail / TOC ChatRow.
- New `LatexActions.resolveChatMarker(hash)` walks anchored roots, calls `resolveAnchorThread` for each, then deletes every marker for `hash` bottom-up per file across scanned files. New `cancelPendingAnchorThread(pending)` is the no-thread-yet sibling.
- `LatexTOCBody` is exported and reused by both the standalone `latex-toc` frame and the Output frame's Contents tab. ChatRow uses `useAnchoredThreads` per-row (not in a loop) for proper React hook usage.
- Colors use `COLORS.*` constants (BS_GREEN_LL/ANTD_GREEN/BS_GREEN_D for resolve green, ANTD_LINK_BLUE for TOC icons, WHITE for unread pill text). No hardcoded hex.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec prettier --check` clean on all 19 branch-touched files
- [x] `pnpm exec jest project/history/utils.test packages/frontend/frame-editors/latex-editor/chat-markers.test` — 50/50 pass
- [x] Static build emits cleanly
- [x] Browser smoke (admin1 on Test Calc-2):
  - [x] LaTeX TOC pill click opens chat; label click jumps; pill tooltip "N messages — click to open chat"
  - [x] Inline-tail `✓` Popconfirm copy + resolve flow (single + multi-marker hash, bottom-up delete)
  - [x] Side-chat header `✓` button (icon-only, green-tinted)
  - [x] Drawer "Resolved" section (collapsed, count, dimmed/strikethrough rows)
  - [x] Resolved-thread read-only panel + Start-new-chat-thread Popconfirm with target file:line
  - [x] Pending-anchor Cancel removes the just-inserted marker AND clears pending; only when no chat root references the hash
  - [x] Stale-marker `_isStaleChatHash` correctly true for resolved hashes, false for active
  - [x] Jump button reads "Jump to f2.tex:104" (no hash)
  - [x] Standalone `.sage-chat` renders with no regressions
  - [x] Jupyter `.ipynb` per-cell chat works; "Jump to Cell 1" via getAnchorLabel fallback; resolve button correctly hidden (no `resolveChatMarker` on Jupyter actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)