### PR TITLE
fix(dates): store date picker crash — register antd's required dayjs plugins

### DIFF
--- a/src/packages/frontend/app/dayjs-antd-plugins.test.ts
+++ b/src/packages/frontend/app/dayjs-antd-plugins.test.ts
@@ -1,0 +1,87 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+/*
+Regression test for the antd DatePicker "weekday is not a function" crash.
+
+antd's pickers (via rc-picker) call dayjs plugin methods such as
+`.weekday()` and `.localeData()` on the dayjs objects we hand them. Those
+methods only exist if the corresponding plugins were registered via
+`dayjs.extend(...)` on *our* dayjs instance. When they aren't, the store's
+license start/end date picker throws:
+
+    TypeError: t.weekday is not a function
+        at Object.getWeekDay ...
+
+See ./dayjs-antd-plugins.ts for the full explanation.
+*/
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import dayjs from "dayjs";
+
+// Importing the setup module for its side effects is exactly what the app
+// entry points do. After this, our dayjs instance must have all the plugins.
+import "./dayjs-antd-plugins";
+
+describe("antd dayjs plugin registration", () => {
+  it("exposes the plugin methods rc-picker needs on a dayjs object", () => {
+    const d = dayjs();
+    expect(typeof d.weekday).toBe("function");
+    expect(typeof d.localeData).toBe("function");
+    expect(typeof d.week).toBe("function"); // weekOfYear
+    expect(typeof d.weekYear).toBe("function");
+  });
+
+  it("reproduces rc-picker's getWeekDay() without throwing", () => {
+    // This mirrors rc-picker/es/generate/dayjs.js getWeekDay(), the exact
+    // call site that threw "t.weekday is not a function" in production.
+    const getWeekDay = (date: dayjs.Dayjs): number => {
+      const clone = date.locale("en");
+      return clone.weekday() + clone.localeData().firstDayOfWeek();
+    };
+    expect(() => getWeekDay(dayjs("2026-06-08"))).not.toThrow();
+    expect(typeof getWeekDay(dayjs("2026-06-08"))).toBe("number");
+  });
+
+  it("supports advancedFormat tokens (Q, Do, k, ...)", () => {
+    // advancedFormat adds tokens like Q (quarter) and Do (ordinal day).
+    expect(dayjs("2026-06-08").format("Q")).toBe("2");
+    expect(dayjs("2026-06-08").format("Do")).toBe("8th");
+  });
+
+  it("supports customParseFormat parsing", () => {
+    const d = dayjs("08-06-2026", "DD-MM-YYYY");
+    expect(d.isValid()).toBe(true);
+    expect(d.year()).toBe(2026);
+    expect(d.month()).toBe(5); // June (0-indexed)
+    expect(d.date()).toBe(8);
+  });
+});
+
+describe("antd dayjs plugins are wired into the app entry points", () => {
+  // Guard against silently dropping the side-effect import that activates the
+  // fix. If these break, the production picker crash will come back.
+  const setupImport = "app/dayjs-antd-plugins";
+
+  it("frontend entry-point.ts imports the dayjs plugin setup", () => {
+    const src = readFileSync(join(__dirname, "..", "entry-point.ts"), "utf8");
+    expect(src).toContain(setupImport);
+  });
+
+  it("next _app.tsx imports the dayjs plugin setup", () => {
+    const appPath = join(
+      __dirname,
+      "..",
+      "..",
+      "next",
+      "pages",
+      "_app.tsx",
+    );
+    const src = readFileSync(appPath, "utf8");
+    expect(src).toContain(setupImport);
+  });
+});

--- a/src/packages/frontend/app/dayjs-antd-plugins.ts
+++ b/src/packages/frontend/app/dayjs-antd-plugins.ts
@@ -1,0 +1,60 @@
+/*
+ *  This file is part of CoCalc: Copyright © 2026 Sagemath, Inc.
+ *  License: MS-RSL – see LICENSE.md for details
+ */
+
+/*
+Register the dayjs plugins that antd's date/time components (DatePicker,
+RangePicker, TimePicker, ...) rely on.
+
+WHY THIS EXISTS
+===============
+antd's pickers are built on `rc-picker`, whose dayjs adapter
+(rc-picker/es/generate/dayjs.js) calls `dayjs.extend(weekday)`,
+`dayjs.extend(localeData)`, etc. on *its own* imported dayjs instance.
+
+In a production bundle there can be more than one dayjs module instance
+(e.g. our app code resolves `dayjs@1.11.13` while another dependency drags in
+`dayjs@1.11.19`, and ESM/CJS interop can further duplicate instances). When
+that happens, the dayjs objects our app code creates with `import dayjs from
+"dayjs"` and hands to a picker via its `value` prop come from an instance that
+was NEVER extended by rc-picker. rc-picker then calls e.g.
+`generateConfig.getWeekDay(value)` -> `value.weekday()` on our object and
+throws:
+
+    TypeError: t.weekday is not a function
+        at Object.getWeekDay ...
+
+In dev this is usually invisible because the bundler dedupes dayjs to a single
+instance, so rc-picker's own `extend` calls happen to also cover our instance.
+The bug only shows up in the minified production bundle.
+
+THE FIX
+=======
+Extend the same set of plugins rc-picker needs, on the dayjs instance our app
+code uses. Importing this module for its side effects from each app entry point
+(before any picker renders) guarantees that every dayjs object we pass to antd
+has these plugin methods, regardless of how many dayjs instances the bundler
+produced.
+
+Keep this list in sync with rc-picker/es/generate/dayjs.js.
+*/
+
+import dayjs from "dayjs";
+import advancedFormat from "dayjs/plugin/advancedFormat";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import localeData from "dayjs/plugin/localeData";
+import weekday from "dayjs/plugin/weekday";
+import weekOfYear from "dayjs/plugin/weekOfYear";
+import weekYear from "dayjs/plugin/weekYear";
+
+// Register the plugins antd's pickers (via rc-picker) require on the value
+// objects we pass in. Order matches rc-picker's own adapter for clarity.
+dayjs.extend(customParseFormat);
+dayjs.extend(advancedFormat);
+dayjs.extend(weekday);
+dayjs.extend(localeData);
+dayjs.extend(weekOfYear);
+dayjs.extend(weekYear);
+
+export default dayjs;

