### PR TITLE
next: opt-in filesystem cache for local dev builds

### DIFF
--- a/src/packages/next/next.config.js
+++ b/src/packages/next/next.config.js
@@ -20,6 +20,16 @@ const config = {
   env: { BASE_PATH },
   eslint: { ignoreDuringBuilds: true },
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
+    // Opt-in filesystem cache for local dev builds (e.g. cocalc-hub.sh sets
+    // NEXTJS_FS_CACHE=1). Production CI/Docker leaves the var unset, so this
+    // never affects deployed builds.
+    if (process.env.NEXTJS_FS_CACHE) {
+      config.cache = {
+        type: "filesystem",
+        buildDependencies: { config: [__filename] },
+        cacheDirectory,
+      };
+    }
     // Webpack breaks without this pg-native alias, even though it's dead code,
     // due to how the pg module does package detection internally.
     config.resolve.alias["pg-native"] = ".";


### PR DESCRIPTION
## Summary

Restores the next.js webpack filesystem cache that was silently dropped in commit `03439c267b` ("simplify nextjs config"). The `cacheDirectory` constant has been computed but unused ever since — this wires it back up under an opt-in env-var gate so production builds are never affected.

- Gated on `NEXTJS_FS_CACHE`: production CI / Docker doesn't set it, so build behavior there is unchanged.
- Local dev scripts set the var → `/tmp/nextjs-\$USER/<basePath>/<resolved-cwd>/` populates and warms subsequent rebuilds. Useful on RAM-constrained dev machines where uncached `next build` runs hot.

Motivation: tracked it down after a long rebuild on an older 8GB-RAM dev machine — the `todel` cleanup in `cocalc-hub.sh` already prunes `/tmp/nextjs-\$USER/` when it exceeds 5 GB, expecting this cache to be present.

## Test plan

- [ ] CI green on the existing build matrix (no behavior change without the env var)
- [ ] Local: set `NEXTJS_FS_CACHE=1` and run `next build` twice — second build noticeably faster, `/tmp/nextjs-\$USER/...` populated
- [ ] Local: with the var unset, behavior matches pre-change baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)