### PR TITLE
cookie banner: consent with force-mode on auth pages

### DIFF
--- a/src/docs/auth.md
+++ b/src/docs/auth.md
@@ -281,6 +281,268 @@ another user for debugging/support.
 `packages/server/accounts/is-banned.ts` — banned users are blocked at every
 authentication checkpoint (cookie validation, API key use, SSO login).
 
+## Cookie Consent (GDPR Banner)
+
+CoCalc ships a GDPR-style cookie consent banner powered by
+[vanilla-cookieconsent v3](https://cookieconsent.orestbida.com). It is shared
+between the SPA frontend (`packages/frontend`) and the Next.js landing pages
+(`packages/next`) — same configuration object, same React helpers, no
+duplication.
+
+### Categories and the consent contract
+
+Three categories, with a hard constraint:
+
+| Category    | Read-only? | Default  | Used for                                                                  |
+| ----------- | ---------- | -------- | ------------------------------------------------------------------------- |
+| `necessary` | yes        | accepted | Sign-in, session, `remember_me`, version sync                             |
+| `analytics` | no         | declined | Third-party tracking cookies (Google Analytics, etc.)                     |
+| `usage`     | no         | declined | First-party usage metrics — `TrackingClient.user_tracking` event recording |
+
+The `usage` category gates `frontend/client/tracking.ts#user_tracking`, the
+internal click/toggle/event recorder. Two layers must agree before an event
+is written: the admin-side `user_tracking` server setting AND the visitor's
+acceptance of the `usage` category. If the admin disables the banner site-
+wide, the cookie consent layer collapses to a passthrough and the admin
+setting alone gates (legacy behaviour).
+
+Sign-up, sign-in, and "use anonymously" are blocked until the user
+acknowledges the banner. The Sign In / Sign Up buttons stay disabled and
+show *"Acknowledge cookie banner to continue"*. On `/auth/sign-in`,
+`/auth/sign-up`, and `/auth/try`, the banner runs in **force-consent mode**:
+a dark overlay covers the page and clicks outside the banner are blocked
+(via vanilla-cookieconsent's `disablePageInteraction: true`).
+
+**SSO fallback in the SPA**: a successful SSO callback can drop a
+logged-in user on `/app` without ever passing through the auth-page
+overlay (e.g. when they followed a bookmarked SSO start URL). The SPA's
+root `App` component (`packages/frontend/app/render.tsx`) waits for
+`accountStore.waitUntilReady()` — so the dim never flashes during boot
+for users whose customize/account is still loading — and only then, if
+the user is logged in *and* `hasEssentialConsent()` is false, calls
+`enableForceConsent()`. That helper toggles the same `disable--interaction`
+class on `<html>` that vanilla-cookieconsent uses for its built-in
+overlay, and auto-removes it when the user accepts or declines (via
+`cc:onConsent` / `cc:onChange`). This is belt-and-braces: the auth pages
+already gate the common path; the SPA fallback covers users who reached
+`/app` through any other route.
+
+### Admin settings
+
+Two server settings, both tagged `"Cookie Banner"`:
+
+| Setting key             | Type                | Effect                                       |
+| ----------------------- | ------------------- | -------------------------------------------- |
+| `cookie_banner_enabled` | bool (`yes`/`no`)   | Master on/off — disables the banner entirely |
+| `cookie_banner_text`    | Markdown (multiline) | Body shown in banner + preferences modal     |
+
+Defined in `packages/util/db-schema/site-defaults.ts`. They flow through the
+existing `customize` pipeline:
+
+- **SPA**: `customize.cookie_banner_enabled` / `customize.cookie_banner_text`
+  in the Redux `customize` store
+- **Next.js**: `pageProps.customize.cookieBannerEnabled` /
+  `pageProps.customize.cookieBannerText`
+
+When `cookie_banner_enabled` is `no`, the banner runtime is never
+instantiated and all helpers (`hasEssentialConsent`, `useEssentialConsent`,
+`requireEssentialConsent`) pass through — no gating applied.
+
+### Retrieving consent (this is the public API)
+
+```typescript
+// Synchronous helpers (work in both SPA and Next.js)
+import {
+  hasEssentialConsent,    // user has acknowledged the banner at all
+  hasCategoryConsent,     // generic per-category check: hasCategoryConsent("usage")
+  hasTrackingConsent,     // alias for hasCategoryConsent("analytics")
+  getConsentSnapshot,     // {necessary, analytics, usage, timestamp, revision} | null
+  showPreferences,        // open the preferences modal programmatically
+  showConsentModal,       // re-open the initial banner
+  requireEssentialConsent,// returns true or surfaces the banner
+  enableForceConsent,     // SSO fallback: dim page + show banner until consent
+} from "@cocalc/frontend/cookie-consent";
+
+// React hook — re-renders when consent flips
+import { useEssentialConsent } from "@cocalc/frontend/cookie-consent";
+
+const ready = useEssentialConsent(); // boolean, reactive
+
+// Subscribe to consent changes (use this before loading any analytics
+// script — return early or defer until tracking flips true)
+import { onConsentChange } from "@cocalc/frontend/cookie-consent";
+useEffect(
+  () => onConsentChange((snap) => { /* react to changes */ }),
+  [],
+);
+```
+
+When `cookieBannerEnabled` is false (admin disabled the banner),
+`hasEssentialConsent` and `useEssentialConsent` return `true` so legacy
+callers don't break.
+
+### Adding a new analytics cookie
+
+When wiring up new tracking — Google Analytics, Plausible, internal
+tracking — gate on `hasTrackingConsent()` AND register the cookie name with
+the `analytics` category's `autoClearCookies` in
+`packages/frontend/cookie-consent/categories.ts`:
+
+```typescript
+{
+  key: "analytics",
+  label: "Analytics cookies",
+  readOnly: false,
+  defaultEnabled: false,
+  autoClearCookies: [
+    { name: /^_ga/ },     // Google Analytics
+    { name: /^_gid/ },    // Google Analytics
+    { name: "CC_ANA" },   // legacy CoCalc analytics
+    // add new cookie names here
+  ],
+},
+```
+
+`autoClearCookies` is `true` by default in v3, so listing the cookie name
+is sufficient — no manual revocation callback required. Reload the page
+after revocation only if needed (set `autoClear.reloadPage: true` in
+`init.ts`'s `buildCategoriesConfig`).
+
+For scripts you load conditionally (like `gtag.js`), wrap the load logic in
+a `useEffect` + `onConsentChange` listener: load when `analytics` is
+accepted; on revocation the cookies disappear automatically and the script
+itself just stops getting fresh consent. See
+`packages/frontend/customize.tsx#init_analytics` for the existing pattern
+that defers Google Analytics + the legacy `analytics.js` until tracking
+consent.
+
+### Adding a new cookie category (e.g. marketing)
+
+Cookie categories are defined in one place,
+`packages/frontend/cookie-consent/categories.ts`. The v3 runtime config,
+the `ConsentSnapshot` type that's persisted to
+`accounts.other_settings.cookie_consent`, and the SPA settings panel all
+derive from this list — so adding a category is essentially one entry
+plus a revision bump.
+
+**Step 1**: append to `COOKIE_CATEGORIES`:
+
+```typescript
+// packages/frontend/cookie-consent/categories.ts
+export const COOKIE_CATEGORIES = [
+  { key: "necessary", label: "Necessary cookies", readOnly: true,  defaultEnabled: true },
+  { key: "analytics", label: "Analytics cookies", readOnly: false, defaultEnabled: false,
+    autoClearCookies: [/* … */] },
+  // NEW:
+  {
+    key: "marketing",
+    label: "Marketing cookies",
+    description: "Optional. Used to deliver targeted advertising and measure campaign effectiveness.",
+    readOnly: false,
+    defaultEnabled: false,
+    autoClearCookies: [
+      { name: /^_fbp/ },        // Facebook Pixel
+      { name: "_hubspotutk" },  // HubSpot
+    ],
+  },
+] as const satisfies ReadonlyArray<CookieCategory>;
+```
+
+That's it for the runtime config and the snapshot type — TypeScript
+narrows `CookieCategoryKey` to include `"marketing"` automatically and
+flags any callsite (e.g. existing `hasTrackingConsent` semantics, future
+consent-aware loaders) that should consider the new category.
+
+**Step 2**: bump `COOKIE_CONSENT_REVISION` in
+`packages/frontend/cookie-consent/index.ts`:
+
+```typescript
+export const COOKIE_CONSENT_REVISION = 2; // was 1
+```
+
+vanilla-cookieconsent compares the revision in the user's `cc_cookie`
+against the configured one and re-prompts if they differ. Without a bump,
+existing users keep their stale consent record (which doesn't mention the
+new category) and never get asked.
+
+**Step 3** (optional): if scripts/cookies are gated on the new category,
+add a helper alongside `hasTrackingConsent` in `index.ts`:
+
+```typescript
+export function hasMarketingConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return CookieConsent.acceptedCategory("marketing");
+  } catch {
+    return false;
+  }
+}
+```
+
+Then gate any cookie-setting code on this helper. Cookies you list in
+`autoClearCookies` for the category are removed automatically on revoke,
+so the only manual code is "don't load the script unless consent is
+granted."
+
+**Step 4** (optional): the per-category title and `description` in the
+preferences modal are derived from `COOKIE_CATEGORIES` automatically. The
+banner intro / button labels live in `translations.ts` if you want to
+tweak those.
+
+After deploy: existing logged-in users see the banner reappear (because
+of the revision bump), make a choice, and the new category boolean is
+written to `accounts.other_settings.cookie_consent.marketing` — visible
+in the settings panel without further changes.
+
+### Persistence to account preferences
+
+The browser cookie (`cc_cookie`) is the authoritative source for the live
+session. Once the user is signed in, the SPA mirrors the choice into
+`accounts.other_settings.cookie_consent`:
+
+```json
+{
+  "necessary": true,
+  "analytics": false,
+  "timestamp": "2026-05-06T14:15:13.031Z",
+  "revision": 1
+}
+```
+
+Wired in `packages/frontend/app/render.tsx` via `onConsentChange` while
+`is_logged_in` is true. The server record is for audit + UI display — we do
+not restore it back into the browser (consent is browser-bound under GDPR).
+Booleans rather than a `categories: string[]` array because immutable.js
+mangles arrays into `{0: "x"}` when round-tripping through JSONB.
+
+The "Cookie preferences" panel in **Account → Preferences → Communication**
+(`packages/frontend/account/cookie-consent-settings.tsx`) shows the current
+choice, last-updated timestamp, and a button that re-opens the preferences
+modal so users can change their mind.
+
+### Revisioning
+
+`COOKIE_CONSENT_REVISION` (in `packages/frontend/cookie-consent/index.ts`)
+is the consent version number. Bump it whenever the categories or the
+banner text materially change — vanilla-cookieconsent will then re-prompt
+anyone with a stale `cc_cookie`. The revision is stored alongside each
+snapshot in `accounts.other_settings.cookie_consent.revision`, so old
+records are easy to identify.
+
+### Key Files
+
+| File                                                            | Purpose                                                |
+| --------------------------------------------------------------- | ------------------------------------------------------ |
+| `packages/frontend/cookie-consent/categories.ts`                | Single source of truth for cookie categories           |
+| `packages/frontend/cookie-consent/init.ts`                      | `initCookieConsent` — derives v3 config from categories|
+| `packages/frontend/cookie-consent/index.ts`                     | Public helpers + `useEssentialConsent` hook + revision |
+| `packages/frontend/cookie-consent/state.ts`                     | Internal "is banner active" flag                       |
+| `packages/frontend/cookie-consent/translations.ts`              | English strings (i18n integration is follow-up)        |
+| `packages/frontend/account/cookie-consent-settings.tsx`         | SPA settings panel for managing preferences            |
+| `packages/frontend/app/render.tsx`                              | Init + persist-to-account effect                 |
+| `packages/next/pages/_app.tsx`                                  | Init + force-consent detection on auth routes    |
+| `packages/util/db-schema/site-defaults.ts`                      | Admin settings (`cookie_banner_enabled`/`_text`) |
+
 ## Key Source Files
 
 | File                                                | Description                                       |

--- a/src/packages/database/settings/customize.ts
+++ b/src/packages/database/settings/customize.ts
@@ -138,6 +138,8 @@ export default async function getCustomize(
           settings.version_compute_server_min_project,
         ),
       },
+      cookieBannerEnabled: settings.cookie_banner_enabled,
+      cookieBannerText: settings.cookie_banner_text,
     };
   }
   return fields ? copy_with(cachedCustomize, fields) : cachedCustomize;

