### PR TITLE
latex-editor: replace formula AI-edit pencil with shift+click

### DIFF
--- a/src/packages/frontend/frame-editors/latex-editor/rich-edit/types.ts
+++ b/src/packages/frontend/frame-editors/latex-editor/rich-edit/types.ts
@@ -121,11 +121,11 @@ export interface WidgetProps {
    */
   onActivate: () => void;
   /**
-   * Math widgets only: called when the user clicks the trailing AI
-   * pencil. The widget-manager wires this to open the existing
-   * `ai_gen_formula` dialog with the marker's current source, then
-   * replace the marker range with the result. Non-math widgets
-   * leave this undefined.
+   * Math widgets only: called when the user shift+clicks (or presses
+   * shift+Enter on) the rendered formula. The widget-manager wires
+   * this to open the existing `ai_gen_formula` dialog with the
+   * marker's current source, then replace the marker range with the
+   * result. Non-math widgets leave this undefined.
    */
   onAiEdit?: () => Promise<void> | void;
 }

--- a/src/packages/frontend/frame-editors/latex-editor/rich-edit/widget-manager.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/rich-edit/widget-manager.tsx
@@ -235,26 +235,14 @@ export function attachWidgetManager(
       cm.focus();
     };
 
-    // Keyboard activation: the host is focusable (role=button,
-    // tabindex=0), so Enter/Space must dissolve it to raw source —
-    // mirroring the mouse-down path in the Widget component. The AI
-    // pencil's own keydown handler stops propagation, so focusing it
-    // and pressing Enter edits instead of dissolving.
-    host.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        onActivate();
-      }
-    });
-
-    // Math widgets get an AI-edit closure (pencil button → AI dialog
-    // → replace source). The accept path is race-safe: we look up
-    // the current marker range via `marker.find()` AFTER the dialog
-    // resolves (it can take seconds), bail on null, and detect cancel
-    // by checking whether the dialog returned the original text
+    // Math widgets get an AI-edit closure (shift+click / shift+Enter →
+    // AI dialog → replace source). The accept path is race-safe: we
+    // look up the current marker range via `marker.find()` AFTER the
+    // dialog resolves (it can take seconds), bail on null, and detect
+    // cancel by checking whether the dialog returned the original text
     // unchanged (ai-formula.tsx resolves cancel that way).
     //
-    // Suppress the pencil entirely in read-only / public frames: CM's
+    // Disable AI edit entirely in read-only / public frames: CM's
     // `readOnly` blocks user typing but NOT programmatic
     // `replaceRange`, so an AI edit would otherwise mutate a buffer the
     // user isn't allowed to change.
@@ -302,6 +290,22 @@ export function attachWidgetManager(
           cm.replaceRange(result, range2.from, range2.to);
         }
       : undefined;
+
+    // Keyboard activation: the host is focusable (role=button,
+    // tabindex=0). Enter/Space dissolves it to raw source — mirroring
+    // the plain-click path in the Widget component. Shift+Enter on an
+    // AI-editable widget (math) opens the AI formula editor instead,
+    // mirroring shift+click.
+    host.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        if (e.shiftKey && onAiEdit != null) {
+          void onAiEdit();
+        } else {
+          onActivate();
+        }
+      }
+    });
 
     const root = createRoot(host);
     // createRoot mounts live outside the editor's <FrameContext.Provider> —

