### PR TITLE
conat/client: fix reconnect subscription resync (backport from cocalc-ai)

### DIFF
--- a/src/packages/conat/core/client.reconnect.test.ts
+++ b/src/packages/conat/core/client.reconnect.test.ts
@@ -1,0 +1,99 @@
+/*
+DEVELOPMENT:
+
+pnpm test ./client.reconnect.test.ts
+*/
+
+describe("core client subscription resync on reconnect", () => {
+  it("does not unsubscribe subjects the client still wants during resync", async () => {
+    jest.resetModules();
+
+    const emitWithAck = jest
+      .fn()
+      .mockResolvedValueOnce(["wanted.subject"])
+      .mockResolvedValueOnce([]);
+    const socket = {
+      on: jest.fn(),
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+      close: jest.fn(),
+      timeout: jest.fn(() => ({ emitWithAck })),
+      io: {
+        on: jest.fn(),
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+      },
+    };
+    const connectToSocketIO = jest.fn(() => socket);
+
+    jest.doMock("socket.io-client", () => ({
+      connect: connectToSocketIO,
+    }));
+
+    const { Client } = require("./client");
+    const client = new Client({
+      address: "http://example.com",
+      autoConnect: false,
+      noCache: true,
+    });
+    const anyClient = client as any;
+    anyClient.info = { user: { hub_id: "hub" } };
+    anyClient.state = "connected";
+    anyClient.queueGroups = { "wanted.subject": "0" };
+
+    const stable = await anyClient.syncSubscriptions0(1000);
+
+    expect(stable).toBe(true);
+    expect(emitWithAck).toHaveBeenCalledTimes(1);
+    expect(emitWithAck).toHaveBeenCalledWith("subscriptions", null);
+
+    client.close();
+  });
+
+  it("unsubscribes only server-side extras during resync", async () => {
+    jest.resetModules();
+
+    const emitWithAck = jest
+      .fn()
+      .mockResolvedValueOnce(["wanted.subject", "stale.subject"])
+      .mockResolvedValueOnce([]);
+    const socket = {
+      on: jest.fn(),
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+      close: jest.fn(),
+      timeout: jest.fn(() => ({ emitWithAck })),
+      io: {
+        on: jest.fn(),
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+      },
+    };
+    const connectToSocketIO = jest.fn(() => socket);
+
+    jest.doMock("socket.io-client", () => ({
+      connect: connectToSocketIO,
+    }));
+
+    const { Client } = require("./client");
+    const client = new Client({
+      address: "http://example.com",
+      autoConnect: false,
+      noCache: true,
+    });
+    const anyClient = client as any;
+    anyClient.info = { user: { hub_id: "hub" } };
+    anyClient.state = "connected";
+    anyClient.queueGroups = { "wanted.subject": "0" };
+
+    const stable = await anyClient.syncSubscriptions0(1000);
+
+    expect(stable).toBe(false);
+    expect(emitWithAck).toHaveBeenNthCalledWith(1, "subscriptions", null);
+    expect(emitWithAck).toHaveBeenNthCalledWith(2, "unsubscribe", [
+      { subject: "stale.subject" },
+    ]);
+
+    client.close();
+  });
+});

--- a/src/packages/conat/core/client.ts
+++ b/src/packages/conat/core/client.ts
@@ -808,8 +808,8 @@ export class Client extends EventEmitter {
       }
     }
     const extra: { subject: string }[] = [];
-    for (const subject in subs) {
-      if (this.queueGroups[subject] != null) {
+    for (const subject of subs) {
+      if (this.queueGroups[subject] == null) {
         // server thinks we're subscribed but we do not think so, so cancel that
         extra.push({ subject });
       }


### PR DESCRIPTION
## Summary

Backport of [cocalc-ai 29844d13c4](https://github.com/sagemathinc/cocalc-ai/commit/29844d13c4ad1009c964dcadf7ad4e976266c342) (William Stein, 2026-05-01) — a long-standing correctness bug in the Conat client reconnect path.

In `Client.syncSubscriptions0` (the path that reconciles client and server subscription sets after a reconnect), two bugs:

1. The server set was iterated with `for...in`, which yields nothing on a `Set`, making the server-side reconciliation loop a no-op.
2. The check against `queueGroups` was inverted: `if (this.queueGroups[subject] != null)` flagged subjects we *do* want as extras to drop (the comment above it correctly says we should drop subjects we *do not* want).

Fix is two characters: `in` → `of` and `!=` → `==`.

The visible symptom upstream was that long-lived clients (project-host, hub) could lose subscriptions after a hub disconnect, leaving things "connected" but silently broken (timeouts, `no subscribers matching`).

## Changes

- `src/packages/conat/core/client.ts` — the 2-char fix.
- `src/packages/conat/core/client.reconnect.test.ts` — new file, two regression tests for `syncSubscriptions0`. Verified the "unsubscribes only server-side extras" test fails when the fix is reverted; both pass with the fix.

The upstream test file also contains `autoConnect: false` / `reconnection: false` tests; those depend on other cocalc-ai client changes not part of this backport, so they were dropped.

## Test plan

- [x] `pnpm test ./core/client.reconnect.test.ts` in `packages/conat` — 2 passed
- [x] Tests verified to fail on the buggy version (before the fix) and pass after
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)