--- a/src/packages/frontend/account/account-preferences-communication.tsx
+++ b/src/packages/frontend/account/account-preferences-communication.tsx
@@ -11,6 +11,7 @@ import { redux, useTypedRedux } from "@cocalc/frontend/app-framework";
 import { Icon, IconName } from "@cocalc/frontend/components";
 import { labels } from "@cocalc/frontend/i18n";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
+import { CookieConsentSettings } from "./cookie-consent-settings";
 
 export const COMMUNICATION_ICON_NAME: IconName = "mail";
 
@@ -114,18 +115,21 @@ export function AccountPreferencesCommunication(): React.JSX.Element {
   }
 
   return (
-    <Panel
-      size="small"
-      header={
-        <>
-          <Icon name={COMMUNICATION_ICON_NAME} />{" "}
-          {intl.formatMessage(labels.communication)}
-        </>
-      }
-    >
-      {render_global_banner()}
-      {render_no_free_warnings()}
-      {render_no_email_new_messages()}
-    </Panel>
+    <>
+      <Panel
+        size="small"
+        header={
+          <>
+            <Icon name={COMMUNICATION_ICON_NAME} />{" "}
+            {intl.formatMessage(labels.communication)}
+          </>
+        }
+      >
+        {render_global_banner()}
+        {render_no_free_warnings()}
+        {render_no_email_new_messages()}
+      </Panel>
+      <CookieConsentSettings />
+    </>
   );
 }

--- a/src/packages/frontend/account/cookie-consent-settings.tsx
+++ b/src/packages/frontend/account/cookie-consent-settings.tsx
@@ -1,0 +1,95 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import { Alert, Button, Space } from "antd";
+import { useEffect, useState } from "react";
+
+import { Panel } from "@cocalc/frontend/antd-bootstrap";
+import { useTypedRedux } from "@cocalc/frontend/app-framework";
+import { Icon } from "@cocalc/frontend/components";
+import { TimeAgo } from "@cocalc/frontend/components/time-ago";
+import {
+  COOKIE_CATEGORIES,
+  ConsentSnapshot,
+  getConsentSnapshot,
+  onConsentChange,
+  showPreferences,
+} from "@cocalc/frontend/cookie-consent";
+import { COLORS } from "@cocalc/util/theme";
+
+// Visual style mirrors project Settings → Features (project-capabilites.tsx)
+// — green check-square for accepted, red minus-square for declined, one row
+// per category. The list is driven by COOKIE_CATEGORIES, so future
+// categories show up here automatically.
+function CategoryStatus({
+  accepted,
+  label,
+}: {
+  accepted: boolean;
+  label: string;
+}) {
+  return (
+    <div>
+      <Icon
+        name={accepted ? "check-square" : "minus-square"}
+        style={{ color: accepted ? COLORS.BS_GREEN_D : COLORS.BS_RED }}
+      />{" "}
+      {label}
+    </div>
+  );
+}
+
+export function CookieConsentSettings(): React.JSX.Element | null {
+  const cookieBannerEnabled = useTypedRedux(
+    "customize",
+    "cookie_banner_enabled",
+  );
+  const [snap, setSnap] = useState<ConsentSnapshot | null>(() =>
+    getConsentSnapshot(),
+  );
+
+  useEffect(() => onConsentChange(setSnap), []);
+
+  if (!cookieBannerEnabled) return null;
+
+  return (
+    <Panel
+      size="small"
+      header={
+        <>
+          <Icon name="lock" /> Cookie preferences
+        </>
+      }
+    >
+      {snap == null ? (
+        <Alert
+          type="warning"
+          showIcon
+          message="You have not yet acknowledged the cookie banner."
+        />
+      ) : (
+        <Space direction="vertical" size="small" style={{ width: "100%" }}>
+          {COOKIE_CATEGORIES.map((c) => (
+            <CategoryStatus
+              key={c.key}
+              accepted={!!snap[c.key]}
+              label={c.label}
+            />
+          ))}
+          {snap.timestamp && (
+            <div style={{ color: COLORS.GRAY }}>
+              Last updated: <TimeAgo date={snap.timestamp} />
+            </div>
+          )}
+        </Space>
+      )}
+      <div style={{ marginTop: 12 }}>
+        <Button onClick={() => showPreferences()}>
+          <Icon name="cog" /> Manage cookie preferences
+        </Button>
+      </div>
+    </Panel>
+  );
+}

--- a/src/packages/frontend/app/render.tsx
+++ b/src/packages/frontend/app/render.tsx
@@ -3,12 +3,24 @@
  *  License: MS-RSL – see LICENSE.md for details
  */
 
+import { useEffect } from "react";
+
+import "vanilla-cookieconsent/dist/cookieconsent.css";
+
 import {
   redux,
   Redux,
   useAsyncEffect,
   useTypedRedux,
 } from "@cocalc/frontend/app-framework";