--- a/src/packages/frontend/frame-editors/latex-editor/rich-edit/widget-renderer.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/rich-edit/widget-renderer.tsx
@@ -142,7 +142,7 @@ const WIDGETS: Record<WidgetType, ComponentType<WidgetProps>> = {
 };
 
 /**
- * Widget types that get the trailing AI-edit pencil. Only math
+ * Widget types that support shift+click AI editing. Only math
  * widgets today; future widgets that want AI editing can be added
  * here. Used by the widget-manager to decide whether to set up the
  * onAiEdit closure.

--- a/src/packages/frontend/frame-editors/latex-editor/rich-edit/widgets/common.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/rich-edit/widgets/common.tsx
@@ -35,6 +35,7 @@ interface WidgetBaseProps extends WidgetProps {
 export function Widget({
   descriptor,
   onActivate,
+  onAiEdit,
   children,
   style,
   display,
@@ -43,15 +44,30 @@ export function Widget({
   return (
     <Tooltip
       title={
-        <code
-          style={{
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-word",
-            fontSize: "0.9em",
-          }}
-        >
-          {descriptor.source}
-        </code>
+        <div>
+          <code
+            style={{
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              fontSize: "0.9em",
+            }}
+          >
+            {descriptor.source}
+          </code>
+          {onAiEdit != null && (
+            <>
+              <div
+                style={{
+                  borderTop: "1px solid rgba(255, 255, 255, 0.25)",
+                  margin: "5px 0",
+                }}
+              />
+              <div style={{ fontSize: "0.85em", opacity: 0.85 }}>
+                Shift+click to edit with AI
+              </div>
+            </>
+          )}
+        </div>
       }
       placement="top"
       mouseEnterDelay={0.3}
@@ -66,7 +82,13 @@ export function Widget({
           // comment) and our explicit dissolve runs.
           e.stopPropagation();
           e.preventDefault();
-          onActivate();
+          // Shift+click on an AI-editable widget (math) opens the AI
+          // formula editor; a plain click dissolves to raw source.
+          if (e.shiftKey && onAiEdit != null) {
+            void onAiEdit();
+          } else {
+            onActivate();
+          }
         }}
         style={{
           display: display ?? "inline",

--- a/src/packages/frontend/frame-editors/latex-editor/rich-edit/widgets/math.tsx
+++ b/src/packages/frontend/frame-editors/latex-editor/rich-edit/widgets/math.tsx
@@ -12,24 +12,23 @@ Three flavors:
  - MathEnv          \begin{equation|align|gather|multline}…\end{…}
                     (multi-line, starred variants supported)
 
-All three render via `mathToHtml` (KaTeX) and ship with a trailing
-pencil button. Clicking the pencil opens the `ai_gen_formula` dialog in
-edit mode: the current formula is shown as context (plus a few lines of
-surrounding document text), the user types what to change, and on accept
-the source is replaced. The wire-up lives in the widget-manager (it has
-access to cm + the live marker).
+All three render via `mathToHtml` (KaTeX). Shift+clicking a rendered
+formula opens the `ai_gen_formula` dialog in edit mode: the current
+formula is shown as context (plus a few lines of surrounding document
+text), the user types what to change, and on accept the source is
+replaced. A plain click dissolves the widget to raw source for manual
+editing. The shift+click hand-off and tooltip hint live in the shared
+`Widget` component; the actual edit closure is wired in the
+widget-manager (it has access to cm + the live marker).
 
 A KaTeX render error doesn't break the widget — we fall back to a
 muted red "?math?" so the user sees something is off and can hover
 to inspect the source.
 */
 
-import { Tooltip } from "antd";
-import { CSSProperties, ReactNode, useContext, useState } from "react";
+import { ReactNode, useContext } from "react";
 
-import { Icon } from "@cocalc/frontend/components";
 import mathToHtml from "@cocalc/frontend/misc/math-to-html";
-import { COLORS } from "@cocalc/util/theme";
 
 import { MathMacrosContext } from "../math-macros-context";
 import { WidgetProps } from "../types";
@@ -59,60 +58,12 @@ function renderMath(
   return <span dangerouslySetInnerHTML={{ __html }} />;
 }
 
