### PR TITLE
conat/client: respect reconnect options

### DIFF
--- a/src/packages/conat/core/client.reconnect.test.ts
+++ b/src/packages/conat/core/client.reconnect.test.ts
@@ -4,6 +4,77 @@ DEVELOPMENT:
 pnpm test ./client.reconnect.test.ts
 */
 
+function mockSocketIO({ emitWithAck = jest.fn() } = {}) {
+  const socket = {
+    on: jest.fn(),
+    emit: jest.fn(),
+    disconnect: jest.fn(),
+    close: jest.fn(),
+    timeout: jest.fn(() => ({ emitWithAck })),
+    io: {
+      on: jest.fn(),
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    },
+  };
+  const connectToSocketIO = jest.fn(() => socket);
+
+  jest.doMock("socket.io-client", () => ({
+    connect: connectToSocketIO,
+  }));
+
+  return { socket, connectToSocketIO, emitWithAck };
+}
+
+describe("core client socket.io reconnect policy", () => {
+  it("respects reconnection false passed by callers", async () => {
+    jest.resetModules();
+
+    const { connectToSocketIO } = mockSocketIO();
+
+    const { connect } = require("./client");
+    const client = connect({
+      address: "http://example.com",
+      reconnection: false,
+    });
+
+    expect(connectToSocketIO).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        reconnection: false,
+      }),
+    );
+
+    client.close();
+  });
+
+  it("does not auto-connect when callers pass autoConnect false", async () => {
+    jest.resetModules();
+
+    const { connectToSocketIO, socket } = mockSocketIO();
+
+    const { connect } = require("./client");
+    const client = connect({
+      address: "http://example.com",
+      autoConnect: false,
+      noCache: true,
+    });
+
+    expect(connectToSocketIO).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        autoConnect: false,
+      }),
+    );
+    expect(socket.io.connect).not.toHaveBeenCalled();
+
+    client.connect();
+    expect(socket.io.connect).toHaveBeenCalledTimes(1);
+
+    client.close();
+  });
+});
+
 describe("core client subscription resync on reconnect", () => {
   it("does not unsubscribe subjects the client still wants during resync", async () => {
     jest.resetModules();
@@ -12,23 +83,7 @@ describe("core client subscription resync on reconnect", () => {
       .fn()
       .mockResolvedValueOnce(["wanted.subject"])
       .mockResolvedValueOnce([]);
-    const socket = {
-      on: jest.fn(),
-      emit: jest.fn(),
-      disconnect: jest.fn(),
-      close: jest.fn(),
-      timeout: jest.fn(() => ({ emitWithAck })),
-      io: {
-        on: jest.fn(),
-        connect: jest.fn(),
-        disconnect: jest.fn(),
-      },
-    };
-    const connectToSocketIO = jest.fn(() => socket);
-
-    jest.doMock("socket.io-client", () => ({
-      connect: connectToSocketIO,
-    }));
+    mockSocketIO({ emitWithAck });
 
     const { Client } = require("./client");
     const client = new Client({
@@ -57,23 +112,7 @@ describe("core client subscription resync on reconnect", () => {
       .fn()
       .mockResolvedValueOnce(["wanted.subject", "stale.subject"])
       .mockResolvedValueOnce([]);
-    const socket = {
-      on: jest.fn(),
-      emit: jest.fn(),
-      disconnect: jest.fn(),
-      close: jest.fn(),
-      timeout: jest.fn(() => ({ emitWithAck })),
-      io: {
-        on: jest.fn(),
-        connect: jest.fn(),
-        disconnect: jest.fn(),
-      },
-    };
-    const connectToSocketIO = jest.fn(() => socket);
-
-    jest.doMock("socket.io-client", () => ({
-      connect: connectToSocketIO,
-    }));
+    mockSocketIO({ emitWithAck });
 
     const { Client } = require("./client");
     const client = new Client({

--- a/src/packages/conat/core/client.ts
+++ b/src/packages/conat/core/client.ts
@@ -449,11 +449,9 @@ export class Client extends EventEmitter {
       // it is necessary to manually managed reconnects due to a bugs
       // in socketio that has stumped their devs
       //   -- https://github.com/socketio/socket.io/issues/5197
-      // So no matter what options are set, we never use socketio's
-      // reconnection logic. if options.reconnection is true or
-      // not given, then we implement (in this file) reconnect ourselves.
-      // The browser frontend explicit sets options.reconnection false
-      // and uses its own logic.
+      // By default, node clients use socket.io reconnects. The browser
+      // frontend explicitly sets options.reconnection false and uses its own
+      // reconnect loop.
       ...options,
       ...(options.systemAccountPassword
         ? {
@@ -464,7 +462,8 @@ export class Client extends EventEmitter {
           }
         : undefined),
       path,
-      reconnection: true,
+      reconnection:
+        options.reconnection ?? DEFAULT_SOCKETIO_CLIENT_OPTIONS.reconnection,
     });
 
     this.conn.on("info", (info, ack) => {
@@ -500,7 +499,9 @@ export class Client extends EventEmitter {
       this.setState("disconnected");
       this.disconnectAllSockets();
     });
-    this.conn.io.connect();
+    if (options.autoConnect !== false) {
+      this.conn.io.connect();
+    }
     this.initInbox();
     this.statsLoop();
   }
@@ -516,6 +517,10 @@ export class Client extends EventEmitter {
     this.disconnectAllSockets();
     // @ts-ignore
     setTimeout(() => this.conn.io.disconnect(), 1);
+  };
+
+  connect = () => {
+    this.conn.io.connect();
   };
 
   // this has NO timeout by default
@@ -1395,14 +1400,14 @@ export class Client extends EventEmitter {
   };
 
   sync = {
-    dkv: async <T,>(opts: DKVOptions): Promise<DKV<T>> =>
+    dkv: async <T>(opts: DKVOptions): Promise<DKV<T>> =>
       await dkv<T>({ ...opts, client: this }),
-    akv: <T,>(opts: DKVOptions): AKV<T> => akv<T>({ ...opts, client: this }),
-    dko: async <T,>(opts: DKVOptions): Promise<DKO<T>> =>
+    akv: <T>(opts: DKVOptions): AKV<T> => akv<T>({ ...opts, client: this }),
+    dko: async <T>(opts: DKVOptions): Promise<DKO<T>> =>
       await dko<T>({ ...opts, client: this }),
-    dstream: async <T,>(opts: DStreamOptions): Promise<DStream<T>> =>
+    dstream: async <T>(opts: DStreamOptions): Promise<DStream<T>> =>
       await dstream<T>({ ...opts, client: this }),
-    astream: <T,>(opts: DStreamOptions): AStream<T> =>
+    astream: <T>(opts: DStreamOptions): AStream<T> =>
       astream<T>({ ...opts, client: this }),
     synctable: async (opts: SyncTableOptions): Promise<ConatSyncTable> =>
       await createSyncTable({ ...opts, client: this }),


### PR DESCRIPTION
## Summary

- Backport the cocalc-ai Conat reconnect option fixes into mainline.
- Preserve caller-supplied `reconnection: false` instead of forcing Socket.IO reconnects back on.
- Honor `autoConnect: false` so callers can construct a client without immediately opening the socket, and expose `client.connect()` for the explicit start.
- Add regression coverage for both reconnect policy cases alongside the existing subscription resync tests.

## Why

The browser frontend intentionally disables Socket.IO's built-in reconnect behavior and uses its own reconnect loop. Mainline was overriding `reconnection: false` to `true` in the core client constructor, which could leave suspend/resume recovery using the Socket.IO path we meant to avoid.

## Test Plan

- `pnpm exec prettier -w core/client.ts core/client.reconnect.test.ts` in `src/packages/conat`
- `pnpm build` in `src/packages/conat`
- `pnpm test ./core/client.reconnect.test.ts` in `src/packages/conat`
- `pnpm test -- conat/test/core/connect.test.ts` in `src/packages/backend`
- `pnpm test -- conat/test/socket/basic.test.ts` in `src/packages/backend`