+import {
+  ConsentSnapshot,
+  enableForceConsent,
+  hasEssentialConsent,
+  onConsentChange,
+  restoreConsentCookieFromSnapshot,
+} from "@cocalc/frontend/cookie-consent";
+import { initCookieConsent } from "@cocalc/frontend/cookie-consent/init";
 import {
   getLocale,
   LOCALIZATIONS,
@@ -24,6 +36,131 @@ function App({ children }) {
   const appState = useAppContextProvider();
   const { setLocale } = useLocalizationCtx();
   const other_settings = useTypedRedux("account", "other_settings");
+  const customizeReady = useTypedRedux("customize", "_is_configured");
+  const cookieBannerEnabled = useTypedRedux(
+    "customize",
+    "cookie_banner_enabled",
+  );
+  const cookieBannerText = useTypedRedux("customize", "cookie_banner_text");
+
+  useEffect(() => {
+    if (!customizeReady) return;
+    let cancelled = false;
+    let timer: number | undefined;
+    const accountStore = redux.getStore("account");
+
+    const proceed = () => {
+      if (cancelled) return;
+      // For signed-in users with a stored consent snapshot in their account,
+      // synthesise the cc_cookie from that record before v3 reads it. The
+      // server-side consent log is authoritative; the browser cookie is
+      // just runtime state that legitimately gets cleared (private mode,
+      // browser data wipe, new device). Re-prompting in those cases is
+      // redundant since we already have approval on file.
+      //
+      // We do NOT gate on `is_logged_in` here: that flag flips in a
+      // separate code path (`signed_in` event → wait for table.connected →
+      // set_user_type("signed_in")) that races with the AccountTable's
+      // first-sync `is_ready` emit. is_logged_in can still be false at the
+      // moment is_ready fires, even though other_settings.cookie_consent
+      // is already populated from the same first-sync setState. Reading
+      // cookie_consent directly is the more reliable signal — anonymous
+      // visitors won't have it.
+      if (cookieBannerEnabled) {
+        const stored: any = accountStore.getIn([
+          "other_settings",
+          "cookie_consent",
+        ]);
+        if (stored != null && typeof stored?.toJS === "function") {
+          restoreConsentCookieFromSnapshot(stored.toJS() as ConsentSnapshot);
+        }
+      }
+      initCookieConsent({
+        enabled: !!cookieBannerEnabled,
+        textMarkdown: cookieBannerText,
+      });
+    };
+
+    if (accountStore.get("is_ready")) {
+      proceed();
+    } else {
+      // Wait for the account table to load (so we can look at
+      // other_settings.cookie_consent), with a short fallback timeout for
+      // anonymous visitors who never trigger the is_ready event.
+      let done = false;
+      const onReady = () => {
+        if (done) return;
+        done = true;
+        if (timer != null) window.clearTimeout(timer);
+        proceed();
+      };
+      accountStore.once("is_ready", onReady);
+      timer = window.setTimeout(() => {
+        if (done) return;
+        done = true;
+        accountStore.removeListener("is_ready", onReady);
+        proceed();
+      }, 2000);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer != null) window.clearTimeout(timer);
+    };
+  }, [customizeReady, cookieBannerEnabled, cookieBannerText]);
+
+  // SSO fallback: a successful SSO callback can drop a logged-in user on
+  // /app without ever passing through the auth-page force-consent overlay.
+  // Once the account store reports ready (so we don't flash this during
+  // boot for users whose customize/account is still loading), check whether
+  // the user actually acknowledged the banner — if not, dim the page until
+  // they do. This is belt-and-braces; the auth pages already gate the
+  // common path, but bookmarked SSO start URLs / direct visits can skip it.
+  useEffect(() => {
+    if (!customizeReady || !cookieBannerEnabled) return;
+    let cancelled = false;
+    let cleanup: (() => void) | undefined;
+    (async () => {
+      const ready = await redux.getStore("account").waitUntilReady();
+      if (cancelled || !ready) return;
+      if (!redux.getStore("account").get("is_logged_in")) return;
+      if (hasEssentialConsent()) return;
+      cleanup = enableForceConsent();
+    })();
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, [customizeReady, cookieBannerEnabled]);
+
+  // Persist consent (categories + last-changed timestamp) to the account
+  // record so users can review/audit their choice from settings, and so we
+  // have a server-side record of consent. The browser cookie is still the
+  // authoritative source for the running session — we only push *to* the
+  // account, never restore from it (consent is browser-bound under GDPR).
+  const isLoggedIn = useTypedRedux("account", "is_logged_in");
+  useEffect(() => {
+    if (!cookieBannerEnabled || !isLoggedIn) return;
+    return onConsentChange((snap: ConsentSnapshot | null) => {
+      // Skip null: vanilla-cookieconsent flickers through validConsent ===
+      // false mid-write during category toggles, and the cc_cookie can
+      // expire after a year. Neither should wipe the account record — the
+      // last-known state is the audit trail.
+      if (snap == null) return;
+      const stored: any = redux
+        .getStore("account")
+        .getIn(["other_settings", "cookie_consent"]);
+      if (
+        stored != null &&
+        typeof stored?.get === "function" &&
+        stored.get("timestamp") === snap.timestamp &&
+        stored.get("revision") === snap.revision
+      ) {
+        return; // already in sync
+      }
+      redux.getActions("account").set_other_settings("cookie_consent", snap);
+    });
+  }, [cookieBannerEnabled, isLoggedIn]);
 
   // setting via ?lang=[locale] takes precedence over account settings
   // additionally ?lang_temp=[locale] temporarily changes it, used by these impersonation admin links

--- a/src/packages/frontend/app/verify-email-banner.tsx
+++ b/src/packages/frontend/app/verify-email-banner.tsx
@@ -17,6 +17,7 @@ import {
 } from "@cocalc/frontend/app-framework";
 import { getNow } from "@cocalc/frontend/app/util";
 import { Icon, Paragraph, Text } from "@cocalc/frontend/components";
+import { useEssentialConsent } from "@cocalc/frontend/cookie-consent";
 import { labels } from "@cocalc/frontend/i18n";
 import * as LS from "@cocalc/frontend/misc/local-storage-typed";
 import { webapp_client } from "@cocalc/frontend/webapp-client";
@@ -195,6 +196,12 @@ export function useShowVerifyEmail(): boolean {
 
   const created = useTypedRedux("account", "created");
 
+  // Suppress the modal while the cookie banner is still demanding consent —
+  // otherwise the email-verify dialog renders on top of the dimmed page and
+  // appears interactive even though the cc-wrapper intercepts mouse clicks
+  // at z-index max-int. Once consent is granted we let it through normally.
+  const consentReady = useEssentialConsent();
+
   const dismissedTS = LS.get<number>(DISMISSED_KEY_LS);
 
   const show_verify_email =
@@ -214,6 +221,7 @@ export function useShowVerifyEmail(): boolean {
     loaded &&
     notTooNew &&
     !dismissed &&
-    emailSendingEnabled
+    emailSendingEnabled &&
+    consentReady
   );
 }

--- a/src/packages/frontend/client/tracking.ts
+++ b/src/packages/frontend/client/tracking.ts
@@ -21,9 +21,23 @@ export class TrackingClient {
         .getStore("customize")
         ?.get("user_tracking");
     }
-    if (this.userTrackingEnabled == "yes") {
-      await this.client.conat_client.hub.system.userTracking({ event, value });
+    // Master kill-switch: admin must enable user tracking site-wide.
+    if (this.userTrackingEnabled != "yes") return;
+
+    // When the cookie banner is enabled, additionally require the visitor
+    // to have opted into the "usage" category. The admin setting is the
+    // operator's say-so; the cookie banner is the user's. Both must agree
+    // for the event to be recorded. Banner disabled by admin → existing
+    // behaviour (admin setting alone gates).
+    const customize = redux.getStore("customize");
+    if (customize?.get("cookie_banner_enabled")) {
+      const { hasCategoryConsent } = await import(
+        "@cocalc/frontend/cookie-consent"
+      );
+      if (!hasCategoryConsent("usage")) return;
     }
+
+    await this.client.conat_client.hub.system.userTracking({ event, value });
   };
 
   log_error = (error: any): void => {

--- a/src/packages/frontend/cookie-consent/categories.ts
+++ b/src/packages/frontend/cookie-consent/categories.ts
@@ -1,0 +1,71 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+// Single source of truth for cookie categories. Anything that varies per
+// category — vanilla-cookieconsent v3 runtime config, the snapshot shape we
+// persist into accounts.other_settings, the labels in the account settings
+// panel — derives from this list. Adding a new category (e.g. "marketing")
+// means:
+//
+//   1. append an entry here with key + label + autoClearCookies as needed
+//   2. bump COOKIE_CONSENT_REVISION so existing users get re-prompted
+//
+// Everything else falls into place automatically.
+
+interface CookieItem {
+  name: string | RegExp;
+}
+
+export interface CookieCategory {
+  readonly key: string;
+  // Short user-visible name (banner/preferences modal title + settings panel).
+  readonly label: string;
+  // Body copy for the preferences modal section. Plain text — kept short and
+  // factual; longer explanation belongs in the admin-configurable banner text.
+  readonly description: string;
+  // True for cookies the user can't opt out of (e.g. session). v3 renders
+  // these toggles as locked-on.
+  readonly readOnly: boolean;
+  // Default state on first visit, before the user has acknowledged.
+  readonly defaultEnabled: boolean;
+  // Cookies that vanilla-cookieconsent should erase when the user revokes
+  // this category. autoClearCookies is on by default in v3, so listing the
+  // names here is sufficient — runtime takes care of the actual removal.
+  readonly autoClearCookies?: ReadonlyArray<CookieItem>;
+}
+
+export const COOKIE_CATEGORIES = [
+  {
+    key: "necessary",
+    label: "Necessary cookies",
+    description:
+      "Required for sign-in and to keep your session active. These cookies cannot be turned off.",
+    readOnly: true,
+    defaultEnabled: true,
+  },
+  {
+    key: "analytics",
+    label: "Analytics cookies",
+    description:
+      "Third-party analytics that help us understand how the site is used.",
+    readOnly: false,
+    defaultEnabled: false,
+    autoClearCookies: [
+      { name: /^_ga/ }, // Google Analytics (gtag/GA4)
+      { name: /^_gid/ }, // Google Analytics
+      { name: "CC_ANA" }, // legacy CoCalc analytics cookie
+    ],
+  },
+  {
+    key: "usage",
+    label: "Usage metrics",
+    description:
+      "First-party metrics (e.g. which buttons get clicked) recorded in our own database to help us improve the product.",
+    readOnly: false,
+    defaultEnabled: false,
+  },
+] as const satisfies ReadonlyArray<CookieCategory>;
+
+export type CookieCategoryKey = (typeof COOKIE_CATEGORIES)[number]["key"];

--- a/src/packages/frontend/cookie-consent/index.ts
+++ b/src/packages/frontend/cookie-consent/index.ts
@@ -1,0 +1,294 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+// Public helpers shared by sign-in/sign-up flows and analytics gating. This
+// module deliberately does NOT import the vanilla-cookieconsent CSS — that
+// happens in ./init, which is the only entry point allowed to do a global CSS
+// import (Next.js restricts global CSS imports to pages/_app.tsx).
+
+import { useEffect, useState } from "react";
+
+import * as CookieConsent from "vanilla-cookieconsent";
+
+import { COOKIE_CATEGORIES, type CookieCategoryKey } from "./categories";
+import { BANNER_STATE_EVENT, isBannerActive, isBannerDecided } from "./state";
+
+export { COOKIE_CATEGORIES };
+export type { CookieCategoryKey };
+
+// Bump this if the cookie categories or banner text change in a way that
+// invalidates prior consent. vanilla-cookieconsent will re-prompt the user.
+export const COOKIE_CONSENT_REVISION = 1;
+
+// Snapshot of the user's consent we persist in account.other_settings. Kept
+// minimal on purpose: the browser cookie is authoritative for the session;
+// this record is for audit/UI display.
+//
+// Per-category booleans are derived from COOKIE_CATEGORIES rather than
+// hand-listed — adding a new category in categories.ts automatically
+// extends this type. Stored as individual fields rather than an array
+// because the immutable.js layer that backs other_settings turns arrays
+// into objects with numeric keys when round-tripping through JSONB.
+export type ConsentSnapshot = Record<CookieCategoryKey, boolean> & {
+  timestamp: string; // ISO 8601, last time the user changed their choice
+  revision: number;
+};
+
+// True once the user has acted on the banner (accepted necessary or all).
+// Until then we block sign-up/sign-in. Returns:
+//   * false while customize is still loading (we don't yet know whether the
+//     banner will activate — be conservative so modals don't render on top
+//     of a banner that's about to appear)
+//   * true if the admin has the banner disabled (nothing to acknowledge)
+//   * v3's validConsent() if the banner is active
+export function hasEssentialConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  if (!isBannerDecided()) return false;
+  if (!isBannerActive()) return true;
+  try {
+    return CookieConsent.validConsent();
+  } catch {
+    return false;
+  }
+}
+
+// Generic per-category consent check. Returns false if the v3 runtime
+// isn't running (banner admin-disabled or not yet initialised) — callers
+// that want "passthrough when banner is off" should check
+// `cookie_banner_enabled` from customize separately, mirroring the pattern
+// in `customize.tsx#init_analytics`.
+export function hasCategoryConsent(key: CookieCategoryKey): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return CookieConsent.acceptedCategory(key);
+  } catch {
+    return false;
+  }
+}
+
+// Backwards-compatible alias for the analytics category. Existing callers
+// (next/components/analytics, frontend/customize, sign-in-hooks) keep their
+// import unchanged.
+export function hasTrackingConsent(): boolean {
+  return hasCategoryConsent("analytics");
+}
+
+// Open the consent modal for first-time consent (e.g. when user clicks
+// sign-in without having accepted yet).
+export function showConsentModal(): void {
+  if (typeof window === "undefined") return;
+  try {
+    CookieConsent.show(true);
+  } catch {
+    // banner not initialised — nothing to show
+  }
+}
+
+// Force-consent fallback for the SPA: an SSO callback can drop a logged-in
+// user on /app without ever passing through the auth-page overlay. Once the
+// account is loaded and we see the user has no valid consent, apply the same
+// dimmed-overlay treatment manually (vanilla-cookieconsent's
+// `disablePageInteraction` is config-time only; we replicate it by toggling
+// the `disable--interaction` class on <html>, which the v3 stylesheet hooks
+// into for the backdrop and scroll-lock).
+//
+// Returns a cleanup function. The class is also auto-removed when the user
+// makes a choice (cc:onConsent / cc:onChange), so this is mostly belt &
+// braces — callers should still invoke the returned cleanup on unmount.
+export function enableForceConsent(): () => void {
+  if (typeof window === "undefined") return () => {};
+  if (!isBannerActive()) return () => {}; // banner disabled by admin
+  if (hasEssentialConsent()) return () => {}; // nothing to enforce
+  const html = document.documentElement;
+  html.classList.add("disable--interaction");
+  try {
+    CookieConsent.show(true);
+  } catch {
+    /* banner runtime not ready yet — class will still dim the page */
+  }
+  let removed = false;
+  const remove = () => {
+    if (removed) return;
+    removed = true;
+    html.classList.remove("disable--interaction");
+    window.removeEventListener("cc:onConsent", remove);
+    window.removeEventListener("cc:onChange", remove);
+  };
+  window.addEventListener("cc:onConsent", remove);
+  window.addEventListener("cc:onChange", remove);
+  return remove;
+}
+
+// Open the preferences modal so a user can change their choice.
+export function showPreferences(): void {
+  if (typeof window === "undefined") return;
+  try {
+    CookieConsent.showPreferences();
+  } catch {
+    // banner not initialised
+  }
+}
+
+// Returns true if the user can proceed (essential consent already given, or
+// banner not enabled), or false after surfacing the consent modal so the user
+// can grant it.
+export function requireEssentialConsent(): boolean {
+  if (hasEssentialConsent()) return true;
+  showConsentModal();
+  return false;
+}
+
+// Restore the browser cc_cookie from a previously-saved snapshot (e.g. from
+// accounts.other_settings.cookie_consent). Used to skip the banner for
+// signed-in users who have cleared cookies but already gave consent in
+// their account — the consent record on the server stands as proof of
+// approval, the browser cookie is just a runtime artifact.
+//
+// MUST be called BEFORE initCookieConsent / CookieConsent.run(), since v3
+// reads the cookie once during run(). Returns true if a cookie was written,
+// false if anything blocked the restore (no snapshot, revision mismatch,
+// browser cookie already present, etc.).
+export function restoreConsentCookieFromSnapshot(
+  snap: ConsentSnapshot | null,
+): boolean {
+  if (typeof document === "undefined") return false;
+  if (snap == null) return false;
+  // Don't trample an existing cookie — browser is authoritative for the
+  // current session.
+  if (document.cookie.split(";").some((c) => c.trim().startsWith("cc_cookie=")))
+    return false;
+  // Re-prompt if the saved consent is for an older revision (categories or
+  // text changed materially since the user last decided).
+  if (snap.revision !== COOKIE_CONSENT_REVISION) return false;
+
+  const categories: string[] = [];
+  const services: Record<string, string[]> = {};
+  for (const c of COOKIE_CATEGORIES) {
+    services[c.key] = [];
+    if ((snap as Record<string, unknown>)[c.key]) categories.push(c.key);
+  }
+  // Necessary is always-on; ensure it's listed even if the snapshot somehow
+  // omits it.
+  if (!categories.includes("necessary")) categories.push("necessary");
+
+  const timestamp = snap.timestamp || new Date().toISOString();
+  const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+  const value = {
+    categories,
+    revision: snap.revision,
+    data: null,
+    consentTimestamp: timestamp,
+    consentId: cryptoRandomId(),
+    services,
+    languageCode: "en",
+    lastConsentTimestamp: timestamp,
+    expirationTime: Date.now() + oneYearMs,
+  };
+  document.cookie =
+    "cc_cookie=" +
+    encodeURIComponent(JSON.stringify(value)) +
+    `; path=/; max-age=${oneYearMs / 1000}; SameSite=Lax`;
+  return true;
+}
+
+function cryptoRandomId(): string {
+  // Best-effort UUID-ish identifier for cc_cookie.consentId. The DB record
+  // is the authoritative consent log; this id is just v3's internal handle.
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+// Read the current consent state from vanilla-cookieconsent's cookie. Returns
+// null if the user has not yet acted on the banner.
+export function getConsentSnapshot(): ConsentSnapshot | null {
+  if (typeof window === "undefined") return null;
+  try {
+    if (!CookieConsent.validConsent()) return null;
+    const cookie = CookieConsent.getCookie();
+    if (cookie == null) return null;
+    const accepted = new Set<string>(cookie.categories ?? []);
+    const snap = {
+      timestamp:
+        cookie.lastConsentTimestamp ?? cookie.consentTimestamp ?? "",
+      revision: cookie.revision ?? 0,
+    } as ConsentSnapshot;
+    for (const c of COOKIE_CATEGORIES) {
+      (snap as Record<string, boolean | string | number>)[c.key] =
+        accepted.has(c.key);
+    }
+    return snap;
+  } catch {
+    return null;
+  }
+}
+
+type Unsubscribe = () => void;
+
+// Subscribe to consent changes. Fires immediately with the current snapshot
+// (or null if the user hasn't acted yet) and again on every cc:onConsent /
+// cc:onChange event. Callers receive null when there's no valid consent —
+// most callers should ignore those events rather than treat them as "consent
+// was revoked"; the cc_cookie can expire naturally after a year. Persistence-
+// style callers should skip null; UI-style callers should render the
+// absence-of-consent state.
+//
+// Note: vanilla-cookieconsent fires cc:onChange synchronously while it's
+// still flushing the new cookie value, so reading getConsentSnapshot() at
+// event time can return a stale snapshot (or briefly null). We call the
+// handler again on the next macrotask so callers always settle on the
+// post-toggle state.
+export function onConsentChange(
+  cb: (snap: ConsentSnapshot | null) => void,
+): Unsubscribe {
+  if (typeof window === "undefined") return () => {};
+  let timer: number | undefined;
+  const handler = () => {
+    cb(getConsentSnapshot());
+    if (timer != null) window.clearTimeout(timer);
+    timer = window.setTimeout(() => cb(getConsentSnapshot()), 0);
+  };
+  window.addEventListener("cc:onConsent", handler);
+  window.addEventListener("cc:onChange", handler);
+  window.addEventListener(BANNER_STATE_EVENT, handler);
+  // Fire once for the current state.
+  handler();
+  return () => {
+    window.removeEventListener("cc:onConsent", handler);
+    window.removeEventListener("cc:onChange", handler);
+    window.removeEventListener(BANNER_STATE_EVENT, handler);
+    if (timer != null) window.clearTimeout(timer);
+  };
+}
+
+// React hook: re-renders when essential consent state flips. Used to disable
+// sign-in / sign-up submit buttons until the user acknowledges the banner.
+//
+// First render returns false to avoid a Next.js hydration mismatch (the
+// server can't read the cc_cookie). The synchronous useEffect-on-mount call
+// then reconciles to the real value before the next paint, so a returning
+// user with valid consent never sees the "Acknowledge cookie banner to
+// continue" label flash. We also subscribe to BANNER_STATE_EVENT so we
+// re-render when initCookieConsent decides whether the banner activates —
+// otherwise the hook could be stuck at "consented" while customize is
+// loading, since the inactive-banner branch returns true.
+export function useEssentialConsent(): boolean {
+  const [accepted, setAccepted] = useState<boolean>(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const update = () => setAccepted(hasEssentialConsent());
+    update(); // sync reconcile post-hydration
+    window.addEventListener("cc:onConsent", update);
+    window.addEventListener("cc:onChange", update);
+    window.addEventListener(BANNER_STATE_EVENT, update);
+    return () => {
+      window.removeEventListener("cc:onConsent", update);
+      window.removeEventListener("cc:onChange", update);
+      window.removeEventListener(BANNER_STATE_EVENT, update);
+    };
+  }, []);
+  return accepted;
+}