-function PencilButton({
-  onClick,
-  style,
-}: {
-  onClick: () => void;
-  style?: CSSProperties;
-}) {
-  const [hover, setHover] = useState(false);
-  return (
-    <Tooltip title="Edit with AI" placement="top" mouseEnterDelay={0.3}>
-      <span
-        role="button"
-        aria-label="Edit math with AI"
-        tabIndex={0}
-        onMouseDown={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          onClick();
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.stopPropagation();
-            e.preventDefault();
-            onClick();
-          }
-        }}
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
-        style={{
-          marginLeft: 4,
-          padding: "0 2px",
-          opacity: hover ? 1 : 0.35,
-          cursor: "pointer",
-          color: COLORS.GRAY_D,
-          fontSize: "0.85em",
-          verticalAlign: "middle",
-          ...style,
-        }}
-      >
-        <Icon name="pencil" />
-      </span>
-    </Tooltip>
-  );
-}
-
 // Display math ($$…$$, \[…\], and the equation/align/… envs) is laid
 // out as a centered block. The host span is made `display:block` by the
 // widget-manager for these types so the centering spans the line. The
 // formula sits in its own horizontally-scrollable box (wide equations
-// scroll instead of blowing out the line), and the AI-edit pencil is
-// pinned to the top-right corner so it sits NEXT TO the formula rather
-// than wrapping onto its own line below it.
+// scroll instead of blowing out the line).
 const DISPLAY_WIDGET_STYLE = {
-  position: "relative",
   textAlign: "center",
   width: "100%",
 } as const;
@@ -122,13 +73,6 @@ const DISPLAY_SCROLL_STYLE = {
   maxWidth: "100%",
   overflowX: "auto",
 } as const;
-
-const DISPLAY_PENCIL_STYLE: CSSProperties = {
-  position: "absolute",
-  top: 0,
-  right: 0,
-  marginLeft: 0,
-};
 
 function DisplayMath({
   props,
@@ -140,12 +84,6 @@ function DisplayMath({
   return (
     <Widget {...props} display="block" style={DISPLAY_WIDGET_STYLE}>
       <span style={DISPLAY_SCROLL_STYLE}>{children}</span>
-      {props.onAiEdit != null && (
-        <PencilButton
-          style={DISPLAY_PENCIL_STYLE}
-          onClick={() => void props.onAiEdit!()}
-        />
-      )}
     </Widget>
   );
 }
@@ -160,9 +98,6 @@ export function MathInline(props: WidgetProps) {
         <EmptyPlaceholder label="empty math" />
       ) : (
         renderMath(content, true, macros, props.descriptor.source)
-      )}
-      {props.onAiEdit != null && (
-        <PencilButton onClick={() => void props.onAiEdit!()} />
       )}
     </Widget>
   );


### PR DESCRIPTION
## Summary
- Follow-up to #8895 based on team feedback: a trailing edit pencil on **every** rendered formula was too much visual noise.
- Removes the per-formula pencil button entirely and gates the AI formula editor behind **shift+click** on the formula (and **shift+Enter** for keyboard activation). A plain click still dissolves the widget to raw source.
- The hover tooltip now shows the raw LaTeX source, a divider line, then a **"Shift+click to edit with AI"** reminder — shown only for AI-editable (math) widgets.

## Implementation
- `widgets/math.tsx` — delete `PencilButton` + its plumbing (display-pencil style, render sites, now-unused imports).
- `widgets/common.tsx` — shared `Widget` reads `onAiEdit`; shift+click routes to it, and the tooltip gains the divider + hint when present.
- `widget-manager.tsx` — host keydown supports shift+Enter → AI edit; stale pencil comments updated.
- `types.ts` / `widget-renderer.tsx` — doc comments updated to describe shift+click.

## Test plan
- [x] `tsc --noEmit` clean for `packages/frontend`
- [x] rich-edit jest suites pass (57 tests)
- [x] `pnpm build-dev` in `packages/static` compiles
- [ ] Manual: hover a formula shows source + divider + hint; shift+click opens AI editor; plain click dissolves to source; no pencil rendered; read-only frames don't mutate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)