### PR TITLE
next/cookies: improve consent banner behavior

### DIFF
--- a/src/packages/frontend/cookie-consent/index.ts
+++ b/src/packages/frontend/cookie-consent/index.ts
@@ -20,7 +20,7 @@ export type { CookieCategoryKey };
 
 // Bump this if the cookie categories or banner text change in a way that
 // invalidates prior consent. vanilla-cookieconsent will re-prompt the user.
-export const COOKIE_CONSENT_REVISION = 1;
+export const COOKIE_CONSENT_REVISION = 2;
 
 // Snapshot of the user's consent we persist in account.other_settings. Kept
 // minimal on purpose: the browser cookie is authoritative for the session;
@@ -212,13 +212,13 @@ export function getConsentSnapshot(): ConsentSnapshot | null {
     if (cookie == null) return null;
     const accepted = new Set<string>(cookie.categories ?? []);
     const snap = {
-      timestamp:
-        cookie.lastConsentTimestamp ?? cookie.consentTimestamp ?? "",
+      timestamp: cookie.lastConsentTimestamp ?? cookie.consentTimestamp ?? "",
       revision: cookie.revision ?? 0,
     } as ConsentSnapshot;
     for (const c of COOKIE_CATEGORIES) {
-      (snap as Record<string, boolean | string | number>)[c.key] =
-        accepted.has(c.key);
+      (snap as Record<string, boolean | string | number>)[c.key] = accepted.has(
+        c.key,
+      );
     }
     return snap;
   } catch {

--- a/src/packages/frontend/cookie-consent/index.ts
+++ b/src/packages/frontend/cookie-consent/index.ts
@@ -311,7 +311,10 @@ export function clearAllConsentCookies(): void {
   const names = new Set<string>(["cc_cookie"]);
   const matchers: Array<string | RegExp> = [];
   for (const category of COOKIE_CATEGORIES) {
-    for (const item of category.autoClearCookies ?? []) {
+    // `as const satisfies` narrows each entry to its literal type, so only
+    // entries that declare autoClearCookies expose the property.
+    if (!("autoClearCookies" in category)) continue;
+    for (const item of category.autoClearCookies) {
       matchers.push(item.name);
     }
   }

--- a/src/packages/frontend/cookie-consent/index.ts
+++ b/src/packages/frontend/cookie-consent/index.ts
@@ -14,6 +14,7 @@ import * as CookieConsent from "vanilla-cookieconsent";
 
 import { COOKIE_CATEGORIES, type CookieCategoryKey } from "./categories";
 import { BANNER_STATE_EVENT, isBannerActive, isBannerDecided } from "./state";
+import { revokeYouTubeConsent } from "./youtube";
 
 export { COOKIE_CATEGORIES };
 export type { CookieCategoryKey };
@@ -291,4 +292,66 @@ export function useEssentialConsent(): boolean {
     };
   }, []);
   return accepted;
+}
+
+// Erase every cookie this module is responsible for: the vanilla-cookieconsent
+// state cookie (cc_cookie), the dedicated YouTube consent cookie, and the
+// autoClearCookies declared by each category in categories.ts. Used by the
+// "Clear cookies" affordance in the next.js footer for signed-out visitors
+// who can't reach the in-app preferences modal. Best-effort: we don't know
+// the (domain, path) attributes used at write time, so we issue an expiring
+// write for every plausible variant of the current hostname — browsers
+// silently reject invalid public-suffix domains, so over-attempting is
+// harmless.
+export function clearAllConsentCookies(): void {
+  if (typeof document === "undefined" || typeof window === "undefined") return;
+
+  // Collect names: cc_cookie itself plus everything categories.ts knows about.
+  // RegExp matchers (e.g. /^_ga/) are expanded against the live cookie jar.
+  const names = new Set<string>(["cc_cookie"]);
+  const matchers: Array<string | RegExp> = [];
+  for (const category of COOKIE_CATEGORIES) {
+    for (const item of category.autoClearCookies ?? []) {
+      matchers.push(item.name);
+    }
+  }
+  for (const m of matchers) {
+    if (typeof m === "string") {
+      names.add(m);
+    } else {
+      for (const cookie of document.cookie.split(";")) {
+        const n = cookie.trim().split("=")[0];
+        if (n && m.test(n)) names.add(n);
+      }
+    }
+  }
+
+  const domains = parentDomainCandidates(window.location.hostname);
+  for (const name of names) {
+    for (const domain of domains) {
+      document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax${
+        domain == null ? "" : `; domain=${domain}`
+      }`;
+    }
+  }
+
+  // YouTube consent has its own module that owns the cookie name + change
+  // event. Defer to it rather than duplicating the constant here.
+  revokeYouTubeConsent();
+}
+
+// Every parent suffix of hostname in both `host` and `.host` form, plus an
+// `undefined` first entry (= write without a domain attribute, matching
+// host-only cookies). Robust against multi-level TLDs (.co.uk, .com.au)
+// without needing the Public Suffix List: invalid candidates (`co.uk`, `com`)
+// are rejected by the browser.
+function parentDomainCandidates(hostname: string): Array<string | undefined> {
+  const result: Array<string | undefined> = [undefined];
+  const parts = hostname.split(".");
+  for (let i = 0; i < parts.length; i++) {
+    const suffix = parts.slice(i).join(".");
+    if (!suffix) continue;
+    result.push(suffix, `.${suffix}`);
+  }
+  return result;
 }

--- a/src/packages/next/components/landing/footer.tsx
+++ b/src/packages/next/components/landing/footer.tsx
@@ -4,7 +4,9 @@
  */
 
 import { Col, Flex, Layout, Row, Space, Typography } from "antd";
+import { MouseEvent } from "react";
 
+import { clearAllConsentCookies } from "@cocalc/frontend/cookie-consent";
 import { COLORS } from "@cocalc/util/theme";
 
 import { is_valid_email_address as isValidEmailAddress } from "@cocalc/util/misc";
@@ -49,9 +51,9 @@ const LOGO_COLUMN_STYLE = {
 
 interface FooterLink {
   text: string;
-  url?: string;
+  url: string;
   hide?: boolean;
-  onClick?: () => void;
+  onClick?: (e: MouseEvent) => void;
 }
 
 interface FooterColumn {
@@ -197,8 +199,13 @@ export default function Footer() {
         },
         {
           text: "Clear cookies",
+          url: "#",
           hide: !cookieBannerEnabled || !!isAuthenticated,
-          onClick: clearCookieChoices,
+          onClick: (e) => {
+            e.preventDefault();
+            clearAllConsentCookies();
+            window.location.reload();
+          },
         },
         {
           text: "Terms of Service",
@@ -226,10 +233,18 @@ export default function Footer() {
         {column.links
           .filter((footerLink) => !footerLink.hide)
           .map((footerLink) => (
-            <FooterColumnLink
-              footerLink={footerLink}
-              key={footerLink.url ?? footerLink.text}
-            />
+            <A
+              key={footerLink.url}
+              href={
+                isValidEmailAddress(footerLink.url)
+                  ? `mailto:${footerLink.url}`
+                  : footerLink.url
+              }
+              onClick={footerLink.onClick}
+              style={FOOTER_LINK_STYLE}
+            >
+              {footerLink.text}
+            </A>
           ))}
       </Space>
     ));
@@ -276,62 +291,3 @@ export default function Footer() {
   );
 }
 
-function FooterColumnLink({ footerLink }: { footerLink: FooterLink }) {
-  if (footerLink.onClick != null) {
-    return (
-      <Typography.Link onClick={footerLink.onClick} style={FOOTER_LINK_STYLE}>
-        {footerLink.text}
-      </Typography.Link>
-    );
-  }
-  const url = footerLink.url ?? "";
-  return (
-    <A
-      href={isValidEmailAddress(url) ? `mailto:${url}` : url}
-      style={FOOTER_LINK_STYLE}
-    >
-      {footerLink.text}
-    </A>
-  );
-}
-
-function clearCookieChoices(): void {
-  if (typeof document === "undefined" || typeof window === "undefined") {
-    return;
-  }
-
-  const names = new Set(["cc_cookie", "cocalc_youtube_consent", "CC_ANA"]);
-  for (const cookie of document.cookie.split(";")) {
-    const name = cookie.trim().split("=")[0];
-    if (/^_ga/.test(name) || /^_gid/.test(name)) {
-      names.add(name);
-    }
-  }
-
-  const domains = getCookieClearDomains(window.location.hostname);
-  for (const name of names) {
-    for (const domain of domains) {
-      clearCookie(name, domain);
-    }
-  }
-  window.location.reload();
-}
-
-function getCookieClearDomains(hostname: string): Array<string | undefined> {
-  const domains: Array<string | undefined> = [
-    undefined,
-    hostname,
-    `.${hostname}`,
-  ];
-  const parts = hostname.split(".");
-  if (parts.length > 2) {
-    domains.push(`.${parts.slice(-2).join(".")}`);
-  }
-  return domains;
-}
-
-function clearCookie(name: string, domain?: string): void {
-  document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax${
-    domain == null ? "" : `; domain=${domain}`
-  }`;
-}

--- a/src/packages/next/components/landing/footer.tsx
+++ b/src/packages/next/components/landing/footer.tsx
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -18,8 +18,8 @@ import { liveDemoUrl } from "components/landing/live-demo";
 import SocialMediaIconList from "./social-media-icon-list";
 
 const FOOTER_STYLE: CSS = {
-  borderTop: "1px solid lightgrey",
-  backgroundColor: "white",
+  borderTop: `1px solid ${COLORS.GRAY_L}`,
+  backgroundColor: COLORS.WHITE,
 };
 
 const FOOTER_COLUMNS_STYLE: CSS = {
@@ -38,6 +38,10 @@ const FOOTER_TABLE_STYLE: CSS = {
   width: "100%",
 } as const;
 
+const FOOTER_LINK_STYLE: CSS = {
+  color: COLORS.GRAY_D,
+} as const;
+
 const LOGO_COLUMN_STYLE = {
   paddingBottom: "24px",
   marginTop: "32px",
@@ -45,8 +49,9 @@ const LOGO_COLUMN_STYLE = {
 
 interface FooterLink {
   text: string;
-  url: string;
+  url?: string;
   hide?: boolean;
+  onClick?: () => void;
 }
 
 interface FooterColumn {
@@ -61,6 +66,8 @@ export default function Footer() {
     organizationName,
     organizationURL,
     enabledPages,
+    cookieBannerEnabled,
+    isAuthenticated,
     termsOfServiceURL,
     supportVideoCall,
   } = useCustomize();
@@ -189,6 +196,11 @@ export default function Footer() {
           hide: !enabledPages?.policies.index,
         },
         {
+          text: "Clear cookies",
+          hide: !cookieBannerEnabled || !!isAuthenticated,
+          onClick: clearCookieChoices,
+        },
+        {
           text: "Terms of Service",
           url: termsOfServiceURL || "",
           hide: !enabledPages?.termsOfService,
@@ -214,17 +226,10 @@ export default function Footer() {
         {column.links
           .filter((footerLink) => !footerLink.hide)
           .map((footerLink) => (
-            <A
-              key={footerLink.url}
-              href={
-                isValidEmailAddress(footerLink.url)
-                  ? `mailto:${footerLink.url}`
-                  : footerLink.url
-              }
-              style={{ color: COLORS.GRAY_D }}
-            >
-              {footerLink.text}
-            </A>
+            <FooterColumnLink
+              footerLink={footerLink}
+              key={footerLink.url ?? footerLink.text}
+            />
           ))}
       </Space>
     ));
@@ -269,4 +274,64 @@ export default function Footer() {
       </Flex>
     </Layout.Footer>
   );
+}
+
+function FooterColumnLink({ footerLink }: { footerLink: FooterLink }) {
+  if (footerLink.onClick != null) {
+    return (
+      <Typography.Link onClick={footerLink.onClick} style={FOOTER_LINK_STYLE}>
+        {footerLink.text}
+      </Typography.Link>
+    );
+  }
+  const url = footerLink.url ?? "";
+  return (
+    <A
+      href={isValidEmailAddress(url) ? `mailto:${url}` : url}
+      style={FOOTER_LINK_STYLE}
+    >
+      {footerLink.text}
+    </A>
+  );
+}
+
+function clearCookieChoices(): void {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return;
+  }
+
+  const names = new Set(["cc_cookie", "cocalc_youtube_consent", "CC_ANA"]);
+  for (const cookie of document.cookie.split(";")) {
+    const name = cookie.trim().split("=")[0];
+    if (/^_ga/.test(name) || /^_gid/.test(name)) {
+      names.add(name);
+    }
+  }
+
+  const domains = getCookieClearDomains(window.location.hostname);
+  for (const name of names) {
+    for (const domain of domains) {
+      clearCookie(name, domain);
+    }
+  }
+  window.location.reload();
+}
+
+function getCookieClearDomains(hostname: string): Array<string | undefined> {
+  const domains: Array<string | undefined> = [
+    undefined,
+    hostname,
+    `.${hostname}`,
+  ];
+  const parts = hostname.split(".");
+  if (parts.length > 2) {
+    domains.push(`.${parts.slice(-2).join(".")}`);
+  }
+  return domains;
+}
+
+function clearCookie(name: string, domain?: string): void {
+  document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax${
+    domain == null ? "" : `; domain=${domain}`
+  }`;
 }

--- a/src/packages/next/pages/features/sage.tsx
+++ b/src/packages/next/pages/features/sage.tsx
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2021 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -17,6 +17,7 @@ import SignIn from "components/landing/sign-in";
 import Snapshots from "components/landing/snapshots";
 import { Paragraph, Text, Title } from "components/misc";
 import A from "components/misc/A";
+import { VideoItem } from "components/videos";
 import { Customize } from "lib/customize";
 import withCustomize from "lib/with-customize";
 
@@ -147,15 +148,11 @@ export default function Sage({ customize }) {
                       worry about messing up your own computer.{" "}
                     </li>
                   </ul>
-                  <iframe
-                    width="560"
-                    height="315"
-                    src="https://www.youtube.com/embed/b8e8qq-KWbA?si=620SEO8C1JBYXpJL"
-                    title="YouTube video player"
-                    frameBorder="0"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    allowFullScreen
-                  ></iframe>
+                  <VideoItem
+                    id="b8e8qq-KWbA"
+                    title="Using SageMath online in CoCalc"
+                    width={560}
+                  />
                 </Paragraph>
               </>
             }

--- a/src/packages/next/pages/policies/privacy.tsx
+++ b/src/packages/next/pages/policies/privacy.tsx
@@ -28,7 +28,7 @@ export default function Privacy({ customize }) {
           >
             <div style={{ textAlign: "center", color: "#444" }}>
               <h1 style={{ fontSize: "28pt" }}>CoCalc - Privacy Policy</h1>
-              <h2>Last Updated: April 21, 2026</h2>
+              <h2>Last Updated: May 12, 2026</h2>
             </div>
             <div style={{ fontSize: "12pt" }}>
               <p>
@@ -1362,6 +1362,13 @@ export default function Privacy({ customize }) {
                     <tr>
                       <td>Update: simplify vendor references</td>
                       <td> 2026-04-21 </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Update: list cookie-consent and YouTube embed
+                        consent cookies
+                      </td>
+                      <td> 2026-05-12 </td>
                     </tr>
                   </tbody>
                 </table>

--- a/src/packages/next/pages/policies/privacy.tsx
+++ b/src/packages/next/pages/policies/privacy.tsx
@@ -503,6 +503,25 @@ export default function Privacy({ customize }) {
                               HAProxy.{" "}
                             </td>
                           </tr>
+                          <tr>
+                            <td> cc_cookie </td>
+                            <td>
+                              {" "}
+                              Records your cookie banner choices (which
+                              categories you accepted and when), so the
+                              banner doesn't reappear on every page load.{" "}
+                            </td>
+                          </tr>
+                          <tr>
+                            <td> cocalc_youtube_consent </td>
+                            <td>
+                              {" "}
+                              Remembers your consent to load embedded
+                              YouTube videos. Until set, video embeds show
+                              a placeholder and no request is made to
+                              YouTube.{" "}
+                            </td>
+                          </tr>
                         </tbody>
                       </table>
                       Please note that we do our best to keep this table

--- a/src/packages/util/db-schema/site-defaults.ts
+++ b/src/packages/util/db-schema/site-defaults.ts
@@ -1,5 +1,5 @@
 /*
- *  This file is part of CoCalc: Copyright © 2020 Sagemath, Inc.
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
  *  License: MS-RSL – see LICENSE.md for details
  */
 
@@ -544,7 +544,7 @@ export const site_settings_conf: SiteSettings = {
   },
   cookie_banner_enabled: {
     name: "Cookie banner",
-    desc: "Show a GDPR-style cookie consent banner with two categories: *necessary* (sign-in / session) and *analytics* (optional tracking). Page-blocking on sign-up, SSO launch, and inside the web app for signed-in users.",
+    desc: "Show a GDPR-style cookie consent banner with strictly necessary cookies, optional analytics / usage metrics, and embedded video consent. Page-blocking on sign-up, SSO launch, and inside the web app for signed-in users.",
     default: "no",
     valid: only_booleans,
     to_val: to_bool,
@@ -554,7 +554,7 @@ export const site_settings_conf: SiteSettings = {
     name: "Cookie banner text",
     desc: "Markdown body shown in the cookie banner and preferences modal. Links to the privacy policy and terms of service are rendered as separate footer links and do not need to be repeated here.",
     default:
-      "We use cookies that are strictly necessary for sign-in and session management, and optional analytics cookies to understand how the site is used. Embedded YouTube videos are blocked until you click them. You can change your preferences at any time.",
+      "We use cookies that are strictly necessary for sign-in and session management. With your consent, we use optional analytics cookies and first-party usage metrics to understand how the site is used. Embedded YouTube videos are not loaded until you choose to play them. Signed-in users can manage these preferences in Account settings; signed-out visitors can clear cookie choices from the footer.",
     clearable: true,
     multiline: 5,
     tags: ["Cookie Banner"],


### PR DESCRIPTION
Polish the wording of the cookie banner to reflect all categories, clarify how to change consent later, and for non-authenticated users add a link in the footer that removes all cookies (and saved consent) and reloads the page to bring back the original banner. Also catch the last non-wrapped youtube video.