### PR TITLE
Jupyter: versioned-kernel update awareness

### DIFF
--- a/src/docs/jupyter.md
+++ b/src/docs/jupyter.md
@@ -405,6 +405,111 @@ export async function nbconvert(opts: NbconvertParams): Promise<void>;
 - Checksum validation for tamper detection
 - Clear solutions/hidden tests for student distribution
 
+## Versioned Kernels (Kernel Update Awareness)
+
+When a notebook is pinned to an old kernel (e.g. `sage-10.5`) and a newer
+kernel of the same software is installed, a yellow "Update…" button appears in
+the kernel status line so users notice.
+
+### Kernel metadata
+
+Optional fields on a kernelspec's `metadata.cocalc`
+(`packages/util/jupyter/types.ts`):
+
+| Field             | Type     | Meaning                                                            |
+| ----------------- | -------- | ------------------------------------------------------------------ |
+| `family`          | `string` | Stable id for a line of versioned kernels (e.g. `"sagemath"`).      |
+| `version`         | `string` | Dotted numeric version `^\d+(\.\d+)*$` (e.g. `10`, `10.6`, `3.12`). |
+| `display_version` | `string` | Optional human-readable version label.                             |
+
+A kernel participates only if it has both `family` and a contract-valid
+`version` (no name/`language` fallback). `family` is intentionally distinct
+from the Jupyter `language`: e.g. `python-system` / `python-cocalc` /
+`python-anaconda` share `language: "python"` but are different families and
+must not be offered as updates of one another.
+
+The two **existing** `metadata.cocalc` fields `disabled` and `priority` are
+distinct concepts and must not be conflated:
+
+- **`disabled: true`** — the kernel is **fully hidden** from the CoCalc UI:
+  filtered out by `get_kernels_by_name_or_language`, so it never appears in
+  the select-kernel dialog or the Change Kernel menu and cannot be picked.
+  Use this for broken/unwanted kernels (the original motivation was a broken
+  GAP kernel; see `browser-actions.ts:1059`).
+- **`priority: < 0`** — **deprecated but still selectable**: the kernel
+  appears normally in the selector and Change Kernel menu, and the user can
+  choose it. It is just skipped by `closest_kernel_match` (never auto-suggested
+  as a fallback for an unknown kernel) and by `kernelUpdateInfo` (never
+  offered as an update target).
+- **`priority: >= 10`** — appears in the "Suggested kernels" list and gets a
+  ⭐ (see `KERNEL_POPULAR_THRESHOLD`).
+
+So to truly hide a kernel, use `disabled: true`; `priority: -1` is the right
+choice when you want the kernel to remain pickable but never auto-suggested
+or offered as an update.
+
+### Detection
+
+`kernelUpdateInfo(currentKernelName, kernels)` in
+`packages/jupyter/util/misc.ts` (pure) returns the newest kernel in the same
+`family` with a strictly greater `version`, compared via
+`compareDottedVersions()` (per-segment numeric, shorter is less; the existing
+private `compareVersionStrings()` is left untouched). Candidates that are
+`disabled` or have `priority < 0` are excluded. `priority` and `version` are
+orthogonal — "latest" is decided by `version`, not `priority`.
+
+The status line (`packages/frontend/jupyter/status.tsx`) calls this reactively
+from the `kernel` / `kernels` / notebook-`metadata` redux state, so the button
+updates immediately on any kernel change (Update button, selector, `.ipynb`
+import, remote sync).
+
+### Update dialog & "Keep"
+
+The button opens a modal with three exits:
+
+- **Update to &lt;latest&gt;** — `actions.set_kernel(latestKernelName)`.
+- **Keep** — writes `metadata.cocalc.update_dismissed = <currentKernelName>`
+  via `actions.set_global_metadata` (shallow-merging the existing `cocalc`
+  object). Scoped to the kept kernel: suppressed only while the notebook is on
+  that exact kernel (render-time compare).
+- **X** — no action; the button stays.
+
+An **explicit** kernel switch resets the dismissal: `browser-actions.set_kernel`
+(the common path for the selector, the Change Kernel menu, and the Update
+dialog) deletes `update_dismissed` when changing to a kernel other than the
+dismissed one — so returning to a kernel you moved away from prompts again,
+while re-selecting the kept kernel keeps it silent. `.ipynb` import and
+remote-sync changes do not go through this path, so they don't clear it
+(degrades to the scoped behavior — harmless).
+
+### Selector & menu grouping
+
+Both kernel pickers keep their per-`language` grouping and add `family` as a
+secondary grouping:
+
+- **Select-a-kernel dialog** (`select-kernel.tsx`): within a language, each
+  family renders as a prominent button for the latest version plus compact
+  version-number buttons for older versions; kernels without a family keep the
+  flat rendering.
+- **Kernel → Change Kernel menu** (`frame-editors/jupyter-editor/editor.ts`):
+  per language submenu, family+version kernels first (family asc, version
+  desc) with a divider between family groups, then a divider, then the
+  remaining kernels in display-name order. Submenu dividers are a
+  `{ type: "divider" }` child, supported in `frame-tree/commands`.
+
+The frontend caches kernelspecs for 5 minutes; the selector's Refresh forwards
+`noCache` (`frontend/jupyter/kernelspecs.ts`) so freshly added/edited
+kernelspecs show up.
+
+### Local testing
+
+`src/scripts/make_test_kernels.py` creates throwaway versioned kernelspecs
+under `~/.local/share/jupyter/kernels` (reusing the existing python `argv`):
+`testfam-{1.0,1.1,2.0}`, `otherfam-{3.4,3.5}`, `otherfam-3.7`
+(`priority: -1` — must not be offered as an update), and `plainkernel-{a,b}`
+(no family/version). Run with `--clean` to remove; click **Refresh** in the
+kernel selector afterwards.
+
 ## Key Source Files
 
 | File                                               | Description                            |

