### PR TITLE
db-schema: repurpose deprecated projects.storage field for NFS storage migration

### DIFF
--- a/src/packages/database/postgres-server-queries.coffee
+++ b/src/packages/database/postgres-server-queries.coffee
@@ -1740,45 +1740,9 @@ exports.extend_PostgreSQL = (ext) -> class PostgreSQL extends ext
             where : 'project_id :: UUID = $' : opts.project_id
             cb    : one_result('host', opts.cb)
 
-    set_project_storage: (opts) =>
-        opts = defaults opts,
-            project_id : required
-            host       : required
-            cb         : required
-        @get_project_storage
-            project_id : opts.project_id
-            cb         : (err, current) =>
-                if err
-                    opts.cb(err)
-                    return
-                if current?.host? and current.host != opts.host
-                    opts.cb("change storage not implemented yet -- need to implement saving previous host")
-                else
-                    # easy case -- assigning for the first time
-                    assigned = new Date()
-                    @_query
-                        query : "UPDATE projects"
-                        jsonb_set :
-                            storage : {host:opts.host, assigned:assigned}
-                        where : 'project_id :: UUID = $' : opts.project_id
-                        cb    : (err) => opts.cb(err, assigned)
-
-    get_project_storage: (opts) =>
-        opts = defaults opts,
-            project_id : required
-            cb         : required
-        @_get_project_column('storage', opts.project_id, opts.cb)
-
-    update_project_storage_save: (opts) =>
-        opts = defaults opts,
-            project_id : required
-            cb         : required
-        @_query
-            query : "UPDATE projects"
-            jsonb_merge :
-                storage : {saved:new Date()}
-            where : 'project_id :: UUID = $' : opts.project_id
-            cb    : opts.cb
+    # Removed dead set_project_storage / get_project_storage /
+    # update_project_storage_save: the projects.storage column is now
+    # owned by the kucalc layer (see db-schema/projects.ts `storage`).
 
     set_project_storage_request: (opts) =>
         opts = defaults opts,

--- a/src/packages/util/db-schema/projects.ts
+++ b/src/packages/util/db-schema/projects.ts
@@ -311,8 +311,8 @@ Table({
     },
     storage: {
       type: "map",
-      desc: "(DEPRECATED) This is a map {host:'hostname_of_server', assigned:when first saved here, saved:when last saved here}.",
-      date: ["assigned", "saved"],
+      desc: "Project storage backend selection and placement, used to coordinate the lazy migration off the legacy ZFS pools onto the NFS/btrfs storage system. Map of the form {driver:'zfs'|'nfs', nfs_server:'<shard-id>' (set only when driver='nfs'), size_bytes:?, inodes:?, quota_capacity_bytes:? (current btrfs qgroup limit), archive_format:'legacy-streams-bup'|'nfs-tar-zst', flipped_at:<when archive flipped driver to nfs>, materialized_at:<when last unarchived onto NFS>, evicted_at:<when LRU eviction last archived it>, last_active_seen:<mirror of last_active for LRU>}. Written by the kucalc management layer, not the hub.",
+      date: ["flipped_at", "materialized_at", "evicted_at", "last_active_seen"],
     },
     last_backup: {
       type: "timestamp",


### PR DESCRIPTION
## Summary

Repurposes the dead `projects.storage` JSONB column to coordinate KuCalc's lazy migration off the legacy ZFS-on-NFS-sparse-image project storage onto a simpler btrfs-on-NFS stack (btrfs read-only snapshots + simple quotas, GCS holding only archive/backup tarballs).

The migration is *lazy* and DB-coordinated: the existing archive cron flips a project's storage `driver` from `zfs` to `nfs` when it archives it; the next unarchive materializes the project onto an NFS shard from its bup backup. Over time every project passes through one archive cycle and the ZFS pools drain empty.

- **`db-schema/projects.ts`** — rewrite the `storage` field schema description and `date` key list to the new shape (`driver`, `nfs_server`, `size_bytes`, `inodes`, `quota_capacity_bytes`, `archive_format`, and the `flipped_at` / `materialized_at` / `evicted_at` / `last_active_seen` timestamps). Column is already JSONB → no SQL migration.
- **`postgres-server-queries.coffee`** — remove the three dead legacy methods (`set_project_storage`, `get_project_storage`, `update_project_storage_save`) that read/wrote the old `{host, assigned, saved}` shape. They were unreferenced and would now corrupt the repurposed column.

Reads/writes of this column are owned by the kucalc management layer (archive cron + storage controller), not the hub. This is an intentionally minimal change with no behavioral impact on the running hub.

## Test plan

- [ ] `pnpm build` in `packages/util` compiles with the updated schema
- [ ] Confirm no remaining references to the removed `set_project_storage` / `get_project_storage` / `update_project_storage_save` methods
- [ ] Hub starts cleanly (no read/write of `storage` from core code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)