--- a/src/packages/frontend/cookie-consent/init.ts
+++ b/src/packages/frontend/cookie-consent/init.ts
@@ -1,0 +1,116 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+// GDPR cookie consent banner shared between the SPA frontend and the Next.js
+// landing pages. We use vanilla-cookieconsent v3 because it is framework
+// agnostic — the same configuration object initialises the banner in both the
+// SPA and the SSR-rendered Next.js app.
+//
+// Note: callers must `import "vanilla-cookieconsent/dist/cookieconsent.css"`
+// themselves, alongside calling initCookieConsent. Next.js refuses global CSS
+// imports from any file other than pages/_app.tsx, even transitively through
+// an imported module — so the CSS import has to live directly in the entry.
+// Helpers that don't need the CSS (e.g. the requireEssentialConsent gate used
+// in sign-in/sign-up) live in ./index.
+
+import { join } from "path";
+
+import * as CookieConsent from "vanilla-cookieconsent";
+
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { markdown_to_html } from "@cocalc/frontend/markdown";
+
+import { COOKIE_CATEGORIES, type CookieCategory } from "./categories";
+import { COOKIE_CONSENT_REVISION } from "./index";
+import { markBannerActive, markBannerDecidedDisabled } from "./state";
+import { buildTranslation } from "./translations";
+
+function buildCategoriesConfig(): Record<string, CookieConsent.Category> {
+  const out: Record<string, CookieConsent.Category> = {};
+  for (const raw of COOKIE_CATEGORIES) {
+    // Widen from `as const satisfies` narrowing so optional fields are visible.
+    const c: CookieCategory = raw;
+    const entry: CookieConsent.Category = {
+      enabled: c.defaultEnabled,
+      readOnly: c.readOnly,
+    };
+    if (c.autoClearCookies && c.autoClearCookies.length > 0) {
+      entry.autoClear = {
+        cookies: c.autoClearCookies.map((x) => ({ name: x.name })),
+      };
+    }
+    out[c.key] = entry;
+  }
+  return out;
+}
+
+let initialized = false;
+
+export interface InitOptions {
+  enabled?: boolean;
+  // Markdown body shown in the banner & preferences modal.
+  textMarkdown?: string;
+}
+
+// We never pass disablePageInteraction here. v3 only honours that at init,
+// so it would not survive client-side navigation between non-auth and auth
+// routes. Force-consent mode is applied separately via enableForceConsent
+// from ./index, which toggles the same `disable--interaction` class on
+// <html> as v3's built-in option and can be flipped on route changes.
+export function initCookieConsent({
+  enabled,
+  textMarkdown,
+}: InitOptions): void {
+  if (initialized) return;
+  if (typeof window === "undefined") return;
+  if (!enabled) {
+    // Customize loaded with banner disabled — flip the "decided" flag so
+    // gate helpers (hasEssentialConsent, useEssentialConsent) stop being
+    // conservative and pass through.
+    markBannerDecidedDisabled();
+    return;
+  }
+  initialized = true;
+  markBannerActive();
+
+  const descHtml = markdown_to_html(textMarkdown?.trim() || "");
+  const privacyUrl = join(appBasePath, "policies/privacy");
+  const termsUrl = join(appBasePath, "policies/terms");
+
+  try {
+    const runResult: any = CookieConsent.run({
+      revision: COOKIE_CONSENT_REVISION,
+      guiOptions: {
+        consentModal: {
+          layout: "box inline",
+          position: "bottom right",
+          equalWeightButtons: true,
+          flipButtons: false,
+        },
+        preferencesModal: {
+          layout: "bar",
+          position: "right",
+          equalWeightButtons: true,
+          flipButtons: false,
+        },
+      },
+      categories: buildCategoriesConfig(),
+      language: {
+        default: "en",
+        translations: {
+          en: buildTranslation(descHtml, privacyUrl, termsUrl),
+        },
+      },
+    });
+    if (runResult && typeof runResult.catch === "function") {
+      runResult.catch((err: unknown) =>
+        console.error("cookie-consent: run rejected", err),
+      );
+    }
+  } catch (err) {
+    console.error("cookie-consent: run threw", err);
+  }
+}
+