--- a/src/packages/frontend/frame-editors/frame-tree/commands/manage.tsx
+++ b/src/packages/frontend/frame-editors/frame-tree/commands/manage.tsx
@@ -553,15 +553,17 @@ export class ManageCommands {
     const children = noChildren
       ? undefined
       : this.getCommandChildren(cmd)?.map((x, i) =>
-          this.commandToMenuItem({
-            // If the child has a name and this is a top-level command (name is set),
-            // construct a compound key "parent/child" so the pin toggle works for
-            // submenu items.
-            name: x.name && name ? `${name}/${x.name}` : "",
-            cmd: x,
-            key: `${key}-${i}-${x.stayOpenOnClick ? STAY_OPEN_ON_CLICK : ""}`,
-            noChildren,
-          }),
+          x.type === "divider"
+            ? { type: "divider", key: `${key}-${i}-divider` }
+            : this.commandToMenuItem({
+                // If the child has a name and this is a top-level command (name is set),
+                // construct a compound key "parent/child" so the pin toggle works for
+                // submenu items.
+                name: x.name && name ? `${name}/${x.name}` : "",
+                cmd: x,
+                key: `${key}-${i}-${x.stayOpenOnClick ? STAY_OPEN_ON_CLICK : ""}`,
+                noChildren,
+              }),
         );
     if (button) {
       label = (

--- a/src/packages/frontend/frame-editors/frame-tree/commands/types.ts
+++ b/src/packages/frontend/frame-editors/frame-tree/commands/types.ts
@@ -80,6 +80,13 @@ export type CommandText =
  */
 export interface Command {
   /**
+   * If "divider", this entry is not a command but a visual separator in a
+   * submenu (rendered as an antd Menu divider). Used inside `children` arrays
+   * to group related items.
+   */
+  type?: "divider";
+
+  /**
    * The menu group this command belongs to.
    * Commands are organized into groups for logical menu structure.
    */

--- a/src/packages/frontend/frame-editors/jupyter-editor/editor.ts
+++ b/src/packages/frontend/frame-editors/jupyter-editor/editor.ts
@@ -20,6 +20,10 @@ import { labels, menu } from "@cocalc/frontend/i18n";
 import { editor, jupyter } from "@cocalc/frontend/i18n/common";
 import { AllActions, commands } from "@cocalc/frontend/jupyter/commands";
 import { shortcut_to_string } from "@cocalc/frontend/jupyter/keyboard-shortcuts";
+import {
+  compareDottedVersions,
+  isDottedVersion,
+} from "@cocalc/jupyter/util/misc";
 import { capitalize, field_cmp, set } from "@cocalc/util/misc";
 import { createEditor } from "../frame-tree/editor";
 import { EditorDescription } from "../frame-tree/types";
@@ -519,44 +523,95 @@ const JUPYTER_MENUS = {
               actions.fetch_jupyter_kernels();
               return [];
             }
-            const languages: Partial<Command>[] = [];
-            const addKernel = (kernelName: string) => {
-              const { language = "language", metadata } = kernels[kernelName];
-              const menuItem = {
-                label: createElement(KernelMenuItem, {
-                  ...kernels[kernelName],
-                  currentKernel,
-                }),
-                onClick: () => {
-                  actions.set_kernel(kernelName);
-                  actions.set_default_kernel(kernelName);
-                },
-              };
-              const Language = capitalize(language);
-              let done = false;
-              for (const z of languages) {
-                if (z.label == Language) {
-                  // @ts-ignore
-                  z.children.push(menuItem);
-                  done = true;
-                  break;
+            // Group kernel names by language, preserving the existing
+            // (display-name) order from kernels_by_name.
+            const byLanguage: { [lang: string]: string[] } = {};
+            const langOrder: string[] = [];
+            const langPriority: { [lang: string]: number } = {};
+            for (const kernelName in kernels) {
+              const spec = kernels[kernelName];
+              const language = spec.language ?? "language";
+              if (byLanguage[language] == null) {
+                byLanguage[language] = [];
+                langOrder.push(language);
+              }
+              byLanguage[language].push(kernelName);
+              const prio = spec.metadata?.cocalc?.priority ?? 0;
+              if (
+                langPriority[language] == null ||
+                prio > langPriority[language]
+              ) {
+                langPriority[language] = prio;
+              }
+            }
+            const cocalcAttr = (name: string, key: string) =>
+              kernels[name]?.metadata?.cocalc?.[key];
+            const makeItem = (kernelName: string) => ({
+              label: createElement(KernelMenuItem, {
+                ...kernels[kernelName],
+                currentKernel,
+              }),
+              onClick: () => {
+                actions.set_kernel(kernelName);
+                actions.set_default_kernel(kernelName);
+              },
+            });
+            const languages: Partial<Command>[] = langOrder.map((language) => {
+              const names = byLanguage[language];
+              // Partition into family+version kernels vs. the rest.
+              const families: { [fam: string]: string[] } = {};
+              const familyOrder: string[] = [];
+              const ungrouped: string[] = [];
+              for (const name of names) {
+                const fam = cocalcAttr(name, "family");
+                const ver = cocalcAttr(name, "version");
+                if (
+                  typeof fam === "string" &&
+                  fam !== "" &&
+                  isDottedVersion(ver)
+                ) {
+                  if (families[fam] == null) {
+                    families[fam] = [];
+                    familyOrder.push(fam);
+                  }
+                  families[fam].push(name);
+                } else {
+                  ungrouped.push(name);
                 }
               }
-              if (!done) {
-                languages.push({
-                  pos: -(metadata?.cocalc?.priority ?? 0),
-                  icon: languageToIcon(language),
-                  // Explicitly don't use this, since it adds no value and gets in the way.
-                  // title: `Select the ${display_name} Jupyter kernel for writing code in ${Language}.`,
-                  label: Language,
-                  children: [menuItem],
-                  disabled: ({ readOnly }) => readOnly,
-                });
+              familyOrder.sort(); // family ascending
+              const children: Partial<Command>[] = [];
+              familyOrder.forEach((fam, idx) => {
+                if (idx > 0) {
+                  children.push({ type: "divider" });
+                }
+                const members = families[fam]
+                  .slice()
+                  .sort(
+                    (a, b) =>
+                      -compareDottedVersions(
+                        cocalcAttr(a, "version"),
+                        cocalcAttr(b, "version"),
+                      ),
+                  ); // version descending (newest first)
+                for (const n of members) {
+                  children.push(makeItem(n));
+                }
+              });
+              if (children.length > 0 && ungrouped.length > 0) {
+                children.push({ type: "divider" });
               }
-            };
-            for (const kernelName in kernels) {
-              addKernel(kernelName);
-            }
+              for (const n of ungrouped) {
+                children.push(makeItem(n));
+              }
+              return {
+                pos: -(langPriority[language] ?? 0),
+                icon: languageToIcon(language),
+                label: capitalize(language),
+                children,
+                disabled: ({ readOnly }) => readOnly,
+              };
+            });
             languages.sort(field_cmp("pos"));
             return languages;
           },

--- a/src/packages/frontend/jupyter/browser-actions.ts
+++ b/src/packages/frontend/jupyter/browser-actions.ts
@@ -1217,6 +1217,22 @@ export class JupyterActions extends JupyterActions0 {
       });
       // clear error when changing the kernel
       this.set_error(null);
+      // Versioned kernels: an explicit kernel switch (selector, Change
+      // Kernel menu, or the Update dialog all funnel through here, while
+      // .ipynb import / remote-sync do not) resets a prior "Keep"
+      // dismissal, UNLESS we're switching *to* the dismissed kernel
+      // itself. So returning to a kernel you moved away from prompts
+      // again, while picking the kept kernel keeps it silent.
+      const cocalc = this.syncdb
+        .get_one({ type: "settings" })
+        ?.toJS()?.metadata?.cocalc;
+      if (
+        cocalc?.update_dismissed != null &&
+        cocalc.update_dismissed !== kernel
+      ) {
+        const { update_dismissed: _drop, ...rest } = cocalc;
+        this.set_global_metadata({ cocalc: rest });
+      }
     }
     if (this.store.get("show_kernel_selector") || kernel === "") {
       this.hide_select_kernel();

--- a/src/packages/frontend/jupyter/kernelspecs.ts
+++ b/src/packages/frontend/jupyter/kernelspecs.ts
@@ -38,7 +38,7 @@ const getKernelSpec = reuseInFlight(
       compute_server_id,
       timeout: 7500,
     });
-    const spec = await api.editor.jupyterKernels();
+    const spec = await api.editor.jupyterKernels({ noCache });
     cache.set(key, spec);
     return spec;
   },

--- a/src/packages/frontend/jupyter/select-kernel.tsx
+++ b/src/packages/frontend/jupyter/select-kernel.tsx
@@ -14,6 +14,7 @@ import {
   Checkbox,
   Descriptions,
   Popover,
+  Space,
   Spin,
   Tabs,
   Tooltip,
@@ -43,7 +44,11 @@ import { SiteName } from "@cocalc/frontend/customize";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
 import { labels } from "@cocalc/frontend/i18n";
 import track from "@cocalc/frontend/user-tracking";
-import { Kernel as KernelType } from "@cocalc/jupyter/util/misc";
+import {
+  compareDottedVersions,
+  isDottedVersion,
+  Kernel as KernelType,
+} from "@cocalc/jupyter/util/misc";
 import * as misc from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import { KernelStar } from "../components/run-button/kernel-star";
@@ -176,6 +181,87 @@ export const KernelSelector: React.FC<KernelSelectorProps> = React.memo(
       );
     }
 
+    function cocalc_attr(name: string, key: string): any {
+      return kernels_by_name?.getIn([name, "metadata", "cocalc", key]);
+    }
+
+    // Compact button for an older version in a family: shows just the
+    // version number (display_version preferred), with the full kernel
+    // name in a tooltip.
+    function render_version_button(name: string): Rendered {
+      const ver = (cocalc_attr(name, "display_version") ??
+        cocalc_attr(name, "version") ??
+        name) as string;
+      const key = `kernel-v-${name}`;
+      return (
+        <Tooltip key={key} title={kernel_name(name) || name}>
+          <Button
+            onClick={() => {
+              actions.select_kernel(name);
+              track("jupyter", {
+                action: "select-kernel",
+                kernel: name,
+                how: "click-button-in-dialog",
+              });
+            }}
+            style={{ height: "35px" }}
+          >
+            {ver}
+          </Button>
+        </Tooltip>
+      );
+    }
+
+    // Render all kernels of one language: kernels that declare a
+    // metadata.cocalc.family + version are grouped by family (latest version
+    // as a prominent button, older versions as compact version buttons next
+    // to it); kernels without family/version keep the flat rendering.
+    function render_lang_kernels(names: List<string>): Rendered {
+      const families: { [family: string]: string[] } = {};
+      const familyOrder: string[] = [];
+      const ungrouped: string[] = [];
+      names.forEach((name) => {
+        const fam = cocalc_attr(name, "family");
+        const ver = cocalc_attr(name, "version");
+        if (typeof fam === "string" && fam !== "" && isDottedVersion(ver)) {
+          if (families[fam] == null) {
+            families[fam] = [];
+            familyOrder.push(fam);
+          }
+          families[fam].push(name);
+        } else {
+          ungrouped.push(name);
+        }
+      });
+      familyOrder.sort();
+      const groups: Rendered[] = familyOrder.map((fam) => {
+        const members = families[fam].slice().sort((a, b) =>
+          -compareDottedVersions(
+            cocalc_attr(a, "version"),
+            cocalc_attr(b, "version"),
+          ),
+        );
+        const [latest, ...older] = members;
+        return (
+          <Space.Compact
+            key={`fam-${fam}`}
+            style={{ marginRight: "10px", marginBottom: "5px" }}
+          >
+            {render_kernel_button(latest)}
+            {older.map((n) => render_version_button(n))}
+          </Space.Compact>
+        );
+      });
+      return (
+        <div
+          style={{ display: "flex", flexWrap: "wrap", alignItems: "center" }}
+        >
+          {groups}
+          {ungrouped.map((n) => render_kernel_button(n))}
+        </div>
+      );
+    }
+
     function render_suggested() {
       if (kernel_selection == null || kernels_by_name == null) return;
 
@@ -274,17 +360,13 @@ export const KernelSelector: React.FC<KernelSelectorProps> = React.memo(
 
       const all: Rendered[] = [];
       kernels_by_language.forEach((names, lang) => {
-        const kernels = names.map((name) => render_kernel_button(name));
-
         const label = (
           <span style={ALL_LANGS_LABEL_STYLE}>{misc.capitalize(lang)}</span>
         );
 
         all.push(
           <Descriptions.Item key={lang} label={label}>
-            <Button.Group style={{ display: "flex", flexWrap: "wrap" }}>
-              {kernels}
-            </Button.Group>
+            {render_lang_kernels(names)}
           </Descriptions.Item>,
         );
         return true;

--- a/src/packages/frontend/jupyter/status.tsx
+++ b/src/packages/frontend/jupyter/status.tsx
@@ -10,10 +10,15 @@ import { A, Icon, IconName, Loading } from "@cocalc/frontend/components";
 import ComputeServer from "@cocalc/frontend/compute/inline";
 import { IS_MOBILE } from "@cocalc/frontend/feature";
 import { AlertLevel, BackendState, Usage } from "@cocalc/jupyter/types";
+import {
+  kernelUpdateInfo,
+  type KernelUpdateInfo,
+} from "@cocalc/jupyter/util/misc";
 import { capitalize, closest_kernel_match, rpad_html } from "@cocalc/util/misc";
 import { COLORS } from "@cocalc/util/theme";
 import {
   Button,
+  Modal,
   Popconfirm,
   Popover,
   Progress,
@@ -23,7 +28,14 @@ import {
   Typography,
 } from "antd";
 import * as immutable from "immutable";
-import { ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import ProgressEstimate from "../components/progress-estimate";
 import { jupyter as jupyterI18n, labels } from "../i18n";
@@ -128,6 +140,20 @@ export function Kernel({
     "backend_state",
   ]);
   const kernel_state: undefined | string = useRedux([name, "kernel_state"]);
+  const metadata: undefined | immutable.Map<string, any> = useRedux([
+    name,
+    "metadata",
+  ]);
+
+  // Versioned kernels: is a newer version of the same family available, and
+  // has the user dismissed ("Keep") the prompt for the current kernel?
+  const kernelUpdate: KernelUpdateInfo | null = useMemo(
+    () => kernelUpdateInfo(kernel, kernels),
+    [kernel, kernels],
+  );
+  const updateDismissed =
+    kernel != null && metadata?.getIn(["cocalc", "update_dismissed"]) === kernel;
+  const [updateModalOpen, setUpdateModalOpen] = useState(false);
 
   const backendIsStarting =
     backend_state === "starting" || backend_state === "spawning";
@@ -220,6 +246,90 @@ export function Kernel({
       return;
     }
     return <Logo kernel={kernel} />;
+  }
+
+  function doKernelUpdate() {
+    if (kernelUpdate == null) return;
+    actions.set_kernel(kernelUpdate.latestKernelName);
+    setUpdateModalOpen(false);
+  }
+
+  function dismissKernelUpdate() {
+    if (kernel == null) return;
+    const cur = metadata?.get("cocalc")?.toJS?.() ?? {};
+    actions.set_global_metadata({
+      cocalc: { ...cur, update_dismissed: kernel },
+    });
+    setUpdateModalOpen(false);
+  }
+
+  // Yellow "Update…" button shown when a newer version of the same kernel
+  // family is available and the user hasn't dismissed it for this kernel.
+  function renderKernelUpdate() {
+    if (kernelUpdate == null || updateDismissed || read_only || IS_MOBILE) {
+      return;
+    }
+    return (
+      <>
+        <Tooltip
+          title={`A newer version (${kernelUpdate.latestDisplayName}) of this kernel is available.`}
+        >
+          <Button
+            size="small"
+            onClick={() => setUpdateModalOpen(true)}
+            style={{
+              margin: "0 6px",
+              height: "auto",
+              lineHeight: 1.4,
+              padding: "0 8px",
+              fontSize: "inherit",
+              backgroundColor: COLORS.YELL_L,
+              borderColor: COLORS.YELL_L,
+              color: COLORS.GRAY_D,
+            }}
+          >
+            <Icon name="exclamation-triangle" /> Update…
+          </Button>
+        </Tooltip>
+        <Modal
+          open={updateModalOpen}
+          title={
+            <>
+              <Icon name="exclamation-triangle" /> Kernel update available
+            </>
+          }
+          onCancel={() => setUpdateModalOpen(false)}
+          footer={[
+            <Button key="keep" onClick={dismissKernelUpdate}>
+              Keep {kernel_info?.get("display_name") ?? kernel}
+            </Button>,
+            <Button key="update" type="primary" onClick={doKernelUpdate}>
+              Update to {kernelUpdate.latestDisplayName}
+            </Button>,
+          ]}
+        >
+          <p>
+            A newer version of this kernel is available:{" "}
+            <b>{kernelUpdate.latestDisplayName}</b> (version{" "}
+            {kernelUpdate.latestVersion}). You are currently using version{" "}
+            {kernelUpdate.currentVersion}.
+          </p>
+          <ul>
+            <li>
+              <b>Update to {kernelUpdate.latestDisplayName}</b> — switch this
+              notebook to the new kernel now.
+            </li>
+            <li>
+              <b>Keep</b> — stay on the current kernel and stop showing this
+              prompt for it.
+            </li>
+            <li>
+              Closing this dialog leaves the button so you can decide later.
+            </li>
+          </ul>
+        </Modal>
+      </>
+    );
   }
 
   // this renders the name of the kernel, if known, or a button to change to a similar but known one
@@ -794,10 +904,12 @@ export function Kernel({
         flex: "1 0",
         flexDirection: "row",
         flexWrap: "nowrap",
+        alignItems: "center",
       }}
     >
       {render_name()}
       {render_backend_state_icon()}
+      {renderKernelUpdate()}
       {render_trust()}
     </div>
   );

--- a/src/packages/jupyter/util/misc.test.ts
+++ b/src/packages/jupyter/util/misc.test.ts
@@ -1,8 +1,175 @@
 import expect from "expect";
-import { times_n } from "./misc";
+import * as immutable from "immutable";
+import {
+  compareDottedVersions,
+  get_kernels_by_name_or_language,
+  isDottedVersion,
+  kernelUpdateInfo,
+  times_n,
+} from "./misc";
 
 describe("test times_n", () => {
   it("does what it is supposed to do", () => {
     expect(times_n("x", 3)).toBe("xxx");
+  });
+});
+
+describe("isDottedVersion", () => {
+  it("accepts dotted numeric versions", () => {
+    for (const v of ["10", "11", "10.6", "3.12", "4.3.1"]) {
+      expect(isDottedVersion(v)).toBe(true);
+    }
+  });
+  it("rejects non-conforming strings", () => {
+    for (const v of ["", "3.12.", "1.0a", "v1.0", "python3", undefined, 10]) {
+      expect(isDottedVersion(v as any)).toBe(false);
+    }
+  });
+});
+
+describe("compareDottedVersions", () => {
+  it("compares major/minor/patch numerically", () => {
+    expect(compareDottedVersions("10.7", "10.6")).toBe(1);
+    expect(compareDottedVersions("10.6", "10.7")).toBe(-1);
+    expect(compareDottedVersions("2.0", "1.9")).toBe(1);
+    expect(compareDottedVersions("1.0", "1.0")).toBe(0);
+    // numeric, not lexicographic: 10 > 9
+    expect(compareDottedVersions("1.10", "1.9")).toBe(1);
+  });
+  it("treats the shorter version as less when prefixes are equal", () => {
+    expect(compareDottedVersions("3.12", "3.12.1")).toBe(-1);
+    expect(compareDottedVersions("10", "10.0.1")).toBe(-1);
+    expect(compareDottedVersions("3.12.1", "3.12")).toBe(1);
+  });
+});
+
+function kspec(
+  name: string,
+  cocalc: Record<string, any> | undefined,
+  display_name = name,
+) {
+  return immutable.fromJS({
+    name,
+    display_name,
+    language: "python",
+    ...(cocalc != null ? { metadata: { cocalc } } : {}),
+  });
+}
+
+describe("kernelUpdateInfo", () => {
+  const kernels = immutable.List([
+    kspec("testfam-1.0", { family: "testfam", version: "1.0" }, "Test 1.0"),
+    kspec("testfam-1.1", { family: "testfam", version: "1.1" }, "Test 1.1"),
+    kspec("testfam-2.0", { family: "testfam", version: "2.0" }, "Test 2.0"),
+    kspec("python3", { priority: 100 }),
+  ]);
+
+  it("reports the newest version of the same family", () => {
+    const info = kernelUpdateInfo("testfam-1.0", kernels as any);
+    expect(info).not.toBeNull();
+    expect(info!.family).toBe("testfam");
+    expect(info!.currentVersion).toBe("1.0");
+    expect(info!.latestVersion).toBe("2.0");
+    expect(info!.latestKernelName).toBe("testfam-2.0");
+    expect(info!.latestDisplayName).toBe("Test 2.0");
+  });
+
+  it("returns null when already on the latest", () => {
+    expect(kernelUpdateInfo("testfam-2.0", kernels as any)).toBeNull();
+  });
+
+  it("returns null for kernels without family/version", () => {
+    expect(kernelUpdateInfo("python3", kernels as any)).toBeNull();
+  });
+
+  it("excludes disabled and negative-priority candidates", () => {
+    const ks = immutable.List([
+      kspec("fam-1.0", { family: "fam", version: "1.0" }),
+      kspec("fam-2.0", { family: "fam", version: "2.0", disabled: true }),
+      kspec("fam-3.0", { family: "fam", version: "3.0", priority: -1 }),
+    ]);
+    expect(kernelUpdateInfo("fam-1.0", ks as any)).toBeNull();
+  });
+
+  it("skips a newer negative-priority kernel but still offers a valid one", () => {
+    const ks = immutable.List([
+      kspec("of-3.4", { family: "of", version: "3.4" }, "OF 3.4"),
+      kspec("of-3.5", { family: "of", version: "3.5" }, "OF 3.5"),
+      kspec("of-3.7", { family: "of", version: "3.7", priority: -1 }, "OF 3.7"),
+    ]);
+    const info = kernelUpdateInfo("of-3.4", ks as any);
+    expect(info).not.toBeNull();
+    expect(info!.latestVersion).toBe("3.5");
+    expect(info!.latestKernelName).toBe("of-3.5");
+  });
+
+  it("ignores candidates with an invalid version", () => {
+    const ks = immutable.List([
+      kspec("z-1.0", { family: "z", version: "1.0" }),
+      kspec("z-bad", { family: "z", version: "two" }),
+    ]);
+    expect(kernelUpdateInfo("z-1.0", ks as any)).toBeNull();
+  });
+
+  it("skips a newer disabled candidate but still offers a valid one", () => {
+    const ks = immutable.List([
+      kspec("d-1.0", { family: "d", version: "1.0" }),
+      kspec("d-1.5", { family: "d", version: "1.5" }),
+      kspec("d-2.0", { family: "d", version: "2.0", disabled: true }),
+    ]);
+    const info = kernelUpdateInfo("d-1.0", ks as any);
+    expect(info).not.toBeNull();
+    expect(info!.latestVersion).toBe("1.5");
+  });
+
+  it("returns null for an empty kernel list, missing current name, or unknown current kernel", () => {
+    const ks = immutable.List([
+      kspec("a-1.0", { family: "a", version: "1.0" }),
+    ]);
+    expect(kernelUpdateInfo("a-1.0", immutable.List() as any)).toBeNull();
+    expect(kernelUpdateInfo(null, ks as any)).toBeNull();
+    expect(kernelUpdateInfo(undefined, ks as any)).toBeNull();
+    expect(kernelUpdateInfo("does-not-exist", ks as any)).toBeNull();
+  });
+});
+
+function spec(
+  name: string,
+  display_name: string,
+  language: string | null,
+  cocalc?: Record<string, any>,
+) {
+  const obj: any = { name, display_name };
+  if (language != null) obj.language = language;
+  if (cocalc != null) obj.metadata = { cocalc };
+  return immutable.fromJS(obj);
+}
+
+describe("get_kernels_by_name_or_language", () => {
+  it("filters out disabled: true (truly hidden)", () => {
+    const ks = immutable.List([
+      spec("a", "A", "python"),
+      spec("b", "B", "python", { disabled: true }),
+    ]);
+    const [byName, byLang] = get_kernels_by_name_or_language(ks as any);
+    expect(byName.has("a")).toBe(true);
+    expect(byName.has("b")).toBe(false);
+    expect(byLang.get("python")?.toJS()).toEqual(["a"]);
+  });
+
+  it("keeps priority < 0 kernels visible (deprecated, still selectable)", () => {
+    const ks = immutable.List([
+      spec("a", "A", "python"),
+      spec("dep", "Deprecated", "python", { priority: -1 }),
+    ]);
+    const [byName, byLang] = get_kernels_by_name_or_language(ks as any);
+    expect(byName.has("dep")).toBe(true);
+    expect(byLang.get("python")?.toJS()).toContain("dep");
+  });
+
+  it("groups kernels with no language under 'misc'", () => {
+    const ks = immutable.List([spec("nolang", "NoLang", null)]);
+    const [, byLang] = get_kernels_by_name_or_language(ks as any);
+    expect(byLang.get("misc")?.toJS()).toEqual(["nolang"]);
   });
 });

--- a/src/packages/jupyter/util/misc.ts
+++ b/src/packages/jupyter/util/misc.ts
@@ -198,3 +198,116 @@ export function get_kernel_selection(
 
   return immutable.Map<string, string>(data);
 }
+
+// ---------------------------------------------------------------------------
+// Versioned kernels: detect that a newer version of the same "family" of
+// kernel is available.  See src/docs/jupyter.md "Versioned Kernels".
+// ---------------------------------------------------------------------------
+
+// A "dotted numeric version": one or more dot-separated non-negative integers,
+// e.g. "10", "10.6", "3.12", "4.3.1".  NOT semver (semver would reject "10").
+const DOTTED_VERSION_RE = /^\d+(\.\d+)*$/;
+
+export function isDottedVersion(v: unknown): v is string {
+  return typeof v === "string" && DOTTED_VERSION_RE.test(v);
+}
+
+// Compare two dotted numeric versions.  Returns 1 if a > b, -1 if a < b,
+// 0 if equal.  Comparison is segment-by-segment numeric; when one runs out
+// of segments the shorter one is "less" (so "3.12" < "3.12.1", "10" < "10.0.1").
+// Inputs are expected to satisfy DOTTED_VERSION_RE; anything non-conforming
+// is treated as lower than a conforming version (and two non-conforming
+// values compare equal) so callers never throw.
+export function compareDottedVersions(a: string, b: string): -1 | 0 | 1 {
+  const aOk = isDottedVersion(a);
+  const bOk = isDottedVersion(b);
+  if (!aOk || !bOk) {
+    if (aOk === bOk) return 0;
+    return aOk ? 1 : -1;
+  }
+  const av = a.split(".");
+  const bv = b.split(".");
+  for (let i = 0; i < Math.max(av.length, bv.length); i++) {
+    // missing segment counts as 0 only when the other side also ran out;
+    // a present segment always makes the longer version larger.
+    if (i >= av.length) return -1;
+    if (i >= bv.length) return 1;
+    const x = parseInt(av[i], 10);
+    const y = parseInt(bv[i], 10);
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+  return 0;
+}
+
+export interface KernelUpdateInfo {
+  family: string;
+  currentVersion: string;
+  latestVersion: string;
+  latestKernelName: string;
+  latestDisplayName: string;
+}
+
+function kernelCocalc(spec: Kernel | undefined, key: string): any {
+  return spec?.getIn(["metadata", "cocalc", key]);
+}
+
+// Pure: given the currently selected kernel name and the list of available
+// kernel specs, return info about a strictly-newer kernel in the same
+// `metadata.cocalc.family`, or null if none / not applicable.  Participation
+// requires an explicit family + a contract-valid version; there is no
+// name-derived fallback.
+export function kernelUpdateInfo(
+  currentKernelName: string | null | undefined,
+  kernels: Kernels | undefined,
+): KernelUpdateInfo | null {
+  if (!currentKernelName || kernels == null) return null;
+  const target = currentKernelName.toLowerCase();
+  const current = kernels.find(
+    (k) => (k.get("name") ?? "").toLowerCase() === target,
+  );
+  if (current == null) return null;
+
+  const family = kernelCocalc(current, "family");
+  const currentVersion = kernelCocalc(current, "version");
+  if (
+    typeof family !== "string" ||
+    family === "" ||
+    !isDottedVersion(currentVersion)
+  ) {
+    return null;
+  }
+
+  let best: Kernel | undefined;
+  let bestVersion: string | undefined;
+  kernels.forEach((k) => {
+    if (kernelCocalc(k, "family") !== family) return;
+    if (kernelCocalc(k, "disabled") === true) return;
+    const priority = (kernelCocalc(k, "priority") ?? 0) as number;
+    if (priority < 0) return;
+    const v = kernelCocalc(k, "version");
+    if (!isDottedVersion(v)) return;
+    if (bestVersion == null || compareDottedVersions(v, bestVersion) === 1) {
+      best = k;
+      bestVersion = v;
+    }
+  });
+
+  if (
+    best == null ||
+    bestVersion == null ||
+    compareDottedVersions(bestVersion, currentVersion) !== 1
+  ) {
+    return null;
+  }
+
+  const latestKernelName = best.get("name") as string;
+  return {
+    family,
+    currentVersion,
+    latestVersion: bestVersion,
+    latestKernelName,
+    latestDisplayName:
+      (best.get("display_name") as string) || latestKernelName,
+  };
+}

--- a/src/packages/util/jupyter/types.ts
+++ b/src/packages/util/jupyter/types.ts
@@ -52,11 +52,15 @@ export interface KernelSpec {
 export type KernelMetadata = {
   // top level could contain a "cocalc" key, containing special settings understood by cocalc
   cocalc?: {
-    priority?: number; // level 10 means it is important, on short list of choices, etc. 1 is low priority, for older versions
-    description: string; // Explains what the kernel is, eventually visible to the user
-    url: string; // a link to a website with more info about the kernel
-  } & {
-    // nested string/string key/value dictionary
-    [key: string]: string | Record<string, string>;
+    priority?: number; // 10+ = "Suggested"/starred; 1 = older version (still selectable); <0 = deprecated: still visible/selectable but excluded from closest_kernel_match and from update-detection candidates. To hide entirely use `disabled: true`.
+    description?: string; // Explains what the kernel is, eventually visible to the user
+    url?: string; // a link to a website with more info about the kernel
+    disabled?: boolean; // if true, the kernel is hidden from the cocalc notebook UI
+    // Versioned-kernel support: two kernels with the same "family" are the
+    // same software line; "version" is a dotted numeric version (^\d+(\.\d+)*$)
+    // used to detect that a newer version of the same family is available.
+    family?: string;
+    version?: string;
+    display_version?: string; // optional human-readable version label
   };
 };

--- a/src/scripts/make_test_kernels.py
+++ b/src/scripts/make_test_kernels.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+Create artificial versioned Jupyter kernels for testing the "versioned
+kernels / kernel update awareness" feature.
+
+See src/docs/jupyter.md -> "Versioned Kernels" -> "Local testing plan".
+
+Run this INSIDE the project/user environment you want to test in (so that
+$HOME points at that environment). It writes throwaway kernelspecs next to
+your existing ones under the Jupyter data dir:
+
+    $JUPYTER_DATA_DIR/kernels/   (default: ~/.local/share/jupyter/kernels)
+
+It reuses the `argv` of the already-installed `python3` kernel, so the test
+kernels actually launch. They are all the same Python interpreter; only the
+cocalc metadata and the `language` label differ. Two languages are used so
+the per-language grouping is exercised: the real "python" and a fake
+"snake".
+
+Kernels created:
+
+  language "python":
+    testfam-1.0, testfam-1.1  (prio 0), testfam-2.0 (prio 10)
+      -> select 1.0 -> yellow "Update..." offering 2.0; 1.1 compact.
+         testfam-2.0 has priority 10, so it is also "Suggested"/starred.
+    otherfam-3.4, otherfam-3.5                      (family otherfam, prio 0)
+    otherfam-3.7                                    (family otherfam, prio -1)
+      -> second family group; otherfam-3.4 must offer 3.5 (NOT the
+         negative-priority 3.7), and 3.7 must not be "Suggested".
+
+  language "snake" (fake):
+    snakefam-1.0, snakefam-2.0                      (family snakefam, prio 0)
+    cobra-5.1, cobra-5.2                            (family cobra, prio 0)
+      -> a separate language group with two families of its own.
+
+  plain kernels (no family/version) -> never show "Update", render in the
+  ungrouped section after the final menu divider:
+    plainkernel-a  (no metadata.cocalc at all, like the stock python3)
+    plainkernel-b  (metadata.cocalc present but no family/version)
+    plainkernel-c  (language "snake")
+
+The pre-existing `python3` kernel (no family/version) also stays untouched
+and likewise verifies non-participation + the ungrouped section.
+
+Usage:
+    src/scripts/make_test_kernels.py            # create / refresh them
+    src/scripts/make_test_kernels.py --clean    # remove them again
+    src/scripts/make_test_kernels.py --list     # show kernels dir contents
+
+After creating/removing, click "Refresh" in the CoCalc kernel selector
+(the frontend caches kernelspecs for 5 minutes).
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+# (family, version, display_name, language, priority)
+# priority 10 -> "Suggested" / starred (needs >=10); newest in a family
+#                normally gets this, mirroring the real Sage convention.
+# priority 0  -> out of "Suggested" but update-eligible (>=0).
+# priority -1 -> filtered out of "Suggested", update detection and
+#                closest_kernel_match (but still selectable in the full
+#                kernel list / Change Kernel menu).
+#
+# All kernels run the same Python under the hood; `language` is just a
+# label so we can exercise the per-language grouping. We use two languages:
+# the real "python" and a fake "snake".
+TEST_KERNELS = [
+    # language: python
+    ("testfam", "1.0", "Test Family 1.0", "python", 0),
+    ("testfam", "1.1", "Test Family 1.1", "python", 0),
+    # newest in testfam: priority 10 -> also shows in "Suggested"/starred,
+    # while still being the version-based update target.
+    ("testfam", "2.0", "Test Family 2.0", "python", 10),
+    ("otherfam", "3.4", "Other Family 3.4", "python", 0),
+    ("otherfam", "3.5", "Other Family 3.5", "python", 0),
+    # negative priority: must NOT be offered as an update for otherfam-3.4
+    # (so 3.5 stays the latest), and must not appear in "Suggested".
+    ("otherfam", "3.7", "Other Family 3.7", "python", -1),
+    # language: snake (fake) -- two families, so the "Snake" group/submenu
+    # also shows family grouping + a divider between groups.
+    ("snakefam", "1.0", "Snake Family 1.0", "snake", 0),
+    ("snakefam", "2.0", "Snake Family 2.0", "snake", 0),
+    ("cobra", "5.1", "Cobra 5.1", "snake", 0),
+    ("cobra", "5.2", "Cobra 5.2", "snake", 0),
+]
+
+# Plain kernels WITHOUT family/version -> must never show an "Update"
+# button and must render in the ungrouped section (after the final menu
+# divider). (name, display_name, language, cocalc_metadata_or_None)
+#  - plainkernel-a: no metadata.cocalc at all (like the stock python3).
+#  - plainkernel-b: has metadata.cocalc but no family/version, to confirm
+#    that presence of cocalc metadata alone does not opt a kernel in.
+PLAIN_KERNELS = [
+    ("plainkernel-a", "Plain Kernel A", "python", None),
+    (
+        "plainkernel-b",
+        "Plain Kernel B",
+        "python",
+        {
+            "priority": 0,
+            "description": "Artificial test kernel without family/version.",
+            "url": "https://doc.cocalc.com/jupyter.html",
+        },
+    ),
+    # a plain kernel in the fake "snake" language
+    ("plainkernel-c", "Plain Kernel C", "snake", None),
+]
+
+# kernel.json prefixes we own and may delete with --clean
+OWNED_PREFIXES = (
+    "testfam-",
+    "otherfam-",
+    "snakefam-",
+    "cobra-",
+    "plainkernel-",
+)
+
+DEFAULT_ARGV = [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}",
+]
+
+
+def kernels_dir() -> str:
+    data_dir = os.environ.get("JUPYTER_DATA_DIR") or os.path.join(
+        os.path.expanduser("~"), ".local", "share", "jupyter"
+    )
+    return os.path.join(data_dir, "kernels")
+
+
+def has_ipykernel(py: str) -> bool:
+    """True if `py -m ipykernel_launcher` can at least import ipykernel."""
+    try:
+        r = subprocess.run(
+            [py, "-c", "import ipykernel"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def resolve_interpreter(argv0: str) -> tuple:
+    """Pick an absolute interpreter path that can import ipykernel.
+
+    Kernels are spawned by the CoCalc project server, whose PATH may not
+    contain a bare `python` (the stock python3 kernelspec has this same
+    fragility -> 'spawn python ENOENT'); and even when found, the wrong
+    interpreter may lack ipykernel -> the kernel exits and CoCalc reports
+    'timeout'. So we build a candidate list, prefer the first that can
+    `import ipykernel`, and report whether any could.
+
+    Returns (path, has_ipykernel)."""
+    candidates = [sys.executable]  # run THIS script with the project python
+    if os.path.isabs(argv0) and os.path.exists(argv0):
+        candidates.append(argv0)
+    for cand in (argv0, "python3", "python"):
+        w = shutil.which(cand)
+        if w:
+            candidates.append(w)
+    # de-duplicate, preserve order
+    seen = set()
+    ordered = []
+    for c in candidates:
+        if c and c not in seen:
+            seen.add(c)
+            ordered.append(c)
+    for c in ordered:
+        if has_ipykernel(c):
+            return c, True
+    return (ordered[0] if ordered else sys.executable), False
+
+
+def discover_python_argv(kdir: str) -> tuple:
+    """Reuse the argv of an existing real python kernel so the test
+    kernels actually start, but force argv[0] to an absolute interpreter
+    that has ipykernel. Falls back to a sane default.
+
+    Returns (argv, has_ipykernel)."""
+    argv = list(DEFAULT_ARGV)
+    for name in ("python3", "python"):
+        path = os.path.join(kdir, name, "kernel.json")
+        if os.path.isfile(path):
+            try:
+                with open(path) as f:
+                    spec = json.load(f)
+                found = spec.get("argv")
+                if isinstance(found, list) and found:
+                    argv = list(found)
+                    break
+            except (OSError, ValueError):
+                pass
+    argv[0], ok = resolve_interpreter(argv[0])
+    return argv, ok
+
+
+def kernel_name(family: str, version: str) -> str:
+    return f"{family}-{version}"
+
+
+def write_kernel(kdir: str, name: str, argv: list, display_name: str,
+                 language: str, cocalc) -> str:
+    """Write a kernels/<name>/kernel.json. `cocalc` is the
+    metadata.cocalc dict, or None for no cocalc metadata at all."""
+    path = os.path.join(kdir, name)
+    os.makedirs(path, exist_ok=True)
+    metadata = {"cocalc": cocalc} if cocalc is not None else {}
+    spec = {
+        "argv": list(argv),
+        "display_name": display_name,
+        "language": language,
+        "metadata": metadata,
+    }
+    with open(os.path.join(path, "kernel.json"), "w") as f:
+        json.dump(spec, f, indent=1)
+        f.write("\n")
+    return name
+
+
+def make_kernel(kdir: str, argv: list, family: str, version: str,
+                display_name: str, language: str, priority: int = 0) -> str:
+    return write_kernel(
+        kdir,
+        kernel_name(family, version),
+        argv,
+        display_name,
+        language,
+        {
+            "priority": priority,
+            "description": f"Artificial test kernel ({family} {version}).",
+            "url": "https://doc.cocalc.com/jupyter.html",
+            "family": family,
+            "version": version,
+        },
+    )
+
+
+def clean(kdir: str) -> None:
+    if not os.path.isdir(kdir):
+        print(f"nothing to clean: {kdir} does not exist")
+        return
+    removed = 0
+    for entry in sorted(os.listdir(kdir)):
+        if entry.startswith(OWNED_PREFIXES):
+            shutil.rmtree(os.path.join(kdir, entry), ignore_errors=True)
+            print(f"  removed {entry}")
+            removed += 1
+    print(f"removed {removed} test kernel(s) from {kdir}")
+
+
+def list_dir(kdir: str) -> None:
+    if not os.path.isdir(kdir):
+        print(f"{kdir} does not exist")
+        return
+    print(f"kernels in {kdir}:")
+    for entry in sorted(os.listdir(kdir)):
+        marker = " (test)" if entry.startswith(OWNED_PREFIXES) else ""
+        print(f"  {entry}{marker}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create artificial versioned Jupyter test kernels."
+    )
+    parser.add_argument(
+        "--clean", action="store_true",
+        help="remove the test kernels instead of creating them",
+    )
+    parser.add_argument(
+        "--list", action="store_true",
+        help="list the kernels directory and exit",
+    )
+    args = parser.parse_args()
+
+    kdir = kernels_dir()
+
+    if args.list:
+        list_dir(kdir)
+        return 0
+
+    if args.clean:
+        clean(kdir)
+        return 0
+
+    os.makedirs(kdir, exist_ok=True)
+    argv, ipykernel_ok = discover_python_argv(kdir)
+    print(f"kernels dir : {kdir}")
+    print(f"interpreter : {argv[0]}")
+    print(f"full argv   : {argv}")
+    if not ipykernel_ok:
+        print()
+        print("WARNING: none of the candidate interpreters could "
+              "'import ipykernel'.")
+        print("  The kernels will spawn but fail with a 3s timeout.")
+        print("  Re-run this script with the project's Python (the one")
+        print("  that has ipykernel installed), e.g.:")
+        print("    /path/to/project/python make_test_kernels.py")
+        print("  or:  python -m pip install ipykernel")
+        print()
+    for family, version, display_name, language, priority in TEST_KERNELS:
+        name = make_kernel(
+            kdir, argv, family, version, display_name, language, priority
+        )
+        print(
+            f"  created {name}  "
+            f"(family={family} version={version} priority={priority})"
+        )
+    for name, display_name, language, cocalc in PLAIN_KERNELS:
+        write_kernel(kdir, name, argv, display_name, language, cocalc)
+        kind = "no metadata.cocalc" if cocalc is None else "no family/version"
+        print(f"  created {name}  ({kind})")
+    print()
+    print("Done. In CoCalc: open a notebook, click 'Refresh' in the kernel")
+    print("selector, then select 'Test Family 1.0' to see the Update button.")
+    print("Run with --clean to remove these again.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Notebooks pin a kernel by name (e.g. `sage-10.5`), so after a software update users keep running an old kernel without noticing a newer one exists. This adds **kernel update awareness**: a yellow "Update…" button in the notebook status line when a newer version of the same kernel *family* is installed.

- **Metadata**: optional `metadata.cocalc.family` / `version` / `display_version` on kernelspecs. `KernelMetadata` tightened (all members optional, loose index signature dropped). `family` is deliberately separate from the Jupyter `language` (e.g. `python-system` vs `python-cocalc` vs `python-anaconda` must not be offered as updates of one another).
- **Detection**: pure `kernelUpdateInfo()` + `compareDottedVersions()` in `packages/jupyter/util/misc.ts` (per-segment numeric compare, `^\d+(\.\d+)*$`; the existing private `compareVersionStrings()` is left untouched). Excludes `disabled` / `priority < 0`. Computed reactively in the status line so it updates on any kernel change.
- **Dialog**: Update / Keep / X. "Keep" writes a kernel-scoped `metadata.cocalc.update_dismissed` (no auto-clear; suppressed only while on that kernel).
- **Presentation**: the select-kernel dialog and the `Kernel → Change Kernel` menu now group by `family` within each language (latest prominent, older versions compact; dividers between family groups in the menu — adds `{ type: "divider" }` support to `frame-tree/commands`).
- **Cache**: forward `noCache` through the frontend kernelspecs fetch so the selector's Refresh actually picks up new/edited kernelspecs.
- **Dev tooling**: `src/scripts/make_test_kernels.py` creates throwaway versioned test kernelspecs (`--clean` / `--list`).

Design notes: `src/docs/jupyter.md` → "Versioned Kernels (Kernel Update Awareness)".

## Test plan

- [x] `packages/util` + `packages/jupyter` build clean; `packages/frontend` `tsc --noEmit` exit 0
- [x] Unit tests: 11 new (`packages/jupyter/util/misc.test.ts`) covering the version contract + `kernelUpdateInfo` (newest-in-family, already-latest, no metadata, disabled / negative-priority exclusion, invalid version); existing util/jupyter suites green
- [ ] Manual: run `src/scripts/make_test_kernels.py` in a project, Refresh the kernel selector, select **Test Family 1.0** → yellow "Update…" → verify Update / Keep / X; confirm `otherfam-3.4` offers `3.5` (not the `priority:-1` `3.7`); confirm `plainkernel-*` never prompt; check family grouping + dividers in the Change Kernel menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)