### PR TITLE
deps: patch tmp and qs Dependabot alerts via overrides

### DIFF
--- a/src/packages/pnpm-lock.yaml
+++ b/src/packages/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   es5-ext@<0.10.63: ^0.10.63
   undici@<5.28.3: ^5.28.4
   postcss@<8.5.10: ^8.5.10
-  qs@<6.14.1: ^6.14.1
+  qs@<6.15.2: ^6.15.2
   retry-request@<7.0.1: ^7.0.2
   ansi-styles@>=6: 5.2.0
   katex@<0.16.9: ^0.16.10
@@ -24,7 +24,7 @@ overrides:
   '@types/request@2.48.12': 2.48.13
   '@types/node-fetch@2.6.12': 2.6.13
   axios@<1.15.2: ^1.15.2
-  tmp@<0.2.4: ^0.2.4
+  tmp@<0.2.6: ^0.2.6
   lodash@>=4.0.0 <4.18.1: 4.18.1
   lodash-es@>=4.0.0 <4.18.1: 4.18.1
   '@isaacs/brace-expansion@<=5.0.0': 5.0.1
@@ -1201,8 +1201,8 @@ importers:
         specifier: ^0.9.4
         version: 0.9.4
       tmp:
-        specifier: 0.2.4
-        version: 0.2.4
+        specifier: ^0.2.6
+        version: 0.2.7
       uuid:
         specifier: ^11.1.1
         version: 11.1.1
@@ -10570,10 +10570,6 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -11971,8 +11967,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.4:
-    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -18028,7 +18024,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -19891,7 +19887,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -23740,10 +23736,6 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.14.1:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -25223,7 +25215,7 @@ snapshots:
   stripe@17.7.0:
     dependencies:
       '@types/node': 18.19.122
-      qs: 6.14.1
+      qs: 6.15.2
 
   strnum@2.2.3: {}
 
@@ -25485,9 +25477,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.4
+      tmp: 0.2.7
 
-  tmp@0.2.4: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 

--- a/src/packages/pnpm-workspace.yaml
+++ b/src/packages/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ overrides:
   es5-ext@<0.10.63: ^0.10.63
   undici@<5.28.3: ^5.28.4
   postcss@<8.5.10: ^8.5.10
-  qs@<6.14.1: ^6.14.1
+  qs@<6.15.2: ^6.15.2
   retry-request@<7.0.1: ^7.0.2
   ansi-styles@>=6: 5.2.0
   katex@<0.16.9: ^0.16.10
@@ -57,7 +57,7 @@ overrides:
   "@types/request@2.48.12": 2.48.13
   "@types/node-fetch@2.6.12": 2.6.13
   axios@<1.15.2: ^1.15.2
-  tmp@<0.2.4: ^0.2.4
+  tmp@<0.2.6: ^0.2.6
   lodash@>=4.0.0 <4.18.1: 4.18.1
   lodash-es@>=4.0.0 <4.18.1: 4.18.1
   "@isaacs/brace-expansion@<=5.0.0": 5.0.1


### PR DESCRIPTION
## Summary
- Widen the `tmp` pnpm override to `<0.2.6` (resolves **0.2.7**) for the path-traversal fix.
- Widen the `qs` pnpm override to `<6.15.2` (resolves **6.15.2**) for the `qs.stringify` DoS fix.

These are override-level fixes, which is how this monorepo pins these packages. Dependabot's direct-`package.json` PRs (#8899, #8896) couldn't actually move the resolved version because the existing `tmp@<0.2.4` override held it at 0.2.4; this supersedes them and also covers transitive usages.

### Verified
- `ws` was already patched (8.20.1) via existing override — no change needed.
- `uuid` direct deps already on 11.1.1 via existing override. Transitive `uuid` 8.3.2/9.0.1 (from `@google-cloud/bigquery`, `@nteract`) left as-is: the advisory's bug is in v3/v5/v6 with an explicit `buf` arg, which those libs don't use, and a v11 major bump there risks breakage for no real gain.

## Test plan
- [ ] `cd src && python3 workspaces.py install` resolves cleanly
- [ ] `grep 'tmp@0.2.4' src/packages/pnpm-lock.yaml` returns nothing
- [ ] `grep 'qs@6.14.1' src/packages/pnpm-lock.yaml` returns nothing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)