--- a/src/packages/frontend/entry-point.ts
+++ b/src/packages/frontend/entry-point.ts
@@ -10,6 +10,10 @@
 import debug from "debug";
 debug.log = console.log.bind(console); // see https://github.com/debug-js/debug#output-streams
 
+// Register the dayjs plugins antd's date/time pickers need, on *our* dayjs
+// instance. Must run before any picker renders. See the module for details.
+import "./app/dayjs-antd-plugins";
+
 import { COCALC_MINIMAL } from "./fullscreen";
 
 // Load/initialize Redux-based react functionality

--- a/src/packages/next/pages/_app.tsx
+++ b/src/packages/next/pages/_app.tsx
@@ -10,6 +10,10 @@
 import "antd/dist/reset.css";
 import "@ant-design/v5-patch-for-react-19";
 
+// Register the dayjs plugins antd's date/time pickers need, on *our* dayjs
+// instance. Must run before any picker renders. See the module for details.
+import "@cocalc/frontend/app/dayjs-antd-plugins";
+
 import { ConfigProvider } from "antd";
 import { useRouter } from "next/router";
 import { useEffect } from "react";


### PR DESCRIPTION
## Summary

The store license purchase flow (and any other antd date/time picker) crashes when opening the start/end date selector:

```
TypeError: t.weekday is not a function
    at Object.getWeekDay (rc-picker dayjs adapter)
```

This registers the dayjs plugins antd needs on **our** dayjs instance, fixing the crash, and adds a regression test.

## Root cause

antd's `DatePicker`/`RangePicker`/`TimePicker` are built on `rc-picker`, whose dayjs adapter (`rc-picker/es/generate/dayjs.js`) registers the `weekday`, `localeData`, `weekOfYear`, `weekYear`, `advancedFormat` and `customParseFormat` plugins — but on **its own** imported dayjs instance.

Our app code creates dayjs values with `import dayjs from "dayjs"` (e.g. `next/components/misc/date-range.tsx`, `frontend/purchases/license-editor.tsx`) and passes them to the picker via its `value` prop. rc-picker then calls `generateConfig.getWeekDay(value)` → `value.weekday()` on **our** object. If the bundler produced more than one dayjs module instance, our values come from an instance rc-picker never extended, so `.weekday()` is `undefined` and the picker throws.

**Why it only breaks in production:** in dev the bundler dedupes dayjs to a single instance, so rc-picker's `extend` calls happen to also cover our instance. The minified production bundle ends up with two instances, so the app's dayjs objects lack the plugin methods. This is why it could not be reproduced locally.

## When/why it broke

The fragility is old — our picker code has *never* registered these plugins itself; it always relied on rc-picker doing so on a shared instance. What turned the latent bug into a live crash:

- **2026-01-26** (`2ab95cf56d`, bump mermaid): mermaid pulled in a second dayjs version (`1.11.19`) alongside the app's `1.11.13`. Two versions have coexisted since then, but the store bundle didn't trip on it.
- **2026-06-02** (`f8308ed8d6`, pnpm 11 migration): a pnpm major upgrade regenerated the dependency graph — overrides moved out of `package.json` into `pnpm-workspace.yaml`, and peer resolution was rewritten (visible in the lockfile, e.g. rc-picker's peer set changed from `4.11.3(date-fns@2.30.0)(dayjs@1.11.13)…` to `4.11.3(dayjs@1.11.13)…`). A pnpm-major reshuffle of the virtual store / peer hashing is exactly what flips a transitive dep like dayjs from one deduplicated instance to two in the production bundle.

Timing matches: the change landed 2026-06-02 and the first report came 2026-06-08, after the next production rebuild/deploy.

## The fix

`packages/frontend/app/dayjs-antd-plugins.ts` — a side-effect module that registers the same plugin set rc-picker needs, on our dayjs instance. Imported at both app entry points before any picker renders:

- `next/pages/_app.tsx`
- `frontend/entry-point.ts`

This is correct **regardless** of how many dayjs instances the bundler produces, and it's idempotent (harmless if instances happen to be shared). It won't regress if a future pnpm/antd/next bump reshuffles the graph again.

## Test

`packages/frontend/app/dayjs-antd-plugins.test.ts`:
- reproduces rc-picker's exact `getWeekDay()` call that threw,
- asserts the required plugin methods exist on a dayjs object,
- checks `advancedFormat`/`customParseFormat` behavior,
- and guards that both entry points keep importing the setup module (so the fix can't be silently dropped).

## Scope check

I audited the other libraries with the same "shared singleton / identity" shape that could be affected by the pnpm 11 reshuffle. The high-risk singletons (`react`, `react-dom`, `react-redux`, `redux`, `react-intl`, `moment`, `scheduler`) are all single-version. The duplicated ones are isolated: `immutable` 4 vs 5 — the `5.x` copy is pulled only by `sass`/`sass-loader` (build tooling, never in the runtime bundle); `rxjs` and `katex` duplicates are transitive leaf deps that don't exchange identity-checked objects with app code. dayjs/antd was the only library where app code consumed a third party's `dayjs.extend()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)