### PR TITLE
next/landing: hide "Book a Demo" button off cocalc.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ src/packages/frontend/i18n/trans/*.compiled.json
 **/*.bash_history
 
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # test reports by jest-junit
 junit.xml

--- a/src/packages/next/components/landing/live-demo.tsx
+++ b/src/packages/next/components/landing/live-demo.tsx
@@ -22,9 +22,9 @@ interface Props {
 }
 
 export default function LiveDemo({ label, btnType }: Props) {
-  const { supportVideoCall } = useCustomize();
+  const { supportVideoCall, onCoCalcCom } = useCustomize();
 
-  if (!supportVideoCall) {
+  if (!supportVideoCall || !onCoCalcCom) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- The `LiveDemo` button rendered on every feature/landing page hero ([content.tsx:222](src/packages/next/components/landing/content.tsx)) was only gated by `supportVideoCall`. Since `support_video_call` defaults to a non-empty calendly URL in `site-defaults.ts`, the button appeared on on-prem deployments even though the admin UI hides that field there.
- Add `onCoCalcCom` to the gate inside `LiveDemo` so the button only renders on cocalc.com, matching how `header.tsx` already gates its instance.
- Drive-by: ignore `.claude/scheduled_tasks.lock`.

## Test plan
- [ ] On cocalc.com (`kucalc=cocalc-com`): "Book a Demo!" button still visible on `/features/*` hero and signup page.
- [ ] On an on-prem hub (`kucalc=onprem`): "Book a Demo!" button no longer rendered on `/features/*` hero.
- [ ] No regression in header (already gated by `onCoCalcCom`) or footer "Get a Live Demo" link (gated by `enabledPages.liveDemo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)