--- a/src/packages/frontend/cookie-consent/state.ts
+++ b/src/packages/frontend/cookie-consent/state.ts
@@ -1,0 +1,48 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+// Tiny shared-state module so ./init can flip flags that ./index reads,
+// without a circular import. Importing this module is side-effect free.
+//
+// Three observable states:
+//   undecided → customize hasn't loaded yet, we don't know if the banner
+//               will activate. Gate helpers should be conservative (treat
+//               as "not yet acknowledged") so modals like verify-email
+//               don't render on top of a banner that's about to appear.
+//   active    → initCookieConsent ran with enabled=true; v3 runtime is up.
+//   decided-disabled → admin has the banner off; helpers pass through.
+
+const EVENT_NAME = "cc:internalStateChange";
+
+let active = false;
+let decided = false;
+
+function emit(): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(EVENT_NAME));
+  }
+}
+
+export function markBannerActive(): void {
+  active = true;
+  decided = true;
+  emit();
+}
+
+export function markBannerDecidedDisabled(): void {
+  // active stays false. decided=true tells helpers to stop being conservative.
+  decided = true;
+  emit();
+}
+
+export function isBannerActive(): boolean {
+  return active;
+}
+
+export function isBannerDecided(): boolean {
+  return decided;
+}
+
+export const BANNER_STATE_EVENT = EVENT_NAME;

--- a/src/packages/frontend/cookie-consent/translations.ts
+++ b/src/packages/frontend/cookie-consent/translations.ts
@@ -1,0 +1,49 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+import type { Translation } from "vanilla-cookieconsent";
+
+import { COOKIE_CATEGORIES } from "./categories";
+
+// English-only for the first version. The rest of CoCalc uses simplelocalize +
+// JSON files; integrating the cookie banner with that pipeline is deferred to
+// a follow-up PR. The vanilla-cookieconsent `autoDetect: 'browser'` setting
+// still works — every locale just falls back to the `en` translation here.
+
+export function buildTranslation(
+  descHtml: string,
+  privacyUrl: string,
+  termsUrl: string,
+): Translation {
+  const footerLinks = `<a href="${privacyUrl}" target="_blank" rel="noopener noreferrer">Privacy policy</a>\n<a href="${termsUrl}" target="_blank" rel="noopener noreferrer">Terms of service</a>`;
+  // The preferences modal has no built-in footer slot in v3, so we append the
+  // policy links to the lead-in description as a small paragraph.
+  const prefsLead = `${descHtml}\n<p style="margin-top: 0.75em; font-size: 0.9em;">${footerLinks.replace("\n", " · ")}</p>`;
+  // Per-category sections derive from COOKIE_CATEGORIES, so adding a new
+  // category there automatically adds it to the preferences modal too.
+  const categorySections = COOKIE_CATEGORIES.map((c) => ({
+    title: c.label,
+    description: c.description,
+    linkedCategory: c.key,
+  }));
+  return {
+    consentModal: {
+      title: "We value your privacy",
+      description: descHtml,
+      acceptAllBtn: "Accept all",
+      acceptNecessaryBtn: "Necessary only",
+      showPreferencesBtn: "Manage preferences",
+      footer: footerLinks,
+    },
+    preferencesModal: {
+      title: "Cookie preferences",
+      acceptAllBtn: "Accept all",
+      acceptNecessaryBtn: "Necessary only",
+      savePreferencesBtn: "Save preferences",
+      closeIconLabel: "Close",
+      sections: [{ description: prefsLead }, ...categorySections],
+    },
+  };
+}

