### PR TITLE
deps: bump uuid 8 to 11 in hub/jupyter/next/project/server/util

### DIFF
--- a/src/packages/hub/package.json
+++ b/src/packages/hub/package.json
@@ -39,7 +39,7 @@
     "random-key": "^0.3.2",
     "react": "^19.1.1",
     "uglify-js": "^3.14.1",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "validator": "^13.15.22",
     "webpack-dev-middleware": "^7.4.2",
     "webpack-hot-middleware": "^2.26.1"

--- a/src/packages/jupyter/package.json
+++ b/src/packages/jupyter/package.json
@@ -50,7 +50,7 @@
     "mkdirp": "^1.0.4",
     "node-cleanup": "^2.1.2",
     "shell-escape": "^0.2.0",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "zeromq": "^6.4.2"
   },
   "devDependencies": {

--- a/src/packages/next/package.json
+++ b/src/packages/next/package.json
@@ -91,7 +91,7 @@
     "serve-index": "^1.9.1",
     "timeago-react": "^3.0.4",
     "use-async-effect": "^2.2.7",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "vanilla-cookieconsent": "^3.1.0",
     "xmlbuilder2": "^4.0.1",
     "zod": "^3.23.5"

--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -874,8 +874,8 @@ importers:
         specifier: ^3.14.1
         version: 3.19.3
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^11.1.1
+        version: 11.1.1
       validator:
         specifier: ^13.15.22
         version: 13.15.22
@@ -956,8 +956,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^11.1.1
+        version: 11.1.1
       zeromq:
         specifier: ^6.4.2
         version: 6.5.0
@@ -1077,8 +1077,8 @@ importers:
         specifier: ^2.2.7
         version: 2.2.7(react@19.1.1)
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^11.1.1
+        version: 11.1.1
       vanilla-cookieconsent:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1204,8 +1204,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^11.1.1
+        version: 11.1.1
       websocket-sftp:
         specifier: ^0.8.4
         version: 0.8.4(bufferutil@4.0.9)(utf-8-validate@6.0.5)
@@ -1231,9 +1231,6 @@ importers:
       '@types/primus':
         specifier: ^7.3.9
         version: 7.3.9
-      '@types/uuid':
-        specifier: ^8.3.1
-        version: 8.3.4
 
   server:
     dependencies:
@@ -1451,8 +1448,8 @@ importers:
         specifier: ^17.5.0
         version: 17.7.0
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^11.1.1
+        version: 11.1.1
     devDependencies:
       '@types/async':
         specifier: ^2.0.43
@@ -1903,8 +1900,8 @@ importers:
         specifier: ^3.10.0
         version: 3.11.0
       uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
+        specifier: ^11.1.1
+        version: 11.1.1
       voucher-code-generator:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1921,9 +1918,6 @@ importers:
       '@types/seedrandom':
         specifier: ^3.0.8
         version: 3.0.8
-      '@types/uuid':
-        specifier: ^8.3.1
-        version: 8.3.4
       expect:
         specifier: ^26.6.2
         version: 26.6.2
@@ -4954,9 +4948,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@8.3.4':
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -11924,10 +11915,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -16175,8 +16168,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@8.3.4': {}
 
   '@types/ws@8.18.1':
     dependencies:

--- a/src/packages/project/package.json
+++ b/src/packages/project/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^5.0.5",
     "temp": "^0.9.4",
     "tmp": "0.2.4",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "websocket-sftp": "^0.8.4",
     "which": "^2.0.2",
     "ws": "^8.20.1"
@@ -60,8 +60,7 @@
     "@types/express": "^5.0.6",
     "@types/lodash": "^4.14.202",
     "@types/node": "^18.16.14",
-    "@types/primus": "^7.3.9",
-    "@types/uuid": "^8.3.1"
+    "@types/primus": "^7.3.9"
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -113,7 +113,7 @@
     "safe-json-stringify": "^1.2.0",
     "sanitize-html": "^2.17.0",
     "stripe": "^17.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "homepage": "https://github.com/sagemathinc/cocalc/tree/master/src/packages/server",
   "repository": {

--- a/src/packages/util/package.json
+++ b/src/packages/util/package.json
@@ -61,7 +61,7 @@
     "reselect": "^4.1.8",
     "sha1": "^1.1.1",
     "utility-types": "^3.10.0",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "voucher-code-generator": "^1.3.0"
   },
   "repository": {
@@ -74,7 +74,6 @@
     "@types/lodash": "^4.14.202",
     "@types/node": "^18.16.14",
     "@types/seedrandom": "^3.0.8",
-    "@types/uuid": "^8.3.1",
     "expect": "^26.6.2",
     "seedrandom": "^3.0.5",
     "tsd": "^0.22.0"


### PR DESCRIPTION
## Summary

Bumps direct uuid dependency from `^8.3.2` to `^11.1.1` in:
- hub, jupyter, next, project, server, util

Drops `@types/uuid` from project and util — uuid ≥9 ships its own TypeScript types.

### Why

Closes the direct-dep portion of Dependabot's `uuid` moderate alert ("Missing buffer bounds check in v3/v5/v6 when buf is provided"). cocalc only ever calls `uuid.v4()` (verified via grep — 13 import sites, all `import { v4 } from "uuid"`), so the vulnerable v3/v5/v6 code path was never reachable through our code, but this puts us on a maintained line and silences the alert for the direct usage.

Mermaid 11.15 also uses uuid@11 — its install now dedupes onto the same version.

### Caveats

Transitive `uuid@8.3.2` and `uuid@9.0.1` remain in the lockfile, pulled in by:
- `@google-cloud/storage`, `@google-cloud/bigquery`, google-auth-library, googleapis, etc.
- `@nteract/commutable` / `kernelspecs`
- `jest-junit`
- `sockjs` (via `webpack-dev-server`)

We don't control their declared uuid ranges; force-overriding them risks breakage and Dependabot will likely keep flagging until they update upstream.

### Verification
- `python3 workspaces.py version-check` passes
- `python3 workspaces.py install` succeeds
- `tsc --noEmit` in all 6 affected packages produces no uuid-related errors (pre-existing dist/build errors are unrelated and present on master)
- Runtime smoke: `const { v4 } = require("uuid"); v4()` works, resolved version is 11.1.1

## Test plan

- [ ] CI green (build + tests)