### PR TITLE
cookie banner: only force-consent on sign-up and /sso/*

### DIFF
--- a/src/docs/auth.md
+++ b/src/docs/auth.md
@@ -306,26 +306,31 @@ acceptance of the `usage` category. If the admin disables the banner site-
 wide, the cookie consent layer collapses to a passthrough and the admin
 setting alone gates (legacy behaviour).
 
-Sign-up, sign-in, and "use anonymously" are blocked until the user
-acknowledges the banner. The Sign In / Sign Up buttons stay disabled and
-show *"Acknowledge cookie banner to continue"*. On `/auth/sign-in`,
-`/auth/sign-up`, and `/auth/try`, the banner runs in **force-consent mode**:
+`/auth/sign-up` and `/sso/*` run the banner in **force-consent mode**:
 a dark overlay covers the page and clicks outside the banner are blocked
-(via vanilla-cookieconsent's `disablePageInteraction: true`).
+(via vanilla-cookieconsent's `disablePageInteraction: true`). On sign-up,
+the Sign Up button stays disabled and shows *"Acknowledge cookie banner
+to continue"* until consent is given. `/sso/*` is gated for the same
+reason — its redirect hands control to an external IdP whose callback
+sets session cookies, so consent must be settled before that handoff.
+`/auth/sign-in` and `/auth/try` show the banner but do not enforce it —
+those flows land the user in the SPA, where the in-app force-consent
+fallback (described below) kicks in if consent is still missing.
 
-**SSO fallback in the SPA**: a successful SSO callback can drop a
-logged-in user on `/app` without ever passing through the auth-page
-overlay (e.g. when they followed a bookmarked SSO start URL). The SPA's
-root `App` component (`packages/frontend/app/render.tsx`) waits for
-`accountStore.waitUntilReady()` — so the dim never flashes during boot
-for users whose customize/account is still loading — and only then, if
-the user is logged in *and* `hasEssentialConsent()` is false, calls
-`enableForceConsent()`. That helper toggles the same `disable--interaction`
-class on `<html>` that vanilla-cookieconsent uses for its built-in
-overlay, and auto-removes it when the user accepts or declines (via
-`cc:onConsent` / `cc:onChange`). This is belt-and-braces: the auth pages
-already gate the common path; the SPA fallback covers users who reached
-`/app` through any other route.
+**Force-consent in the SPA**: this is the primary enforcement point for
+every signed-in user. Sign-in and anonymous-try land on `/app` without
+going through a force-consent overlay, and a returning user with a
+`remember_me` cookie skips the auth pages entirely. (SSO is the
+exception: its launch page is gated up front, since the IdP callback
+drops cookies before the SPA boots.)
+The SPA's root `App` component (`packages/frontend/app/render.tsx`)
+waits for `accountStore.waitUntilReady()` — so the dim never flashes
+during boot for users whose customize/account is still loading — and
+only then, if the user is logged in *and* `hasEssentialConsent()` is
+false, calls `enableForceConsent()`. That helper toggles the same
+`disable--interaction` class on `<html>` that vanilla-cookieconsent uses
+for its built-in overlay, and auto-removes it when the user accepts or
+declines (via `cc:onConsent` / `cc:onChange`).
 
 ### Admin settings
 

--- a/src/packages/frontend/account/cookie-consent-settings.tsx
+++ b/src/packages/frontend/account/cookie-consent-settings.tsx
@@ -17,6 +17,10 @@ import {
   onConsentChange,
   showPreferences,
 } from "@cocalc/frontend/cookie-consent";
+import {
+  revokeYouTubeConsent,
+  useYouTubeConsent,
+} from "@cocalc/frontend/cookie-consent/youtube";
 import { COLORS } from "@cocalc/util/theme";
 
 // Visual style mirrors project Settings → Features (project-capabilites.tsx)
@@ -49,6 +53,11 @@ export function CookieConsentSettings(): React.JSX.Element | null {
   const [snap, setSnap] = useState<ConsentSnapshot | null>(() =>
     getConsentSnapshot(),
   );
+  // YouTube consent is stored in a dedicated cookie, parallel to the v3
+  // banner (see frontend/cookie-consent/youtube.ts). We surface it in
+  // this same panel because users naturally come here looking for "all
+  // cookie-style consents I've granted on this site".
+  const ytAllowed = useYouTubeConsent();
 
   useEffect(() => onConsentChange(setSnap), []);
 
@@ -78,6 +87,10 @@ export function CookieConsentSettings(): React.JSX.Element | null {
               label={c.label}
             />
           ))}
+          <CategoryStatus
+            accepted={ytAllowed}
+            label="Embedded YouTube videos"
+          />
           {snap.timestamp && (
             <div style={{ color: COLORS.GRAY }}>
               Last updated: <TimeAgo date={snap.timestamp} />
@@ -86,9 +99,20 @@ export function CookieConsentSettings(): React.JSX.Element | null {
         </Space>
       )}
       <div style={{ marginTop: 12 }}>
-        <Button onClick={() => showPreferences()}>
-          <Icon name="cog" /> Manage cookie preferences
-        </Button>
+        <Space wrap>
+          <Button onClick={() => showPreferences()}>
+            <Icon name="cog" /> Manage cookie preferences
+          </Button>
+          {ytAllowed && (
+            <Button
+              danger
+              onClick={() => revokeYouTubeConsent()}
+              title="Block embedded YouTube videos again. They will show a click-to-load placeholder."
+            >
+              <Icon name="youtube" /> Revoke YouTube embed consent
+            </Button>
+          )}
+        </Space>
       </div>
     </Panel>
   );

--- a/src/packages/frontend/cookie-consent/init.ts
+++ b/src/packages/frontend/cookie-consent/init.ts
@@ -25,7 +25,18 @@ import { markdown_to_html } from "@cocalc/frontend/markdown";
 import { COOKIE_CATEGORIES, type CookieCategory } from "./categories";
 import { COOKIE_CONSENT_REVISION } from "./index";
 import { markBannerActive, markBannerDecidedDisabled } from "./state";
-import { buildTranslation } from "./translations";
+import {
+  YOUTUBE_SECTION_BUTTON_ID,
+  YOUTUBE_SECTION_CSS,
+  YOUTUBE_SECTION_STATUS_ID,
+  buildTranslation,
+} from "./translations";
+import {
+  YOUTUBE_CONSENT_EVENT,
+  grantYouTubeConsent,
+  hasYouTubeConsent,
+  revokeYouTubeConsent,
+} from "./youtube";
 
 function buildCategoriesConfig(): Record<string, CookieConsent.Category> {
   const out: Record<string, CookieConsent.Category> = {};
@@ -109,8 +120,64 @@ export function initCookieConsent({
         console.error("cookie-consent: run rejected", err),
       );
     }
+    injectYouTubeSectionStyles();
+    wireYouTubePreferencesSection();
   } catch (err) {
     console.error("cookie-consent: run threw", err);
   }
+}
+
+// Mount the YouTube section stylesheet into <head>. v3 places our section
+// description inside a <p>, which can't host a <style> child without the
+// HTML parser auto-closing the paragraph. Putting the rules in <head>
+// avoids that and applies them to every modal open.
+function injectYouTubeSectionStyles(): void {
+  if (typeof document === "undefined") return;
+  const id = "cocalc-yt-styles";
+  if (document.getElementById(id) != null) return;
+  const style = document.createElement("style");
+  style.id = id;
+  style.textContent = YOUTUBE_SECTION_CSS;
+  document.head.appendChild(style);
+}
+
+// Hook up the "Embedded videos" section the translations file injected into
+// the preferences modal. v3 only renders that HTML — it doesn't know about
+// our parallel YouTube consent cookie — so we re-populate the status badge
+// and bind the toggle checkbox each time the modal opens, and refresh
+// state whenever the cookie changes (e.g. from a click-to-load gate on the
+// landing page while the modal is already open).
+function wireYouTubePreferencesSection(): void {
+  if (typeof window === "undefined") return;
+  const refresh = () => {
+    const status = document.getElementById(YOUTUBE_SECTION_STATUS_ID);
+    const toggle = document.getElementById(
+      YOUTUBE_SECTION_BUTTON_ID,
+    ) as HTMLInputElement | null;
+    if (status == null || toggle == null) return;
+    const granted = hasYouTubeConsent();
+    status.textContent = granted ? "Allowed" : "Blocked";
+    status.classList.toggle("cocalc-yt-status--on", granted);
+    status.classList.toggle("cocalc-yt-status--off", !granted);
+    if (toggle.checked !== granted) toggle.checked = granted;
+  };
+  // v3 fires cc:onModalShow when either modal opens; we don't try to
+  // filter to just the preferences modal because the elements are scoped
+  // by id and absent when the consent modal is open.
+  window.addEventListener("cc:onModalShow", refresh);
+  window.addEventListener(YOUTUBE_CONSENT_EVENT, refresh);
+  // Delegated change handler — the checkbox is re-rendered each time v3
+  // mounts the preferences modal, so binding directly on the element
+  // would miss subsequent opens.
+  document.addEventListener("change", (ev) => {
+    const target = ev.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.id !== YOUTUBE_SECTION_BUTTON_ID) return;
+    if (target.checked) {
+      grantYouTubeConsent();
+    } else {
+      revokeYouTubeConsent();
+    }
+  });
 }
 

--- a/src/packages/frontend/cookie-consent/translations.ts
+++ b/src/packages/frontend/cookie-consent/translations.ts
@@ -28,6 +28,15 @@ export function buildTranslation(
     description: c.description,
     linkedCategory: c.key,
   }));
+  // Embedded YouTube videos use a separate consent flag (see
+  // cookie-consent/youtube.ts) so that accepting a video does not mark the
+  // main banner as decided. We still surface it in the preferences modal
+  // so users can review/revoke it alongside the v3 categories. The button
+  // is wired up by init.ts on `cc:onModalShow`.
+  const youtubeSection = {
+    title: "Embedded videos",
+    description: buildYouTubeSectionHtml(),
+  };
   return {
     consentModal: {
       title: "We value your privacy",
@@ -43,7 +52,147 @@ export function buildTranslation(
       acceptNecessaryBtn: "Necessary only",
       savePreferencesBtn: "Save preferences",
       closeIconLabel: "Close",
-      sections: [{ description: prefsLead }, ...categorySections],
+      sections: [
+        { description: prefsLead },
+        ...categorySections,
+        youtubeSection,
+      ],
     },
   };
+}
+
+// Container HTML for the "Embedded videos" preferences section. The
+// toggle state and status badge are filled in at modal-open time by
+// init.ts so they reflect the current cookie state without our having to
+// re-render the v3 modal config.
+//
+// The styling here mimics v3's own per-category section so the YouTube
+// row visually slots in alongside Necessary / Analytics / Usage even
+// though it isn't backed by a real v3 category. Scoped class names
+// (`cocalc-yt-*`) avoid colliding with v3's `pm__` namespace.
+export const YOUTUBE_SECTION_STATUS_ID = "cocalc-yt-status";
+export const YOUTUBE_SECTION_TOGGLE_ID = "cocalc-yt-toggle";
+// Kept as an alias so init.ts doesn't have to know which DOM element it
+// is actually toggling (we switched from a <button> to a checkbox).
+export const YOUTUBE_SECTION_BUTTON_ID = YOUTUBE_SECTION_TOGGLE_ID;
+
+// CSS for the YouTube section. Three constraints conspire here:
+//
+//  1. v3 injects `section.description` via innerHTML into a <p>, so block
+//     children (<div>, <style>) get ejected by the HTML parser. We use
+//     only inline elements (<span>/<label>) below.
+//  2. v3's stylesheet has a top-of-file rule
+//       `#cc-main :before, #cc-main span, #cc-main input ... { all: unset }`
+//     which carries the specificity of an id selector. Plain class
+//     selectors lose to it, so every rule below is scoped under
+//     `#cc-main` to match and source-order-override the reset.
+//  3. The stylesheet is mounted into <head> by init.ts so it works
+//     regardless of where in the cookie-consent modal the markup ends up.
+export const YOUTUBE_SECTION_CSS = `
+#cc-main .cocalc-yt-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 1em;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0.75em;
+  padding: 0.75em 1em;
+  border: 1px solid var(--cc-toggle-border-color, #d1d5db);
+  border-radius: 0.5em;
+  background: var(--cc-section-category-block-bg, #f9fafb);
+  vertical-align: top;
+}
+#cc-main .cocalc-yt-card__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25em;
+  align-items: flex-start;
+}
+#cc-main .cocalc-yt-card__label {
+  font-weight: 600;
+  display: inline-block;
+}
+#cc-main .cocalc-yt-status {
+  display: inline-block;
+  padding: 0.15em 0.6em;
+  border-radius: 999px;
+  font-size: 0.85em;
+  font-weight: 600;
+  line-height: 1.4;
+}
+#cc-main .cocalc-yt-status--on {
+  background: #d1fae5;
+  color: #065f46;
+}
+#cc-main .cocalc-yt-status--off {
+  background: #fee2e2;
+  color: #991b1b;
+}
+#cc-main .cocalc-yt-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex: 0 0 auto;
+  cursor: pointer;
+}
+#cc-main .cocalc-yt-switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+#cc-main .cocalc-yt-slider {
+  position: absolute;
+  inset: 0;
+  background: #cbd5e1;
+  border-radius: 999px;
+  transition: background 0.2s;
+  display: inline-block;
+}
+#cc-main .cocalc-yt-slider::before {
+  content: "";
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 3px;
+  top: 3px;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  transition: transform 0.2s;
+}
+#cc-main .cocalc-yt-switch input:checked + .cocalc-yt-slider {
+  background: #10b981;
+}
+#cc-main .cocalc-yt-switch input:checked + .cocalc-yt-slider::before {
+  transform: translateX(20px);
+}
+#cc-main .cocalc-yt-switch input:focus-visible + .cocalc-yt-slider {
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.35);
+}
+`;
+
+export function buildYouTubeSectionHtml(): string {
+  // Every wrapper is an inline element so the surrounding <p> v3 creates
+  // for `section.description` stays valid HTML. Visual block layout is
+  // recovered via display:inline-flex / inline-block in YOUTUBE_SECTION_CSS.
+  return `
+<span>
+  Some pages embed YouTube videos. Playing them allows YouTube to set
+  cookies in your browser, separately from the cookies described above.
+  Videos stay blocked until you click them.
+</span>
+<span class="cocalc-yt-card">
+  <span class="cocalc-yt-card__text">
+    <span class="cocalc-yt-card__label">Embedded YouTube videos</span>
+    <span id="${YOUTUBE_SECTION_STATUS_ID}" class="cocalc-yt-status cocalc-yt-status--off">Blocked</span>
+  </span>
+  <label class="cocalc-yt-switch" aria-label="Allow embedded YouTube videos">
+    <input id="${YOUTUBE_SECTION_TOGGLE_ID}" type="checkbox" />
+    <span class="cocalc-yt-slider"></span>
+  </label>
+</span>`;
 }

--- a/src/packages/frontend/cookie-consent/youtube.ts
+++ b/src/packages/frontend/cookie-consent/youtube.ts
@@ -1,0 +1,61 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+// Stand-alone "consent for embedded YouTube" flag. Kept separate from the
+// vanilla-cookieconsent v3 banner state on purpose: accepting a YouTube
+// embed must not mark the main banner as "decided", otherwise the
+// force-consent overlay on sign-up / SSO launch would stop triggering for
+// a visitor who only clicked a video on the landing page.
+//
+// The preferences modal still surfaces this consent (see translations.ts +
+// init.ts) so users can review and revoke it alongside the categories;
+// internally that UI just reads/writes the dedicated cookie below.
+
+import { useEffect, useState } from "react";
+
+const YT_COOKIE = "cocalc_youtube_consent";
+const ONE_YEAR_S = 365 * 24 * 60 * 60;
+export const YOUTUBE_CONSENT_EVENT = "cocalc:youtube-consent";
+
+export function hasYouTubeConsent(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.cookie
+    .split(";")
+    .some((c) => c.trim() === `${YT_COOKIE}=1`);
+}
+
+function emitChange(): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(YOUTUBE_CONSENT_EVENT));
+  }
+}
+
+export function grantYouTubeConsent(): void {
+  if (typeof document === "undefined") return;
+  document.cookie =
+    `${YT_COOKIE}=1; path=/; max-age=${ONE_YEAR_S}; SameSite=Lax`;
+  emitChange();
+}
+
+export function revokeYouTubeConsent(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${YT_COOKIE}=; path=/; max-age=0; SameSite=Lax`;
+  emitChange();
+}
+
+// React hook: re-renders when YouTube consent state flips. First render
+// returns false to avoid a Next.js hydration mismatch (the server can't
+// read document.cookie); useEffect reconciles to the real value.
+export function useYouTubeConsent(): boolean {
+  const [granted, setGranted] = useState(false);
+  useEffect(() => {
+    const update = () => setGranted(hasYouTubeConsent());
+    update();
+    window.addEventListener(YOUTUBE_CONSENT_EVENT, update);
+    return () =>
+      window.removeEventListener(YOUTUBE_CONSENT_EVENT, update);
+  }, []);
+  return granted;
+}

--- a/src/packages/next/components/auth/in-place-sign-in-or-up.tsx
+++ b/src/packages/next/components/auth/in-place-sign-in-or-up.tsx
@@ -6,11 +6,13 @@
 // TODO: below we need to get the strategies!
 // and also requiresToken for SignUp!
 import { Icon } from "@cocalc/frontend/components/icon";
+import { enableForceConsent } from "@cocalc/frontend/cookie-consent";
 import { Divider } from "antd";
 import SignInAuth from "components/auth/sign-in";
 import SignUpAuth from "components/auth/sign-up";
+import useCustomize from "lib/use-customize";
 import { useRouter } from "next/router";
-import { CSSProperties, ReactNode, useState } from "react";
+import { CSSProperties, ReactNode, useEffect, useState } from "react";
 
 import { AUTH_WRAPPER_STYLE } from "./shared";
 
@@ -37,7 +39,21 @@ export default function InPlaceSignInOrUp({
   publicPathId,
 }: InPlaceOrSignUpProps) {
   const router = useRouter();
+  const { cookieBannerEnabled } = useCustomize();
   const [show, setShow] = useState<SelectedView>(defaultView);
+
+  // The in-place sign-in/up panel mounts on billing, voucher, share and
+  // similar Next.js pages whose route doesn't match the `_app.tsx`
+  // mandatory-route regex, and whose default `onSuccess` keeps the user
+  // on the same Next page rather than routing into the SPA. The SPA's
+  // own force-consent fallback therefore never fires for these flows, so
+  // we replicate it here: as long as the banner is admin-enabled and the
+  // panel is on screen, enable the page-dim overlay until the user
+  // accepts. The helper is a no-op when consent already exists.
+  useEffect(() => {
+    if (!cookieBannerEnabled) return;
+    return enableForceConsent();
+  }, [cookieBannerEnabled]);
 
   return (
     <div style={{ ...style, ...AUTH_WRAPPER_STYLE }}>

--- a/src/packages/next/components/auth/sign-in.tsx
+++ b/src/packages/next/components/auth/sign-in.tsx
@@ -11,10 +11,6 @@ import {
 } from "react-google-recaptcha-v3";
 
 import { Icon } from "@cocalc/frontend/components/icon";
-import {
-  requireEssentialConsent,
-  useEssentialConsent,
-} from "@cocalc/frontend/cookie-consent";
 import Contact from "components/landing/contact";
 import A from "components/misc/A";
 import apiPost from "lib/api/post";
@@ -55,7 +51,6 @@ function SignIn0(props: SignInProps) {
   const [error, setError] = useState<string>("");
   const [haveSSO, setHaveSSO] = useState<boolean>(false);
   const { executeRecaptcha } = useGoogleReCaptcha();
-  const consentReady = useEssentialConsent();
 
   useEffect(() => {
     setHaveSSO(strategies != null && strategies.length > 0);
@@ -66,7 +61,6 @@ function SignIn0(props: SignInProps) {
 
   async function signIn() {
     if (signingIn) return;
-    if (!requireEssentialConsent()) return;
     setError("");
     try {
       setSigningIn(true);
@@ -154,12 +148,6 @@ function SignIn0(props: SignInProps) {
       <form>
         {haveSSO && (
           <div
-            onClickCapture={(e) => {
-              if (!requireEssentialConsent()) {
-                e.preventDefault();
-                e.stopPropagation();
-              }
-            }}
             style={{
               textAlign: "center",
               margin: "20px 0",
@@ -209,7 +197,6 @@ function SignIn0(props: SignInProps) {
               shape="round"
               size="large"
               type="primary"
-              disabled={!consentReady}
               style={{ width: "100%", marginTop: "20px" }}
               onClick={signIn}
             >
@@ -217,8 +204,6 @@ function SignIn0(props: SignInProps) {
                 <>
                   <Icon name="spinner" spin /> Signing In...
                 </>
-              ) : !consentReady ? (
-                "Acknowledge cookie banner to continue"
               ) : (
                 "Sign In"
               )}

--- a/src/packages/next/components/auth/try.tsx
+++ b/src/packages/next/components/auth/try.tsx
@@ -53,6 +53,10 @@ function Try0({ minimal, onSuccess, publicPathId }: Props) {
     anonymousSignupLicensedShares,
   } = useCustomize();
   const [state, setState] = useState<"wait" | "creating" | "done">("wait");
+  // The anonymous trial flow is mounted both on /auth/try and inside the
+  // share-page OpenAnonymously block. Neither path routes through the
+  // SPA's force-consent fallback after success, so we keep the cookie
+  // banner explicitly gating the action here.
   const consentReady = useEssentialConsent();
   const [error, setError] = useState<string>("");
   const { executeRecaptcha } = useGoogleReCaptcha();

--- a/src/packages/next/components/videos.tsx
+++ b/src/packages/next/components/videos.tsx
@@ -1,6 +1,13 @@
 import { Carousel } from "antd";
+import { join } from "path";
 import { useState } from "react";
+
 import { Icon } from "@cocalc/frontend/components/icon";
+import { appBasePath } from "@cocalc/frontend/customize/app-base-path";
+import {
+  grantYouTubeConsent,
+  useYouTubeConsent,
+} from "@cocalc/frontend/cookie-consent/youtube";
 import { Paragraph } from "components/misc";
 import A from "components/misc/A";
 
@@ -49,6 +56,19 @@ export function VideoItem({
   style?;
   width?: number;
 }) {
+  // Embedded YouTube videos are gated behind a dedicated consent cookie
+  // (see frontend/cookie-consent/youtube.ts). Until the visitor clicks the
+  // gate we render a proxied thumbnail and never contact Google. Once
+  // allowed, we still use the youtube-nocookie domain — it defers cookie
+  // setting until playback and is the documented "privacy-enhanced" embed.
+  const ytAllowed = useYouTubeConsent();
+  // True only when the user just dismissed the gate for THIS card. We use
+  // it to autoplay the video they actually asked to watch — without
+  // autoplaying every other embed on the page that becomes visible by
+  // side-effect of the shared consent cookie.
+  const [justAccepted, setJustAccepted] = useState(false);
+  const isActive = current === number;
+  const height = Math.round((width * 9) / 16);
   return (
     <div style={style}>
       <div
@@ -64,16 +84,32 @@ export function VideoItem({
           </A>
         )}
         <div style={{ textAlign: "center" }}>
-          <iframe
-            style={{ marginTop: "30px", maxWidth: "100%" }}
-            width={width}
-            height={(width * 9) / 16}
-            src={`https://www.youtube.com/embed/${current == number ? id : ""}`}
-            title="YouTube video player"
-            frameBorder={0}
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          ></iframe>
+          {ytAllowed && isActive ? (
+            <iframe
+              style={{ marginTop: "30px", maxWidth: "100%" }}
+              width={width}
+              height={height}
+              // autoplay=1 only when the user just clicked this gate, so we
+              // don't surprise visitors with sibling carousel slides or
+              // returning visitors with a previously-granted consent.
+              src={`https://www.youtube-nocookie.com/embed/${id}${justAccepted ? "?autoplay=1" : ""}`}
+              title="YouTube video player"
+              frameBorder={0}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            ></iframe>
+          ) : (
+            <VideoGate
+              id={id}
+              width={width}
+              height={height}
+              title={title}
+              onAccept={() => {
+                setJustAccepted(true);
+                grantYouTubeConsent();
+              }}
+            />
+          )}
         </div>
         <A
           style={{ color: "white", float: "right", marginRight: "10px" }}
@@ -83,5 +119,74 @@ export function VideoItem({
         </A>
       </div>
     </div>
+  );
+}
+
+function VideoGate({
+  id,
+  width,
+  height,
+  title,
+  onAccept,
+}: {
+  id: string;
+  width: number;
+  height: number;
+  title?: string;
+  onAccept: () => void;
+}) {
+  // Server-side thumbnail proxy — see pages/api/youtube-thumbnail/[id].ts.
+  // appBasePath keeps this working on installations served under a
+  // non-root prefix.
+  const thumbUrl = join(
+    appBasePath,
+    "api/youtube-thumbnail",
+    encodeURIComponent(id),
+  );
+  return (
+    <button
+      type="button"
+      onClick={onAccept}
+      aria-label={
+        title ? `Load YouTube video: ${title}` : "Load YouTube video"
+      }
+      style={{
+        position: "relative",
+        marginTop: "30px",
+        width,
+        maxWidth: "100%",
+        height,
+        padding: 0,
+        border: 0,
+        cursor: "pointer",
+        color: "white",
+        background: `#000 url(${thumbUrl}) center / cover no-repeat`,
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: "rgba(0,0,0,0.55)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "8px",
+          padding: "12px",
+          textAlign: "center",
+        }}
+      >
+        <Icon
+          name="youtube"
+          style={{ color: "red", fontSize: "48px" }}
+        />
+        <span style={{ fontWeight: 600, fontSize: "18px" }}>Play video</span>
+        <span style={{ fontSize: "13px", maxWidth: "85%", lineHeight: 1.4 }}>
+          Loading this video allows YouTube to set cookies in your browser.
+          Click to accept and play.
+        </span>
+      </span>
+    </button>
   );
 }

--- a/src/packages/next/pages/_app.tsx
+++ b/src/packages/next/pages/_app.tsx
@@ -60,20 +60,28 @@ AppProps & { locale: Locale }) {
     });
   }, [customizeAvailable, cookieBannerEnabled, cookieBannerText]);
 
-  // Force-consent mode on auth + SSO launch pages: a dark overlay blocks
-  // interaction with the form until the user accepts the banner. We toggle
-  // this on every route change rather than baking it into the banner config
-  // at init — `disablePageInteraction` is a one-shot config option, so a
-  // user who lands on `/` first and then navigates to `/auth/sign-in`
-  // wouldn't see the dim otherwise. enableForceConsent is also a no-op when
-  // the user has already consented.
+  // Force-consent mode on sign-up / anonymous-try / SSO launch pages: a
+  // dark overlay blocks interaction with the form until the user accepts
+  // the banner. We toggle this on every route change rather than baking
+  // it into the banner config at init — `disablePageInteraction` is a
+  // one-shot config option, so a user who lands on `/` first and then
+  // navigates to `/auth/sign-up` wouldn't see the dim otherwise.
+  // enableForceConsent is also a no-op when the user has already
+  // consented. Sign-up gates the new-account flow before the first
+  // remember_me cookie is set; /auth/try gates anonymous account
+  // creation (the redirect lands back on a Next page, so the SPA's
+  // fallback never fires); /sso/* gates the redirect that hands control
+  // to the external IdP, since the callback drops session cookies.
+  // Sign-in is intentionally *not* gated here — once that flow reaches
+  // the SPA, the SPA's own force-consent fallback (app/render.tsx)
+  // takes over, and the in-place sign-in/up panel adds its own gate.
   const path = router.pathname ?? "";
-  const isAuthRoute =
-    /^\/auth\/(sign-in|sign-up|try)/.test(path) || /^\/sso(\/|$)/.test(path);
+  const isMandatoryRoute =
+    /^\/auth\/(sign-up|try)/.test(path) || /^\/sso(\/|$)/.test(path);
   useEffect(() => {
-    if (!cookieBannerEnabled || !isAuthRoute) return;
+    if (!cookieBannerEnabled || !isMandatoryRoute) return;
     return enableForceConsent();
-  }, [cookieBannerEnabled, isAuthRoute]);
+  }, [cookieBannerEnabled, isMandatoryRoute]);
   return (
     <AppContext.Provider value={{ ...DEFAULT_CONTEXT }}>
       <ConfigProvider theme={antdTheme}>

--- a/src/packages/next/pages/api/youtube-thumbnail/[id].ts
+++ b/src/packages/next/pages/api/youtube-thumbnail/[id].ts
@@ -1,0 +1,59 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+// Server-side proxy for YouTube video thumbnails. The click-to-load video
+// gate (components/videos.tsx) uses this so visitors see a still image
+// without their browser contacting i.ytimg.com / Google before they have
+// explicitly consented to YouTube embeds.
+//
+// Thumbnails are effectively immutable per id, so we cache aggressively at
+// the CDN / browser layer. We do not buffer in-process — Next.js / the
+// upstream proxy handles concurrency fine, and adding a per-process LRU
+// here would complicate cold start without measurable wins.
+
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// YouTube video ids are 11 chars of [A-Za-z0-9_-]. Be slightly lenient
+// (6-20) so a future id-length change doesn't silently break the page,
+// while still rejecting obvious junk that would just produce a 404.
+const ID_RE = /^[A-Za-z0-9_-]{6,20}$/;
+
+// hqdefault is 480x360 with letterboxing for 16:9 sources — good enough
+// for the carousel at 672px wide and always present. mqdefault is the
+// fallback for the rare id where hqdefault is missing.
+const VARIANTS = ["hqdefault", "mqdefault"] as const;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  const id = String(req.query.id ?? "");
+  if (!ID_RE.test(id)) {
+    res.status(400).send("invalid id");
+    return;
+  }
+  for (const variant of VARIANTS) {
+    const url = `https://i.ytimg.com/vi/${id}/${variant}.jpg`;
+    let upstream: Response;
+    try {
+      upstream = await fetch(url);
+    } catch (err) {
+      // Network blip; try next variant before giving up. We don't log
+      // every failure — a misconfigured firewall would otherwise flood
+      // the hub logs with one entry per page view.
+      continue;
+    }
+    if (!upstream.ok) continue;
+    const buf = Buffer.from(await upstream.arrayBuffer());
+    res.setHeader("content-type", "image/jpeg");
+    res.setHeader(
+      "cache-control",
+      "public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800",
+    );
+    res.status(200).send(buf);
+    return;
+  }
+  res.status(404).send("not found");
+}

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -544,7 +544,7 @@ export const site_settings_conf: SiteSettings = {
   },
   cookie_banner_enabled: {
     name: "Cookie banner",
-    desc: "Show a GDPR-style cookie consent banner to all visitors, regardless of geolocation. The banner offers two categories of cookies: *necessary* (required to sign in and keep a session) and *analytics* (optional tracking). Until the user accepts the *necessary* category, sign-up and sign-in are blocked.",
+    desc: "Show a GDPR-style cookie consent banner with two categories: *necessary* (sign-in / session) and *analytics* (optional tracking). Page-blocking on sign-up, SSO launch, and inside the web app for signed-in users.",
     default: "no",
     valid: only_booleans,
     to_val: to_bool,
@@ -554,7 +554,7 @@ export const site_settings_conf: SiteSettings = {
     name: "Cookie banner text",
     desc: "Markdown body shown in the cookie banner and preferences modal. Links to the privacy policy and terms of service are rendered as separate footer links and do not need to be repeated here.",
     default:
-      "We use cookies that are strictly necessary for sign-in and session management, and optional analytics cookies to understand how the site is used. You can change your preferences at any time.",
+      "We use cookies that are strictly necessary for sign-in and session management, and optional analytics cookies to understand how the site is used. Embedded YouTube videos are blocked until you click them. You can change your preferences at any time.",
     clearable: true,
     multiline: 5,
     tags: ["Cookie Banner"],


### PR DESCRIPTION
## Summary

Follow-up to #8875. Trims where the cookie banner runs in page-blocking force-consent mode on the next.js side, and adds a parallel consent gate for embedded YouTube videos.

### Cookie banner gating

- **Page-blocking on:** `/auth/sign-up` and `/sso/*` (first-contact flows where no per-account consent snapshot exists yet, or where the IdP callback drops cookies before the SPA boots).
- **Shown but not enforced on:** `/auth/sign-in` and `/auth/try`. Per-account consent (`accounts.other_settings.cookie_consent`) is replayed into the browser cookie before the banner runtime starts, so a returning user who already consented on another device signs in without re-acknowledging. The SPA's `enableForceConsent` fallback in `app/render.tsx` still catches the rare signed-in user with no prior consent.

Also tightens the admin description for `cookie_banner_enabled` and updates `docs/auth.md` to reflect the asymmetry.

### YouTube embed gate (click-to-load)

Embedded YouTube videos on landing / features / support / about pages used to contact `youtube.com` (cookies, fingerprinting) on first paint, before any consent. Now:

- Videos are replaced with a **click-to-load placeholder** showing a proxied thumbnail served by `pages/api/youtube-thumbnail/[id].ts` (server-side fetch from `i.ytimg.com`, cached). No browser → Google traffic until the user clicks.
- Clicking the placeholder grants a dedicated `cocalc_youtube_consent` cookie (kept *separate* from the v3 banner state so the main banner still triggers force-consent on sign-up / SSO afterwards) and renders the iframe against `youtube-nocookie.com`. Autoplay starts only for the video the user just clicked.
- The preferences modal grows an "Embedded videos" section with a colored Allowed/Blocked pill and an iOS-style slider for revoking.
- The account settings "Cookie preferences" panel shows a matching row and a "Revoke YouTube embed consent" button when granted.

## Test plan
- [ ] Fresh browser, banner enabled: `/auth/sign-up` is page-blocked until consent; Sign Up button shows "Acknowledge cookie banner to continue".
- [ ] Fresh browser, banner enabled: `/sso/google` (or any provider landing page) is page-blocked until consent.
- [ ] Fresh browser, banner enabled: `/auth/sign-in` and `/auth/try` show the banner but are *not* page-blocked; sign-in works without dismissing the banner.
- [ ] After signing in without consenting on `/auth/sign-in`, the SPA's force-consent overlay appears in `/app`.
- [ ] Returning user on a fresh browser with a prior consent record on the account: sign in normally, no banner shown anywhere.
- [ ] Banner disabled site-wide (`cookie_banner_enabled=no`): no overlay anywhere, no console errors.
- [ ] Landing page (`/`) carousel videos: thumbnail placeholder renders, no network requests to `youtube.com` / `ytimg.com` before clicking.
- [ ] Click placeholder → iframe loads from `youtube-nocookie.com`, video autoplays. Other carousel slides do *not* autoplay when their consent flips by side-effect.
- [ ] Preferences modal "Embedded videos" section: pill turns green/red, slider toggles, status survives modal reopen.
- [ ] Account settings "Cookie preferences" panel: YouTube row mirrors current state; "Revoke YouTube embed consent" hides after click; videos go back to placeholder on next page load.
- [ ] Sign out → delete cookies → sign up forces banner; accepting just YouTube via a landing-page click does *not* satisfy the sign-up gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)