### PR TITLE
next: preserve class/function names when minifying to fix compute-server serialization

### DIFF
--- a/src/packages/next/next.config.js
+++ b/src/packages/next/next.config.js
@@ -44,6 +44,37 @@ const config = {
     config.devServer = {
       hot: true,
     };
+    // Keep minification, but do NOT mangle class/function names. The minifier
+    // otherwise renames classes (e.g. `Long` -> `n`), which breaks libraries
+    // that identify types by `constructor.name`. Concretely: google-gax's
+    // proto3-json-serializer detects a protobuf `Long` via
+    // `value.constructor.name === 'Long'`; once mangled the check fails and
+    // serializing any int64 field (e.g. a compute server's diskSizeGb) throws
+    //   "toProto3JSON: don't know how to convert value 30".
+    // This surfaced in the Rspack-bundled hub-next runtime (the compute server
+    // "start" action runs in-process there), but the same class of bug can bite
+    // browser code too, so we preserve names in both the client and server
+    // bundles while still stripping whitespace / mangling locals for size.
+    for (const plugin of config.optimization?.minimizer ?? []) {
+      if (plugin?.constructor?.name === "SwcJsMinimizerRspackPlugin") {
+        const args = (plugin._args ??= [{}]);
+        const opts = (args[0] ??= {});
+        const min = (opts.minimizerOptions ??= {});
+        const mangle = (min.mangle ??= {});
+        mangle.keep_classnames = true;
+        mangle.keep_fnames = true;
+      }
+    }
+    // The server bundle isn't size-sensitive and it runs the compute-server ->
+    // GCP code that depends on the above (the "start" action executes in-process
+    // in hub-next). Disable its minification entirely as a robust backstop via
+    // the standard webpack option -- independent of the minifier-plugin internals
+    // the loop above pokes at -- so a future next-rspack change can't silently
+    // reintroduce the mangled-`Long` bug on the server.
+    if (isServer) {
+      config.optimization = config.optimization ?? {};
+      config.optimization.minimize = false;
+    }
     // Important: return the modified config
     return config;
   },


### PR DESCRIPTION
## Problem

GCP compute servers fail to provision with:

```
Error: toProto3JSON: don't know how to convert value 30
```

The value is always the server's `diskSizeGb` (10/30/50/75/125 → "value 10/30/50/75/125"). Stored in `compute_servers.error`, not stdout, so it doesn't appear in `kubectl logs`.

## Root cause

`proto3-json-serializer` (used by `google-gax` / `@google-cloud/compute`) identifies a protobuf `Long` **purely** by `value.constructor.name === 'Long'`. The compute-server **"start" / `createInstance`** path runs in-process inside **`hub-next`**, whose bundle is minified by **Rspack** (`next.config.js`, `withRspack`). The minifier renames the `Long` class, so the check fails and serializing any `int64` field (here `diskSizeGb`) throws with its `.toString()` value.

Only manifests in the Rspack-bundled `hub-next` runtime, never in the raw-node hubs — which is why the deployed dependency tree looked clean (single `long@5.3.2`, protobufjs 7.5.9/7.6.3 both serialize fine in raw node) and it never reproduced locally.

## Fix

- Set `keep_classnames`/`keep_fnames` on Rspack's `SwcJsMinimizerRspackPlugin` so class/function names survive in **both** bundles. The client/static bundle stays minified for size — this only stops name *mangling*, which also protects browser code from the same `constructor.name` class of bug.
- Additionally disable minification for the **server** bundle (not size-sensitive) via the standard `optimization.minimize` option, as a robust backstop independent of the minifier-plugin internals, so a future `next-rspack` change can't silently reintroduce the bug server-side.

Note: stringifying `diskSizeGb` does **not** help — protobufjs converts a string `int64` to a `Long` too.

## Verification (A/B production build)

Inspected the server chunk containing proto3-json-serializer's throw:

| build | `Long` name in the chunk | result |
|---|---|---|
| master (mangle on) | `function Long(` absent → **mangled** | `constructor.name !== 'Long'` → **throws** |
| this PR | `function Long(r,ab,ac)` → **name kept, still minified** | guard passes |

Also confirmed the client/static bundle stays minified (multi-MB single-line chunks) and the server bundle is un-minified with `Long` intact. Both builds exit 0.

## Deploy

Needs a new `hub` image; deploy to `hub-next` (`co hub run -t <tag> -s next`). The raw-node hubs (`hub-conat-api`, `hub-mentions`, …) are unaffected.