### PR TITLE
[trial] conat-fast-rpc + Group 1 partial (transports/httpCompression/env var)

### DIFF
--- a/src/packages/backend/conat/test/socket/cluster.test.ts
+++ b/src/packages/backend/conat/test/socket/cluster.test.ts
@@ -16,6 +16,14 @@ import {
 
 beforeAll(before);
 
+// Cross-cluster connect involves multiple round-trips of cluster sync
+// (interest propagation for the status subject, the connect command, the
+// client subject, and the inbox).  Default jest 5s budget can be too tight
+// under CI parallelism.  Bump to 15s as a fail-fast guardrail: if a real
+// hang happens we want jest to abort each test promptly rather than stall
+// the suite for retries.
+jest.setTimeout(15000);
+
 describe("most basic possible test of creating a socket in a cluster built from scratch", () => {
   let client0, client1;
   it("a 2-node cluster", async () => {

--- a/src/packages/conat/core/client.ts
+++ b/src/packages/conat/core/client.ts
@@ -350,6 +350,17 @@ interface SubscriptionOptions {
   timeout?: number;
 }
 
+interface RpcServiceOptions {
+  queue?: string;
+  timeout?: number;
+}
+
+type RpcServiceHandle = {
+  subject: string;
+  close: () => void;
+  stop: () => void;
+};
+
 // WARNING!  This is the default and you can't just change it!
 // Yes, for specific messages you can, but in general DO NOT.  The reason is because, e.g.,
 // JSON will turn Dates into strings, and we no longer fix that.  So unless you modify the
@@ -395,6 +406,8 @@ export class Client extends EventEmitter {
   // queueGroups is a map from subject to the queue group for the subscription to that subject
   private queueGroups: { [subject: string]: string } = {};
   private subs: { [subject: string]: SubscriptionEmitter } = {};
+  private rpcServiceQueues: { [subject: string]: string } = {};
+  private rpcServiceImpls: { [subject: string]: any } = {};
   private sockets: {
     // all socket servers created using this Client
     servers: { [subject: string]: ConatSocketServer };
@@ -474,12 +487,16 @@ export class Client extends EventEmitter {
       const firstTime = this.info == null;
       this.info = info;
       this.emit("info", info);
-      setTimeout(this.syncSubscriptions, firstTime ? 3000 : 0);
+      setTimeout(() => {
+        void this.syncSubscriptions();
+        void this.syncRpcServices();
+      }, firstTime ? 3000 : 0);
     });
     this.conn.on("permission", ({ message, type, subject }) => {
       logger.debug(message);
       this.permissionError[type]?.set(subject, message);
     });
+    this.conn.on("rpc-request", this.handleRpcRequest);
     this.conn.on("connect", async () => {
       logger.debug(`Conat: Connected to ${this.options.address}`);
       if (this.conn.connected) {
@@ -713,6 +730,11 @@ export class Client extends EventEmitter {
       this.conn.emit("unsubscribe", { subject });
       delete this.queueGroups[subject];
     }
+    for (const subject in this.rpcServiceQueues) {
+      this.conn.emit("rpc-service-close", { subject });
+      delete this.rpcServiceQueues[subject];
+      delete this.rpcServiceImpls[subject];
+    }
     for (const sub of Object.values(this.subs)) {
       sub.refCount = 0;
       sub.close();
@@ -721,6 +743,10 @@ export class Client extends EventEmitter {
     }
     // @ts-ignore
     delete this.queueGroups;
+    // @ts-ignore
+    delete this.rpcServiceQueues;
+    // @ts-ignore
+    delete this.rpcServiceImpls;
     // @ts-ignore
     delete this.inboxSubject;
     delete this.inbox;
@@ -819,6 +845,87 @@ export class Client extends EventEmitter {
       stable = false;
     }
     return stable;
+  };
+
+  private syncRpcServices = reuseInFlight(async () => {
+    if (this.isClosed() || isEmpty(this.rpcServiceQueues)) {
+      return;
+    }
+    await this.waitUntilConnected();
+    if (this.isClosed() || isEmpty(this.rpcServiceQueues)) {
+      return;
+    }
+    const services = Object.entries(this.rpcServiceQueues).map(
+      ([subject, queue]) => ({ subject, queue }),
+    );
+    const resp = await this.conn
+      .timeout(DEFAULT_SUBSCRIPTION_TIMEOUT)
+      .emitWithAck("rpc-service", services);
+    for (let i = 0; i < services.length; i++) {
+      if (resp?.[i]?.error) {
+        logger.debug(
+          `WARNING: rpc service '${services[i].subject}' failed to (re-)register: ${resp[i].error}`,
+        );
+      }
+    }
+  });
+
+  private handleRpcRequest = async (
+    { subject, pattern, encoding, raw, headers },
+    respond,
+  ) => {
+    if (respond == null) {
+      return;
+    }
+    const impl = this.rpcServiceImpls[pattern];
+    if (impl == null) {
+      respond({
+        error: `rpc service '${pattern}' is not registered`,
+        code: 503,
+      });
+      return;
+    }
+    const request = new Message({
+      encoding,
+      raw,
+      headers,
+      client: this,
+      subject,
+    });
+    this.recvStats(raw?.byteLength ?? raw?.length ?? 0);
+    try {
+      const [name, args] = request.data;
+      const f = impl[name];
+      if (f == null) {
+        throw Error(`${name} not defined`);
+      }
+      const response = messageData(await f.apply(request, args));
+      this.stats.send.messages += 1;
+      this.stats.send.bytes += response.raw.length;
+      respond({
+        encoding: response.encoding,
+        raw: response.raw,
+        headers: response.headers,
+      });
+    } catch (err) {
+      const response = messageData(null, {
+        headers: {
+          error: err instanceof Error ? err.message : `${err}`,
+          error_attrs: {
+            code: (err as any)?.code,
+            errno: (err as any)?.errno,
+            path: (err as any)?.path,
+            syscall: (err as any)?.syscall,
+            subject: (err as any)?.subject,
+          },
+        },
+      });
+      respond({
+        encoding: response.encoding,
+        raw: response.raw,
+        headers: response.headers,
+      });
+    }
   };
 
   numSubscriptions = () => Object.keys(this.queueGroups).length;
@@ -1061,6 +1168,111 @@ export class Client extends EventEmitter {
     loop();
     return sub;
   };
+
+  rpcService: <T = any>(
+    subject: string,
+    impl: T,
+    opts?: RpcServiceOptions,
+  ) => Promise<RpcServiceHandle> = async (subject, impl, opts = {}) => {
+    if (!isValidSubject(subject)) {
+      throw Error(`invalid rpc service subject '${subject}'`);
+    }
+    await this.waitUntilSignedIn();
+    const queue = opts.queue ?? "0";
+    this.rpcServiceQueues[subject] = queue;
+    this.rpcServiceImpls[subject] = impl;
+    try {
+      const response = await this.conn
+        .timeout(opts.timeout ?? DEFAULT_SUBSCRIPTION_TIMEOUT)
+        .emitWithAck("rpc-service", { subject, queue });
+      if (response?.error) {
+        throw new ConatError(response.error, { code: response.code });
+      }
+    } catch (err) {
+      delete this.rpcServiceQueues[subject];
+      delete this.rpcServiceImpls[subject];
+      throw err;
+    }
+    const close = () => {
+      if (this.rpcServiceQueues?.[subject] == null) {
+        return;
+      }
+      delete this.rpcServiceQueues[subject];
+      delete this.rpcServiceImpls[subject];
+      if (!this.isClosed()) {
+        this.conn.emit("rpc-service-close", { subject });
+      }
+    };
+    return { subject, close, stop: close };
+  };
+
+  rpcRequest = async (
+    subject: string,
+    mesg: any,
+    {
+      timeout = DEFAULT_REQUEST_TIMEOUT,
+      ignoreErrorHeader,
+      ...options
+    }: PublishOptions & { ignoreErrorHeader?: boolean } = {},
+  ): Promise<Message> => {
+    if (timeout <= 0) {
+      throw Error("timeout must be positive");
+    }
+    await this.waitUntilSignedIn();
+    const request = messageData(mesg, options);
+    this.stats.send.messages += 1;
+    this.stats.send.bytes += request.raw.length;
+    let response;
+    try {
+      response = await this.conn.timeout(timeout).emitWithAck("rpc", {
+        subject,
+        encoding: request.encoding,
+        raw: request.raw,
+        headers: request.headers,
+        timeout,
+      });
+    } catch (err) {
+      throw toConatError(err);
+    }
+    if (response?.error) {
+      throw new ConatError(response.error, { code: response.code });
+    }
+    const resp = new Message({
+      encoding: response.encoding,
+      raw: response.raw,
+      headers: response.headers,
+      client: this,
+      subject,
+    });
+    this.recvStats(response.raw?.byteLength ?? response.raw?.length ?? 0);
+    if (!ignoreErrorHeader && resp.headers?.error) {
+      throw Error(`${resp.headers.error}`);
+    }
+    return resp;
+  };
+
+  rpcCall<T = any>(subject: string, opts?: PublishOptions): T {
+    const call = async (name: string, args: any[]) => {
+      const resp = await this.rpcRequest(subject, [name, args], opts);
+      return resp.data;
+    };
+
+    return new Proxy(
+      { subject },
+      {
+        get: (target, name) => {
+          const s = target[String(name)];
+          if (s !== undefined) {
+            return s;
+          }
+          if (typeof name !== "string" || name == "then") {
+            return undefined;
+          }
+          return async (...args) => await call(name, args);
+        },
+      },
+    ) as T;
+  }
 
   // Call a service as defined above.
   call<T = any>(subject: string, opts?: PublishOptions): T {

--- a/src/packages/conat/core/client.ts
+++ b/src/packages/conat/core/client.ts
@@ -221,7 +221,8 @@ import {
 } from "socket.io-client";
 import { EventIterator } from "@cocalc/util/event-iterator";
 import type { ConnectionStats, ServerInfo } from "./types";
-import * as msgpack from "@msgpack/msgpack";
+import { DataEncoding, decode, encode } from "./codec";
+export { DataEncoding, decode, encode } from "./codec";
 import { randomId } from "@cocalc/conat/names";
 import type { JSONValue } from "@cocalc/util/types";
 import { EventEmitter } from "events";
@@ -261,12 +262,6 @@ import {
 export const MAX_INTEREST_TIMEOUT = 90_000;
 
 const DEFAULT_WAIT_FOR_INTEREST_TIMEOUT = 30_000;
-
-const MSGPACK_ENCODER_OPTIONS = {
-  // ignoreUndefined is critical so database queries work properly, and
-  // also we have a lot of api calls with tons of wasted undefined values.
-  ignoreUndefined: true,
-};
 
 export const DEFAULT_SOCKETIO_CLIENT_OPTIONS = {
   // A major problem if we allow long polling is that we must always use at most
@@ -333,11 +328,6 @@ export function setDefaultTimeouts({
 }) {
   DEFAULT_REQUEST_TIMEOUT = request;
   DEFAULT_PUBLISH_TIMEOUT = publish;
-}
-
-export enum DataEncoding {
-  MsgPack = 0,
-  JsonCodec = 1,
 }
 
 interface SubscriptionOptions {
@@ -1871,55 +1861,6 @@ interface PublishOptions {
 interface RequestManyOptions extends PublishOptions {
   maxWait?: number;
   maxMessages?: number;
-}
-
-export function encode({
-  encoding,
-  mesg,
-}: {
-  encoding: DataEncoding;
-  mesg: any;
-}) {
-  if (encoding == DataEncoding.MsgPack) {
-    return msgpack.encode(mesg, MSGPACK_ENCODER_OPTIONS);
-  } else if (encoding == DataEncoding.JsonCodec) {
-    return jsonEncoder(mesg);
-  } else {
-    throw Error(`unknown encoding ${encoding}`);
-  }
-}
-
-export function decode({
-  encoding,
-  data,
-}: {
-  encoding: DataEncoding;
-  data;
-}): any {
-  if (encoding == DataEncoding.MsgPack) {
-    return msgpack.decode(data);
-  } else if (encoding == DataEncoding.JsonCodec) {
-    return jsonDecoder(data);
-  } else {
-    throw Error(`unknown encoding ${encoding}`);
-  }
-}
-
-let textEncoder: TextEncoder | undefined = undefined;
-let textDecoder: TextDecoder | undefined = undefined;
-
-function jsonEncoder(obj: any) {
-  if (textEncoder === undefined) {
-    textEncoder = new TextEncoder();
-  }
-  return textEncoder.encode(JSON.stringify(obj));
-}
-
-function jsonDecoder(data: Buffer): any {
-  if (textDecoder === undefined) {
-    textDecoder = new TextDecoder();
-  }
-  return JSON.parse(textDecoder.decode(data));
 }
 
 interface Chunk {

--- a/src/packages/conat/core/client.ts
+++ b/src/packages/conat/core/client.ts
@@ -408,6 +408,9 @@ export class Client extends EventEmitter {
   private subs: { [subject: string]: SubscriptionEmitter } = {};
   private rpcServiceQueues: { [subject: string]: string } = {};
   private rpcServiceImpls: { [subject: string]: any } = {};
+  private fastRpcServiceHandlers: {
+    [subject: string]: (payload: any) => any;
+  } = {};
   private sockets: {
     // all socket servers created using this Client
     servers: { [subject: string]: ConatSocketServer };
@@ -497,6 +500,7 @@ export class Client extends EventEmitter {
       this.permissionError[type]?.set(subject, message);
     });
     this.conn.on("rpc-request", this.handleRpcRequest);
+    this.conn.on("fast-rpc-request", this.handleFastRpcRequest);
     this.conn.on("connect", async () => {
       logger.debug(`Conat: Connected to ${this.options.address}`);
       if (this.conn.connected) {
@@ -734,6 +738,7 @@ export class Client extends EventEmitter {
       this.conn.emit("rpc-service-close", { subject });
       delete this.rpcServiceQueues[subject];
       delete this.rpcServiceImpls[subject];
+      delete this.fastRpcServiceHandlers[subject];
     }
     for (const sub of Object.values(this.subs)) {
       sub.refCount = 0;
@@ -747,6 +752,8 @@ export class Client extends EventEmitter {
     delete this.rpcServiceQueues;
     // @ts-ignore
     delete this.rpcServiceImpls;
+    // @ts-ignore
+    delete this.fastRpcServiceHandlers;
     // @ts-ignore
     delete this.inboxSubject;
     delete this.inbox;
@@ -924,6 +931,28 @@ export class Client extends EventEmitter {
         encoding: response.encoding,
         raw: response.raw,
         headers: response.headers,
+      });
+    }
+  };
+
+  private handleFastRpcRequest = async ({ pattern, payload }, respond) => {
+    if (respond == null) {
+      return;
+    }
+    const handler = this.fastRpcServiceHandlers[pattern];
+    if (handler == null) {
+      respond({
+        error: `fast rpc service '${pattern}' is not registered`,
+        code: 503,
+      });
+      return;
+    }
+    try {
+      respond(await handler(payload));
+    } catch (err) {
+      respond({
+        error: err instanceof Error ? err.message : `${err}`,
+        code: (err as any)?.code,
       });
     }
   };
@@ -1204,6 +1233,68 @@ export class Client extends EventEmitter {
       }
     };
     return { subject, close, stop: close };
+  };
+
+  fastRpcService = async (
+    subject: string,
+    handler: (payload: any) => any,
+    opts: RpcServiceOptions = {},
+  ): Promise<RpcServiceHandle> => {
+    if (!isValidSubject(subject)) {
+      throw Error(`invalid fast rpc service subject '${subject}'`);
+    }
+    await this.waitUntilSignedIn();
+    const queue = opts.queue ?? "0";
+    this.rpcServiceQueues[subject] = queue;
+    this.fastRpcServiceHandlers[subject] = handler;
+    try {
+      const response = await this.conn
+        .timeout(opts.timeout ?? DEFAULT_SUBSCRIPTION_TIMEOUT)
+        .emitWithAck("rpc-service", { subject, queue });
+      if (response?.error) {
+        throw new ConatError(response.error, { code: response.code });
+      }
+    } catch (err) {
+      delete this.rpcServiceQueues[subject];
+      delete this.fastRpcServiceHandlers[subject];
+      throw err;
+    }
+    const close = () => {
+      if (this.rpcServiceQueues?.[subject] == null) {
+        return;
+      }
+      delete this.rpcServiceQueues[subject];
+      delete this.fastRpcServiceHandlers[subject];
+      if (!this.isClosed()) {
+        this.conn.emit("rpc-service-close", { subject });
+      }
+    };
+    return { subject, close, stop: close };
+  };
+
+  fastRpcRequest = async (
+    subject: string,
+    payload: any,
+    { timeout = DEFAULT_REQUEST_TIMEOUT }: { timeout?: number } = {},
+  ): Promise<any> => {
+    if (timeout <= 0) {
+      throw Error("timeout must be positive");
+    }
+    await this.waitUntilSignedIn();
+    let response;
+    try {
+      response = await this.conn.timeout(timeout).emitWithAck("fast-rpc", {
+        subject,
+        payload,
+        timeout,
+      });
+    } catch (err) {
+      throw toConatError(err);
+    }
+    if (response?.error) {
+      throw new ConatError(response.error, { code: response.code });
+    }
+    return response;
   };
 
   rpcRequest = async (

--- a/src/packages/conat/core/client.ts
+++ b/src/packages/conat/core/client.ts
@@ -2076,21 +2076,27 @@ export class Message<T = any> extends MessageData<T> {
     return this.client.publishSync(subject, mesg, opts);
   };
 
-  respond = async (
+  respond = (
     mesg,
     opts: PublishOptions = {},
   ): Promise<{ bytes: number; count: number }> => {
     const subject = this.respondSubject();
     if (!subject) {
-      return { bytes: 0, count: 0 };
+      return Promise.resolve({ bytes: 0, count: 0 });
     }
-    return await this.client.publish(subject, mesg, {
+    const promise = this.client.publish(subject, mesg, {
       // we *always* wait for interest for async respond, since
       // it is by far the most likely situation where it wil be needed, due
       // to inboxes when users first sign in.
       waitForInterest: true,
       ...opts,
     });
+    // Many request handlers use mesg.respond(...) fire-and-forget.  Keep
+    // awaited callers seeing failures, but prevent cleanup races from
+    // becoming process-level unhandled rejections when the caller
+    // intentionally ignores the returned promise.
+    promise.catch(() => undefined);
+    return promise;
   };
 }
 

--- a/src/packages/conat/core/codec.ts
+++ b/src/packages/conat/core/codec.ts
@@ -1,0 +1,62 @@
+import * as msgpack from "@msgpack/msgpack";
+
+export enum DataEncoding {
+  MsgPack = 0,
+  JsonCodec = 1,
+}
+
+// WARNING: do NOT change MSGPACK_ENCODER_OPTIONS unless you know what you're doing!
+const MSGPACK_ENCODER_OPTIONS = {
+  // ignoreUndefined is critical so database queries work properly, and
+  // also we have a lot of api calls with tons of wasted undefined values.
+  ignoreUndefined: true,
+};
+
+let textEncoder: any = undefined;
+let textDecoder: any = undefined;
+
+export function encode({
+  encoding,
+  mesg,
+}: {
+  encoding: DataEncoding;
+  mesg: any;
+}) {
+  if (encoding == DataEncoding.MsgPack) {
+    return msgpack.encode(mesg, MSGPACK_ENCODER_OPTIONS);
+  } else if (encoding == DataEncoding.JsonCodec) {
+    return jsonEncoder(mesg);
+  } else {
+    throw Error(`unknown encoding ${encoding}`);
+  }
+}
+
+export function decode({
+  encoding,
+  data,
+}: {
+  encoding: DataEncoding;
+  data;
+}): any {
+  if (encoding == DataEncoding.MsgPack) {
+    return msgpack.decode(data);
+  } else if (encoding == DataEncoding.JsonCodec) {
+    return jsonDecoder(data);
+  } else {
+    throw Error(`unknown encoding ${encoding}`);
+  }
+}
+
+function jsonEncoder(obj: any) {
+  if (textEncoder === undefined) {
+    textEncoder = new TextEncoder();
+  }
+  return textEncoder.encode(JSON.stringify(obj));
+}
+
+function jsonDecoder(data: Buffer): any {
+  if (textDecoder === undefined) {
+    textDecoder = new TextDecoder();
+  }
+  return JSON.parse(textDecoder.decode(data));
+}

--- a/src/packages/conat/core/server.ts
+++ b/src/packages/conat/core/server.ts
@@ -173,6 +173,8 @@ export class ConatServer extends EventEmitter {
 
   private subscriptions: { [socketId: string]: Set<string> } = {};
   public interest: Interest = new Patterns();
+  public rpcServices: Interest = new Patterns();
+  private rpcServiceSubjects: { [socketId: string]: Set<string> } = {};
 
   private clusterStreams?: ClusterStreams;
   private clusterLinks: {
@@ -344,7 +346,14 @@ export class ConatServer extends EventEmitter {
 
     await delay(100);
     await this.io.close();
-    for (const prop of ["interest", "subscriptions", "sockets", "services"]) {
+    for (const prop of [
+      "interest",
+      "rpcServices",
+      "rpcServiceSubjects",
+      "subscriptions",
+      "sockets",
+      "services",
+    ]) {
       delete this[prop];
     }
     this.usage?.close();
@@ -373,6 +382,48 @@ export class ConatServer extends EventEmitter {
     const room = socketSubjectRoom({ socket, subject });
     socket.leave(room);
     await this.updateInterest({ op: "delete", subject, room });
+  };
+
+  private unregisterRpcService = async ({ socket, subject }) => {
+    updateInterest(
+      { op: "delete", subject, room: socket.id },
+      this.rpcServices,
+    );
+    this.rpcServiceSubjects[socket.id]?.delete(subject);
+  };
+
+  private registerRpcService = async ({ socket, subject, queue, user }) => {
+    if (typeof queue != "string") {
+      throw Error("queue must be defined");
+    }
+    if (!isValidSubject(subject)) {
+      throw Error("invalid subject");
+    }
+    if (!(await this.isAllowed({ user, subject, type: "sub" }))) {
+      const message = `permission denied registering RPC service '${subject}' from ${JSON.stringify(
+        user,
+      )}`;
+      this.log(message);
+      throw new ConatError(message, { code: 403 });
+    }
+    updateInterest(
+      { op: "add", subject, queue, room: socket.id },
+      this.rpcServices,
+    );
+    this.rpcServiceSubjects[socket.id] ??= new Set<string>();
+    this.rpcServiceSubjects[socket.id].add(subject);
+  };
+
+  private resolveRpcService = (subject: string) => {
+    for (const pattern of this.rpcServices.matches(subject)) {
+      const g = this.rpcServices.get(pattern)!;
+      for (const queue in g) {
+        const target = this.loadBalance({ targets: g[queue] });
+        if (target !== undefined) {
+          return { pattern, target };
+        }
+      }
+    }
   };
 
   ////////////////////////////////////
@@ -770,6 +821,11 @@ export class ConatServer extends EventEmitter {
         this.unsubscribe({ socket, subject });
       }
       delete this.subscriptions[id];
+      const rpcSubjects = Array.from(this.rpcServiceSubjects[id] ?? []);
+      for (const subject of rpcSubjects) {
+        await this.unregisterRpcService({ socket, subject });
+      }
+      delete this.rpcServiceSubjects[id];
     });
 
     if (user?.error) {
@@ -856,6 +912,146 @@ export class ConatServer extends EventEmitter {
         respond?.({ error: `${err}`, code: err.code });
       }
     });
+
+    const registerRpcService = async ({ subject, queue }) => {
+      try {
+        await this.registerRpcService({ socket, subject, queue, user });
+        this.stats[socket.id].active = Date.now();
+        return { status: "added" };
+      } catch (err) {
+        if (err.code == 403) {
+          socket.emit("permission", {
+            message: err.message,
+            subject,
+            type: "sub",
+          });
+        }
+        return { error: `${err}`, code: err.code };
+      }
+    };
+
+    socket.on(
+      "rpc-service",
+      async (x: { subject; queue } | { subject; queue }[], respond) => {
+        let r;
+        if (is_array(x)) {
+          const v: any[] = [];
+          for (const y of x) {
+            v.push(await registerRpcService(y));
+          }
+          r = v;
+        } else {
+          r = await registerRpcService(x);
+        }
+        respond?.(r);
+      },
+    );
+
+    const unregisterRpcService = ({ subject }: { subject: string }) => {
+      if (!this.rpcServiceSubjects[id]?.has(subject)) {
+        return;
+      }
+      this.unregisterRpcService({ socket, subject });
+      this.stats[socket.id].active = Date.now();
+    };
+
+    socket.on(
+      "rpc-service-close",
+      (x: { subject: string } | { subject: string }[], respond) => {
+        let r;
+        if (is_array(x)) {
+          r = x.map(unregisterRpcService);
+        } else {
+          r = unregisterRpcService(x);
+        }
+        respond?.(r);
+      },
+    );
+
+    socket.on(
+      "rpc",
+      async (
+        { subject, encoding, raw, headers, timeout = MAX_INTEREST_TIMEOUT },
+        respond,
+      ) => {
+        const handlerStart = Date.now();
+        if (respond == null) {
+          return;
+        }
+        if (!isValidSubjectWithoutWildcards(subject)) {
+          respond({ error: "invalid subject" });
+          return;
+        }
+        const authStart = Date.now();
+        if (!(await this.isAllowed({ user, subject, type: "pub" }))) {
+          const message = `permission denied RPC to '${subject}' from ${JSON.stringify(
+            user,
+          )}`;
+          this.log(message);
+          socket.emit("permission", {
+            message,
+            subject,
+            type: "pub",
+          });
+          respond({ error: message, code: 403 });
+          return;
+        }
+        const authMs = Date.now() - authStart;
+        const routeStart = Date.now();
+        const target = this.resolveRpcService(subject);
+        const routeMs = Date.now() - routeStart;
+        if (target == null) {
+          respond({
+            error: `rpc -- no services matching '${subject}'`,
+            code: 503,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+          return;
+        }
+        const targetSocket = this.sockets[target.target];
+        if (targetSocket == null) {
+          respond({
+            error: `rpc -- target service disconnected for '${subject}'`,
+            code: 503,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+          return;
+        }
+        try {
+          const response = await emitWithAckTimeoutValue(
+            targetSocket,
+            "rpc-request",
+            {
+              subject,
+              pattern: target.pattern,
+              encoding,
+              raw,
+              headers,
+            },
+            Math.min(timeout, MAX_INTEREST_TIMEOUT),
+          );
+          respond({
+            ...response,
+            count: 1,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+        } catch (err) {
+          respond({
+            error: `${err}`,
+            code: 408,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+        }
+      },
+    );
 
     const subscribe = async ({ subject, queue }) => {
       try {
@@ -1601,6 +1797,24 @@ export function randomChoice(v: Set<string>): string {
 // See https://socket.io/how-to/get-the-ip-address-of-the-client
 function getAddress(socket) {
   return getClientIpAddress(socket.handshake) ?? socket.handshake.address;
+}
+
+function emitWithAckTimeoutValue(
+  socket: any,
+  event: string,
+  payload: any,
+  timeoutMs: number,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`timeout waiting for ${event} ack`));
+    }, timeoutMs);
+    timer.unref?.();
+    socket.emit(event, payload, (response) => {
+      clearTimeout(timer);
+      resolve(response);
+    });
+  });
 }
 
 export function updateInterest(update: InterestUpdate, interest: Interest) {

--- a/src/packages/conat/core/server.ts
+++ b/src/packages/conat/core/server.ts
@@ -1053,6 +1053,86 @@ export class ConatServer extends EventEmitter {
       },
     );
 
+    socket.on(
+      "fast-rpc",
+      async ({ subject, payload, timeout = MAX_INTEREST_TIMEOUT }, respond) => {
+        const handlerStart = Date.now();
+        if (respond == null) {
+          return;
+        }
+        if (!isValidSubjectWithoutWildcards(subject)) {
+          respond({ error: "invalid subject", code: 400 });
+          return;
+        }
+        const authStart = Date.now();
+        if (!(await this.isAllowed({ user, subject, type: "pub" }))) {
+          const message = `permission denied fast RPC to '${subject}' from ${JSON.stringify(
+            user,
+          )}`;
+          this.log(message);
+          socket.emit("permission", {
+            message,
+            subject,
+            type: "pub",
+          });
+          respond({ error: message, code: 403 });
+          return;
+        }
+        const authMs = Date.now() - authStart;
+        const routeStart = Date.now();
+        const target = this.resolveRpcService(subject);
+        const routeMs = Date.now() - routeStart;
+        if (target == null) {
+          respond({
+            error: `fast-rpc -- no services matching '${subject}'`,
+            code: 503,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+          return;
+        }
+        const targetSocket = this.sockets[target.target];
+        if (targetSocket == null) {
+          respond({
+            error: `fast-rpc -- target service disconnected for '${subject}'`,
+            code: 503,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+          return;
+        }
+        try {
+          const response = await emitWithAckTimeoutValue(
+            targetSocket,
+            "fast-rpc-request",
+            {
+              subject,
+              pattern: target.pattern,
+              payload,
+            },
+            Math.min(timeout, MAX_INTEREST_TIMEOUT),
+          );
+          respond({
+            ...response,
+            count: 1,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+        } catch (err) {
+          respond({
+            error: `${err}`,
+            code: 408,
+            serverAuthMs: authMs,
+            serverRouteMs: routeMs,
+            serverHandlerMs: Date.now() - handlerStart,
+          });
+        }
+      },
+    );
+
     const subscribe = async ({ subject, queue }) => {
       try {
         if (this.subscriptions[id].has(subject)) {

--- a/src/packages/conat/core/server.ts
+++ b/src/packages/conat/core/server.ts
@@ -77,6 +77,20 @@ import { sysApi, sysApiSubject, type SysConatServer } from "./sys";
 
 const logger = getLogger("conat:core:server");
 
+// Operational escape hatch for the router compression setting (see
+// socketioOptions below).  Compression is OFF by default on the
+// control-plane hot path -- most conat traffic is tiny messages where
+// compression negotiation + zlib overhead is pure cost.  Set
+// `COCALC_CONAT_SOCKET_IO_COMPRESSION=1` (or `true`/`yes`) at process
+// start to flip it back on without a redeploy, e.g. for benchmarking
+// or to roll back in production if a regression is suspected.
+function socketIoCompressionEnabled(): boolean {
+  const value = `${process.env.COCALC_CONAT_SOCKET_IO_COMPRESSION ?? ""}`
+    .trim()
+    .toLowerCase();
+  return value === "1" || value === "true" || value === "yes";
+}
+
 const DEFAULT_AUTOSCAN_INTERVAL = 15_000;
 const DEFAULT_LONG_AUTOSCAN_INTERVAL = 60_000;
 
@@ -254,23 +268,40 @@ export class ConatServer extends EventEmitter {
     // when restarting the server.
     let adapter: any = undefined;
 
+    const socketIoCompression = socketIoCompressionEnabled();
     const socketioOptions = {
       maxHttpBufferSize: MAX_PAYLOAD,
       path,
       adapter,
-      // Effectively skip per-message compression: most conat traffic is tiny
-      // control-plane messages, so a 1 GiB threshold means messages never hit
-      // zlib while keeping the socket.io extension active. (Setting
-      // perMessageDeflate: false outright triggers a socket.io code path that
-      // breaks message ordering on our backend conat tests -- even with the
-      // dedicated connect-control handshake, dataQueue/flushDataQueue,
-      // publishQueue, Message.respond fire-and-forget safety, persist
-      // stream-initialized error wakeup, and CoreStream waitForLocalPublish
-      // all in place, the basic.test.ts "client first, then server" path
-      // still loses the queued pre-connect writes.  cocalc-ai must rely on
-      // additional plumbing not yet backported here -- defer until we've
-      // identified it.)
-      perMessageDeflate: { threshold: 1 << 30 },
+      // Conat clients always force websocket transport, so make the server
+      // explicit about that and disable the long-poll fallback +
+      // HTTP-level gzip on the router hot path -- most conat traffic is
+      // tiny control-plane messages where transport negotiation + zlib
+      // overhead is pure cost.
+      //
+      // perMessageDeflate stays in threshold-1<<30 mode by default rather
+      // than `false`, even though the cocalc-ai/main upstream does set it
+      // to `false`.  Empirically, `perMessageDeflate: false` on top of
+      // this branch's stack still loses queued pre-connect writes in
+      // basic.test.ts "client first, then server" -- there is additional
+      // plumbing on cocalc-ai/main (suspected: sequential await handleMesg
+      // + publishQueue + transport-scoped liveness 8b5668f83e + idle stats
+      // suppression 8f2ae20611) that we have not yet identified as a
+      // minimal sufficient set.  Sequential await alone or with
+      // publishQueue both regressed cluster.test.ts cross-cluster connect
+      // when tried here, so we keep the threshold workaround.  The threshold
+      // already eliminates per-message zlib cost; what we lose vs `false`
+      // is just the ws-extension's send-pipeline overhead, which is small.
+      //
+      // `socketIoCompressionEnabled()` is an operational escape hatch:
+      // set COCALC_CONAT_SOCKET_IO_COMPRESSION=1 (or true/yes) at process
+      // start to flip to full perMessageDeflate (default 1024-byte
+      // threshold) for benchmarking or rollback without a redeploy.
+      transports: ["websocket" as const],
+      httpCompression: socketIoCompression,
+      perMessageDeflate: socketIoCompression
+        ? true
+        : { threshold: 1 << 30 },
     };
     this.log(socketioOptions);
     if (httpServer) {

--- a/src/packages/conat/core/server.ts
+++ b/src/packages/conat/core/server.ts
@@ -262,7 +262,14 @@ export class ConatServer extends EventEmitter {
       // control-plane messages, so a 1 GiB threshold means messages never hit
       // zlib while keeping the socket.io extension active. (Setting
       // perMessageDeflate: false outright triggers a socket.io code path that
-      // breaks message ordering on our backend conat tests.)
+      // breaks message ordering on our backend conat tests -- even with the
+      // dedicated connect-control handshake, dataQueue/flushDataQueue,
+      // publishQueue, Message.respond fire-and-forget safety, persist
+      // stream-initialized error wakeup, and CoreStream waitForLocalPublish
+      // all in place, the basic.test.ts "client first, then server" path
+      // still loses the queued pre-connect writes.  cocalc-ai must rely on
+      // additional plumbing not yet backported here -- defer until we've
+      // identified it.)
       perMessageDeflate: { threshold: 1 << 30 },
     };
     this.log(socketioOptions);

--- a/src/packages/conat/core/server.ts
+++ b/src/packages/conat/core/server.ts
@@ -1825,8 +1825,10 @@ export class ConatServer extends EventEmitter {
         throw Error("timeout");
       }
       try {
-        // if signal is set only wait for the change for up to 1 second.
-        await once(this.interest, "change", signal != null ? 1000 : undefined);
+        // Always recheck every 1s so a "change" that lands between
+        // hasMatch() and the once() listener registration cannot stall
+        // this waiter until an unrelated future interest update.
+        await once(this.interest, "change", 1000);
       } catch {
         continue;
       }

--- a/src/packages/conat/persist/server.ts
+++ b/src/packages/conat/persist/server.ts
@@ -169,8 +169,14 @@ export function server({
           socket.emit("stream-initialized");
         } catch (err) {
           error = `${err}`;
-          errorCode = err.code;
+          errorCode =
+            err.code ??
+            (error.includes("permission denied") ? 403 : undefined);
           socket.write(null, { headers: { error, code: errorCode } });
+          // Wake any pending `await once(socket, "stream-initialized")`
+          // waiters in the request handler below so they re-check `error`
+          // and rethrow instead of stalling to the request timeout.
+          socket.emit("stream-initialized");
         }
       }
     });

--- a/src/packages/conat/service/service.ts
+++ b/src/packages/conat/service/service.ts
@@ -57,11 +57,22 @@ export async function callConatService(opts: ServiceCall): Promise<any> {
   const timeout = opts.timeout ?? DEFAULT_TIMEOUT;
   // ensure not undefined, since undefined can't be published.
   const data = opts.mesg ?? null;
+  const start = Date.now();
 
   const doRequest = async () => {
+    // Wait for interest in `subject` first (when retrying is allowed) and
+    // then issue the request with the remaining budget.  Splitting these
+    // gives the request itself a clean `waitForInterest:false` so it cannot
+    // get tangled up with cluster-side wait machinery during the publish.
+    const canPrewait =
+      !opts.noRetry && typeof cn.waitForInterest == "function";
+    if (canPrewait) {
+      await cn.waitForInterest(subject, { timeout });
+    }
+    const remaining = Math.max(1, timeout - (Date.now() - start));
     resp = await cn.request(subject, data, {
-      timeout,
-      waitForInterest: !opts.noRetry,
+      timeout: canPrewait ? remaining : timeout,
+      waitForInterest: !opts.noRetry && !canPrewait,
     });
     const result = resp.data;
     if (result?.error) {

--- a/src/packages/conat/service/typed.ts
+++ b/src/packages/conat/service/typed.ts
@@ -1,12 +1,86 @@
 import {
   callConatService,
   createConatService,
-  pingConatService,
-  waitForConatService,
+  serviceSubject,
   type ConatService,
 } from "./service";
 import type { Options, ServiceCall } from "./service";
+import { until } from "@cocalc/util/async-utils";
+import { conat } from "@cocalc/conat/client";
+import { randomId } from "@cocalc/conat/names";
+import { DataEncoding, decode, encode } from "../core/codec";
 export type { ConatService };
+
+type ServiceTransport = "fast-rpc" | "request";
+
+interface TypedServiceCall extends Omit<ServiceCall, "mesg"> {
+  mesg: { name: string; args: any[] };
+  transport?: ServiceTransport;
+}
+
+type TypedServiceOptions = Omit<TypedServiceCall, "mesg">;
+
+const FAST_RPC_PING = "__conat_ping";
+const TYPED_SERVICE_ENCODING = DataEncoding.MsgPack;
+const MAX_FAST_RPC_TYPED_SERVICE_BYTES = 4 * 1024 * 1024;
+
+function serviceTransport(options: { transport?: ServiceTransport }) {
+  return (
+    options.transport ??
+    (process.env.COCALC_CONAT_SERVICE_TRANSPORT == "request"
+      ? "request"
+      : "fast-rpc")
+  );
+}
+
+async function callTypedConatService({
+  transport,
+  ...options
+}: TypedServiceCall): Promise<any> {
+  if (serviceTransport({ transport }) == "request") {
+    return await callConatService(options);
+  }
+  const raw = encode({ encoding: TYPED_SERVICE_ENCODING, mesg: options.mesg });
+  if (raw.length > MAX_FAST_RPC_TYPED_SERVICE_BYTES) {
+    return await callConatService(options);
+  }
+  const cn = options.client ?? (await conat());
+  let response;
+  try {
+    response = await cn.fastRpcRequest(
+      serviceSubject(options),
+      { raw },
+      { timeout: options.timeout },
+    );
+  } catch (err) {
+    if ((err as any)?.code == 413 || `${err}`.includes("disconnected")) {
+      return await callConatService(options);
+    }
+    throw err;
+  }
+  if (
+    response?.error &&
+    (response.code == 413 || `${response.error}`.includes("too large"))
+  ) {
+    return await callConatService(options);
+  }
+  if (response?.raw == null) {
+    throw Error("fast-rpc typed service response is missing raw payload");
+  }
+  return decode({ encoding: TYPED_SERVICE_ENCODING, data: response?.raw });
+}
+
+function requireFastRpcSizedRaw(mesg: any): Uint8Array {
+  const raw = encode({ encoding: TYPED_SERVICE_ENCODING, mesg });
+  if (raw.length > MAX_FAST_RPC_TYPED_SERVICE_BYTES) {
+    const err = new Error(
+      `typed service response too large for fast-rpc (${raw.length} bytes)`,
+    );
+    (err as any).code = 413;
+    throw err;
+  }
+  return raw;
+}
 
 export interface Extra {
   ping: (opts?: { maxWait?: number }) => Promise<void>;
@@ -17,7 +91,7 @@ export interface ServiceApi {
   conat: Extra;
 }
 
-export function createServiceClient<Api>(options: Omit<ServiceCall, "mesg">) {
+export function createServiceClient<Api>(options: TypedServiceOptions) {
   return new Proxy(
     {},
     {
@@ -27,21 +101,24 @@ export function createServiceClient<Api>(options: Omit<ServiceCall, "mesg">) {
         }
         if (prop == "conat") {
           return {
-            ping: async (opts: { id?: string; maxWait?: number } = {}) =>
-              await pingConatService({ options, ...opts }),
+            ping: async (opts: { maxWait?: number } = {}) =>
+              await pingTypedConatService({ options, ...opts }),
             waitFor: async (opts: { maxWait?: number } = {}) =>
-              await waitForConatService({ options, ...opts }),
+              await waitForTypedConatService({ options, ...opts }),
           };
         }
         return async (...args) => {
           try {
-            return await callConatService({
+            return await callTypedConatService({
               ...options,
               mesg: { name: prop, args },
             });
           } catch (err) {
-            err.message = `calling remote function '${prop}': ${err.message}`;
-            throw err;
+            if (err instanceof Error) {
+              err.message = `calling remote function '${prop}': ${err.message}`;
+              throw err;
+            }
+            throw Error(`calling remote function '${prop}': ${err}`);
           }
         };
       },
@@ -52,9 +129,115 @@ export function createServiceClient<Api>(options: Omit<ServiceCall, "mesg">) {
 export function createServiceHandler<Api>({
   impl,
   ...options
-}: Omit<Options, "handler"> & { impl: Api }): ConatService {
-  return createConatService({
+}: Omit<Options, "handler"> & {
+  impl: Api;
+  transport?: ServiceTransport;
+}): ConatService {
+  if (serviceTransport(options) == "request") {
+    return createConatService({
+      ...options,
+      handler: async (mesg) => await impl[mesg.name](...mesg.args),
+    });
+  }
+  const subject = serviceSubject(options);
+  let closed = false;
+  let handle: { close: () => void; stop: () => void } | undefined;
+  void (async () => {
+    const cn = options.client ?? (await conat());
+    handle = await cn.fastRpcService(
+      subject,
+      async ({ raw }: { raw: Uint8Array }) => {
+        const mesg = decode({ encoding: TYPED_SERVICE_ENCODING, data: raw });
+        if (mesg?.name == FAST_RPC_PING) {
+          return {
+            raw: requireFastRpcSizedRaw("pong"),
+          };
+        }
+        const name = mesg?.name;
+        const args = mesg?.args ?? [];
+        if (typeof name != "string" || typeof impl[name] != "function") {
+          throw Error(`unknown service method '${String(name)}'`);
+        }
+        return {
+          raw: requireFastRpcSizedRaw(await impl[name](...args)),
+        };
+      },
+      { queue: options.all ? randomId() : "0" },
+    );
+    if (closed) {
+      handle.close();
+    }
+  })();
+  const legacyService = createConatService({
     ...options,
     handler: async (mesg) => await impl[mesg.name](...mesg.args),
   });
+
+  return {
+    subject,
+    name: options.service,
+    close: () => {
+      closed = true;
+      handle?.close();
+      legacyService.close();
+    },
+    stop: () => {
+      closed = true;
+      handle?.stop();
+      legacyService.close();
+    },
+  } as unknown as ConatService;
+}
+
+async function pingTypedConatService({
+  options,
+  maxWait = 3000,
+}: {
+  options: TypedServiceOptions;
+  maxWait?: number;
+}): Promise<string[]> {
+  if (serviceTransport(options) == "request") {
+    const pong = await callConatService({
+      ...options,
+      mesg: "ping",
+      timeout: Math.max(3000, maxWait),
+      noRetry: true,
+    });
+    return [pong];
+  }
+  const pong = await callTypedConatService({
+    ...options,
+    mesg: { name: FAST_RPC_PING, args: [] },
+    timeout: Math.max(3000, maxWait),
+  });
+  return [pong];
+}
+
+async function waitForTypedConatService({
+  options,
+  maxWait = 60000,
+}: {
+  options: TypedServiceOptions;
+  maxWait?: number;
+}) {
+  let ping: string[] = [];
+  let pingMaxWait = 250;
+  await until(
+    async () => {
+      pingMaxWait = Math.min(3000, pingMaxWait * 1.4);
+      try {
+        ping = await pingTypedConatService({ options, maxWait: pingMaxWait });
+        return ping.length > 0;
+      } catch {
+        return false;
+      }
+    },
+    {
+      start: 1000,
+      max: 10000,
+      decay: 1.3,
+      timeout: maxWait,
+    },
+  );
+  return ping;
 }

--- a/src/packages/conat/service/typed.ts
+++ b/src/packages/conat/service/typed.ts
@@ -40,11 +40,14 @@ async function callTypedConatService({
   if (serviceTransport({ transport }) == "request") {
     return await callConatService(options);
   }
+  const cn = options.client ?? (await conat());
+  if (typeof cn.fastRpcRequest != "function") {
+    return await callConatService(options);
+  }
   const raw = encode({ encoding: TYPED_SERVICE_ENCODING, mesg: options.mesg });
   if (raw.length > MAX_FAST_RPC_TYPED_SERVICE_BYTES) {
     return await callConatService(options);
   }
-  const cn = options.client ?? (await conat());
   let response;
   try {
     response = await cn.fastRpcRequest(
@@ -53,7 +56,12 @@ async function callTypedConatService({
       { timeout: options.timeout },
     );
   } catch (err) {
-    if ((err as any)?.code == 413 || `${err}`.includes("disconnected")) {
+    const message = `${err}`;
+    if (
+      (err as any)?.code == 413 ||
+      message.includes("disconnected") ||
+      message.includes("no services matching")
+    ) {
       return await callConatService(options);
     }
     throw err;

--- a/src/packages/conat/socket/client.ts
+++ b/src/packages/conat/socket/client.ts
@@ -23,12 +23,27 @@ const logger = getLogger("socket:client");
 // DO NOT directly instantiate here -- instead, call the
 // socket.connect method on ConatClient.
 
+// Schedule a callback for the next event-loop turn.  Falls back to
+// setTimeout(..., 0) if setImmediate isn't available (e.g. jsdom).
+const nextTurn = (f: () => void) => {
+  if (typeof globalThis.setImmediate == "function") {
+    globalThis.setImmediate(f);
+  } else {
+    setTimeout(f, 0);
+  }
+};
+
 export class ConatSocketClient extends ConatSocketBase {
   queuedWrites: { data: any; headers?: Headers }[] = [];
   private tcp?: TCP;
   private alive?: KeepAlive;
   private serverId?: string;
   private loadBalancer?: (subject:string) => Promise<string>;
+  // Inbound `data` events are buffered and emitted one per event-loop
+  // turn so back-to-back data events don't get coalesced from the
+  // perspective of synchronous EventEmitter consumers.
+  private dataQueue: { data: any; headers?: Headers }[] = [];
+  private dataQueueScheduled = false;
   // For the connect-control handshake: each connect attempt gets a unique id
   // we tag onto the publish so the matching `connected` reply can be
   // correlated.  Not strictly required for correctness today but lets us
@@ -103,12 +118,46 @@ export class ConatSocketClient extends ConatSocketBase {
     this.client.on("disconnected", this.tcp.send.resendLastUntilAcked);
 
     this.tcp.recv.on("message", (mesg) => {
-      this.emit("data", mesg.data, mesg.headers);
+      this.enqueueData(mesg.data, mesg.headers);
     });
     this.tcp.send.on("drain", () => {
       this.emit("drain");
     });
   }
+
+  private enqueueData = (data: any, headers?: Headers) => {
+    this.dataQueue.push({ data, headers });
+    this.scheduleDataDelivery();
+  };
+
+  private scheduleDataDelivery = () => {
+    if (this.dataQueueScheduled) {
+      return;
+    }
+    this.dataQueueScheduled = true;
+    nextTurn(() => {
+      this.dataQueueScheduled = false;
+      const mesg = this.dataQueue.shift();
+      if (mesg == null || this.state == "closed") {
+        return;
+      }
+      this.emit("data", mesg.data, mesg.headers);
+      if (this.dataQueue.length > 0) {
+        this.scheduleDataDelivery();
+      }
+    });
+  };
+
+  // Synchronously drain pending data events.  Used by the request path
+  // so a request handler sees any preceding data first.
+  flushDataQueue = () => {
+    while (this.dataQueue.length > 0 && this.state != "closed") {
+      const mesg = this.dataQueue.shift();
+      if (mesg != null) {
+        this.emit("data", mesg.data, mesg.headers);
+      }
+    }
+  };
 
   waitUntilDrain = async () => {
     await this.tcp?.send.waitUntilDrain();
@@ -214,6 +263,9 @@ export class ConatSocketClient extends ConatSocketBase {
       } else if (cmd == "ping") {
         mesg.respondSync(null);
       } else if (mesg.isRequest()) {
+        // Flush any pending data events first so the request handler
+        // sees them in order, not after the request.
+        this.flushDataQueue();
         this.emit("request", mesg);
       } else {
         this.tcp?.recv.process(mesg);

--- a/src/packages/conat/socket/client.ts
+++ b/src/packages/conat/socket/client.ts
@@ -8,6 +8,7 @@ import { ConatSocketBase } from "./base";
 import { type TCP, createTCP } from "./tcp";
 import {
   SOCKET_HEADER_CMD,
+  SOCKET_HEADER_CONNECT_ATTEMPT,
   DEFAULT_COMMAND_TIMEOUT,
   type ConatSocketOptions,
   serverStatusSubject,
@@ -15,7 +16,7 @@ import {
 import { EventIterator } from "@cocalc/util/event-iterator";
 import { keepAlive, KeepAlive } from "./keepalive";
 import { getLogger } from "@cocalc/conat/client";
-import { until } from "@cocalc/util/async-utils";
+import { once } from "@cocalc/util/async-utils";
 
 const logger = getLogger("socket:client");
 
@@ -28,6 +29,12 @@ export class ConatSocketClient extends ConatSocketBase {
   private alive?: KeepAlive;
   private serverId?: string;
   private loadBalancer?: (subject:string) => Promise<string>;
+  // For the connect-control handshake: each connect attempt gets a unique id
+  // we tag onto the publish so the matching `connected` reply can be
+  // correlated.  Not strictly required for correctness today but lets us
+  // ignore stale `connected` replies after disconnect+reconnect.
+  private nextConnectAttemptId = 0;
+  private connectAttempts = new Set<number>();
 
   constructor(opts: ConatSocketOptions) {
     super(opts);
@@ -108,7 +115,7 @@ export class ConatSocketClient extends ConatSocketBase {
   };
 
   private sendCommandToServer = async (
-    cmd: "close" | "ping" | "connect",
+    cmd: "close" | "ping",
     timeout = DEFAULT_COMMAND_TIMEOUT,
   ) => {
     const headers = {
@@ -120,7 +127,6 @@ export class ConatSocketClient extends ConatSocketBase {
     const resp = await this.client.request(subject, null, {
       headers,
       timeout,
-      waitForInterest: cmd == "connect", // connect is exactly when other side might not be visible yet.
     });
 
     const value = resp.data;
@@ -130,6 +136,40 @@ export class ConatSocketClient extends ConatSocketBase {
     } else {
       return value;
     }
+  };
+
+  // Fire-and-forget publish of a `connect` control message to the server.
+  // The reply (`connected`) lands on the client subject we already
+  // subscribed to, and is handled by handleConnected below.
+  private sendConnectCommand = () => {
+    const attempt = this.nextConnectAttemptId++;
+    this.connectAttempts.add(attempt);
+    const subject = this.serverSubject();
+    logger.silly("sendConnectCommand", { attempt, subject });
+    this.client.publishSync(subject, null, {
+      headers: {
+        [SOCKET_HEADER_CMD]: "connect",
+        [SOCKET_HEADER_CONNECT_ATTEMPT]: attempt,
+        id: this.id,
+      },
+    });
+  };
+
+  private handleConnected = (mesg) => {
+    if (this.state == "ready" || this.state == "closed") {
+      return;
+    }
+    const rawAttempt = mesg.headers?.[SOCKET_HEADER_CONNECT_ATTEMPT];
+    const attempt =
+      typeof rawAttempt == "number" ? rawAttempt : Number(rawAttempt);
+    if (!Number.isFinite(attempt) || !this.connectAttempts.has(attempt)) {
+      // stale or unrelated reply -- ignore
+      return;
+    }
+    this.connectAttempts.clear();
+    this.setState("ready");
+    this.alive?.recv();
+    this.initKeepAlive();
   };
 
   private getServerId = async () => {
@@ -148,75 +188,90 @@ export class ConatSocketClient extends ConatSocketBase {
     this.serverId = id;
   };
 
+  // Drives the client subscription loop.  Started concurrently with
+  // waitForConnected() so we are already consuming the subscription before
+  // the server's `connected` control message arrives.
+  private processMessages = async () => {
+    if (this.sub == null) {
+      return;
+    }
+    for await (const mesg of this.sub) {
+      if ((this.state as any) == "closed") {
+        return;
+      }
+      this.alive?.recv();
+      const cmd = mesg.headers?.[SOCKET_HEADER_CMD];
+      if (cmd) {
+        logger.silly("client got cmd", cmd);
+      }
+      if (cmd == "connected") {
+        this.handleConnected(mesg);
+      } else if (cmd == "socket") {
+        this.tcp?.send.handleRequest(mesg);
+      } else if (cmd == "close") {
+        this.close();
+        return;
+      } else if (cmd == "ping") {
+        mesg.respondSync(null);
+      } else if (mesg.isRequest()) {
+        this.emit("request", mesg);
+      } else {
+        this.tcp?.recv.process(mesg);
+      }
+    }
+  };
+
+  // Backoff loop: publish a `connect` control message and wait up to
+  // `timeoutMs` for the matching `connected` reply (which lands in
+  // processMessages and flips state to "ready").  If we time out, retry
+  // with a longer budget.
+  private waitForConnected = async () => {
+    let timeoutMs = 500;
+    while (
+      (this.state as any) != "closed" &&
+      (this.state as any) != "ready"
+    ) {
+      this.sendConnectCommand();
+      try {
+        await once(this, "ready", timeoutMs);
+        return;
+      } catch {
+        // timed out waiting for `connected` -- retry with backoff
+      }
+      timeoutMs = Math.min(10_000, Math.round(timeoutMs * 1.3));
+    }
+  };
+
   protected async run() {
     if (this.state == "closed") {
       return;
     }
-    //     console.log(
-    //       "client socket -- subscribing to ",
-    //       `${this.subject}.client.${this.id}`,
-    //     );
+    // Drop any stale connect-attempt ids from a previous session so a late
+    // `connected` reply for an aborted attempt cannot mark this session
+    // ready prematurely.
+    this.connectAttempts.clear();
     try {
       await this.getServerId();
-
       logger.silly("run: getting subscription");
-      const sub = await this.client.subscribe(
+      // subscribeSync so we are already buffering inbound messages by the
+      // time we publish the `connect` control message.  The server's
+      // `connected` reply must not be missed.
+      this.sub = this.client.subscribeSync(
         `${this.subject}.client.${this.id}`,
       );
       // @ts-ignore
       if (this.state == "closed") {
-        sub.close();
+        this.sub.close();
         return;
       }
-      // the disconnect function does this.sub.close()
-      this.sub = sub;
-      let resp: any = undefined;
-      await until(
-        async () => {
-          if (this.state == "closed") {
-            logger.silly("closed -- giving up on connecting");
-            return true;
-          }
-          try {
-            logger.silly("sending connect command to server", this.subject);
-            resp = await this.sendCommandToServer("connect");
-            this.alive?.recv();
-            return true;
-          } catch (err) {
-            logger.silly("failed to connect", this.subject, err);
-          }
-          return false;
-        },
-        { start: 500, decay: 1.3, max: 10000 },
-      );
-
-      if (resp != "connected") {
+      // Start consuming the subscription concurrently with the connect
+      // handshake so the `connected` reply is processed when it arrives.
+      const messagesDone = this.processMessages();
+      await this.waitForConnected();
+      if ((this.state as any) != "ready") {
         throw Error("failed to connect");
       }
-      this.setState("ready");
-      this.initKeepAlive();
-      for await (const mesg of this.sub) {
-        this.alive?.recv();
-        const cmd = mesg.headers?.[SOCKET_HEADER_CMD];
-        if (cmd) {
-          logger.silly("client got cmd", cmd);
-        }
-        if (cmd == "socket") {
-          this.tcp?.send.handleRequest(mesg);
-        } else if (cmd == "close") {
-          this.close();
-          return;
-        } else if (cmd == "ping") {
-          // logger.silly("responding to ping from server", this.id);
-          mesg.respondSync(null);
-        } else if (mesg.isRequest()) {
-          // logger.silly("client got request");
-          this.emit("request", mesg);
-        } else {
-          // logger.silly("client got data"); //, { data: mesg.data });
-          this.tcp?.recv.process(mesg);
-        }
-      }
+      await messagesDone;
     } catch (err) {
       logger.silly("socket connect failed", err);
       this.disconnect();
@@ -281,6 +336,7 @@ export class ConatSocketClient extends ConatSocketBase {
     if (this.state == "closed") {
       return;
     }
+    this.connectAttempts.clear();
     this.sub?.close();
     if (this.tcp != null) {
       this.client.removeListener(

--- a/src/packages/conat/socket/client.ts
+++ b/src/packages/conat/socket/client.ts
@@ -205,7 +205,11 @@ export class ConatSocketClient extends ConatSocketBase {
   };
 
   private handleConnected = (mesg) => {
-    if (this.state == "ready" || this.state == "closed") {
+    // Only accept "connected" while we are actively connecting.  Any other
+    // state means the reply is stale: state == "ready" already handshook,
+    // state == "disconnected" or "closed" means the session has been torn
+    // down -- a delayed reply must not promote the socket back to ready.
+    if (this.state != "connecting") {
       return;
     }
     const rawAttempt = mesg.headers?.[SOCKET_HEADER_CONNECT_ATTEMPT];
@@ -277,12 +281,14 @@ export class ConatSocketClient extends ConatSocketBase {
   // `timeoutMs` for the matching `connected` reply (which lands in
   // processMessages and flips state to "ready").  If we time out, retry
   // with a longer budget.
+  //
+  // Only loop while state == "connecting".  If base.disconnect() flipped
+  // us to "disconnected", reconnect logic in base will start a fresh
+  // connect via base.connect() which calls run() again -- this loop must
+  // not keep publishing on a torn-down attempt.
   private waitForConnected = async () => {
     let timeoutMs = 500;
-    while (
-      (this.state as any) != "closed" &&
-      (this.state as any) != "ready"
-    ) {
+    while (this.state == "connecting") {
       this.sendConnectCommand();
       try {
         await once(this, "ready", timeoutMs);

--- a/src/packages/conat/socket/server-socket.ts
+++ b/src/packages/conat/socket/server-socket.ts
@@ -16,6 +16,16 @@ import { getLogger } from "@cocalc/conat/client";
 
 const logger = getLogger("socket:server-socket");
 
+// Schedule a callback for the next event-loop turn.  Falls back to
+// setTimeout(..., 0) if setImmediate isn't available (e.g. jsdom).
+const nextTurn = (f: () => void) => {
+  if (typeof globalThis.setImmediate == "function") {
+    globalThis.setImmediate(f);
+  } else {
+    setTimeout(f, 0);
+  }
+};
+
 // One specific socket from the point of view of a server.
 export class ServerSocket extends EventEmitter {
   private conatSocket: ConatSocketServer;
@@ -24,6 +34,15 @@ export class ServerSocket extends EventEmitter {
 
   private queuedWrites: { data: any; headers?: Headers }[] = [];
   public readonly clientSubject: string;
+
+  // Inbound `data` events are buffered and emitted one per event-loop
+  // turn so back-to-back data events don't get coalesced from the
+  // perspective of synchronous EventEmitter consumers (which would
+  // otherwise miss intermediate events when the consumer awaits between
+  // them).  A request handler that needs ordered data must call
+  // flushDataQueue() to drain pending entries synchronously first.
+  private dataQueue: { data: any; headers?: Headers }[] = [];
+  private dataQueueScheduled = false;
 
   public state: State = "ready";
   // the non-pattern subject the client connected to
@@ -91,13 +110,46 @@ export class ServerSocket extends EventEmitter {
     );
 
     this.tcp.recv.on("message", (mesg) => {
-      // console.log("tcp recv emitted message", mesg.data);
-      this.emit("data", mesg.data, mesg.headers);
+      this.enqueueData(mesg.data, mesg.headers);
     });
     this.tcp.send.on("drain", () => {
       this.emit("drain");
     });
   }
+
+  private enqueueData = (data: any, headers?: Headers) => {
+    this.dataQueue.push({ data, headers });
+    this.scheduleDataDelivery();
+  };
+
+  private scheduleDataDelivery = () => {
+    if (this.dataQueueScheduled) {
+      return;
+    }
+    this.dataQueueScheduled = true;
+    nextTurn(() => {
+      this.dataQueueScheduled = false;
+      const mesg = this.dataQueue.shift();
+      if (mesg == null || this.state == "closed") {
+        return;
+      }
+      this.emit("data", mesg.data, mesg.headers);
+      if (this.dataQueue.length > 0) {
+        this.scheduleDataDelivery();
+      }
+    });
+  };
+
+  // Synchronously drain pending data events.  Used by the server's
+  // request path so a request handler sees any preceding data first.
+  flushDataQueue = () => {
+    while (this.dataQueue.length > 0 && this.state != "closed") {
+      const mesg = this.dataQueue.shift();
+      if (mesg != null) {
+        this.emit("data", mesg.data, mesg.headers);
+      }
+    }
+  };
 
   disconnect = () => {
     this.setState("disconnected");

--- a/src/packages/conat/socket/server.ts
+++ b/src/packages/conat/socket/server.ts
@@ -132,6 +132,9 @@ export class ConatSocketServer extends ConatSocketBase {
       this.handleCommandFromClient({ socket, cmd: cmd as Command, mesg });
     } else if (mesg.isRequest()) {
       // a request to support the socket.on('request', (mesg) => ...) protocol:
+      // Flush any pending data events first so the request handler sees
+      // them in order, not after the request.
+      socket.flushDataQueue();
       socket.emit("request", mesg);
     } else {
       socket.receiveDataFromClient(mesg);

--- a/src/packages/conat/socket/server.ts
+++ b/src/packages/conat/socket/server.ts
@@ -3,6 +3,7 @@ import {
   PING_PONG_INTERVAL,
   type Command,
   SOCKET_HEADER_CMD,
+  SOCKET_HEADER_CONNECT_ATTEMPT,
   clientSubject,
   serverStatusSubject,
 } from "./util";
@@ -214,9 +215,22 @@ export class ConatSocketServer extends ConatSocketBase {
       delete this.sockets[id];
       mesg.respondSync("closed");
     } else if (cmd == "connect") {
-      // very important that connected is successfully delivered, so do not use respondSync.
-      // Using respond waits for interest.
-      mesg.respond("connected", { noThrow: true });
+      // Dedicated connect-control handshake: instead of replying to the
+      // client's request inbox, publish a `connected` control message to the
+      // client subject the client has already subscribed to.  By the time we
+      // reach here the new-connection branch above has already awaited
+      // waitForInterest(socket.clientSubject), so the publish is delivered
+      // through the same path the rest of the socket lifetime uses.  This
+      // avoids coupling the connect step to generic request/reply machinery
+      // (inboxes, reply subscriptions, request timeouts), which is
+      // particularly fragile across cluster nodes.
+      this.client.publishSync(socket.clientSubject, null, {
+        headers: {
+          [SOCKET_HEADER_CMD]: "connected",
+          [SOCKET_HEADER_CONNECT_ATTEMPT]:
+            mesg.headers?.[SOCKET_HEADER_CONNECT_ATTEMPT],
+        },
+      });
     } else {
       mesg.respondSync({ error: `unknown command - '${cmd}'` });
     }

--- a/src/packages/conat/socket/server.ts
+++ b/src/packages/conat/socket/server.ts
@@ -220,19 +220,26 @@ export class ConatSocketServer extends ConatSocketBase {
     } else if (cmd == "connect") {
       // Dedicated connect-control handshake: instead of replying to the
       // client's request inbox, publish a `connected` control message to the
-      // client subject the client has already subscribed to.  By the time we
-      // reach here the new-connection branch above has already awaited
-      // waitForInterest(socket.clientSubject), so the publish is delivered
-      // through the same path the rest of the socket lifetime uses.  This
-      // avoids coupling the connect step to generic request/reply machinery
+      // client subject the client has already subscribed to.  This avoids
+      // coupling the connect step to generic request/reply machinery
       // (inboxes, reply subscriptions, request timeouts), which is
       // particularly fragile across cluster nodes.
-      this.client.publishSync(socket.clientSubject, null, {
+      //
+      // Use async publish with waitForInterest:true, not publishSync: the
+      // new-connection branch above only awaits waitForInterest on the
+      // FIRST connect for a given socket; retry connects (where this.sockets
+      // already has the entry) skip that wait, so a fire-and-forget publish
+      // here could be dropped if the client's subscription has not yet been
+      // re-established post-reconnect.  noThrow keeps it fire-and-forget at
+      // the call site but the publish itself blocks for interest.
+      this.client.publish(socket.clientSubject, null, {
         headers: {
           [SOCKET_HEADER_CMD]: "connected",
           [SOCKET_HEADER_CONNECT_ATTEMPT]:
             mesg.headers?.[SOCKET_HEADER_CONNECT_ATTEMPT],
         },
+        waitForInterest: true,
+        noThrow: true,
       });
     } else {
       mesg.respondSync({ error: `unknown command - '${cmd}'` });

--- a/src/packages/conat/socket/util.ts
+++ b/src/packages/conat/socket/util.ts
@@ -1,5 +1,9 @@
 export const SOCKET_HEADER_CMD = "CN-SocketCmd";
 export const SOCKET_HEADER_SEQ = "CN-SocketSeq";
+// Correlates a client `connect` control message with the server's
+// `connected` reply.  See dedicated connect-control handshake in
+// socket/client.ts and socket/server.ts.
+export const SOCKET_HEADER_CONNECT_ATTEMPT = "CN-SocketConnectAttempt";
 
 export type State = "disconnected" | "connecting" | "ready" | "closed";
 
@@ -41,7 +45,12 @@ export function setDefaultSocketTimeouts({
   DEFAULT_KEEP_ALIVE_TIMEOUT = keepAliveTimeout;
 }
 
-export type Command = "connect" | "close" | "ping" | "socket";
+export type Command =
+  | "connect"
+  | "connected"
+  | "close"
+  | "ping"
+  | "socket";
 
 import { type Client } from "@cocalc/conat/core/client";
 

--- a/src/packages/conat/sync/core-stream.ts
+++ b/src/packages/conat/sync/core-stream.ts
@@ -534,6 +534,7 @@ export class CoreStream<T = any> extends EventEmitter {
       raw: data,
       key,
     } as RawMsg;
+    let alreadyProcessed = false;
     if (seq > (this.raw.slice(-1)[0]?.seq ?? 0)) {
       // easy fast initial load to the end of the list (common special case)
       this.messages.push(mesg);
@@ -559,7 +560,25 @@ export class CoreStream<T = any> extends EventEmitter {
       } else if (this.raw[i].seq > seq) {
         this.raw.splice(i, 0, raw);
         this.messages.splice(i, 0, mesg);
-      } // other case -- we already have it.
+      } else {
+        // this.raw[i].seq === seq -- already have it.
+        alreadyProcessed = true;
+      }
+    }
+    if (alreadyProcessed) {
+      // Even though the seq is already stored, downstream consumers
+      // (DKV save loops, changefeed waiters) may still be holding local
+      // state that needs to clear once they see this seq as delivered
+      // again.  Re-emit so they can converge.
+      let prev: T | undefined = undefined;
+      if (typeof key == "string") {
+        prev = this.kv[key]?.mesg ?? this.lastValueByKey.get(key);
+      }
+      this.lastSeq = Math.max(this.lastSeq, seq);
+      if (!noEmit) {
+        this.emitChange({ mesg, raw, key, prev, msgID });
+      }
+      return;
     }
     let prev: T | undefined = undefined;
     // Issue #8702: Capture the previous raw message for this key BEFORE updating this.kv.
@@ -765,6 +784,35 @@ export class CoreStream<T = any> extends EventEmitter {
     return this.raw[n]?.headers;
   };
 
+  // After a successful publish/setKv/setKvMany, wait until the local
+  // changefeed has caught up to the published seq.  Without this, a
+  // caller that publishes and then immediately reads back can race:
+  // the persistence layer has accepted the write but our own
+  // raw/messages/kv reflection of it hasn't been delivered yet.
+  // Returns when the local mirror is consistent (or this stream is
+  // closed, or the timeout elapses).
+  private waitForLocalPublish = async (
+    x: { seq: number },
+    options?: PublishOptions,
+  ) => {
+    await until(
+      () => {
+        if (this.raw == null) {
+          // closed -- give up cleanly
+          return true;
+        }
+        if (options?.key != null) {
+          if (options.headers?.[COCALC_TOMBSTONE_HEADER]) {
+            return this.lastSeq >= x.seq && this.kv[options.key] == null;
+          }
+          return this.kv[options.key]?.raw.seq === x.seq;
+        }
+        return this.lastSeq >= x.seq;
+      },
+      { start: 1, min: 1, max: 25, timeout: options?.timeout ?? 5000 },
+    );
+  };
+
   // key:value interface for subset of messages pushed with key option set.
   // NOTE: This does NOT throw an error if our local seq is out of date (leave that
   // to dkv built on this).
@@ -774,9 +822,17 @@ export class CoreStream<T = any> extends EventEmitter {
     options?: {
       headers?: Headers;
       previousSeq?: number;
+      msgID?: string;
+      ttl?: number;
+      timeout?: number;
     },
   ): Promise<{ seq: number; time: number } | undefined> => {
-    return await this.publish(mesg, { ...options, key });
+    const publishOptions = { ...options, key };
+    const x = await this.publish(mesg, publishOptions);
+    if (x != null) {
+      await this.waitForLocalPublish(x, publishOptions);
+    }
+    return x;
   };
 
   setKvMany = async (
@@ -795,7 +851,19 @@ export class CoreStream<T = any> extends EventEmitter {
     for (const { key, mesg, options } of x) {
       messages.push({ mesg, options: { ...options, key } });
     }
-    return await this.publishMany(messages);
+    const results = await this.publishMany(messages);
+    // Wait for local convergence on each successful entry.  Errors are
+    // skipped -- nothing to wait for.
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      if (r != null && (r as any).seq != null) {
+        await this.waitForLocalPublish(
+          r as { seq: number },
+          messages[i].options,
+        );
+      }
+    }
+    return results;
   };
 
   deleteKv = async (
@@ -803,18 +871,32 @@ export class CoreStream<T = any> extends EventEmitter {
     options?: {
       msgID?: string;
       previousSeq?: number;
+      // force=true skips the "this.kv[key] is already undefined, nothing
+      // to do" early-return.  Used by DKV to issue a tombstone write
+      // immediately on delete() without waiting for the coalesced save
+      // loop, even when the local view doesn't show the entry.
+      force?: boolean;
+      // waitForLocal=false skips the post-publish waitForLocalPublish
+      // step.  Used by DKV.delete() for fire-and-forget tombstone
+      // writes where the caller manages local state cleanup itself.
+      waitForLocal?: boolean;
     },
   ) => {
-    if (this.kv[key] === undefined) {
+    if (!options?.force && this.kv[key] === undefined) {
       // nothing to do
       return;
     }
-    return await this.publish(null as any, {
+    const publishOptions = {
       ...options,
       headers: { [COCALC_TOMBSTONE_HEADER]: true },
       key,
       ttl: DEFAULT_TOMBSTONE_TTL,
-    });
+    };
+    const x = await this.publish(null as any, publishOptions);
+    if (x != null && options?.waitForLocal !== false) {
+      await this.waitForLocalPublish(x, publishOptions);
+    }
+    return x;
   };
 
   getKv = (key: string): T | undefined => {

--- a/src/packages/conat/sync/dkv.ts
+++ b/src/packages/conat/sync/dkv.ts
@@ -424,8 +424,28 @@ export class DKV<T = any> extends EventEmitter {
 
   delete = (key) => {
     this._delete(key);
-    if (!this.noAutosave) {
-      this.save();
+    if (!this.noAutosave && this.kv != null) {
+      // Start the tombstone write immediately rather than going through
+      // the coalesced save() loop.  Some callers inspect the underlying
+      // stream inventory right after delete -- if that read can overtake
+      // the save loop's write, they see the stale value.  force:true so
+      // we still emit the tombstone even if the local view already shows
+      // the entry as gone; waitForLocal:false because we manage local
+      // state cleanup ourselves below (the save-coalesced path expects
+      // that, and the wait would needlessly block delete()).
+      this.kv
+        .deleteKv(key, { force: true, waitForLocal: false })
+        .then(() => {
+          if (this.local?.[key] === TOMBSTONE) {
+            this.changed.delete(key);
+            this.discardLocalState(key);
+          }
+        })
+        .catch(() => {
+          // Fall back to the coalesced save loop if the direct write
+          // fails (e.g. transient persist server hiccup).
+          this.save();
+        });
     }
   };
 


### PR DESCRIPTION
Trial branch on top of #8869 to validate the Group 1 narrowed scope before force-pushing into the main PR. Should be closed without merge after validation.

Adds on top of #8869:
- `transports: ["websocket"]`
- `httpCompression: false`
- COCALC_CONAT_SOCKET_IO_COMPRESSION env var escape hatch
- `jest.setTimeout(15000)` safeguard on cluster.test.ts

Defers `perMessageDeflate: false` -- still regresses basic.test.ts, see commit message.