--- a/src/packages/frontend/customize.tsx
+++ b/src/packages/frontend/customize.tsx
@@ -193,6 +193,9 @@ export interface CustomizeState {
   i18n?: List<Locale>;
 
   user_tracking?: string;
+
+  cookie_banner_enabled?: boolean;
+  cookie_banner_text?: string;
 }
 
 export class CustomizeStore extends Store<CustomizeState> {
@@ -702,6 +705,35 @@ async function init_analytics() {
   if (w?.document == null) {
     // Double check that this code can be run on the backend (not in a browser).
     // see https://github.com/sagemathinc/cocalc-landing/issues/2
+    return;
+  }
+
+  // When the cookie banner is enabled, defer analytics until the user opts
+  // in to the analytics category. We listen via the onConsentChange helper
+  // rather than addEventListener directly because v3 fires `cc:onConsent`
+  // (not `cc:onChange`) when the runtime initialises from an existing valid
+  // cookie — a returning user who already accepted analytics on a previous
+  // visit would otherwise never get GA loaded until they toggled prefs.
+  const bannerEnabled = !!store.get("cookie_banner_enabled");
+  if (bannerEnabled) {
+    const { onConsentChange, hasTrackingConsent } = await import(
+      "@cocalc/frontend/cookie-consent"
+    );
+    // onConsentChange invokes its callback synchronously once during
+    // subscription. If the runtime already has valid consent (returning
+    // user), the callback fires before our `const unsubscribe = …`
+    // assignment completes — referencing `unsubscribe` from inside would
+    // hit the TDZ. Just keep the listener attached for the page lifetime;
+    // the `started` flag prevents a second init, and the listener is a
+    // no-op once analytics is loaded.
+    let started = false;
+    onConsentChange(() => {
+      if (started) return;
+      if (!hasTrackingConsent()) return;
+      started = true;
+      setup_google_analytics(w);
+      setup_cocalc_analytics(w);
+    });
     return;
   }
 

--- a/src/packages/frontend/landing-page/sign-in-hooks.ts
+++ b/src/packages/frontend/landing-page/sign-in-hooks.ts
@@ -12,6 +12,8 @@ import * as LS from "../misc/local-storage-typed";
 import { SignedIn } from "@cocalc/util/message-types";
 import { join } from "path";
 import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import { hasTrackingConsent } from "@cocalc/frontend/cookie-consent";
+import { redux } from "@cocalc/frontend/app-framework";
 
 async function tracking_events(): Promise<void> {
   if (localStorage == null) return;
@@ -26,6 +28,15 @@ async function tracking_events(): Promise<void> {
 }
 
 async function analytics_send(mesg: SignedIn): Promise<void> {
+  // Skip account-linked analytics POST when the cookie banner is enabled
+  // and the user did NOT opt into the analytics category. Without this
+  // gate, "Necessary only" still POSTs {account_id} to /analytics.js on
+  // every signed_in event, which is exactly the tracking the user
+  // declined.
+  const bannerEnabled = !!redux
+    .getStore("customize")
+    ?.get("cookie_banner_enabled");
+  if (bannerEnabled && !hasTrackingConsent()) return;
   window
     .fetch(join(appBasePath, "analytics.js"), {
       method: "POST",

--- a/src/packages/frontend/package.json
+++ b/src/packages/frontend/package.json
@@ -8,6 +8,8 @@
     "./app-framework/syncdb": "./dist/app-framework/syncdb/index.js",
     "./components": "./dist/components/index.js",
     "./components/run-button": "./dist/components/run-button/index.js",
+    "./cookie-consent": "./dist/cookie-consent/index.js",
+    "./cookie-consent/init": "./dist/cookie-consent/init.js",
     "./markdown": "./dist/markdown/index.js",
     "./misc": "./dist/misc/index.js",
     "./i18n": "./dist/i18n/index.js",
@@ -144,6 +146,7 @@
     "use-debounce": "^7.0.1",
     "use-resize-observer": "^9.1.0",
     "utility-types": "^3.10.0",
+    "vanilla-cookieconsent": "^3.1.0",
     "video-extensions": "^1.2.0",
     "zlibjs": "^0.3.1"
   },

--- a/src/packages/frontend/user-tracking.ts
+++ b/src/packages/frontend/user-tracking.ts
@@ -20,6 +20,13 @@ import { version } from "@cocalc/util/smc-version";
 import { ANALYTICS_COOKIE_NAME } from "@cocalc/util/consts";
 
 export async function log(eventName: string, payload: any): Promise<void> {
+  // NOTE: this writes to the central_log table, but in practice only fires
+  // for account-lifecycle events (anonymous→email signup, adding an SSO
+  // passport). Those are processed under "performance of contract" — they
+  // are necessary records of what the user did with their account — and so
+  // do NOT require cookie-banner consent. UX telemetry (button clicks etc.)
+  // goes through `track` / TrackingClient.user_tracking, which IS gated on
+  // the "usage" category.
   const central_log = {
     id: uuid(),
     event: `webapp-${eventName}`,

--- a/src/packages/next/components/analytics.tsx
+++ b/src/packages/next/components/analytics.tsx
@@ -4,50 +4,120 @@
  */
 
 import { join } from "path";
+import { useEffect, type JSX } from "react";
+
+import { hasTrackingConsent } from "@cocalc/frontend/cookie-consent";
 import basePath from "lib/base-path";
 import useCustomize from "lib/use-customize";
-
-import type { JSX } from "react";
-
-function GoogleAnalytics() {
-  const { googleAnalytics } = useCustomize();
-
-  const GA4_TRACKING_ID = googleAnalytics;
-  if (!GA4_TRACKING_ID) return [];
-  const ga = `\
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', '${GA4_TRACKING_ID}');\
-`;
-  return [
-    <script
-      key={"google-analytics-0"}
-      async={true}
-      defer={true}
-      src={`https://www.googletagmanager.com/gtag/js?id=${GA4_TRACKING_ID}`}
-    />,
-    <script
-      key={"google-analytics-1"}
-      dangerouslySetInnerHTML={{ __html: ga }}
-    />,
-  ];
-}
-
-function CoCalcAnalytics() {
-  return [
-    <script
-      key="cocalc-analytics"
-      async={true}
-      defer={true}
-      src={join(basePath, "analytics.js")}
-    />,
-  ];
-}
 
 // Why so careful not to nest things?  See
 //    https://nextjs.org/docs/api-reference/next/head
 // NOTE:  Analytics can't be in Head because of script tags! https://github.com/vercel/next.js/pull/26253
+//
+// Cookie consent: when the banner is enabled, we MUST NOT render the GA /
+// `/analytics.js` script tags during SSR — they would execute on the
+// browser's HTML parse, before the user has had any chance to accept or
+// decline. Instead we inject the scripts client-side from a useEffect that
+// fires once tracking consent is granted (and listens for later changes).
+// When the banner is disabled, fall back to the legacy SSR-script approach
+// so existing deployments without the banner are unaffected.
 export default function Analytics(): JSX.Element {
-  return <>{GoogleAnalytics().concat(CoCalcAnalytics())}</>;
+  const customize = useCustomize();
+  const { googleAnalytics, cookieBannerEnabled } = customize;
+  // True iff this page actually went through withCustomize. On pages that
+  // didn't (e.g. 404, _error), useCustomize returns the empty-object default
+  // and we have no way to know the admin's banner choice. cookieBannerEnabled
+  // is always a boolean once customize is populated (admin defaults map to
+  // false), so undefined is a reliable "customize missing" signal.
+  const customizeAvailable = cookieBannerEnabled !== undefined;
+
+  useEffect(() => {
+    if (!cookieBannerEnabled) return; // SSR scripts already loaded (or N/A)
+    if (typeof window === "undefined") return;
+    let loaded = false;
+    const tryLoad = () => {
+      if (loaded) return;
+      if (!hasTrackingConsent()) return;
+      loaded = true;
+      if (googleAnalytics) injectGoogleAnalytics(googleAnalytics);
+      injectCoCalcAnalytics();
+    };
+    tryLoad();
+    window.addEventListener("cc:onConsent", tryLoad);
+    window.addEventListener("cc:onChange", tryLoad);
+    // Banner may initialise after this component mounts; re-check next tick.
+    const t = window.setTimeout(tryLoad, 0);
+    return () => {
+      window.removeEventListener("cc:onConsent", tryLoad);
+      window.removeEventListener("cc:onChange", tryLoad);
+      window.clearTimeout(t);
+    };
+  }, [cookieBannerEnabled, googleAnalytics]);
+
+  // Customize unavailable (404 / _error): defer entirely.
+  if (!customizeAvailable) return <></>;
+
+  // Banner enabled: no SSR scripts; useEffect above handles loading after
+  // consent. Empty fragment so the component still has a valid return.
+  if (cookieBannerEnabled) return <></>;
+
+  // Banner disabled: render scripts during SSR (legacy behavior). The GA
+  // inline-init script uses dangerouslySetInnerHTML because the content is
+  // hand-built from the admin-supplied tracking ID, mirroring the pre-PR
+  // implementation; not new XSS surface.
+  return (
+    <>
+      {googleAnalytics ? renderGoogleAnalyticsScripts(googleAnalytics) : null}
+      <script
+        async={true}
+        defer={true}
+        src={join(basePath, "analytics.js")}
+      />
+    </>
+  );
+}
+
+function renderGoogleAnalyticsScripts(id: string) {
+  const ga = `\
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${id}');\
+`;
+  return (
+    <>
+      <script
+        async={true}
+        defer={true}
+        src={`https://www.googletagmanager.com/gtag/js?id=${id}`}
+      />
+      <script dangerouslySetInnerHTML={{ __html: ga }} />
+    </>
+  );
+}
+
+function injectGoogleAnalytics(id: string): void {
+  const s = document.createElement("script");
+  s.async = true;
+  s.defer = true;
+  s.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+  document.head.appendChild(s);
+  const w = window as unknown as {
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
+  };
+  w.dataLayer = w.dataLayer || [];
+  w.gtag = function gtag(...args: unknown[]) {
+    w.dataLayer.push(args);
+  };
+  w.gtag("js", new Date());
+  w.gtag("config", id);
+}
+
+function injectCoCalcAnalytics(): void {
+  const s = document.createElement("script");
+  s.async = true;
+  s.defer = true;
+  s.src = join(basePath, "analytics.js");
+  document.head.appendChild(s);
 }

--- a/src/packages/next/components/auth/sign-in.tsx
+++ b/src/packages/next/components/auth/sign-in.tsx
@@ -11,6 +11,10 @@ import {
 } from "react-google-recaptcha-v3";
 
 import { Icon } from "@cocalc/frontend/components/icon";
+import {
+  requireEssentialConsent,
+  useEssentialConsent,
+} from "@cocalc/frontend/cookie-consent";
 import Contact from "components/landing/contact";
 import A from "components/misc/A";
 import apiPost from "lib/api/post";
@@ -51,6 +55,7 @@ function SignIn0(props: SignInProps) {
   const [error, setError] = useState<string>("");
   const [haveSSO, setHaveSSO] = useState<boolean>(false);
   const { executeRecaptcha } = useGoogleReCaptcha();
+  const consentReady = useEssentialConsent();
 
   useEffect(() => {
     setHaveSSO(strategies != null && strategies.length > 0);
@@ -61,6 +66,7 @@ function SignIn0(props: SignInProps) {
 
   async function signIn() {
     if (signingIn) return;
+    if (!requireEssentialConsent()) return;
     setError("");
     try {
       setSigningIn(true);
@@ -148,6 +154,12 @@ function SignIn0(props: SignInProps) {
       <form>
         {haveSSO && (
           <div
+            onClickCapture={(e) => {
+              if (!requireEssentialConsent()) {
+                e.preventDefault();
+                e.stopPropagation();
+              }
+            }}
             style={{
               textAlign: "center",
               margin: "20px 0",
@@ -197,6 +209,7 @@ function SignIn0(props: SignInProps) {
               shape="round"
               size="large"
               type="primary"
+              disabled={!consentReady}
               style={{ width: "100%", marginTop: "20px" }}
               onClick={signIn}
             >
@@ -204,6 +217,8 @@ function SignIn0(props: SignInProps) {
                 <>
                   <Icon name="spinner" spin /> Signing In...
                 </>
+              ) : !consentReady ? (
+                "Acknowledge cookie banner to continue"
               ) : (
                 "Sign In"
               )}

--- a/src/packages/next/components/auth/sign-up.tsx
+++ b/src/packages/next/components/auth/sign-up.tsx
@@ -15,6 +15,10 @@ import { reuseInFlight } from "@cocalc/util/reuse-in-flight";
 
 import Markdown from "@cocalc/frontend/editors/slate/static-markdown";
 import {
+  requireEssentialConsent,
+  useEssentialConsent,
+} from "@cocalc/frontend/cookie-consent";
+import {
   MAX_PASSWORD_LENGTH,
   MIN_PASSWORD_LENGTH,
   MIN_PASSWORD_STRENGTH,
@@ -154,6 +158,8 @@ function SignUp0({
   // based on email: if user has to sign up via SSO, this will tell which strategy to use.
   const requiredSSO = useRequiredSSO(strategies, email);
 
+  const consentReady = useEssentialConsent();
+
   if (requiresToken2 === undefined || strategies == null) {
     return <Loading />;
   }
@@ -173,11 +179,13 @@ function SignUp0({
     passwordStrength.score > MIN_PASSWORD_STRENGTH &&
     firstName?.trim() &&
     lastName?.trim() &&
-    !needsTags
+    !needsTags &&
+    consentReady
   );
 
   async function signUp() {
     if (signingUp) return;
+    if (!requireEssentialConsent()) return;
     setIssues({});
     try {
       setSigningUp(true);
@@ -499,9 +507,11 @@ function SignUp0({
                           ? "Enter your first name above"
                           : !lastName?.trim()
                             ? "Enter your last name above"
-                            : signingUp
-                              ? ""
-                              : "Sign Up!"}
+                            : !consentReady
+                              ? "Acknowledge cookie banner to continue"
+                              : signingUp
+                                ? ""
+                                : "Sign Up!"}
           {signingUp && (
             <span style={{ marginLeft: "15px" }}>
               <Loading>Signing Up...</Loading>
@@ -538,7 +548,15 @@ function EmailOrSSO(props: EmailOrSSOProps) {
     };
 
     return (
-      <div style={{ textAlign: "center", margin: "20px 0" }}>
+      <div
+        onClickCapture={(e) => {
+          if (!requireEssentialConsent()) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+        style={{ textAlign: "center", margin: "20px 0" }}
+      >
         <SSO size={email ? 24 : undefined} style={style} />
       </div>
     );

--- a/src/packages/next/components/auth/try.tsx
+++ b/src/packages/next/components/auth/try.tsx
@@ -14,6 +14,10 @@ import {
   useGoogleReCaptcha,
 } from "react-google-recaptcha-v3";
 
+import {
+  requireEssentialConsent,
+  useEssentialConsent,
+} from "@cocalc/frontend/cookie-consent";
 import { len } from "@cocalc/util/misc";
 import A from "components/misc/A";
 import Loading from "components/share/loading";
@@ -49,6 +53,7 @@ function Try0({ minimal, onSuccess, publicPathId }: Props) {
     anonymousSignupLicensedShares,
   } = useCustomize();
   const [state, setState] = useState<"wait" | "creating" | "done">("wait");
+  const consentReady = useEssentialConsent();
   const [error, setError] = useState<string>("");
   const { executeRecaptcha } = useGoogleReCaptcha();
 
@@ -61,6 +66,7 @@ function Try0({ minimal, onSuccess, publicPathId }: Props) {
   }
 
   async function createAnonymousAccount() {
+    if (!requireEssentialConsent()) return;
     setState("creating");
     try {
       let reCaptchaToken: undefined | string;
@@ -116,7 +122,7 @@ function Try0({ minimal, onSuccess, publicPathId }: Props) {
         </A>
         !
         <Button
-          disabled={state != "wait"}
+          disabled={state != "wait" || !consentReady}
           shape="round"
           size="large"
           type="primary"
@@ -125,6 +131,8 @@ function Try0({ minimal, onSuccess, publicPathId }: Props) {
         >
           {state == "creating" ? (
             <Loading>Configuring Anonymous Access...</Loading>
+          ) : !consentReady ? (
+            "Acknowledge cookie banner to continue"
           ) : (
             <>Use {siteName} Anonymously</>
           )}

--- a/src/packages/next/package.json
+++ b/src/packages/next/package.json
@@ -92,6 +92,7 @@
     "timeago-react": "^3.0.4",
     "use-async-effect": "^2.2.7",
     "uuid": "^8.3.2",
+    "vanilla-cookieconsent": "^3.1.0",
     "xmlbuilder2": "^4.0.1",
     "zod": "^3.23.5"
   },

--- a/src/packages/next/pages/_app.tsx
+++ b/src/packages/next/pages/_app.tsx
@@ -11,10 +11,15 @@ import "antd/dist/reset.css";
 import "@ant-design/v5-patch-for-react-19";
 
 import { ConfigProvider } from "antd";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { Locale } from "locales/misc";
 
 // Initialize the appBasePath for the frontend codebase.
 import "@cocalc/frontend/customize/app-base-path";
+import "vanilla-cookieconsent/dist/cookieconsent.css";
+import { enableForceConsent } from "@cocalc/frontend/cookie-consent";
+import { initCookieConsent } from "@cocalc/frontend/cookie-consent/init";
 
 // CoCalc 3rd party libraries
 import "@cocalc/cdn/dist/codemirror/lib/codemirror.css";
@@ -38,6 +43,37 @@ function MyApp({
 }: // router,
 AppProps & { locale: Locale }) {
   const antdTheme = getBaseAntdTheme();
+  const router = useRouter();
+  const customize = pageProps?.customize;
+  // customize is undefined on pages that don't go through withCustomize
+  // (notably 404 / _error). Don't make a "banner disabled" decision in
+  // that case — that would let Analytics render legacy SSR scripts and
+  // bypass the consent contract.
+  const customizeAvailable = customize != null;
+  const cookieBannerEnabled = customize?.cookieBannerEnabled;
+  const cookieBannerText = customize?.cookieBannerText;
+  useEffect(() => {
+    if (!customizeAvailable) return;
+    initCookieConsent({
+      enabled: !!cookieBannerEnabled,
+      textMarkdown: cookieBannerText,
+    });
+  }, [customizeAvailable, cookieBannerEnabled, cookieBannerText]);
+
+  // Force-consent mode on auth + SSO launch pages: a dark overlay blocks
+  // interaction with the form until the user accepts the banner. We toggle
+  // this on every route change rather than baking it into the banner config
+  // at init — `disablePageInteraction` is a one-shot config option, so a
+  // user who lands on `/` first and then navigates to `/auth/sign-in`
+  // wouldn't see the dim otherwise. enableForceConsent is also a no-op when
+  // the user has already consented.
+  const path = router.pathname ?? "";
+  const isAuthRoute =
+    /^\/auth\/(sign-in|sign-up|try)/.test(path) || /^\/sso(\/|$)/.test(path);
+  useEffect(() => {
+    if (!cookieBannerEnabled || !isAuthRoute) return;
+    return enableForceConsent();
+  }, [cookieBannerEnabled, isAuthRoute]);
   return (
     <AppContext.Provider value={{ ...DEFAULT_CONTEXT }}>
       <ConfigProvider theme={antdTheme}>

--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -682,6 +682,9 @@ importers:
       utility-types:
         specifier: ^3.10.0
         version: 3.11.0
+      vanilla-cookieconsent:
+        specifier: ^3.1.0
+        version: 3.1.0
       video-extensions:
         specifier: ^1.2.0
         version: 1.2.0
@@ -1069,6 +1072,9 @@ importers:
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
+      vanilla-cookieconsent:
+        specifier: ^3.1.0
+        version: 3.1.0
       xmlbuilder2:
         specifier: ^4.0.1
         version: 4.0.3
@@ -11900,6 +11906,9 @@ packages:
   validator@13.15.22:
     resolution: {integrity: sha512-uT/YQjiyLJP7HSrv/dPZqK9L28xf8hsNca01HSz1dfmI0DgMfjopp1rO/z13NeGF1tVystF0Ejx3y4rUKPw+bQ==}
     engines: {node: '>= 0.10'}
+
+  vanilla-cookieconsent@3.1.0:
+    resolution: {integrity: sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -24475,6 +24484,8 @@ snapshots:
   validate.io-number@1.0.3: {}
 
   validator@13.15.22: {}
+
+  vanilla-cookieconsent@3.1.0: {}
 
   vary@1.1.2: {}
 

--- a/src/packages/util/db-schema/accounts.ts
+++ b/src/packages/util/db-schema/accounts.ts
@@ -684,6 +684,7 @@ Table({
             [USE_BALANCE_TOWARD_SUBSCRIPTIONS]:
               USE_BALANCE_TOWARD_SUBSCRIPTIONS_DEFAULT,
             hide_navbar_balance: false,
+            cookie_consent: null,
           },
           name: null,
           first_name: "",

--- a/src/packages/util/db-schema/server-settings.ts
+++ b/src/packages/util/db-schema/server-settings.ts
@@ -137,4 +137,6 @@ export interface Customize {
     recommended_browser?: number;
     compute_server_min_project?: number;
   };
+  cookieBannerEnabled?: boolean;
+  cookieBannerText?: string;
 }

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -46,6 +46,7 @@ export const TAGS = [
   "I18N",
   "Security",
   "Support",
+  "Cookie Banner",
 ] as const;
 
 export type Tag = (typeof TAGS)[number];
@@ -129,7 +130,9 @@ export type SiteSettingsKeys =
   | "cloud_filesystems_enabled"
   | "insecure_test_mode"
   | "samesite_remember_me"
-  | "user_tracking";
+  | "user_tracking"
+  | "cookie_banner_enabled"
+  | "cookie_banner_text";
 
 //| "compute_servers_lambda-cloud_enabled"
 
@@ -538,6 +541,23 @@ export const site_settings_conf: SiteSettings = {
     clearable: true,
     show: (conf) => show_theming_vars(conf) && only_cocalc_com(conf),
     tags: ["Theme"],
+  },
+  cookie_banner_enabled: {
+    name: "Cookie banner",
+    desc: "Show a GDPR-style cookie consent banner to all visitors, regardless of geolocation. The banner offers two categories of cookies: *necessary* (required to sign in and keep a session) and *analytics* (optional tracking). Until the user accepts the *necessary* category, sign-up and sign-in are blocked.",
+    default: "no",
+    valid: only_booleans,
+    to_val: to_bool,
+    tags: ["Cookie Banner"],
+  },
+  cookie_banner_text: {
+    name: "Cookie banner text",
+    desc: "Markdown body shown in the cookie banner and preferences modal. Links to the privacy policy and terms of service are rendered as separate footer links and do not need to be repeated here.",
+    default:
+      "We use cookies that are strictly necessary for sign-in and session management, and optional analytics cookies to understand how the site is used. You can change your preferences at any time.",
+    clearable: true,
+    multiline: 5,
+    tags: ["Cookie Banner"],
   },
   // ============== END THEMING ============
 


### PR DESCRIPTION
## Summary

GDPR-compliant cookie consent banner shared between the SPA frontend (`packages/frontend`) and the Next.js landing pages (`packages/next`). Built on [vanilla-cookieconsent v3](https://cookieconsent.orestbida.com).

## Categories

| Category    | Read-only | Default  | Gates                                                                          |
| ----------- | --------- | -------- | ------------------------------------------------------------------------------ |
| `necessary` | yes       | accepted | Sign-in, session, `remember_me`, version sync                                  |
| `analytics` | no        | declined | Third-party tracking (`_ga*`, `_gid*`, `CC_ANA`) — autoClear on revoke         |
| `usage`     | no        | declined | First-party `TrackingClient.user_tracking` events (clicks/toggles/navigation)  |

The `usage` category gates the existing `track(...)` event recorder. Two layers must both be on for an event to write: the admin-side `user_tracking` setting AND the visitor's acceptance of `usage`. If the admin disables the banner site-wide, the consent layer collapses to passthrough and the legacy admin-only gate applies.

## Force-consent UX

- **Auth + SSO routes** (`/auth/sign-{in,up}`, `/auth/try`, `/sso`, `/sso/[id]`): a dark overlay covers the page and clicks outside the banner are blocked; submit buttons display *"Acknowledge cookie banner to continue"* until the user accepts.
- **SPA fallback**: a successful SSO callback can drop a logged-in user on `/app` without ever seeing the auth-page overlay (bookmarked SSO start URLs, direct visits). After `accountStore.waitUntilReady()` resolves, the SPA applies the same dim if the user hasn't acknowledged. The dim never flashes during boot for users who already consented.
- **Verify-email modal**: gated on consent so it doesn't render visually on top of the dim.

## Admin settings

Two new settings under a `"Cookie Banner"` tag in `site-defaults.ts`:

| Setting                 | Type             | Effect                                       |
| ----------------------- | ---------------- | -------------------------------------------- |
| `cookie_banner_enabled` | bool             | Master on/off — disables the banner entirely |
| `cookie_banner_text`    | Markdown         | Body shown in banner + preferences modal     |

Both flow through the existing `customize` pipeline. Categories themselves are defined in `cookie-consent/categories.ts` as a single source of truth — the v3 runtime config, `ConsentSnapshot` type persisted to `accounts.other_settings.cookie_consent`, the preferences-modal sections, and the SPA settings panel all derive from that list.

## Public API for analytics integrations

```ts
import {
  hasEssentialConsent,    // user has acknowledged the banner at all
  hasCategoryConsent,     // generic per-category check
  hasTrackingConsent,     // alias for hasCategoryConsent("analytics")
  useEssentialConsent,    // React hook, reactive
  onConsentChange,        // subscribe to consent changes
  showPreferences,        // open preferences modal
  enableForceConsent,     // dim + force banner until consent (used by SSO fallback)
} from "@cocalc/frontend/cookie-consent";
```

Adding a new category (e.g. `marketing`) is one entry in `categories.ts` plus a revision bump. See `src/docs/auth.md` § *Cookie Consent (GDPR Banner)* for the full reference + recipe.

## Persistence

Consent is mirrored into `accounts.other_settings.cookie_consent` with a timestamp on every change. Browser cookie remains authoritative for the live session — we don't restore back to the browser (consent is browser-bound under GDPR).

A *"Cookie preferences"* panel in **Account → Preferences → Communication** shows the current state per category (green check / red minus, vertical list mirroring the project Settings → Features visual idiom) and re-opens the preferences modal on demand.

## What's English-only

Banner strings (`translations.ts`) are English-only in this PR. Integration with the existing simplelocalize/JSON pipeline is a follow-up.

## Test plan

- [x] Banner renders bottom-right (box, equal-weight buttons) on both SPA `/app` and Next `/auth/*`
- [x] Force-consent on `/auth/sign-in`: page dimmed, form fields disabled, button reads *"Acknowledge cookie banner to continue"*
- [x] Force-consent on `/sso` and `/sso/[id]` (extends regex)
- [x] SPA SSO fallback: clear `cc_cookie` + DB consent + reload `/app` → dim + banner; accept → dim removes, DB record updates
- [x] Verify-email modal hidden during force-consent, appears after accept
- [x] Email/password and SSO submit blocked until consent (button + capture-phase click handler)
- [x] Anonymous "Use without account" gated identically
- [x] Three categories visible in preferences modal: Necessary (locked), Analytics, Usage metrics
- [x] Settings panel mirrors snapshot reactively (revoke → tag flips to declined immediately)
- [x] `_ga` / `CC_ANA` auto-cleared on analytics revoke
- [x] `track()` event recorder respects two-layer gate (admin setting + usage consent)
- [x] Banner-disabled passes through all gates (legacy behaviour)
- [x] Missing `pageProps.customize` (404, _error) → no SSR analytics, no banner-disabled decision
- [x] First-render: no flicker on Sign In / Sign Up button label for users who already consented
- [x] Hydration: no SSR/CSR mismatch
- [x] `pnpm tsc --noEmit` clean across util / database / frontend; only pre-existing TS6307 noise in next
- [x] `pnpm build-dev` in `packages/static` clean

## Follow-ups (out of scope)

- Wire translations through simplelocalize/JSON
- If admin toggles the banner off mid-session, existing tabs need a refresh (vanilla-cookieconsent v3 has no uninstall path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)